### PR TITLE
Don't delete fold factor when rewriting stride to 0

### DIFF
--- a/builder/simplify.cc
+++ b/builder/simplify.cc
@@ -1444,7 +1444,7 @@ public:
       interval_expr bounds_d = mutate(op->dims[d].bounds);
       body = substitute_bounds(body, op->sym, d, bounds_d);
       dim_expr new_dim = {bounds_d, mutate(op->dims[d].stride), mutate(op->dims[d].fold_factor)};
-      if (is_one(new_dim.fold_factor) || prove_true(new_dim.bounds.extent() == 1)) {
+      if (prove_true(new_dim.fold_factor == 1 || new_dim.bounds.extent() == 1)) {
         new_dim.stride = 0;
       }
       changed = changed || !new_dim.same_as(op->dims[d]);

--- a/builder/simplify.cc
+++ b/builder/simplify.cc
@@ -1446,7 +1446,6 @@ public:
       dim_expr new_dim = {bounds_d, mutate(op->dims[d].stride), mutate(op->dims[d].fold_factor)};
       if (is_one(new_dim.fold_factor) || prove_true(new_dim.bounds.extent() == 1)) {
         new_dim.stride = 0;
-        new_dim.fold_factor = expr();
       }
       changed = changed || !new_dim.same_as(op->dims[d]);
       dims.push_back(std::move(new_dim));


### PR DESCRIPTION
It's easy to miss folded dimensions in the IR when they are rewritten from fold factor 1 to stride 0. This PR still rewrites the stride to 0, but doesn't rewrite the fold factor.