### PR TITLE
Add reshape test

### DIFF
--- a/builder/copy_test.cc
+++ b/builder/copy_test.cc
@@ -508,3 +508,65 @@ TEST(copy, reshape) {
     ASSERT_EQ(in_buf.base()[i], out_buf.base()[i]);
   }
 }
+
+TEST(copy, batch_reshape) {
+  // Make the pipeline
+  node_context ctx;
+
+  auto in = buffer_expr::make(ctx, "in", sizeof(int), 4);
+  auto out = buffer_expr::make(ctx, "out", sizeof(int), 4);
+
+  // To be a reshape that we can optimize, we need the buffers to be dense (strides equal to the product of extents of
+  // prior dimensions).
+  for (auto i : {in, out}) {
+    i->dim(0).stride = static_cast<index_t>(sizeof(int));
+    i->dim(1).stride = i->dim(0).stride * i->dim(0).extent();
+    i->dim(2).stride = i->dim(1).stride * i->dim(1).extent();
+  }
+
+  var x(ctx, "x");
+  var y(ctx, "y");
+  var z(ctx, "z");
+  var w(ctx, "w");
+
+  // Compute the "flat" index of the coordinates in the output.
+  expr flat_out = x + y * out->dim(0).extent() + z * out->dim(0).extent() * out->dim(1).extent();
+
+  // Unpack the coordinates in the input from the flat index of the output.
+  box_expr bounds = {
+      point(flat_out % in->dim(0).extent()),
+      point((flat_out / in->dim(0).extent()) % in->dim(1).extent()),
+      point(flat_out / (in->dim(0).extent() * in->dim(1).extent())), 
+      point(w),
+  };
+  func crop = func::make_copy({in, bounds}, {out, {x, y, z, w}});
+
+  pipeline p = build_pipeline(ctx, {in}, {out});
+
+  const int W = 8;
+  const int H = 5;
+  const int D = 3;
+  const int N = 3;
+
+  // Run the pipeline.
+  buffer<int, 4> in_buf({W, H, D, N});
+  init_random(in_buf);
+
+  // The output should be the same size as the input, but with permuted dimensions.
+  buffer<int, 4> out_buf({H, D, W, N});
+  out_buf.allocate();
+
+  const raw_buffer* inputs[] = {&in_buf};
+  const raw_buffer* outputs[] = {&out_buf};
+  eval_context eval_ctx;
+  p.evaluate(inputs, outputs, eval_ctx);
+
+  // This should have been a "flat" copy.
+  for (int n = 0; n < N; ++n) {
+    const int* in_base = &in_buf(0, 0, 0, n);
+    const int* out_base = &out_buf(0, 0, 0, n);
+    for (int i = 0; i < W * H * D; ++i) {
+      ASSERT_EQ(in_base[i], out_base[i]);
+    }
+  }
+}

--- a/builder/copy_test.cc
+++ b/builder/copy_test.cc
@@ -3,8 +3,8 @@
 #include <cassert>
 #include <vector>
 
-#include "runtime/expr.h"
 #include "builder/pipeline.h"
+#include "runtime/expr.h"
 #include "runtime/pipeline.h"
 
 using namespace slinky;
@@ -72,7 +72,7 @@ TEST(copy, trivial_2d) {
   var x(ctx, "x");
   var y(ctx, "y");
   var dy(ctx, "dy");
-  
+
   std::vector<char> padding(sizeof(int), 0);
 
   // This copy should be implemented as a single call to copy.
@@ -451,5 +451,60 @@ TEST(copy, concatenate) {
     for (int x = 0; x < W; ++x) {
       ASSERT_EQ(out_buf(x, y), y < H1 ? in1_buf(x, y) : in2_buf(x, y - H1));
     }
+  }
+}
+
+TEST(copy, reshape) {
+  // Make the pipeline
+  node_context ctx;
+
+  auto in = buffer_expr::make(ctx, "in", sizeof(int), 3);
+  auto out = buffer_expr::make(ctx, "out", sizeof(int), 3);
+
+  // To be a reshape that we can optimize, we need the buffers to be dense (strides equal to the product of extents of
+  // prior dimensions).
+  for (auto i : {in, out}) {
+    i->dim(0).stride = static_cast<index_t>(sizeof(int));
+    i->dim(1).stride = i->dim(0).stride * i->dim(0).extent();
+    i->dim(2).stride = i->dim(1).stride * i->dim(1).extent();
+  }
+
+  var x(ctx, "x");
+  var y(ctx, "y");
+  var z(ctx, "z");
+
+  // Compute the "flat" index of the coordinates in the output.
+  expr flat_out = x + y * out->dim(0).extent() + z * out->dim(0).extent() * out->dim(1).extent();
+
+  // Unpack the coordinates in the input from the flat index of the output.
+  box_expr bounds = {
+      point(flat_out % in->dim(0).extent()),
+      point((flat_out / in->dim(0).extent()) % in->dim(1).extent()),
+      point(flat_out / (in->dim(0).extent() * in->dim(1).extent())),
+  };
+  func crop = func::make_copy({in, bounds}, {out, {x, y, z}});
+
+  pipeline p = build_pipeline(ctx, {in}, {out});
+
+  const int W = 8;
+  const int H = 5;
+  const int D = 3;
+
+  // Run the pipeline.
+  buffer<int, 3> in_buf({W, H, D});
+  init_random(in_buf);
+
+  // The output should be the same size as the input, but with permuted dimensions.
+  buffer<int, 3> out_buf({H, D, W});
+  out_buf.allocate();
+
+  const raw_buffer* inputs[] = {&in_buf};
+  const raw_buffer* outputs[] = {&out_buf};
+  eval_context eval_ctx;
+  p.evaluate(inputs, outputs, eval_ctx);
+
+  // This should have been a "flat" copy.
+  for (int i = 0; i < W * H * D; ++i) {
+    ASSERT_EQ(in_buf.base()[i], out_buf.base()[i]);
   }
 }

--- a/builder/infer_bounds.cc
+++ b/builder/infer_bounds.cc
@@ -531,7 +531,7 @@ stmt infer_bounds(const stmt& s, node_context& ctx, const std::vector<symbol_id>
 
   // Try to reuse buffers and eliminate copies where possible.
   result = alias_buffers(result);
-  result = optimize_copies(result);
+  result = optimize_copies(result, ctx);
 
   result = simplify(result);
   result = reduce_scopes(result);

--- a/builder/optimizations.cc
+++ b/builder/optimizations.cc
@@ -395,6 +395,9 @@ public:
     }
 
     // TODO: Try to optimize reshapes, where the index of the input is an "unpacking" of a flat index of the output.
+    // This will require the simplifier to understand the constraints implied by the checks on the buffer metadata
+    // at the beginning of the pipeline, e.g. that buffer_stride(dst_var, d) == buffer_stride(dst_var, d - 1) *
+    // buffer_extent(dst_var, d - 1).
 
     // Rewrite the source buffer to be only the dimensions of the src we want to pass to copy.
     result = make_buffer::make(op->src, buffer_at(src_var, src_x), buffer_elem_size(src_var), src_dims, result);

--- a/builder/optimizations.cc
+++ b/builder/optimizations.cc
@@ -7,15 +7,15 @@
 #include <optional>
 #include <set>
 #include <tuple>
-#include <vector>
 #include <utility>
+#include <vector>
 
+#include "builder/node_mutator.h"
+#include "builder/substitute.h"
 #include "runtime/buffer.h"
 #include "runtime/depends_on.h"
 #include "runtime/evaluate.h"
 #include "runtime/expr.h"
-#include "builder/node_mutator.h"
-#include "builder/substitute.h"
 #include "runtime/util.h"
 
 namespace slinky {
@@ -67,9 +67,7 @@ bool is_elementwise(const box_expr& in_x, symbol_id out) {
 bool is_copy(expr in, var out, expr& offset) {
   static var x(0), dx(1), negative_dx(2);
   static expr patterns[] = {
-      x,
-      x + dx,
-      x - negative_dx,
+      x, x + dx, x - negative_dx,
       // TODO: we could also handle scaling of x by multiplying the stride.
   };
 
@@ -339,7 +337,11 @@ stmt alias_buffers(const stmt& s) { return buffer_aliaser().mutate(s); }
 namespace {
 
 class copy_optimizer : public node_mutator {
+  node_context& ctx;
+
 public:
+  copy_optimizer(node_context& ctx) : ctx(ctx) {}
+
   void visit(const copy_stmt* op) override {
     // Start by making a call to copy.
     stmt result = call_stmt::make(
@@ -357,7 +359,6 @@ public:
     std::vector<expr> src_x = op->src_x;
     std::vector<dim_expr> src_dims;
     std::vector<std::pair<symbol_id, int>> dst_x;
-    int dst_d = 0;
 
     // If we just leave these two arrays alone, the copy will be correct, but slow.
     // We can speed it up by finding dimensions we can let pass through to the copy.
@@ -375,18 +376,16 @@ public:
         // This dimension is a broadcast. To handle this, we're going to add a dummy dimension to the input.
         // We can just always do this, regardless of whether this broadcast is implicit (the input has fewer
         // dimensions than the output) or not.
-        src_dims.push_back({buffer_bounds(dst_var, dst_d), 0, expr()});
-        dst_d++;
+        src_dims.push_back({buffer_bounds(dst_var, d), 0, expr()});
         handled = true;
       } else if (dep_count == 1) {
         expr offset;
         if (is_copy(src_x[src_d], op->dst_x[d], offset)) {
-          interval_expr dst_bounds = buffer_bounds(dst_var, dst_d);
+          interval_expr dst_bounds = buffer_bounds(dst_var, d);
           interval_expr src_bounds = buffer_bounds(src_var, src_d) - offset;
           src_dims.push_back(
               {dst_bounds & src_bounds, buffer_stride(src_var, src_d), buffer_fold_factor(src_var, src_d)});
-          src_x[src_d] = max(buffer_min(dst_var, dst_d) + offset, buffer_min(src_var, src_d));
-          dst_d++;
+          src_x[src_d] = max(buffer_min(dst_var, d) + offset, buffer_min(src_var, src_d));
           handled = true;
         }
       }
@@ -395,11 +394,39 @@ public:
       }
     }
 
-    // Any dimensions left need loops and slices.
+    // TODO: Try to optimize reshapes, where the index of the input is an "unpacking" of a flat index of the output.
+
+    // Rewrite the source buffer to be only the dimensions of the src we want to pass to copy.
     result = make_buffer::make(op->src, buffer_at(src_var, src_x), buffer_elem_size(src_var), src_dims, result);
+
+    // Any dimensions left need loops and slices.
+    // We're going to make slices here, which invalidates buffer metadata calls in the body. To avoid breaking
+    // the body, we'll make lets of the buffer metadata outside the loops.
+    // TODO: Is this really the right thing to do, or is it an artifact of a bad idea/implementation?
+    std::vector<std::pair<symbol_id, expr>> lets;
+    symbol_id let_id = ctx.insert_unique();
+    auto do_substitute = [&](const expr& value) {
+      stmt new_result = substitute(result, value, variable::make(let_id));
+      if (!new_result.same_as(result)) {
+        lets.push_back({let_id, value});
+        let_id = ctx.insert_unique();
+        result = std::move(new_result);
+      }
+    };
+    for (int d = 0; d < static_cast<index_t>(op->dst_x.size()); ++d) {
+      do_substitute(buffer_min(dst_var, d));
+      do_substitute(buffer_max(dst_var, d));
+      do_substitute(buffer_extent(dst_var, d));
+      do_substitute(buffer_stride(dst_var, d));
+      do_substitute(buffer_fold_factor(dst_var, d));
+    }
+
     for (const std::pair<symbol_id, int>& d : dst_x) {
       result = slice_dim::make(op->dst, d.second, var(d.first), result);
       result = loop::make(d.first, loop_mode::serial, buffer_bounds(dst_var, d.second), 1, result);
+    }
+    for (const auto& i : lets) {
+      result = let_stmt::make(i.first, i.second, result);
     }
 
     set_result(result);
@@ -408,7 +435,7 @@ public:
 
 }  // namespace
 
-stmt optimize_copies(const stmt& s) { return copy_optimizer().mutate(s); }
+stmt optimize_copies(const stmt& s, node_context& ctx) { return copy_optimizer(ctx).mutate(s); }
 
 namespace {
 

--- a/builder/optimizations.h
+++ b/builder/optimizations.h
@@ -9,7 +9,7 @@ namespace slinky {
 stmt alias_buffers(const stmt& s);
 
 // Find copy operations that can be implemented with calls to copy.
-stmt optimize_copies(const stmt& s);
+stmt optimize_copies(const stmt& s, node_context& ctx);
 
 // Attempt to reduce the scope of statements to only the operations required.
 stmt reduce_scopes(const stmt& s);

--- a/builder/substitute.cc
+++ b/builder/substitute.cc
@@ -524,7 +524,7 @@ public:
     for (const dim_expr& i : op->dims) {
       interval_expr bounds = {mutate(i.bounds.min), mutate(i.bounds.max)};
       dims.push_back({std::move(bounds), mutate(i.stride), mutate(i.fold_factor)});
-      changed = changed || dims.back().same_as(i);
+      changed = changed || !dims.back().same_as(i);
     }
     auto s = set_value_in_scope(shadowed, op->sym, true);
     stmt body = mutate_decl_body(op->sym, op->body);
@@ -549,7 +549,7 @@ public:
     bool changed = false;
     for (const expr& i : op->at) {
       at.push_back(mutate(i));
-      changed = changed || at.back().same_as(i);
+      changed = changed || !at.back().same_as(i);
     }
     auto s = set_value_in_scope(shadowed, op->sym, true);
     stmt body = mutate_decl_body(op->sym, op->body);


### PR DESCRIPTION
- Add a test that does a reshape
- Supporting this required tweaking the copy optimization logic. In a way, it's a simplification (don't need to track `dst_d`, which was a very confusing bit of logic to get right), but it still seems like there might be a better way to do all this.
- Actually rewriting reshape copies to be efficient is a TODO. I think the matching isn't actually that hard/brittle (there's only one way to write a reshape that can optimize I think?), but it does require the simplifier to understand constraints more than it does now.