### PR TITLE
Buffer base is the address at 0, instead of the min

### DIFF
--- a/builder/copy_test.cc
+++ b/builder/copy_test.cc
@@ -171,7 +171,7 @@ TEST(copy, flip_x) {
   init_random(in_buf);
 
   buffer<int, 1> out_buf({W});
-  out_buf.dim(0).translate(-W + 1);
+  out_buf.translate(-W + 1);
   out_buf.allocate();
   const raw_buffer* inputs[] = {&in_buf};
   const raw_buffer* outputs[] = {&out_buf};
@@ -212,7 +212,7 @@ TEST(copy, flip_y) {
     init_random(in_buf);
 
     buffer<int, 3> out_buf({W, H, D});
-    out_buf.dim(1).translate(-H + 1);
+    out_buf.translate(0, -H + 1);
     out_buf.allocate();
     const raw_buffer* inputs[] = {&in_buf};
     const raw_buffer* outputs[] = {&out_buf};

--- a/builder/infer_bounds.cc
+++ b/builder/infer_bounds.cc
@@ -370,8 +370,6 @@ public:
 
             expr fold_factor = simplify(bounds_of(ignore_loop_max(cur_bounds_d.extent())).max);
             if (!depends_on(fold_factor, loop_sym)) {
-              // Align the fold factor to the loop step size, so it doesn't try to crop across a folding boundary.
-              fold_factor = simplify(align_up(fold_factor, loop_step));
               vector_at(fold_factors[output], d) = fold_factor;
             } else {
               // The fold factor didn't simplify to something that doesn't depend on the loop variable.

--- a/builder/optimizations.cc
+++ b/builder/optimizations.cc
@@ -95,6 +95,13 @@ bool is_copy(const copy_stmt* op, std::vector<expr>& offset) {
   return true;
 }
 
+expr buffer_base_for_min(expr buf, std::vector<expr> min) {
+  for (int d = 0; d < static_cast<int>(min.size()); ++d) {
+    min[d] -= buffer_min(buf, d);
+  }
+  return buffer_at(buf, min);
+}
+
 // Replaces `copy_stmt` with a call to `pad`.
 class replace_copy_with_pad : public node_mutator {
   symbol_id src;
@@ -196,8 +203,8 @@ public:
         at[d] = max(buffer_min(target_var, d) - at[d], op->dims[d].bounds.min);
         dims[d].bounds &= op->dims[d].bounds;
       }
-      stmt result = make_buffer::make(
-          op->sym, buffer_at(target_var, at), static_cast<index_t>(op->elem_size), std::move(dims), std::move(body));
+      stmt result = make_buffer::make(op->sym, buffer_at(target_var, at), static_cast<index_t>(op->elem_size),
+          std::move(dims), std::move(body));
       // If we aliased the source and destination of a copy, replace the copy with a pad.
       stmt pad_result = replace_copy_with_pad(op->sym, target.first).mutate(result);
       if (pad_result.same_as(result)) {
@@ -385,7 +392,7 @@ public:
           interval_expr src_bounds = buffer_bounds(src_var, src_d) - offset;
           src_dims.push_back(
               {dst_bounds & src_bounds, buffer_stride(src_var, src_d), buffer_fold_factor(src_var, src_d)});
-          src_x[src_d] = max(buffer_min(dst_var, d) + offset, buffer_min(src_var, src_d));
+          src_x[src_d] = offset;
           handled = true;
         }
       }

--- a/builder/optimizations.cc
+++ b/builder/optimizations.cc
@@ -95,13 +95,6 @@ bool is_copy(const copy_stmt* op, std::vector<expr>& offset) {
   return true;
 }
 
-expr buffer_base_for_min(expr buf, std::vector<expr> min) {
-  for (int d = 0; d < static_cast<int>(min.size()); ++d) {
-    min[d] -= buffer_min(buf, d);
-  }
-  return buffer_at(buf, min);
-}
-
 // Replaces `copy_stmt` with a call to `pad`.
 class replace_copy_with_pad : public node_mutator {
   symbol_id src;

--- a/builder/pipeline_test.cc
+++ b/builder/pipeline_test.cc
@@ -539,7 +539,7 @@ TEST(pipeline, stencil) {
       test_context eval_ctx;
       p.evaluate(inputs, outputs, eval_ctx);
       if (lm == loop_mode::serial && split > 0) {
-        ASSERT_EQ(eval_ctx.heap.total_size, (W + 2) * align_up(split + 2, split) * sizeof(short));
+        ASSERT_EQ(eval_ctx.heap.total_size, (W + 2) * (split + 2) * sizeof(short));
       }
       ASSERT_EQ(eval_ctx.heap.total_count, split == 0 || lm == loop_mode::serial ? 1 : 0);
 
@@ -658,7 +658,7 @@ TEST(pipeline, flip_y) {
   init_random(in_buf);
 
   buffer<char, 2> out_buf({W, H});
-  out_buf.dim(1).translate(-H + 1);
+  out_buf.translate(0, -H + 1);
   out_buf.allocate();
   const raw_buffer* inputs[] = {&in_buf};
   const raw_buffer* outputs[] = {&out_buf};
@@ -1151,75 +1151,79 @@ TEST(pipeline, constant) {
 }
 
 TEST(pipeline, parallel_stencils) {
-  // Make the pipeline
-  node_context ctx;
+  for (int split : {0, 1, 2, 3}) {
+    // Make the pipeline
+    node_context ctx;
 
-  auto in1 = buffer_expr::make(ctx, "in1", sizeof(short), 2);
-  auto in2 = buffer_expr::make(ctx, "in2", sizeof(short), 2);
-  auto intm1 = buffer_expr::make(ctx, "intm1", sizeof(short), 2);
-  auto intm2 = buffer_expr::make(ctx, "intm2", sizeof(short), 2);
-  auto intm3 = buffer_expr::make(ctx, "intm3", sizeof(short), 2);
-  auto intm4 = buffer_expr::make(ctx, "intm4", sizeof(short), 2);
-  auto out = buffer_expr::make(ctx, "out", sizeof(short), 2);
+    auto in1 = buffer_expr::make(ctx, "in1", sizeof(short), 2);
+    auto in2 = buffer_expr::make(ctx, "in2", sizeof(short), 2);
+    auto intm1 = buffer_expr::make(ctx, "intm1", sizeof(short), 2);
+    auto intm2 = buffer_expr::make(ctx, "intm2", sizeof(short), 2);
+    auto intm3 = buffer_expr::make(ctx, "intm3", sizeof(short), 2);
+    auto intm4 = buffer_expr::make(ctx, "intm4", sizeof(short), 2);
+    auto out = buffer_expr::make(ctx, "out", sizeof(short), 2);
 
-  var x(ctx, "x");
-  var y(ctx, "y");
+    var x(ctx, "x");
+    var y(ctx, "y");
 
-  func add1 = func::make<const short, short>(add_1<short>, {in1, {point(x), point(y)}}, {intm1, {x, y}});
-  func add2 = func::make<const short, short>(multiply_2<short>, {in2, {point(x), point(y)}}, {intm2, {x, y}});
-  func stencil1 =
-      func::make<const short, short>(sum3x3<short>, {intm1, {bounds(-1, 1) + x, bounds(-1, 1) + y}}, {intm3, {x, y}});
-  func stencil2 =
-      func::make<const short, short>(sum5x5<short>, {intm2, {bounds(-2, 2) + x, bounds(-2, 2) + y}}, {intm4, {x, y}});
-  func diff = func::make<const short, const short, short>(
-      subtract<short>, {intm3, {point(x), point(y)}}, {intm4, {point(x), point(y)}}, {out, {x, y}});
+    func add1 = func::make<const short, short>(add_1<short>, {in1, {point(x), point(y)}}, {intm1, {x, y}});
+    func add2 = func::make<const short, short>(multiply_2<short>, {in2, {point(x), point(y)}}, {intm2, {x, y}});
+    func stencil1 =
+        func::make<const short, short>(sum3x3<short>, {intm1, {bounds(-1, 1) + x, bounds(-1, 1) + y}}, {intm3, {x, y}});
+    func stencil2 =
+        func::make<const short, short>(sum5x5<short>, {intm2, {bounds(-2, 2) + x, bounds(-2, 2) + y}}, {intm4, {x, y}});
+    func diff = func::make<const short, const short, short>(
+        subtract<short>, {intm3, {point(x), point(y)}}, {intm4, {point(x), point(y)}}, {out, {x, y}});
 
-  diff.loops({{y, 2}});
+    if (split > 0) {
+      diff.loops({{y, split}});
+    }
 
-  pipeline p = build_pipeline(ctx, {in1, in2}, {out});
+    pipeline p = build_pipeline(ctx, {in1, in2}, {out});
 
-  // Run the pipeline.
-  const int W = 20;
-  const int H = 10;
-  buffer<short, 2> in1_buf({W + 2, H + 2});
-  buffer<short, 2> in2_buf({W + 4, H + 4});
-  in1_buf.translate(-1, -1);
-  in2_buf.translate(-2, -2);
-  buffer<short, 2> out_buf({W, H});
+    // Run the pipeline.
+    const int W = 20;
+    const int H = 10;
+    buffer<short, 2> in1_buf({W + 2, H + 2});
+    buffer<short, 2> in2_buf({W + 4, H + 4});
+    in1_buf.translate(-1, -1);
+    in2_buf.translate(-2, -2);
+    buffer<short, 2> out_buf({W, H});
 
-  init_random(in1_buf);
-  init_random(in2_buf);
-  out_buf.allocate();
+    init_random(in1_buf);
+    init_random(in2_buf);
+    out_buf.allocate();
 
-  // Not having span(std::initializer_list<T>) is unfortunate.
-  const raw_buffer* inputs[] = {&in1_buf, &in2_buf};
-  const raw_buffer* outputs[] = {&out_buf};
-  test_context eval_ctx;
-  p.evaluate(inputs, outputs, eval_ctx);
+    // Not having span(std::initializer_list<T>) is unfortunate.
+    const raw_buffer* inputs[] = {&in1_buf, &in2_buf};
+    const raw_buffer* outputs[] = {&out_buf};
+    test_context eval_ctx;
+    p.evaluate(inputs, outputs, eval_ctx);
 
-  // Run the pipeline stages manually to get the reference result.
-  buffer<short, 2> ref_intm1({W + 2, H + 2});
-  buffer<short, 2> ref_intm2({W + 4, H + 4});
-  buffer<short, 2> ref_intm3({W, H});
-  buffer<short, 2> ref_intm4({W, H});
-  buffer<short, 2> ref_out({W, H});
-  ref_intm1.translate(-1, -1);
-  ref_intm2.translate(-2, -2);
-  ref_intm1.allocate();
-  ref_intm2.allocate();
-  ref_intm3.allocate();
-  ref_intm4.allocate();
-  ref_out.allocate();
+    // Run the pipeline stages manually to get the reference result.
+    buffer<short, 2> ref_intm1({W + 2, H + 2});
+    buffer<short, 2> ref_intm2({W + 4, H + 4});
+    buffer<short, 2> ref_intm3({W, H});
+    buffer<short, 2> ref_intm4({W, H});
+    buffer<short, 2> ref_out({W, H});
+    ref_intm1.translate(-1, -1);
+    ref_intm2.translate(-2, -2);
+    ref_intm1.allocate();
+    ref_intm2.allocate();
+    ref_intm3.allocate();
+    ref_intm4.allocate();
+    ref_out.allocate();
 
-  add_1<short>(in1_buf.cast<const short>(), ref_intm1.cast<short>());
-  multiply_2<short>(in2_buf.cast<const short>(), ref_intm2.cast<short>());
-  sum3x3<short>(ref_intm1.cast<const short>(), ref_intm3.cast<short>());
-  sum5x5<short>(ref_intm2.cast<const short>(), ref_intm4.cast<short>());
-  subtract<short>(ref_intm3.cast<const short>(), ref_intm4.cast<const short>(), ref_out.cast<short>());
+    add_1<short>(in1_buf.cast<const short>(), ref_intm1.cast<short>());
+    multiply_2<short>(in2_buf.cast<const short>(), ref_intm2.cast<short>());
+    sum3x3<short>(ref_intm1.cast<const short>(), ref_intm3.cast<short>());
+    sum5x5<short>(ref_intm2.cast<const short>(), ref_intm4.cast<short>());
+    subtract<short>(ref_intm3.cast<const short>(), ref_intm4.cast<const short>(), ref_out.cast<short>());
 
-  for (int y = 0; y < H; ++y) {
-    for (int x = 0; x < W; ++x) {
-      ASSERT_EQ(ref_out(x, y), out_buf(x, y));
+    for (int y = 0; y < H; ++y) {
+      for (int x = 0; x < W; ++x) {
+        ASSERT_EQ(ref_out(x, y), out_buf(x, y));
+      }
     }
   }
 }

--- a/builder/simplify.cc
+++ b/builder/simplify.cc
@@ -951,7 +951,7 @@ expr simplify(const call* op, std::vector<expr> args) {
     // Trailing undefined indices can be removed.
     for (index_t d = 1; d < static_cast<index_t>(args.size()); ++d) {
       // buffer_at(b, 0) is equivalent to buffer_base(b)
-      if (args[d].defined() && match(args[d], 0)) {
+      if (args[d].defined() && is_zero(args[d])) {
         args[d] = expr();
         changed = true;
       }

--- a/builder/simplify.cc
+++ b/builder/simplify.cc
@@ -241,61 +241,6 @@ public:
   }
 };
 
-// Check if the buffer metadata for `sym` is mutated in `s`.
-bool is_buffer_mutated(symbol_id sym, const stmt& s) {
-  class visitor : public recursive_node_visitor {
-  public:
-    symbol_id sym;
-    bool result = false;
-
-    visitor(symbol_id sym) : sym(sym) {}
-
-    void visit(const crop_buffer* op) override {
-      result = result || op->sym == sym;
-      recursive_node_visitor::visit(op);
-    }
-    void visit(const crop_dim* op) override {
-      result = result || op->sym == sym;
-      recursive_node_visitor::visit(op);
-    }
-    void visit(const slice_buffer* op) override {
-      result = result || op->sym == sym;
-      recursive_node_visitor::visit(op);
-    }
-    void visit(const slice_dim* op) override {
-      result = result || op->sym == sym;
-      recursive_node_visitor::visit(op);
-    }
-    void visit(const truncate_rank* op) override {
-      result = result || op->sym == sym;
-      recursive_node_visitor::visit(op);
-    }
-
-    // If these nodes shadow the symbol we are looking for, ignore them.
-    void visit(const allocate* op) override {
-      if (op->sym == sym) return;
-      recursive_node_visitor::visit(op);
-    }
-    void visit(const make_buffer* op) override {
-      if (op->sym == sym) return;
-      recursive_node_visitor::visit(op);
-    }
-    void visit(const clone_buffer* op) override {
-      if (op->sym == sym) return;
-      recursive_node_visitor::visit(op);
-    }
-    void visit(const let_stmt* op) override {
-      if (op->sym == sym) return;
-      recursive_node_visitor::visit(op);
-    }
-
-    using recursive_node_visitor::visit;
-  };
-  visitor v(sym);
-  s.accept(&v);
-  return v.result;
-}
-
 }  // namespace
 
 expr simplify(const class min* op, expr a, expr b) {
@@ -1493,66 +1438,46 @@ public:
     }
 
     if (const call* bc = base.as<call>()) {
-      if (bc->intrinsic == intrinsic::buffer_base) {
-        // Check if this make_buffer is truncate_rank, or a clone.
-        const symbol_id* src_buf = as_variable(bc->args[0]);
-        if (src_buf) {
-          var buf(*src_buf);
-          if (match(elem_size, buffer_elem_size(buf))) {
-            bool is_clone = true;
-            for (index_t d = 0; d < static_cast<index_t>(dims.size()); ++d) {
-              is_clone = is_clone && match(dims[d], buffer_dim(buf, d));
-            }
-            if (is_clone) {
-              if (*src_buf == op->sym) {
-                set_result(mutate(truncate_rank::make(op->sym, dims.size(), std::move(body))));
-                return;
-              }
-              const std::optional<box_expr>& src_bounds = buffer_bounds[*src_buf];
-              if (src_bounds && src_bounds->size() == dims.size()) {
-                if (!is_buffer_mutated(op->sym, body) && !is_buffer_mutated(*src_buf, body)) {
-                  // This is a clone of src_buf, and we never mutate either buffer, we can just re-use it.
-                  set_result(let_stmt::make(op->sym, buf, std::move(body)));
-                } else {
-                  // This is a clone of src_buf, but we've mutated one of them. Use clone_buffer instead.
-                  set_result(clone_buffer::make(op->sym, *src_buf, std::move(body)));
-                }
-                return;
-              }
-            }
-
-            // To be a crop, we need dimensions to either be identity, or the buffer_at argument is the same as the min.
-            bool is_crop = true;
-            box_expr crop_bounds(dims.size());
-            for (index_t d = 0; d < static_cast<index_t>(dims.size()); ++d) {
-              if (!match(dims[d].stride, buffer_stride(buf, d)) ||
-                  !match(dims[d].fold_factor, buffer_fold_factor(buf, d))) {
-                is_crop = false;
-                break;
-              }
-
-              // If the argument is defined, we need the min to be the same as the argument.
-              // If it is not defined, it must be buffer_min(buf, d).
-              bool has_at_d = d + 1 < static_cast<index_t>(bc->args.size()) && bc->args[d + 1].defined();
-              expr crop_min = has_at_d ? bc->args[d + 1] : 0;
-              if (match(dims[d].bounds.min, crop_min)) {
-                crop_bounds[d] = dims[d].bounds;
-              } else {
-                is_crop = false;
-                break;
-              }
-            }
-            if (is_crop) {
-              set_result(mutate(crop_buffer::make(op->sym, std::move(crop_bounds), std::move(body))));
-              return;
-            }
+      // Check if this make_buffer is equivalent to a crop, truncate_rank, or clone.
+      if (bc->intrinsic == intrinsic::buffer_base && match(elem_size, buffer_elem_size(bc->args[0]))) {
+        expr buf = bc->args[0];
+        const symbol_id* buf_sym = as_variable(buf);
+        assert(buf_sym);
+        bool is_clone = true;
+        bool is_crop = true;
+        for (index_t d = 0; d < static_cast<index_t>(dims.size()); ++d) {
+          // To be a crop, the strides and fold factors must match.
+          is_crop = is_crop && match(dims[d].stride, buffer_stride(buf, d));
+          is_crop = is_crop && match(dims[d].stride, buffer_fold_factor(buf, d));
+          is_clone = is_clone && match(dims[d], buffer_dim(buf, d));
+        }
+        if (is_clone) {
+          stmt result = truncate_rank::make(op->sym, dims.size(), std::move(body));
+          if (op->sym != *buf_sym) {
+            result = clone_buffer::make(op->sym, *buf_sym, result);
           }
+          set_result(mutate(result));
+          return;
+        }
+        if (is_crop) {
+          box_expr crop_bounds(dims.size());
+          for (index_t d = 0; d < static_cast<index_t>(dims.size()); ++d) {
+            crop_bounds[d] = dims[d].bounds;
+          }
+          stmt result = crop_buffer::make(op->sym, std::move(crop_bounds), std::move(body));
+          if (op->sym != *buf_sym) {
+            result = clone_buffer::make(op->sym, *buf_sym, result);
+          }
+          set_result(mutate(result));
+          return;
         }
       }
 
-      // Check if this make_buffer is equivalent to slice_buffer or crop_buffer
-      var buf(op->sym);
-      if (bc->intrinsic == intrinsic::buffer_at && match(bc->args[0], buf) && match(elem_size, buffer_elem_size(buf))) {
+      // Check if this make_buffer is equivalent to slice_buffer
+      if (bc->intrinsic == intrinsic::buffer_at && match(elem_size, buffer_elem_size(bc->args[0]))) {
+        expr buf = bc->args[0];
+        const symbol_id* buf_sym = as_variable(buf);
+        assert(buf_sym);
         // To be a slice, we need every dimension that is present in the buffer_at call to be skipped, and the rest of
         // the dimensions to be identity.
         std::size_t dim = 0;
@@ -1570,7 +1495,11 @@ public:
         }
         if (is_slice && slice_rank == dims.size()) {
           std::vector<expr> at(bc->args.begin() + 1, bc->args.end());
-          set_result(slice_buffer::make(op->sym, std::move(at), std::move(body)));
+          stmt result = slice_buffer::make(op->sym, std::move(at), std::move(body));
+          if (op->sym != *buf_sym) {
+            result = clone_buffer::make(op->sym, *buf_sym, result);
+          }
+          set_result(mutate(result));
           return;
         }
       }

--- a/runtime/buffer.h
+++ b/runtime/buffer.h
@@ -64,17 +64,13 @@ public:
   void set_stride(index_t stride) { stride_ = stride; }
   void set_fold_factor(index_t fold_factor) { fold_factor_ = fold_factor; }
 
-  void translate(index_t offset) { min_ += offset; }
-
   bool contains(index_t x) const { return min() <= x && x <= max(); }
 
   std::ptrdiff_t flat_offset_bytes(index_t i) const {
-    assert(i >= min_);
-    assert(i <= max());
     if (fold_factor_ == unfolded) {
-      return (i - min_) * stride_;
+      return i * stride_;
     } else {
-      return euclidean_mod(i - min_, fold_factor_) * stride_;
+      return euclidean_mod(i, fold_factor_) * stride_;
     }
   }
 };
@@ -115,11 +111,14 @@ protected:
     return dims->contains(i0) && contains_impl(dims + 1, indices...);
   }
 
-  static void translate_impl(dim* dims, index_t o0) { dims->translate(o0); }
+  void translate_impl(dim* dim, index_t o0) { 
+    base = offset_bytes(base, -dim->flat_offset_bytes(o0));
+    dim->set_min_extent(dim->min() + o0, dim->extent());
+  }
 
   template <typename... Offsets>
-  static void translate_impl(dim* dims, index_t o0, Offsets... offsets) {
-    dims->translate(o0);
+  void translate_impl(dim* dims, index_t o0, Offsets... offsets) {
+    translate_impl(dims, o0);
     translate_impl(dims + 1, offsets...);
   }
 
@@ -192,7 +191,7 @@ public:
   void translate(span<const index_t> offsets) {
     assert(offsets.size() <= rank);
     for (std::size_t i = 0; i < offsets.size(); ++i) {
-      dims[i].translate(offsets[i]);
+      translate_impl(&dims[i], offsets[i]);
     }
   }
 

--- a/runtime/evaluate.cc
+++ b/runtime/evaluate.cc
@@ -107,8 +107,8 @@ void copy_stmt_impl(eval_context& ctx, const raw_buffer& src, const raw_buffer& 
     memcpy(dst.base, src.base, dst.elem_size);
   } else {
     void* dst_base = dst.base;
-    for (int d = 0; d < dst.rank; ++d) {
-      dst_base += dst.dim(d).flat_offset_bytes(dst.dim(d).min());
+    for (std::size_t d = 0; d < dst.rank; ++d) {
+      dst_base = offset_bytes(dst_base, dst.dim(d).flat_offset_bytes(dst.dim(d).min()));
     }
     copy_stmt_impl(ctx, src, dst.dims, dst_base, c, dst.rank - 1);
   }

--- a/runtime/evaluate.cc
+++ b/runtime/evaluate.cc
@@ -106,7 +106,11 @@ void copy_stmt_impl(eval_context& ctx, const raw_buffer& src, const raw_buffer& 
     assert(src.rank == 0);
     memcpy(dst.base, src.base, dst.elem_size);
   } else {
-    copy_stmt_impl(ctx, src, dst.dims, dst.base, c, dst.rank - 1);
+    void* dst_base = dst.base;
+    for (int d = 0; d < dst.rank; ++d) {
+      dst_base += dst.dim(d).flat_offset_bytes(dst.dim(d).min());
+    }
+    copy_stmt_impl(ctx, src, dst.dims, dst_base, c, dst.rank - 1);
   }
 }
 
@@ -390,6 +394,13 @@ public:
 
     if (op->storage == memory_type::stack) {
       buffer->base = alloca(buffer->size_bytes());
+      index_t offset = 0;
+      for (std::size_t i = 0; i < rank; ++i) {
+        if (buffer->dim(i).fold_factor() == dim::unfolded) {
+          offset -= buffer->dim(i).flat_offset_bytes(buffer->dim(i).min());
+        }
+      }
+      buffer->base = offset_bytes(buffer->base, offset);
     } else {
       assert(op->storage == memory_type::heap);
       buffer->allocation = nullptr;
@@ -462,7 +473,6 @@ public:
     std::size_t crop_rank = op->bounds.size();
     interval* old_bounds = reinterpret_cast<interval*>(alloca(sizeof(interval) * crop_rank));
 
-    void* old_base = buffer->base;
     for (std::size_t d = 0; d < crop_rank; ++d) {
       slinky::dim& dim = buffer->dims[d];
       index_t old_min = dim.min();
@@ -473,20 +483,11 @@ public:
       // Allow these expressions to be undefined, and if so, they default to their existing values.
       index_t min = std::max(old_min, eval_expr(op->bounds[d].min, old_min));
       index_t max = std::min(old_max, eval_expr(op->bounds[d].max, old_max));
-
-      if (max >= min) {
-        index_t offset = dim.flat_offset_bytes(min);
-        // Crops can't span a folding boundary if they move the base pointer.
-        assert(offset == 0 || (max - old_min) / dim.fold_factor() == (min - old_min) / dim.fold_factor());
-        buffer->base = offset_bytes(buffer->base, offset);
-      }
-
       dim.set_bounds(min, max);
     }
 
     visit(op->body);
 
-    buffer->base = old_base;
     for (std::size_t d = 0; d < crop_rank; ++d) {
       slinky::dim& dim = buffer->dims[d];
       dim.set_bounds(old_bounds[d].min, old_bounds[d].max);
@@ -502,19 +503,10 @@ public:
 
     index_t min = std::max(old_min, eval_expr(op->bounds.min, old_min));
     index_t max = std::min(old_max, eval_expr(op->bounds.max, old_max));
-
-    void* old_base = buffer->base;
-    if (max >= min) {
-      buffer->base = offset_bytes(buffer->base, dim.flat_offset_bytes(min));
-      // Crops can't span a folding boundary if they move the base pointer.
-      assert(buffer->base == old_base || (max - old_min) / dim.fold_factor() == (min - old_min) / dim.fold_factor());
-    }
-
     dim.set_bounds(min, max);
 
     visit(op->body);
 
-    buffer->base = old_base;
     dim.set_bounds(old_min, old_max);
   }
 


### PR DESCRIPTION
This PR changes the buffer address formula from `((x - min) % fold_factor) * stride` to `(x % fold_factor) * stride`, i.e. the `base` pointer now conceptually points to `0`, instead of `min`. Things to consider from this change:
- `base` now is actually out of bounds for many buffers. We should never actually dereference it, but still.
- Crops get easier, because the base doesn't change.
- Allocations get harder, because the base pointer needs to be updated.
- Folding works much better, because we never need a negative offset from folding (which is currently impossible, because `x % y >= 0`). This means that crops can't fail due to being unaligned and crossing a fold boundary.
