### PR TITLE
Partial fix for #8

### DIFF
--- a/apps/performance.cc
+++ b/apps/performance.cc
@@ -50,7 +50,7 @@ pipeline make_pipeline(bool explicit_y) {
   var x(ctx, "x");
   var y(ctx, "y");
 
-  func copy = func::make<const char, char>(copy_2d<char>, {in, {point(x), point(y)}}, {out, {x, y}});
+  func copy = func::make(copy_2d<char>, {{in, {point(x), point(y)}}}, {{out, {x, y}}});
 
   if (explicit_y) {
     copy.loops({y});

--- a/builder/checks_test.cc
+++ b/builder/checks_test.cc
@@ -26,7 +26,7 @@ TEST(pipeline, checks) {
 
   var x(ctx, "x");
 
-  func mul = func::make<const int, int>(multiply_2<int>, {in, {point(x)}}, {out, {x}});
+  func mul = func::make(multiply_2<int>, {{in, {point(x)}}}, {{out, {x}}});
 
   pipeline p = build_pipeline(ctx, {in}, {out});
 

--- a/builder/elementwise_test.cc
+++ b/builder/elementwise_test.cc
@@ -75,12 +75,11 @@ public:
   template <typename Impl>
   void visit_binary(const char* fn, const buffer_expr_ptr& a, const buffer_expr_ptr& b, const Impl& impl) {
     result = buffer_expr::make(ctx, name(a) + fn + name(b), sizeof(T), Rank);
-    func r = func::make<const T, const T, T>(
-        [=](const buffer<const T>& a, const buffer<const T>& b, const buffer<T>& c) {
-          for_each_index(c, [&](auto i) { c(i) = impl(a(i), b(i)); });
-          return 0;
-        },
-        {a, bounds}, {b, bounds}, {result, dims});
+    auto f = [=](const buffer<const T>& a, const buffer<const T>& b, const buffer<T>& c) {
+      for_each_index(c, [&](auto i) { c(i) = impl(a(i), b(i)); });
+      return 0;
+    };
+    func r = func::make<const T, const T, T>(std::move(f), {{a, bounds}, {b, bounds}}, {{result, dims}});
     result_funcs.push_back(std::move(r));
   }
 
@@ -111,13 +110,13 @@ public:
     buffer_expr_ptr t = visit_expr(op->true_value);
     buffer_expr_ptr f = visit_expr(op->false_value);
     result = buffer_expr::make(ctx, "select_" + name(c) + "_" + name(t) + "_" + name(f), sizeof(T), Rank);
+    auto fn = [](const buffer<const T>& c, const buffer<const T>& t, const buffer<const T>& f,
+                  const buffer<T>& r) -> index_t {
+      for_each_index(c, [&](auto i) { r(i) = c(i) != 0 ? t(i) : f(i); });
+      return 0;
+    };
     func r = func::make<const T, const T, const T, T>(
-        [](const buffer<const T>& c, const buffer<const T>& t, const buffer<const T>& f,
-            const buffer<T>& r) -> index_t {
-          for_each_index(c, [&](auto i) { r(i) = c(i) != 0 ? t(i) : f(i); });
-          return 0;
-        },
-        {c, bounds}, {t, bounds}, {f, bounds}, {result, dims});
+        std::move(fn), {{c, bounds}, {t, bounds}, {f, bounds}}, {{result, dims}});
     result_funcs.push_back(std::move(r));
   }
 

--- a/builder/elementwise_test.cc
+++ b/builder/elementwise_test.cc
@@ -75,8 +75,8 @@ public:
   template <typename Impl>
   void visit_binary(const char* fn_name, const buffer_expr_ptr& a, const buffer_expr_ptr& b, const Impl& impl) {
     result = buffer_expr::make(ctx, name(a) + fn_name + name(b), sizeof(T), Rank);
-    func::user_callable<const T, const T, T> fn = [=](const buffer<const T>& a, const buffer<const T>& b,
-                                                      const buffer<T>& c) {
+    func::callable<const T, const T, T> fn = [=](const buffer<const T>& a, const buffer<const T>& b,
+                                                 const buffer<T>& c) {
       for_each_index(c, [&](auto i) { c(i) = impl(a(i), b(i)); });
       return 0;
     };
@@ -111,9 +111,8 @@ public:
     buffer_expr_ptr t = visit_expr(op->true_value);
     buffer_expr_ptr f = visit_expr(op->false_value);
     result = buffer_expr::make(ctx, "select_" + name(c) + "_" + name(t) + "_" + name(f), sizeof(T), Rank);
-    func::user_callable<const T, const T, const T, T> fn = [](const buffer<const T>& c, const buffer<const T>& t,
-                                                               const buffer<const T>& f,
-                                                               const buffer<T>& r) -> index_t {
+    func::callable<const T, const T, const T, T> fn = [](const buffer<const T>& c, const buffer<const T>& t,
+                                                          const buffer<const T>& f, const buffer<T>& r) -> index_t {
       for_each_index(c, [&](auto i) { r(i) = c(i) != 0 ? t(i) : f(i); });
       return 0;
     };

--- a/builder/pipeline.cc
+++ b/builder/pipeline.cc
@@ -69,7 +69,7 @@ void buffer_expr::set_producer(func* f) {
   producer_ = f;
 }
 
-func::func(callable impl, std::vector<input> inputs, std::vector<output> outputs)
+func::func(call_stmt::callable impl, std::vector<input> inputs, std::vector<output> outputs)
     : impl_(std::move(impl)), inputs_(std::move(inputs)), outputs_(std::move(outputs)) {
   add_this_to_buffers();
 }

--- a/builder/pipeline.h
+++ b/builder/pipeline.h
@@ -176,78 +176,56 @@ public:
   }
   const std::optional<loop_id>& compute_at() const { return compute_at_; }
 
-  // TODO(https://github.com/dsharlet/slinky/issues/8): Try to do this with a variadic template implementation.
-  template <typename Out1>
-  static func make(callable_wrapper<Out1> impl, output out1) {
-    symbol_id out1_sym = out1.sym();
-    return func(
-        [=, impl = std::move(impl)](eval_context& ctx) -> index_t {
-          const raw_buffer* out1_buf = ctx.lookup_buffer(out1_sym);
-          return impl(out1_buf->cast<Out1>());
-        },
-        {}, {std::move(out1)});
+private:
+  template <typename First, typename... Rest>
+  static auto build_tuple(eval_context& ctx, const symbol_id* symbols, std::size_t index = 0) {
+    if constexpr (sizeof...(Rest) == 0) {
+      // Don't use make_tuple() here; it will decay away the references, which we need
+      const buffer<First>& b = ctx.lookup_buffer(symbols[index])->template cast<First>();
+      return std::tuple<const buffer<First>&>(std::move(b));
+    } else {
+      return std::tuple_cat(build_tuple<First>(ctx, symbols, index), build_tuple<Rest...>(ctx, symbols, index + 1));
+    }
   }
 
-  template <typename In1, typename Out1>
-  static func make(callable_wrapper<const In1, Out1> impl, input in1, output out1) {
-    symbol_id in1_sym = in1.sym();
-    symbol_id out1_sym = out1.sym();
-    return func(
-        [=, impl = std::move(impl)](eval_context& ctx) -> index_t {
-          const raw_buffer* in1_buf = ctx.lookup_buffer(in1_sym);
-          const raw_buffer* out1_buf = ctx.lookup_buffer(out1_sym);
-          return impl(in1_buf->cast<const In1>(), out1_buf->cast<Out1>());
-        },
-        {std::move(in1)}, {std::move(out1)});
+public:
+  // Version for plain old function ptrs
+  template <typename... T>
+  static func make(index_t (*fn)(const buffer<T>&...), std::vector<input> inputs, std::vector<output> outputs) {
+    callable_wrapper<T...> impl = std::move(fn);
+    assert(sizeof...(T) == inputs.size() + outputs.size());
+    std::array<symbol_id, sizeof...(T)> symbols;
+    std::size_t i = 0;
+    for (const auto& in : inputs)
+      symbols[i++] = in.sym();
+    for (const auto& out : outputs)
+      symbols[i++] = out.sym();
+
+    const auto wrapper = [symbols = std::move(symbols), impl = std::move(impl)](eval_context& ctx) -> index_t {
+      return std::apply(impl, build_tuple<T...>(ctx, symbols.data()));
+    };
+
+    return func(wrapper, {std::move(inputs)}, {std::move(outputs)});
   }
 
-  template <typename In1, typename In2, typename Out1>
-  static func make(callable_wrapper<const In1, const In2, Out1> impl, input in1, input in2, output out1) {
-    symbol_id in1_sym = in1.sym();
-    symbol_id in2_sym = in2.sym();
-    symbol_id out1_sym = out1.sym();
-    return func(
-        [=, impl = std::move(impl)](eval_context& ctx) -> index_t {
-          const raw_buffer* in1_buf = ctx.lookup_buffer(in1_sym);
-          const raw_buffer* in2_buf = ctx.lookup_buffer(in2_sym);
-          const raw_buffer* out1_buf = ctx.lookup_buffer(out1_sym);
-          return impl(in1_buf->cast<const In1>(), in2_buf->cast<const In2>(), out1_buf->cast<Out1>());
-        },
-        {std::move(in1), std::move(in2)}, {std::move(out1)});
-  }
+  // Version for std::function and lambda
+  template <typename... T, typename LambdaType,
+      typename std::enable_if<std::is_convertible<LambdaType, callable_wrapper<T...>>::value>::type* = nullptr>
+  static func make(LambdaType&& fn, std::vector<input> inputs, std::vector<output> outputs) {
+    callable_wrapper<T...> impl = std::move(fn);
+    assert(sizeof...(T) == inputs.size() + outputs.size());
+    std::array<symbol_id, sizeof...(T)> symbols;
+    std::size_t i = 0;
+    for (const auto& in : inputs)
+      symbols[i++] = in.sym();
+    for (const auto& out : outputs)
+      symbols[i++] = out.sym();
 
-  template <typename In1, typename In2, typename In3, typename Out1>
-  static func make(
-      callable_wrapper<const In1, const In2, const In3, Out1> impl, input in1, input in2, input in3, output out1) {
-    symbol_id in1_sym = in1.sym();
-    symbol_id in2_sym = in2.sym();
-    symbol_id in3_sym = in3.sym();
-    symbol_id out1_sym = out1.sym();
-    return func(
-        [=, impl = std::move(impl)](eval_context& ctx) -> index_t {
-          const raw_buffer* in1_buf = ctx.lookup_buffer(in1_sym);
-          const raw_buffer* in2_buf = ctx.lookup_buffer(in2_sym);
-          const raw_buffer* in3_buf = ctx.lookup_buffer(in3_sym);
-          const raw_buffer* out1_buf = ctx.lookup_buffer(out1_sym);
-          return impl(in1_buf->cast<const In1>(), in2_buf->cast<const In2>(), in3_buf->cast<const In3>(),
-              out1_buf->cast<Out1>());
-        },
-        {std::move(in1), std::move(in2), std::move(in3)}, {std::move(out1)});
-  }
+    const auto wrapper = [symbols = std::move(symbols), impl = std::move(impl)](eval_context& ctx) -> index_t {
+      return std::apply(impl, build_tuple<T...>(ctx, symbols.data()));
+    };
 
-  template <typename In1, typename Out1, typename Out2>
-  static func make(callable_wrapper<const In1, Out1, Out2> impl, input in1, output out1, output out2) {
-    symbol_id in1_sym = in1.sym();
-    symbol_id out1_sym = out1.sym();
-    symbol_id out2_sym = out2.sym();
-    return func(
-        [=, impl = std::move(impl)](eval_context& ctx) -> index_t {
-          const raw_buffer* in1_buf = ctx.lookup_buffer(in1_sym);
-          const raw_buffer* out1_buf = ctx.lookup_buffer(out1_sym);
-          const raw_buffer* out2_buf = ctx.lookup_buffer(out2_sym);
-          return impl(in1_buf->cast<const In1>(), out1_buf->cast<Out1>(), out2_buf->cast<Out2>());
-        },
-        {std::move(in1)}, {std::move(out1), std::move(out2)});
+    return func(wrapper, {std::move(inputs)}, {std::move(outputs)});
   }
 
   static func make_copy(std::vector<input> in, output out) { return func(std::move(in), {std::move(out)}); }

--- a/builder/pipeline.h
+++ b/builder/pipeline.h
@@ -191,7 +191,7 @@ public:
   // Version for plain old function ptrs
   template <typename... T>
   static func make(index_t (*fn)(const buffer<T>&...), std::vector<input> inputs, std::vector<output> outputs) {
-    callable<T...> impl = std::move(fn);
+    callable<T...> impl = fn;
     assert(sizeof...(T) == inputs.size() + outputs.size());
     std::array<symbol_id, sizeof...(T)> symbols;
     std::size_t i = 0;

--- a/builder/pipeline.h
+++ b/builder/pipeline.h
@@ -93,7 +93,7 @@ class func {
 public:
   using callable = call_stmt::callable;
   template <typename... T>
-  using callable_wrapper = std::function<index_t(const buffer<T>&...)>;
+  using user_callable = std::function<index_t(const buffer<T>&...)>;
 
   // TODO(https://github.com/dsharlet/slinky/issues/7): There should be a separate descriptor
   // of a callable and the bounds/dims of inputs/outputs, which is constant over all the
@@ -192,7 +192,7 @@ public:
   // Version for plain old function ptrs
   template <typename... T>
   static func make(index_t (*fn)(const buffer<T>&...), std::vector<input> inputs, std::vector<output> outputs) {
-    callable_wrapper<T...> impl = std::move(fn);
+    user_callable<T...> impl = std::move(fn);
     assert(sizeof...(T) == inputs.size() + outputs.size());
     std::array<symbol_id, sizeof...(T)> symbols;
     std::size_t i = 0;
@@ -208,11 +208,10 @@ public:
     return func(wrapper, {std::move(inputs)}, {std::move(outputs)});
   }
 
-  // Version for std::function and lambda
-  template <typename... T, typename LambdaType,
-      typename std::enable_if<std::is_convertible<LambdaType, callable_wrapper<T...>>::value>::type* = nullptr>
-  static func make(LambdaType&& fn, std::vector<input> inputs, std::vector<output> outputs) {
-    callable_wrapper<T...> impl = std::move(fn);
+  // Version for std::function (usually )
+  template <typename... T>
+  static func make(user_callable<T...>&& fn, std::vector<input> inputs, std::vector<output> outputs) {
+    user_callable<T...> impl = std::move(fn);
     assert(sizeof...(T) == inputs.size() + outputs.size());
     std::array<symbol_id, sizeof...(T)> symbols;
     std::size_t i = 0;

--- a/builder/pipeline.h
+++ b/builder/pipeline.h
@@ -177,8 +177,8 @@ public:
 
 private:
   template <typename... T, std::size_t... Indices>
-  static inline index_t call_impl(
-      const func::callable<T...>& impl, eval_context& ctx, const symbol_id* symbols, std::index_sequence<Indices...>) {
+  static inline index_t call_impl(const func::callable<T...>& impl, eval_context& ctx,
+      const std::array<symbol_id, sizeof...(T)>& symbols, std::index_sequence<Indices...>) {
     return impl(ctx.lookup_buffer(symbols[Indices])->template cast<T>()...);
   }
 
@@ -190,7 +190,7 @@ public:
     assert(sizeof...(T) == inputs.size() + outputs.size());
 
     // TODO: if https://github.com/dsharlet/slinky/issues/13 lands, this needs attention, as the
-    // symol ids we capture may be invalid.
+    // symbol ids we capture may be invalid.
     std::array<symbol_id, sizeof...(T)> symbols;
     std::size_t i = 0;
     for (const auto& in : inputs)
@@ -199,7 +199,7 @@ public:
       symbols[i++] = out.sym();
 
     auto wrapper = [symbols = std::move(symbols), impl = std::move(impl)](eval_context& ctx) -> index_t {
-      return call_impl<T...>(impl, ctx, symbols.data(), std::make_index_sequence<sizeof...(T)>());
+      return call_impl<T...>(impl, ctx, symbols, std::make_index_sequence<sizeof...(T)>());
     };
 
     return func(wrapper, {std::move(inputs)}, {std::move(outputs)});

--- a/builder/pipeline.h
+++ b/builder/pipeline.h
@@ -91,9 +91,8 @@ public:
 // Represents a node of computation in a pipeline.
 class func {
 public:
-  using callable = call_stmt::callable;
   template <typename... T>
-  using user_callable = std::function<index_t(const buffer<T>&...)>;
+  using callable = std::function<index_t(const buffer<T>&...)>;
 
   // TODO(https://github.com/dsharlet/slinky/issues/7): There should be a separate descriptor
   // of a callable and the bounds/dims of inputs/outputs, which is constant over all the
@@ -130,7 +129,7 @@ public:
   };
 
 private:
-  callable impl_;
+  call_stmt::callable impl_;
   std::vector<input> inputs_;
   std::vector<output> outputs_;
 
@@ -144,7 +143,7 @@ private:
 
 public:
   func() {}
-  func(callable impl, std::vector<input> inputs, std::vector<output> outputs);
+  func(call_stmt::callable impl, std::vector<input> inputs, std::vector<output> outputs);
   func(std::vector<input> inputs, output out);
   func(input input, output out, std::vector<char> padding);
   func(func&&);
@@ -192,7 +191,7 @@ public:
   // Version for plain old function ptrs
   template <typename... T>
   static func make(index_t (*fn)(const buffer<T>&...), std::vector<input> inputs, std::vector<output> outputs) {
-    user_callable<T...> impl = std::move(fn);
+    callable<T...> impl = std::move(fn);
     assert(sizeof...(T) == inputs.size() + outputs.size());
     std::array<symbol_id, sizeof...(T)> symbols;
     std::size_t i = 0;
@@ -210,8 +209,8 @@ public:
 
   // Version for std::function (usually )
   template <typename... T>
-  static func make(user_callable<T...>&& fn, std::vector<input> inputs, std::vector<output> outputs) {
-    user_callable<T...> impl = std::move(fn);
+  static func make(callable<T...>&& fn, std::vector<input> inputs, std::vector<output> outputs) {
+    callable<T...> impl = std::move(fn);
     assert(sizeof...(T) == inputs.size() + outputs.size());
     std::array<symbol_id, sizeof...(T)> symbols;
     std::size_t i = 0;

--- a/builder/pipeline.h
+++ b/builder/pipeline.h
@@ -176,8 +176,9 @@ public:
   const std::optional<loop_id>& compute_at() const { return compute_at_; }
 
 private:
+  // Note that the recursion in this function is all unwound at compiletime into inlined code.
   template <typename First, typename... Rest>
-  static auto build_tuple(eval_context& ctx, const symbol_id* symbols, std::size_t index = 0) {
+  static constexpr auto build_tuple(eval_context& ctx, const symbol_id* symbols, std::size_t index = 0) {
     if constexpr (sizeof...(Rest) == 0) {
       // Don't use make_tuple() here; it will decay away the references, which we need
       const buffer<First>& b = ctx.lookup_buffer(symbols[index])->template cast<First>();

--- a/builder/pipeline_test.cc
+++ b/builder/pipeline_test.cc
@@ -237,10 +237,10 @@ TEST(pipeline, elementwise_1d) {
         var x(ctx, "x");
 
         // Here we explicitly use std::functions (in the form of a
-        // func::user_callable typedef) to wrap the local calls
+        // func::callable typedef) to wrap the local calls
         // purely to verify that the relevant func::make calls work correctly.
-        func::user_callable<const int, int> m2 = multiply_2<int>;
-        func::user_callable<const int, int> a1 = add_1<int>;
+        func::callable<const int, int> m2 = multiply_2<int>;
+        func::callable<const int, int> a1 = add_1<int>;
 
         func mul = func::make(std::move(m2), {{in, {point(x)}}}, {{intm, {x}}});
         func add = func::make(std::move(a1), {{intm, {point(x)}}}, {{out, {x}}});
@@ -302,10 +302,10 @@ TEST(pipeline, elementwise_2d) {
         // Here we explicitly use lambdas to wrap the local calls,
         // purely to test the mechanism needed to use them with func::make, which
         // is: they must be wrapped in a std::function (usually )
-        func::user_callable<const int, int> m2 = [](const buffer<const int>& a, const buffer<int>& b) -> index_t {
+        func::callable<const int, int> m2 = [](const buffer<const int>& a, const buffer<int>& b) -> index_t {
           return multiply_2<int>(a, b);
         };
-        func::user_callable<const int, int> a1 = [](const buffer<const int>& a, const buffer<int>& b) -> index_t {
+        func::callable<const int, int> a1 = [](const buffer<const int>& a, const buffer<int>& b) -> index_t {
           return add_1<int>(a, b);
         };
 
@@ -759,8 +759,8 @@ TEST(pipeline, multiple_outputs) {
       auto Y = in->dim(1).bounds;
 
       // For a 3D input in(x, y, z), compute sum_x = sum(input(:, y, z)) and sum_xy = sum(input(:, :, z)) in one stage.
-      func::user_callable<const int, int, int> sum_x_xy = [](const buffer<const int>& in, const buffer<int>& sum_x,
-                                                              const buffer<int>& sum_xy) -> index_t {
+      func::callable<const int, int, int> sum_x_xy = [](const buffer<const int>& in, const buffer<int>& sum_x,
+                                                         const buffer<int>& sum_xy) -> index_t {
         assert(sum_x.dim(1).min() == sum_xy.dim(0).min());
         for (index_t z = sum_xy.dim(0).min(); z <= sum_xy.dim(0).max(); ++z) {
           sum_xy(z) = 0;

--- a/builder/pipeline_test.cc
+++ b/builder/pipeline_test.cc
@@ -189,7 +189,7 @@ TEST(pipeline, trivial) {
 
       var x(ctx, "x");
 
-      func mul = func::make<const int, int>(multiply_2<int>, {in, {point(x)}}, {out, {x}});
+      func mul = func::make(multiply_2<int>, {{in, {point(x)}}}, {{out, {x}}});
       if (split > 0) {
         mul.loops({{x, split, lm}});
       }
@@ -236,8 +236,15 @@ TEST(pipeline, elementwise_1d) {
 
         var x(ctx, "x");
 
-        func mul = func::make<const int, int>(multiply_2<int>, {in, {point(x)}}, {intm, {x}});
-        func add = func::make<const int, int>(add_1<int>, {intm, {point(x)}}, {out, {x}});
+        // Here we explicitly use std::functions to wrap the local calls,
+        // purely to verify that the relevant func::make calls work correctly.
+        func::callable_wrapper<const int, int> m2 = multiply_2<int>;
+        func::callable_wrapper<const int, int> a1 = add_1<int>;
+
+        // When passing in std::function or lambda, we cannot deduce
+        // the argument types and must specify them explicitly
+        func mul = func::make<const int, int>(std::move(m2), {{in, {point(x)}}}, {{intm, {x}}});
+        func add = func::make<const int, int>(std::move(a1), {{intm, {point(x)}}}, {{out, {x}}});
 
         if (split > 0) {
           add.loops({{x, split, lm}});
@@ -293,8 +300,15 @@ TEST(pipeline, elementwise_2d) {
         var x(ctx, "x");
         var y(ctx, "y");
 
-        func mul = func::make<const int, int>(multiply_2<int>, {in, {point(x), point(y)}}, {intm, {x, y}});
-        func add = func::make<const int, int>(add_1<int>, {intm, {point(x), point(y)}}, {out, {x, y}});
+        // Here we explicitly use lambdas to wrap the local calls,
+        // purely to verify that the relevant func::make calls work correctly.
+        auto m2 = [](const buffer<const int>& a, const buffer<int>& b) -> index_t { return multiply_2<int>(a, b); };
+        auto a1 = [](const buffer<const int>& a, const buffer<int>& b) -> index_t { return add_1<int>(a, b); };
+
+        // When passing in std::function or lambda, we cannot deduce
+        // the argument types and must specify them explicitly
+        func mul = func::make<const int, int>(std::move(m2), {{in, {point(x), point(y)}}}, {{intm, {x, y}}});
+        func add = func::make<const int, int>(std::move(a1), {{intm, {point(x), point(y)}}}, {{out, {x, y}}});
 
         if (split > 0) {
           add.loops({{x, split, lm}, {y, split, lm}});
@@ -365,10 +379,8 @@ TEST(pipeline, matmuls) {
       auto K_abc = c->dim(0).bounds;
 
       // We use int for this pipeline so we can test for correctness exactly.
-      func matmul_ab = func::make<const int, const int, int>(
-          matmul<int>, {a, {point(i), K_ab}}, {b, {K_ab, point(j)}}, {ab, {i, j}});
-      func matmul_abc = func::make<const int, const int, int>(
-          matmul<int>, {ab, {point(i), K_abc}}, {c, {K_abc, point(j)}}, {abc, {i, j}});
+      func matmul_ab = func::make(matmul<int>, {{a, {point(i), K_ab}}, {b, {K_ab, point(j)}}}, {{ab, {i, j}}});
+      func matmul_abc = func::make(matmul<int>, {{ab, {point(i), K_abc}}, {c, {K_abc, point(j)}}}, {{abc, {i, j}}});
 
       a->dim(1).stride = a->elem_size();
       b->dim(1).stride = b->elem_size();
@@ -467,10 +479,9 @@ TEST(pipeline, pyramid) {
   var x(ctx, "x");
   var y(ctx, "y");
 
-  func downsample =
-      func::make<const int, int>(downsample2x, {in, {2 * x + bounds(0, 1), 2 * y + bounds(0, 1)}}, {intm, {x, y}});
-  func upsample = func::make<const int, const int, int>(pyramid_upsample2x, {in, {point(x), point(y)}},
-      {intm, {bounds(x, x + 1) / 2, bounds(y, y + 1) / 2}}, {out, {x, y}});
+  func downsample = func::make(downsample2x, {{in, {2 * x + bounds(0, 1), 2 * y + bounds(0, 1)}}}, {{intm, {x, y}}});
+  func upsample = func::make(pyramid_upsample2x,
+      {{in, {point(x), point(y)}}, {intm, {bounds(x, x + 1) / 2, bounds(y, y + 1) / 2}}}, {{out, {x, y}}});
 
   upsample.loops({{y, 1}});
 
@@ -509,9 +520,8 @@ TEST(pipeline, stencil) {
       var x(ctx, "x");
       var y(ctx, "y");
 
-      func add = func::make<const short, short>(add_1<short>, {in, {point(x), point(y)}}, {intm, {x, y}});
-      func stencil =
-          func::make<const short, short>(sum3x3<short>, {intm, {bounds(-1, 1) + x, bounds(-1, 1) + y}}, {out, {x, y}});
+      func add = func::make(add_1<short>, {{in, {point(x), point(y)}}}, {{intm, {x, y}}});
+      func stencil = func::make(sum3x3<short>, {{intm, {bounds(-1, 1) + x, bounds(-1, 1) + y}}}, {{out, {x, y}}});
 
       if (split > 0) {
         stencil.loops({{y, split, lm}});
@@ -573,11 +583,9 @@ TEST(pipeline, stencil_chain) {
       var x(ctx, "x");
       var y(ctx, "y");
 
-      func add = func::make<const short, short>(add_1<short>, {in, {point(x), point(y)}}, {intm, {x, y}});
-      func stencil1 = func::make<const short, short>(
-          sum3x3<short>, {intm, {bounds(-1, 1) + x, bounds(-1, 1) + y}}, {intm2, {x, y}});
-      func stencil2 =
-          func::make<const short, short>(sum3x3<short>, {intm2, {bounds(-1, 1) + x, bounds(-1, 1) + y}}, {out, {x, y}});
+      func add = func::make(add_1<short>, {{in, {point(x), point(y)}}}, {{intm, {x, y}}});
+      func stencil1 = func::make(sum3x3<short>, {{intm, {bounds(-1, 1) + x, bounds(-1, 1) + y}}}, {{intm2, {x, y}}});
+      func stencil2 = func::make(sum3x3<short>, {{intm2, {bounds(-1, 1) + x, bounds(-1, 1) + y}}}, {{out, {x, y}}});
 
       if (split > 0) {
         stencil2.loops({{y, split, lm}});
@@ -646,8 +654,8 @@ TEST(pipeline, flip_y) {
   var x(ctx, "x");
   var y(ctx, "y");
 
-  func copy = func::make<const char, char>(copy_2d<char>, {in, {point(x), point(y)}}, {intm, {x, y}});
-  func flip = func::make<const char, char>(flip_y<char>, {intm, {point(x), point(-y)}}, {out, {x, y}});
+  func copy = func::make(copy_2d<char>, {{in, {point(x), point(y)}}}, {{intm, {x, y}}});
+  func flip = func::make(flip_y<char>, {{intm, {point(x), point(-y)}}}, {{out, {x, y}}});
 
   pipeline p = build_pipeline(ctx, {in}, {out});
 
@@ -691,10 +699,10 @@ TEST(pipeline, padded_copy) {
   var h(ctx, "h");
 
   // Copy the input so we can measure the size of the buffer we think we need internally.
-  func copy = func::make<const char, char>(copy_2d<char>, {in, {point(x), point(y)}}, {intm, {x, y}});
+  func copy = func::make(copy_2d<char>, {{in, {point(x), point(y)}}}, {{intm, {x, y}}});
   // This is elementwise, but with a clamp to limit the bounds required of the input.
-  func crop = func::make<const char, char>(
-      zero_padded_copy<char>, {intm, {point(clamp(x, 0, w - 1)), point(clamp(y, 0, h - 1))}}, {out, {x, y}});
+  func crop = func::make(
+      zero_padded_copy<char>, {{intm, {point(clamp(x, 0, w - 1)), point(clamp(y, 0, h - 1))}}}, {{out, {x, y}}});
 
   crop.loops({y});
 
@@ -763,7 +771,7 @@ TEST(pipeline, multiple_outputs) {
         }
         return 0;
       };
-      func sums = func::make<const int, int, int>(sum_x_xy, {in, {X, Y, point(z)}}, {sum_x, {y, z}}, {sum_xy, {z}});
+      func sums = func::make<const int, int, int>(sum_x_xy, {{in, {X, Y, point(z)}}}, {{sum_x, {y, z}}, {sum_xy, {z}}});
 
       if (split > 0) {
         sums.loops({{z, split, lm}});
@@ -817,8 +825,7 @@ TEST(pipeline, outer_product) {
         var i(ctx, "i");
         var j(ctx, "j");
 
-        func outer =
-            func::make<const int, const int, int>(outer_product<int>, {a, {point(i)}}, {b, {point(j)}}, {out, {i, j}});
+        func outer = func::make(outer_product<int>, {{a, {point(i)}}, {b, {point(j)}}}, {{out, {i, j}}});
 
         std::vector<func::loop_info> loops;
         if (split_i > 0) loops.emplace_back(i, split_i, lm);
@@ -867,12 +874,11 @@ TEST(pipeline, unrelated) {
   var x(ctx, "x");
   var y(ctx, "y");
 
-  func add1 = func::make<const short, short>(add_1<short>, {in1, {point(x), point(y)}}, {intm1, {x, y}});
-  func stencil1 =
-      func::make<const short, short>(sum3x3<short>, {intm1, {bounds(-1, 1) + x, bounds(-1, 1) + y}}, {out1, {x, y}});
+  func add1 = func::make(add_1<short>, {{in1, {point(x), point(y)}}}, {{intm1, {x, y}}});
+  func stencil1 = func::make(sum3x3<short>, {{intm1, {bounds(-1, 1) + x, bounds(-1, 1) + y}}}, {{out1, {x, y}}});
 
-  func mul2 = func::make<const int, int>(multiply_2<int>, {in2, {point(x)}}, {intm2, {x}});
-  func add2 = func::make<const int, int>(add_1<int>, {intm2, {point(x)}}, {out2, {x}});
+  func mul2 = func::make(multiply_2<int>, {{in2, {point(x)}}}, {{intm2, {x}}});
+  func add2 = func::make(add_1<int>, {{intm2, {point(x)}}}, {{out2, {x}}});
 
   stencil1.loops({{y, 2}});
 
@@ -938,8 +944,7 @@ TEST(pipeline, copied_result) {
     var y(ctx, "y");
 
     // In this pipeline, the result is copied to the output. We should just compute the result directly in the output.
-    func stencil =
-        func::make<const short, short>(sum3x3<short>, {in, {bounds(-1, 1) + x, bounds(-1, 1) + y}}, {intm, {x, y}});
+    func stencil = func::make(sum3x3<short>, {{in, {bounds(-1, 1) + x, bounds(-1, 1) + y}}}, {{intm, {x, y}}});
     func padded = func::make_copy({intm, {point(x), point(y)}}, {out, {x, y}});
 
     switch (schedule) {
@@ -1002,8 +1007,8 @@ TEST(pipeline, concatenated_result) {
   var y(ctx, "y");
 
   // In this pipeline, the result is copied to the output. We should just compute the result directly in the output.
-  func add1 = func::make<const short, short>(add_1<short>, {in1, {point(x), point(y)}}, {intm1, {x, y}});
-  func add2 = func::make<const short, short>(add_1<short>, {in2, {point(x), point(y)}}, {intm2, {x, y}});
+  func add1 = func::make(add_1<short>, {{{in1, {point(x), point(y)}}}}, {{{intm1, {x, y}}}});
+  func add2 = func::make(add_1<short>, {{{in2, {point(x), point(y)}}}}, {{{intm2, {x, y}}}});
   func concatenated = func::make_copy(
       {intm1, {point(x), point(y)}}, {intm2, {point(x), point(y - in1->dim(1).extent())}}, {out, {x, y}});
 
@@ -1054,10 +1059,9 @@ TEST(pipeline, padded_stencil) {
     var x(ctx, "x");
     var y(ctx, "y");
 
-    func add = func::make<const short, short>(add_1<short>, {in, {point(x), point(y)}}, {intm, {x, y}});
+    func add = func::make(add_1<short>, {{in, {point(x), point(y)}}}, {{intm, {x, y}}});
     func padded = func::make_copy({intm, {point(x), point(y)}}, {padded_intm, {x, y}}, {6, 0});
-    func stencil = func::make<const short, short>(
-        sum3x3<short>, {padded_intm, {bounds(-1, 1) + x, bounds(-1, 1) + y}}, {out, {x, y}});
+    func stencil = func::make(sum3x3<short>, {{padded_intm, {bounds(-1, 1) + x, bounds(-1, 1) + y}}}, {{out, {x, y}}});
 
     switch (schedule) {
     case 0: break;
@@ -1128,7 +1132,7 @@ TEST(pipeline, constant) {
   var x(ctx, "x");
   var y(ctx, "y");
 
-  func add = func::make<const short, short>(add_1<short>, {constant, {point(x), point(y)}}, {out, {x, y}});
+  func add = func::make(add_1<short>, {{constant, {point(x), point(y)}}}, {{out, {x, y}}});
 
   pipeline p = build_pipeline(ctx, {}, {out});
 
@@ -1165,14 +1169,12 @@ TEST(pipeline, parallel_stencils) {
   var x(ctx, "x");
   var y(ctx, "y");
 
-  func add1 = func::make<const short, short>(add_1<short>, {in1, {point(x), point(y)}}, {intm1, {x, y}});
-  func add2 = func::make<const short, short>(multiply_2<short>, {in2, {point(x), point(y)}}, {intm2, {x, y}});
-  func stencil1 =
-      func::make<const short, short>(sum3x3<short>, {intm1, {bounds(-1, 1) + x, bounds(-1, 1) + y}}, {intm3, {x, y}});
-  func stencil2 =
-      func::make<const short, short>(sum5x5<short>, {intm2, {bounds(-2, 2) + x, bounds(-2, 2) + y}}, {intm4, {x, y}});
-  func diff = func::make<const short, const short, short>(
-      subtract<short>, {intm3, {point(x), point(y)}}, {intm4, {point(x), point(y)}}, {out, {x, y}});
+  func add1 = func::make(add_1<short>, {{in1, {point(x), point(y)}}}, {{intm1, {x, y}}});
+  func add2 = func::make(multiply_2<short>, {{in2, {point(x), point(y)}}}, {{intm2, {x, y}}});
+  func stencil1 = func::make(sum3x3<short>, {{intm1, {bounds(-1, 1) + x, bounds(-1, 1) + y}}}, {{intm3, {x, y}}});
+  func stencil2 = func::make(sum5x5<short>, {{intm2, {bounds(-2, 2) + x, bounds(-2, 2) + y}}}, {{intm4, {x, y}}});
+  func diff =
+      func::make(subtract<short>, {{intm3, {point(x), point(y)}}, {intm4, {point(x), point(y)}}}, {{out, {x, y}}});
 
   diff.loops({{y, 2}});
 


### PR DESCRIPTION
Replace the existing func::make() calls with a variadic one, with a somewhat thinner and more generic wrapper. As a bonus, the template arguments need not be specified if the callsite is a "real" function... but if it's a std::function or lambda, they still do (I haven't figured out if I can get the argument type inference working for these cases). Not sure if this is a finished product yet but PTAL.