### PR TITLE
Rename class select -> select_expr

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,5 +1,6 @@
 common --enable_bzlmod
 build --action_env=BAZEL_CXXOPTS="-std=c++17:-fstrict-aliasing:-Wall"
+# build --action_env=BAZEL_CXXOPTS="-std=c++20:-fstrict-aliasing:-Wall"
 build --copt=-fdiagnostics-color=always
 run --copt=-fdiagnostics-color=always
 test --copt=-fdiagnostics-color=always

--- a/builder/elementwise_test.cc
+++ b/builder/elementwise_test.cc
@@ -106,7 +106,7 @@ public:
   void visit(const not_equal* op) override { visit_binary("==", op->a, op->b, std::not_equal_to<T>()); }
   void visit(const logical_and* op) override { visit_binary("&&", op->a, op->b, std::logical_and<T>()); }
   void visit(const logical_or* op) override { visit_binary("||", op->a, op->b, std::logical_or<T>()); }
-  void visit(const class select* op) override {
+  void visit(const select_expr* op) override {
     buffer_expr_ptr c = visit_expr(op->condition);
     buffer_expr_ptr t = visit_expr(op->true_value);
     buffer_expr_ptr f = visit_expr(op->false_value);
@@ -217,7 +217,7 @@ public:
   void visit(const not_equal* op) override { visit_binary("==", op->a, op->b, std::not_equal_to<T>()); }
   void visit(const logical_and* op) override { visit_binary("&&", op->a, op->b, std::logical_and<T>()); }
   void visit(const logical_or* op) override { visit_binary("||", op->a, op->b, std::logical_or<T>()); }
-  void visit(const class select* op) override {
+  void visit(const select_expr* op) override {
     buffer<T, Rank> c_buf;
     visit_expr(op->condition, c_buf);
     buffer<T, Rank> t_buf;

--- a/builder/node_mutator.cc
+++ b/builder/node_mutator.cc
@@ -85,14 +85,14 @@ void node_mutator::visit(const logical_not* op) {
   }
 }
 
-void node_mutator::visit(const class select* op) {
+void node_mutator::visit(const select_expr* op) {
   expr c = mutate(op->condition);
   expr t = mutate(op->true_value);
   expr f = mutate(op->false_value);
   if (c.same_as(op->condition) && t.same_as(op->true_value) && f.same_as(op->false_value)) {
     set_result(op);
   } else {
-    set_result(select::make(std::move(c), std::move(t), std::move(f)));
+    set_result(select_expr::make(std::move(c), std::move(t), std::move(f)));
   }
 }
 

--- a/builder/node_mutator.h
+++ b/builder/node_mutator.h
@@ -60,7 +60,7 @@ public:
   virtual void visit(const logical_and*) override;
   virtual void visit(const logical_or*) override;
   virtual void visit(const logical_not*) override;
-  virtual void visit(const class select*) override;
+  virtual void visit(const select_expr*) override;
   virtual void visit(const call*) override;
 
   virtual void visit(const block*) override;

--- a/builder/simplify.cc
+++ b/builder/simplify.cc
@@ -138,7 +138,7 @@ public:
       i = !i;
     }
   }
-  void visit(const class select* op) override {
+  void visit(const select_expr* op) override {
     op->condition.accept(this);
     std::vector<expr> c = std::move(results);
     op->true_value.accept(this);
@@ -151,7 +151,7 @@ public:
     for (const expr& i : c) {
       for (const expr& j : t) {
         for (const expr& k : f) {
-          results.push_back(select::make(i, j, k));
+          results.push_back(select_expr::make(i, j, k));
         }
       }
     }
@@ -907,7 +907,7 @@ expr simplify(const logical_not* op, expr a) {
   return rules.apply(e);
 }
 
-expr simplify(const class select* op, expr c, expr t, expr f) {
+expr simplify(const select_expr* op, expr c, expr t, expr f) {
   std::optional<bool> const_c = attempt_to_prove(c);
   if (const_c) {
     if (*const_c) {
@@ -923,7 +923,7 @@ expr simplify(const class select* op, expr c, expr t, expr f) {
   } else if (op && c.same_as(op->condition) && t.same_as(op->true_value) && f.same_as(op->false_value)) {
     e = op;
   } else {
-    e = select::make(std::move(c), std::move(t), std::move(f));
+    e = select_expr::make(std::move(c), std::move(t), std::move(f));
   }
   static rule_set rules = {
       {select(!x, y, z), select(x, z, y)},
@@ -1197,7 +1197,7 @@ public:
     }
   }
 
-  void visit(const class select* op) override {
+  void visit(const select_expr* op) override {
     interval_expr c_bounds;
     expr c = mutate(op->condition, &c_bounds);
     if (is_true(c_bounds.min)) {
@@ -2009,7 +2009,7 @@ interval_expr bounds_of(const logical_not* op, interval_expr a) {
   return {simplify(op, std::move(a.max)), simplify(op, std::move(a.min))};
 }
 
-interval_expr bounds_of(const class select* op, interval_expr c, interval_expr t, interval_expr f) {
+interval_expr bounds_of(const select_expr* op, interval_expr c, interval_expr t, interval_expr f) {
   if (is_true(c.min)) {
     return t;
   } else if (is_false(c.max)) {
@@ -2174,7 +2174,7 @@ public:
   virtual void visit(const logical_or* op) override {}
   virtual void visit(const logical_not* op) override { set_result(-mutate(op->a)); }
 
-  virtual void visit(const class select* op) override {
+  virtual void visit(const select_expr* op) override {
     set_result(select(op->condition, mutate(op->true_value), mutate(op->false_value)));
   }
 

--- a/builder/simplify.h
+++ b/builder/simplify.h
@@ -42,7 +42,7 @@ expr simplify(const not_equal* op, expr a, expr b);
 expr simplify(const logical_and* op, expr a, expr b);
 expr simplify(const logical_or* op, expr a, expr b);
 expr simplify(const logical_not* op, expr a);
-expr simplify(const class select* op, expr c, expr t, expr f);
+expr simplify(const select_expr* op, expr c, expr t, expr f);
 expr simplify(const call* op, std::vector<expr> args);
 
 // Helpers for producing the bounds of ops.
@@ -60,7 +60,7 @@ interval_expr bounds_of(const not_equal* op, interval_expr a, interval_expr b);
 interval_expr bounds_of(const logical_and* op, interval_expr a, interval_expr b);
 interval_expr bounds_of(const logical_or* op, interval_expr a, interval_expr b);
 interval_expr bounds_of(const logical_not* op, interval_expr a);
-interval_expr bounds_of(const class select* op, interval_expr c, interval_expr t, interval_expr f);
+interval_expr bounds_of(const select_expr* op, interval_expr c, interval_expr t, interval_expr f);
 interval_expr bounds_of(const call* op, std::vector<interval_expr> args);
 
 }  // namespace slinky

--- a/builder/substitute.cc
+++ b/builder/substitute.cc
@@ -223,9 +223,9 @@ public:
     try_match(ne->a, op->a);
   }
 
-  void visit(const class select* op) override {
+  void visit(const select_expr* op) override {
     if (match) return;
-    const class select* se = match_self_as(op);
+    const select_expr* se = match_self_as(op);
     if (!se) return;
 
     if (!try_match(se->condition, op->condition)) return;

--- a/runtime/evaluate.cc
+++ b/runtime/evaluate.cc
@@ -195,7 +195,7 @@ public:
   void visit(const logical_or* op) override { result = eval_expr(op->a) != 0 || eval_expr(op->b) != 0; }
   void visit(const logical_not* op) override { result = eval_expr(op->a) == 0; }
 
-  void visit(const class select* op) override {
+  void visit(const select_expr* op) override {
     if (eval_expr(op->condition)) {
       result = eval_expr(op->true_value);
     } else {

--- a/runtime/expr.cc
+++ b/runtime/expr.cc
@@ -133,7 +133,7 @@ expr clamp(expr x, expr a, expr b) {
   if (b.defined()) x = min::make(std::move(x), std::move(b));
   return x;
 }
-expr select(expr c, expr t, expr f) { return select::make(std::move(c), std::move(t), std::move(f)); }
+expr select(expr c, expr t, expr f) { return select_expr::make(std::move(c), std::move(t), std::move(f)); }
 expr operator==(expr a, expr b) { return equal::make(std::move(a), std::move(b)); }
 expr operator!=(expr a, expr b) { return not_equal::make(std::move(a), std::move(b)); }
 expr operator<(expr a, expr b) { return less::make(std::move(a), std::move(b)); }
@@ -287,8 +287,8 @@ box_expr operator&(box_expr a, const box_expr& b) {
   return a;
 }
 
-expr select::make(expr condition, expr true_value, expr false_value) {
-  auto n = new select();
+expr select_expr::make(expr condition, expr true_value, expr false_value) {
+  auto n = new select_expr();
   n->condition = std::move(condition);
   n->true_value = std::move(true_value);
   n->false_value = std::move(false_value);

--- a/runtime/expr.h
+++ b/runtime/expr.h
@@ -425,7 +425,7 @@ public:
 
 // Similar to the C++ ternary operator. `true_value` or `false_value` are only evaluated when the `condition` is true or
 // false, respectively.
-class select : public expr_node<class select> {
+class select_expr : public expr_node<class select_expr> {
 public:
   expr condition;
   expr true_value;
@@ -740,7 +740,7 @@ public:
   virtual void visit(const logical_and*) = 0;
   virtual void visit(const logical_or*) = 0;
   virtual void visit(const logical_not*) = 0;
-  virtual void visit(const class select*) = 0;
+  virtual void visit(const select_expr*) = 0;
   virtual void visit(const call*) = 0;
 
   virtual void visit(const let_stmt*) = 0;
@@ -790,7 +790,7 @@ public:
   virtual void visit(const logical_and* op) override { visit_binary(op); }
   virtual void visit(const logical_or* op) override { visit_binary(op); }
   virtual void visit(const logical_not* op) override { op->a.accept(this); }
-  virtual void visit(const class select* op) override {
+  virtual void visit(const select_expr* op) override {
     op->condition.accept(this);
     op->true_value.accept(this);
     op->false_value.accept(this);
@@ -893,7 +893,7 @@ inline void less_equal::accept(node_visitor* v) const { v->visit(this); }
 inline void logical_and::accept(node_visitor* v) const { v->visit(this); }
 inline void logical_or::accept(node_visitor* v) const { v->visit(this); }
 inline void logical_not::accept(node_visitor* v) const { v->visit(this); }
-inline void select::accept(node_visitor* v) const { v->visit(this); }
+inline void select_expr::accept(node_visitor* v) const { v->visit(this); }
 inline void call::accept(node_visitor* v) const { v->visit(this); }
 
 inline void let_stmt::accept(node_visitor* v) const { v->visit(this); }

--- a/runtime/print.cc
+++ b/runtime/print.cc
@@ -158,7 +158,7 @@ public:
   void visit(const class min* op) override { *this << "min(" << op->a << ", " << op->b << ")"; }
   void visit(const class max* op) override { *this << "max(" << op->a << ", " << op->b << ")"; }
 
-  void visit(const class select* op) override {
+  void visit(const select_expr* op) override {
     *this << "select(" << op->condition << ", " << op->true_value << ", " << op->false_value << ")";
   }
 


### PR DESCRIPTION
When `sys/select.h` is included, we get into an ambiguous name situation between the syscall, this class, and the `expr select(expr, expr, expr);` call that is hard to resolve without adding additional `using` calls in multiple places. SInce the macOS version of GTest likes to include that header, this makes for awkward mac-specific compile errors. Renaming this class seems to be the simplest approach to making the code compile more happily.