### PR TITLE
Partial fix for #11

### DIFF
--- a/builder/pipeline.cc
+++ b/builder/pipeline.cc
@@ -74,11 +74,11 @@ func::func(callable impl, std::vector<input> inputs, std::vector<output> outputs
   add_this_to_buffers();
 }
 
-func::func(input input, output out, std::vector<char> padding) : func(nullptr, {std::move(input)}, {std::move(out)}) {
+func::func(input input, output out, std::vector<char> padding) : func({}, {std::move(input)}, {std::move(out)}) {
   padding_ = std::move(padding);
 }
 
-func::func(std::vector<input> inputs, output out) : func(nullptr, std::move(inputs), {std::move(out)}) {}
+func::func(std::vector<input> inputs, output out) : func({}, std::move(inputs), {std::move(out)}) {}
 
 func::func(func&& m) { *this = std::move(m); }
 func& func::operator=(func&& m) {
@@ -108,7 +108,7 @@ void func::remove_this_from_buffers() {
 }
 
 stmt func::make_call() const {
-  if (impl_) {
+  if (impl_.defined()) {
     call_stmt::symbol_list inputs;
     call_stmt::symbol_list outputs;
     for (const func::input& i : inputs_) {

--- a/builder/pipeline.h
+++ b/builder/pipeline.h
@@ -153,7 +153,7 @@ public:
   func(const func&) = delete;
   func& operator=(const func&) = delete;
 
-  bool defined() const { return impl_ != nullptr; }
+  bool defined() const { return impl_.defined(); }
 
   // Describes which loops should be explicit for this func, and the step size for that loop.
   func& loops(std::vector<loop_info> l) {
@@ -192,13 +192,12 @@ public:
   static func make(callable_wrapper<const In1, Out1> impl, input in1, output out1) {
     symbol_id in1_sym = in1.sym();
     symbol_id out1_sym = out1.sym();
-    return func(
-        [=, impl = std::move(impl)](eval_context& ctx) -> index_t {
-          const raw_buffer* in1_buf = ctx.lookup_buffer(in1_sym);
-          const raw_buffer* out1_buf = ctx.lookup_buffer(out1_sym);
-          return impl(in1_buf->cast<const In1>(), out1_buf->cast<Out1>());
-        },
-        {std::move(in1)}, {std::move(out1)});
+    const auto callable_wrapper = [=, impl = std::move(impl)](eval_context& ctx) -> index_t {
+      const raw_buffer* in1_buf = ctx.lookup_buffer(in1_sym);
+      const raw_buffer* out1_buf = ctx.lookup_buffer(out1_sym);
+      return impl(in1_buf->cast<const In1>(), out1_buf->cast<Out1>());
+    };
+    return func({callable_wrapper, "callable_wrapper"}, {std::move(in1)}, {std::move(out1)});
   }
 
   template <typename In1, typename In2, typename Out1>
@@ -206,14 +205,13 @@ public:
     symbol_id in1_sym = in1.sym();
     symbol_id in2_sym = in2.sym();
     symbol_id out1_sym = out1.sym();
-    return func(
-        [=, impl = std::move(impl)](eval_context& ctx) -> index_t {
-          const raw_buffer* in1_buf = ctx.lookup_buffer(in1_sym);
-          const raw_buffer* in2_buf = ctx.lookup_buffer(in2_sym);
-          const raw_buffer* out1_buf = ctx.lookup_buffer(out1_sym);
-          return impl(in1_buf->cast<const In1>(), in2_buf->cast<const In2>(), out1_buf->cast<Out1>());
-        },
-        {std::move(in1), std::move(in2)}, {std::move(out1)});
+    const auto callable_wrapper = [=, impl = std::move(impl)](eval_context& ctx) -> index_t {
+      const raw_buffer* in1_buf = ctx.lookup_buffer(in1_sym);
+      const raw_buffer* in2_buf = ctx.lookup_buffer(in2_sym);
+      const raw_buffer* out1_buf = ctx.lookup_buffer(out1_sym);
+      return impl(in1_buf->cast<const In1>(), in2_buf->cast<const In2>(), out1_buf->cast<Out1>());
+    };
+    return func({callable_wrapper, "callable_wrapper"}, {std::move(in1), std::move(in2)}, {std::move(out1)});
   }
 
   template <typename In1, typename In2, typename In3, typename Out1>
@@ -223,16 +221,16 @@ public:
     symbol_id in2_sym = in2.sym();
     symbol_id in3_sym = in3.sym();
     symbol_id out1_sym = out1.sym();
+    const auto callable_wrapper = [=, impl = std::move(impl)](eval_context& ctx) -> index_t {
+      const raw_buffer* in1_buf = ctx.lookup_buffer(in1_sym);
+      const raw_buffer* in2_buf = ctx.lookup_buffer(in2_sym);
+      const raw_buffer* in3_buf = ctx.lookup_buffer(in3_sym);
+      const raw_buffer* out1_buf = ctx.lookup_buffer(out1_sym);
+      return impl(
+          in1_buf->cast<const In1>(), in2_buf->cast<const In2>(), in3_buf->cast<const In3>(), out1_buf->cast<Out1>());
+    };
     return func(
-        [=, impl = std::move(impl)](eval_context& ctx) -> index_t {
-          const raw_buffer* in1_buf = ctx.lookup_buffer(in1_sym);
-          const raw_buffer* in2_buf = ctx.lookup_buffer(in2_sym);
-          const raw_buffer* in3_buf = ctx.lookup_buffer(in3_sym);
-          const raw_buffer* out1_buf = ctx.lookup_buffer(out1_sym);
-          return impl(in1_buf->cast<const In1>(), in2_buf->cast<const In2>(), in3_buf->cast<const In3>(),
-              out1_buf->cast<Out1>());
-        },
-        {std::move(in1), std::move(in2), std::move(in3)}, {std::move(out1)});
+        {callable_wrapper, "callable_wrapper"}, {std::move(in1), std::move(in2), std::move(in3)}, {std::move(out1)});
   }
 
   template <typename In1, typename Out1, typename Out2>
@@ -240,14 +238,13 @@ public:
     symbol_id in1_sym = in1.sym();
     symbol_id out1_sym = out1.sym();
     symbol_id out2_sym = out2.sym();
-    return func(
-        [=, impl = std::move(impl)](eval_context& ctx) -> index_t {
-          const raw_buffer* in1_buf = ctx.lookup_buffer(in1_sym);
-          const raw_buffer* out1_buf = ctx.lookup_buffer(out1_sym);
-          const raw_buffer* out2_buf = ctx.lookup_buffer(out2_sym);
-          return impl(in1_buf->cast<const In1>(), out1_buf->cast<Out1>(), out2_buf->cast<Out2>());
-        },
-        {std::move(in1)}, {std::move(out1), std::move(out2)});
+    const auto callable_wrapper = [=, impl = std::move(impl)](eval_context& ctx) -> index_t {
+      const raw_buffer* in1_buf = ctx.lookup_buffer(in1_sym);
+      const raw_buffer* out1_buf = ctx.lookup_buffer(out1_sym);
+      const raw_buffer* out2_buf = ctx.lookup_buffer(out2_sym);
+      return impl(in1_buf->cast<const In1>(), out1_buf->cast<Out1>(), out2_buf->cast<Out2>());
+    };
+    return func({callable_wrapper, "callable_wrapper"}, {std::move(in1)}, {std::move(out1), std::move(out2)});
   }
 
   static func make_copy(std::vector<input> in, output out) { return func(std::move(in), {std::move(out)}); }

--- a/runtime/evaluate.cc
+++ b/runtime/evaluate.cc
@@ -354,12 +354,13 @@ public:
   }
 
   void visit(const call_stmt* op) override {
-    result = op->target(context);
+    result = op->target.fn(context);
     if (result) {
       if (context.call_failed) {
-        context.call_failed(op);
+        context.call_failed(op, op->target.name);
       } else {
-        std::cerr << "call_stmt failed: " << stmt(op) << "->" << result << std::endl;
+        std::cerr << "call_stmt failed for callable '" << op->target.name << "': " << stmt(op) << "->" << result
+                  << std::endl;
         std::abort();
       }
     }

--- a/runtime/evaluate.h
+++ b/runtime/evaluate.h
@@ -19,7 +19,7 @@ public:
   // If these functions are not defined, the default handler will write a
   // message to cerr and abort.
   std::function<void(const expr&)> check_failed;
-  std::function<void(const call_stmt*)> call_failed;
+  std::function<void(const call_stmt*, const std::string&)> call_failed;
 
   // Functions implementing parallelism:
   // - `enqueue_many` should enqueue the task N times for asynchronous execution, where N is the maximum number of

--- a/runtime/evaluate_test.cc
+++ b/runtime/evaluate_test.cc
@@ -40,12 +40,11 @@ TEST(evaluate, call) {
   node_context ctx;
   var x(ctx, "x");
   std::vector<index_t> calls;
-  stmt c = call_stmt::make(
-      [&](eval_context& ctx) -> index_t {
-        calls.push_back(*ctx[x]);
-        return 0;
-      },
-      {}, {});
+  const auto test_fn = [&](eval_context& ctx) -> index_t {
+    calls.push_back(*ctx[x]);
+    return 0;
+  };
+  stmt c = call_stmt::make({test_fn, "test_fn"}, {}, {});
 
   eval_context context;
   context[x] = 2;
@@ -69,12 +68,11 @@ TEST(evaluate, loop) {
 
   for (loop_mode type : {loop_mode::serial, loop_mode::parallel}) {
     std::atomic<index_t> sum_x = 0;
-    stmt c = call_stmt::make(
-        [&](eval_context& ctx) -> index_t {
-          sum_x += *ctx[x];
-          return 0;
-        },
-        {}, {});
+    const auto test_fn = [&](eval_context& ctx) -> index_t {
+      sum_x += *ctx[x];
+      return 0;
+    };
+    stmt c = call_stmt::make({test_fn, "test_fn"}, {}, {});
 
     stmt l = loop::make(x.sym(), type, range(2, 12), 3, c);
 

--- a/runtime/expr.h
+++ b/runtime/expr.h
@@ -457,8 +457,12 @@ class eval_context;
 // Call `target`.
 class call_stmt : public stmt_node<call_stmt> {
 public:
-  typedef index_t (*callable_t)(eval_context&);
-  using callable = std::function<index_t(eval_context&)>;
+  struct callable {
+    std::function<index_t(eval_context&)> fn;
+    std::string name;
+
+    bool defined() const { return fn != nullptr; }
+  };
   using symbol_list = std::vector<symbol_id>;
 
   callable target;


### PR DESCRIPTION
Makes `func::callable` into a struct with a name, so we can report useful info. This doesn't provide for equality comparisons, but we don't (yet) have a use case for that.