### PR TITLE
eval_context shouldn't inherit from symbol_map

### DIFF
--- a/builder/pipeline_test.cc
+++ b/builder/pipeline_test.cc
@@ -1140,7 +1140,7 @@ TEST(pipeline, constant) {
   const raw_buffer* outputs[] = {&out_buf};
   test_context eval_ctx;
   // TODO: Should pipeline understand constants and do this itself?
-  eval_ctx[constant->sym()] = reinterpret_cast<index_t>(constant->constant());
+  eval_ctx.symbols()[constant->sym()] = reinterpret_cast<index_t>(constant->constant());
   p.evaluate({}, outputs, eval_ctx);
 
   for (int y = 0; y < H; ++y) {

--- a/builder/simplify_test.cc
+++ b/builder/simplify_test.cc
@@ -210,8 +210,8 @@ TEST(simplify, bounds_of) {
             eval_context ctx;
             for (int y_val = y_min; y_val <= y_max; ++y_val) {
               for (int x_val = x_min; x_val <= x_max; ++x_val) {
-                ctx[x] = x_val;
-                ctx[y] = y_val;
+                ctx.symbols()[x] = x_val;
+                ctx.symbols()[y] = y_val;
 
                 index_t result = evaluate(e, ctx);
                 index_t min = evaluate(bounds_e.min);
@@ -221,7 +221,7 @@ TEST(simplify, bounds_of) {
                   std::cerr << "bounds_of failure: " << e << " -> " << bounds_e << std::endl;
                   std::cerr << result << " not in [" << min << ", " << max << "]" << std::endl;
                   std::cerr << "ctx: " << std::endl;
-                  dump_context_for_expr(std::cerr, ctx, e, &symbols);
+                  dump_context_for_expr(std::cerr, ctx.symbols(), e, &symbols);
                   std::cerr << std::endl;
                   std::cerr << "bounds: " << std::endl;
                   dump_symbol_map(std::cerr, bounds);
@@ -343,7 +343,7 @@ TEST(simplify, fuzz) {
     buffers.emplace_back(raw_buffer::make(max_rank, 4));
   }
   for (int i = 0; i < static_cast<int>(bufs.size()); ++i) {
-    ctx[bufs[i]] = reinterpret_cast<index_t>(&*buffers[i]);
+    ctx.symbols()[bufs[i]] = reinterpret_cast<index_t>(&*buffers[i]);
   }
 
   symbol_map<interval_expr> var_bounds;
@@ -360,7 +360,7 @@ TEST(simplify, fuzz) {
 
     for (int j = 0; j < checks; ++j) {
       for (const var& v : vars) {
-        ctx[v] = random_constant();
+        ctx.symbols()[v] = random_constant();
       }
       for (auto& b : buffers) {
         for (int d = 0; d < max_rank; ++d) {
@@ -379,7 +379,7 @@ TEST(simplify, fuzz) {
         std::cerr << " -> " << eval_test << std::endl;
         print(std::cerr, simplified, &symbols);
         std::cerr << " -> " << eval_simplified << std::endl;
-        dump_context_for_expr(std::cerr, ctx, test, &symbols);
+        dump_context_for_expr(std::cerr, ctx.symbols(), test, &symbols);
         ASSERT_EQ(eval_test, eval_simplified);
       } else {
         index_t min = !is_infinity(bounds.min) ? evaluate(bounds.min, ctx) : std::numeric_limits<index_t>::min();
@@ -390,7 +390,7 @@ TEST(simplify, fuzz) {
           std::cerr << " -> " << eval_test << std::endl;
           print(std::cerr, bounds.min, &symbols);
           std::cerr << " -> " << min << std::endl;
-          dump_context_for_expr(std::cerr, ctx, test, &symbols);
+          dump_context_for_expr(std::cerr, ctx.symbols(), test, &symbols);
           std::cerr << std::endl;
           ASSERT_LE(min, eval_test);
         }
@@ -400,7 +400,7 @@ TEST(simplify, fuzz) {
           std::cerr << " -> " << eval_test << std::endl;
           print(std::cerr, bounds.max, &symbols);
           std::cerr << " -> " << max << std::endl;
-          dump_context_for_expr(std::cerr, ctx, test, &symbols);
+          dump_context_for_expr(std::cerr, ctx.symbols(), test, &symbols);
           std::cerr << std::endl;
           ASSERT_LE(eval_test, max);
         }

--- a/runtime/evaluate.h
+++ b/runtime/evaluate.h
@@ -5,8 +5,7 @@
 
 namespace slinky {
 
-// TODO: Probably shouldn't inherit here.
-class eval_context : public symbol_map<index_t> {
+class eval_context {
 public:
   // These two functions implement allocation. `allocate` is called before
   // running the body, and `free` is called after.
@@ -32,7 +31,15 @@ public:
   std::function<void(task)> enqueue_one;
   std::function<void(std::function<bool()>)> wait_for;
 
-  const raw_buffer* lookup_buffer(symbol_id id) const { return reinterpret_cast<const raw_buffer*>(*lookup(id)); }
+  const raw_buffer* lookup_buffer(symbol_id id) const {
+    return reinterpret_cast<const raw_buffer*>(*symbols_.lookup(id));
+  }
+
+  symbol_map<index_t>& symbols() { return symbols_; }
+  const symbol_map<index_t>& symbols() const { return symbols_; }
+
+private:
+  symbol_map<index_t> symbols_;
 };
 
 index_t evaluate(const expr& e, eval_context& context);

--- a/runtime/evaluate_test.cc
+++ b/runtime/evaluate_test.cc
@@ -13,7 +13,7 @@ TEST(evaluate, arithmetic) {
   var x(ctx, "x");
 
   eval_context context;
-  context[x] = 4;
+  context.symbols()[x] = 4;
 
   ASSERT_EQ(evaluate(x + 5, context), 9);
   ASSERT_EQ(evaluate(x - 3, context), 1);
@@ -42,13 +42,13 @@ TEST(evaluate, call) {
   std::vector<index_t> calls;
   stmt c = call_stmt::make(
       [&](eval_context& ctx) -> index_t {
-        calls.push_back(*ctx[x]);
+        calls.push_back(*ctx.symbols()[x]);
         return 0;
       },
       {}, {});
 
   eval_context context;
-  context[x] = 2;
+  context.symbols()[x] = 2;
 
   int result = evaluate(c, context);
   ASSERT_EQ(result, 0);
@@ -71,7 +71,7 @@ TEST(evaluate, loop) {
     std::atomic<index_t> sum_x = 0;
     stmt c = call_stmt::make(
         [&](eval_context& ctx) -> index_t {
-          sum_x += *ctx[x];
+          sum_x += *ctx.symbols()[x];
           return 0;
         },
         {}, {});

--- a/runtime/pipeline.cc
+++ b/runtime/pipeline.cc
@@ -19,13 +19,13 @@ index_t pipeline::evaluate(scalars args, buffers inputs, buffers outputs, eval_c
   assert(outputs.size() == outputs_.size());
 
   for (std::size_t i = 0; i < args.size(); ++i) {
-    ctx[args_[i]] = args[i];
+    ctx.symbols()[args_[i]] = args[i];
   }
   for (std::size_t i = 0; i < inputs.size(); ++i) {
-    ctx[inputs_[i]] = reinterpret_cast<index_t>(inputs[i]);
+    ctx.symbols()[inputs_[i]] = reinterpret_cast<index_t>(inputs[i]);
   }
   for (std::size_t i = 0; i < outputs.size(); ++i) {
-    ctx[outputs_[i]] = reinterpret_cast<index_t>(outputs[i]);
+    ctx.symbols()[outputs_[i]] = reinterpret_cast<index_t>(outputs[i]);
   }
 
   return slinky::evaluate(body_, ctx);


### PR DESCRIPTION
Fix a minor TODO to get comfy in the codebase.