### PR TITLE
Enable and test `buffer<void>` more

### DIFF
--- a/runtime/buffer.h
+++ b/runtime/buffer.h
@@ -288,13 +288,11 @@ public:
 
 template <typename NewT>
 const buffer<NewT>& raw_buffer::cast() const {
-  assert(elem_size == sizeof(NewT));
   return *reinterpret_cast<const buffer<NewT>*>(this);
 }
 
 template <typename NewT>
 buffer<NewT>& raw_buffer::cast() {
-  assert(elem_size == sizeof(NewT));
   return *reinterpret_cast<buffer<NewT>*>(this);
 }
 


### PR DESCRIPTION
This mostly already worked, but in order to cast to void, asserts needed to be relaxed. I realized that these asserts aren't really needed (unlike either https://github.com/dsharlet/array or Halide), because our strides are in bytes and not elements, so casts still point at the right elements.