### PR TITLE
Revert #40 to go back to buffer base at the min instead of 0

### DIFF
--- a/builder/copy_test.cc
+++ b/builder/copy_test.cc
@@ -171,7 +171,7 @@ TEST(copy, flip_x) {
   init_random(in_buf);
 
   buffer<int, 1> out_buf({W});
-  out_buf.translate(-W + 1);
+  out_buf.dim(0).translate(-W + 1);
   out_buf.allocate();
   const raw_buffer* inputs[] = {&in_buf};
   const raw_buffer* outputs[] = {&out_buf};
@@ -212,7 +212,7 @@ TEST(copy, flip_y) {
     init_random(in_buf);
 
     buffer<int, 3> out_buf({W, H, D});
-    out_buf.translate(0, -H + 1);
+    out_buf.dim(1).translate(-H + 1);
     out_buf.allocate();
     const raw_buffer* inputs[] = {&in_buf};
     const raw_buffer* outputs[] = {&out_buf};

--- a/builder/infer_bounds.cc
+++ b/builder/infer_bounds.cc
@@ -370,6 +370,8 @@ public:
 
             expr fold_factor = simplify(bounds_of(ignore_loop_max(cur_bounds_d.extent())).max);
             if (!depends_on(fold_factor, loop_sym)) {
+              // Align the fold factor to the loop step size, so it doesn't try to crop across a folding boundary.
+              fold_factor = simplify(align_up(fold_factor, loop_step));
               vector_at(fold_factors[output], d) = fold_factor;
             } else {
               // The fold factor didn't simplify to something that doesn't depend on the loop variable.

--- a/builder/optimizations.cc
+++ b/builder/optimizations.cc
@@ -385,7 +385,7 @@ public:
           interval_expr src_bounds = buffer_bounds(src_var, src_d) - offset;
           src_dims.push_back(
               {dst_bounds & src_bounds, buffer_stride(src_var, src_d), buffer_fold_factor(src_var, src_d)});
-          src_x[src_d] = offset;
+          src_x[src_d] = max(buffer_min(dst_var, d) + offset, buffer_min(src_var, src_d));
           handled = true;
         }
       }

--- a/builder/pipeline_test.cc
+++ b/builder/pipeline_test.cc
@@ -546,7 +546,7 @@ TEST(pipeline, stencil) {
       test_context eval_ctx;
       p.evaluate(inputs, outputs, eval_ctx);
       if (lm == loop_mode::serial && split > 0) {
-        ASSERT_EQ(eval_ctx.heap.total_size, (W + 2) * (split + 2) * sizeof(short));
+        ASSERT_EQ(eval_ctx.heap.total_size, (W + 2) * align_up(split + 2, split) * sizeof(short));
       }
       ASSERT_EQ(eval_ctx.heap.total_count, split == 0 || lm == loop_mode::serial ? 1 : 0);
 
@@ -663,7 +663,7 @@ TEST(pipeline, flip_y) {
   init_random(in_buf);
 
   buffer<char, 2> out_buf({W, H});
-  out_buf.translate(0, -H + 1);
+  out_buf.dim(1).translate(-H + 1);
   out_buf.allocate();
   const raw_buffer* inputs[] = {&in_buf};
   const raw_buffer* outputs[] = {&out_buf};
@@ -1153,77 +1153,73 @@ TEST(pipeline, constant) {
 }
 
 TEST(pipeline, parallel_stencils) {
-  for (int split : {0, 1, 2, 3}) {
-    // Make the pipeline
-    node_context ctx;
+  // Make the pipeline
+  node_context ctx;
 
-    auto in1 = buffer_expr::make(ctx, "in1", sizeof(short), 2);
-    auto in2 = buffer_expr::make(ctx, "in2", sizeof(short), 2);
-    auto intm1 = buffer_expr::make(ctx, "intm1", sizeof(short), 2);
-    auto intm2 = buffer_expr::make(ctx, "intm2", sizeof(short), 2);
-    auto intm3 = buffer_expr::make(ctx, "intm3", sizeof(short), 2);
-    auto intm4 = buffer_expr::make(ctx, "intm4", sizeof(short), 2);
-    auto out = buffer_expr::make(ctx, "out", sizeof(short), 2);
+  auto in1 = buffer_expr::make(ctx, "in1", sizeof(short), 2);
+  auto in2 = buffer_expr::make(ctx, "in2", sizeof(short), 2);
+  auto intm1 = buffer_expr::make(ctx, "intm1", sizeof(short), 2);
+  auto intm2 = buffer_expr::make(ctx, "intm2", sizeof(short), 2);
+  auto intm3 = buffer_expr::make(ctx, "intm3", sizeof(short), 2);
+  auto intm4 = buffer_expr::make(ctx, "intm4", sizeof(short), 2);
+  auto out = buffer_expr::make(ctx, "out", sizeof(short), 2);
 
-    var x(ctx, "x");
-    var y(ctx, "y");
+  var x(ctx, "x");
+  var y(ctx, "y");
 
-    func add1 = func::make(add_1<short>, {{in1, {point(x), point(y)}}}, {{intm1, {x, y}}});
-    func add2 = func::make(multiply_2<short>, {{in2, {point(x), point(y)}}}, {{intm2, {x, y}}});
-    func stencil1 = func::make(sum3x3<short>, {{intm1, {bounds(-1, 1) + x, bounds(-1, 1) + y}}}, {{intm3, {x, y}}});
-    func stencil2 = func::make(sum5x5<short>, {{intm2, {bounds(-2, 2) + x, bounds(-2, 2) + y}}}, {{intm4, {x, y}}});
-    func diff =
-        func::make(subtract<short>, {{intm3, {point(x), point(y)}}, {intm4, {point(x), point(y)}}}, {{out, {x, y}}});
+  func add1 = func::make(add_1<short>, {{in1, {point(x), point(y)}}}, {{intm1, {x, y}}});
+  func add2 = func::make(multiply_2<short>, {{in2, {point(x), point(y)}}}, {{intm2, {x, y}}});
+  func stencil1 = func::make(sum3x3<short>, {{intm1, {bounds(-1, 1) + x, bounds(-1, 1) + y}}}, {{intm3, {x, y}}});
+  func stencil2 = func::make(sum5x5<short>, {{intm2, {bounds(-2, 2) + x, bounds(-2, 2) + y}}}, {{intm4, {x, y}}});
+  func diff =
+      func::make(subtract<short>, {{intm3, {point(x), point(y)}}, {intm4, {point(x), point(y)}}}, {{out, {x, y}}});
 
-    if (split > 0) {
-      diff.loops({{y, split}});
-    }
+  diff.loops({{y, 2}});
 
-    pipeline p = build_pipeline(ctx, {in1, in2}, {out});
+  pipeline p = build_pipeline(ctx, {in1, in2}, {out});
 
-    // Run the pipeline.
-    const int W = 20;
-    const int H = 10;
-    buffer<short, 2> in1_buf({W + 2, H + 2});
-    buffer<short, 2> in2_buf({W + 4, H + 4});
-    in1_buf.translate(-1, -1);
-    in2_buf.translate(-2, -2);
-    buffer<short, 2> out_buf({W, H});
+  // Run the pipeline.
+  const int W = 20;
+  const int H = 10;
+  buffer<short, 2> in1_buf({W + 2, H + 2});
+  buffer<short, 2> in2_buf({W + 4, H + 4});
+  in1_buf.translate(-1, -1);
+  in2_buf.translate(-2, -2);
+  buffer<short, 2> out_buf({W, H});
 
-    init_random(in1_buf);
-    init_random(in2_buf);
-    out_buf.allocate();
+  init_random(in1_buf);
+  init_random(in2_buf);
+  out_buf.allocate();
 
-    // Not having span(std::initializer_list<T>) is unfortunate.
-    const raw_buffer* inputs[] = {&in1_buf, &in2_buf};
-    const raw_buffer* outputs[] = {&out_buf};
-    test_context eval_ctx;
-    p.evaluate(inputs, outputs, eval_ctx);
+  // Not having span(std::initializer_list<T>) is unfortunate.
+  const raw_buffer* inputs[] = {&in1_buf, &in2_buf};
+  const raw_buffer* outputs[] = {&out_buf};
+  test_context eval_ctx;
+  p.evaluate(inputs, outputs, eval_ctx);
 
-    // Run the pipeline stages manually to get the reference result.
-    buffer<short, 2> ref_intm1({W + 2, H + 2});
-    buffer<short, 2> ref_intm2({W + 4, H + 4});
-    buffer<short, 2> ref_intm3({W, H});
-    buffer<short, 2> ref_intm4({W, H});
-    buffer<short, 2> ref_out({W, H});
-    ref_intm1.translate(-1, -1);
-    ref_intm2.translate(-2, -2);
-    ref_intm1.allocate();
-    ref_intm2.allocate();
-    ref_intm3.allocate();
-    ref_intm4.allocate();
-    ref_out.allocate();
+  // Run the pipeline stages manually to get the reference result.
+  buffer<short, 2> ref_intm1({W + 2, H + 2});
+  buffer<short, 2> ref_intm2({W + 4, H + 4});
+  buffer<short, 2> ref_intm3({W, H});
+  buffer<short, 2> ref_intm4({W, H});
+  buffer<short, 2> ref_out({W, H});
+  ref_intm1.translate(-1, -1);
+  ref_intm2.translate(-2, -2);
+  ref_intm1.allocate();
+  ref_intm2.allocate();
+  ref_intm3.allocate();
+  ref_intm4.allocate();
+  ref_out.allocate();
 
-    add_1<short>(in1_buf.cast<const short>(), ref_intm1.cast<short>());
-    multiply_2<short>(in2_buf.cast<const short>(), ref_intm2.cast<short>());
-    sum3x3<short>(ref_intm1.cast<const short>(), ref_intm3.cast<short>());
-    sum5x5<short>(ref_intm2.cast<const short>(), ref_intm4.cast<short>());
-    subtract<short>(ref_intm3.cast<const short>(), ref_intm4.cast<const short>(), ref_out.cast<short>());
+  add_1<short>(in1_buf.cast<const short>(), ref_intm1.cast<short>());
+  multiply_2<short>(in2_buf.cast<const short>(), ref_intm2.cast<short>());
+  sum3x3<short>(ref_intm1.cast<const short>(), ref_intm3.cast<short>());
+  sum5x5<short>(ref_intm2.cast<const short>(), ref_intm4.cast<short>());
+  subtract<short>(ref_intm3.cast<const short>(), ref_intm4.cast<const short>(), ref_out.cast<short>());
 
-    for (int y = 0; y < H; ++y) {
-      for (int x = 0; x < W; ++x) {
-        ASSERT_EQ(ref_out(x, y), out_buf(x, y));
-      }
+  for (int y = 0; y < H; ++y) {
+    for (int x = 0; x < W; ++x) {
+      ASSERT_EQ(ref_out(x, y), out_buf(x, y));
     }
   }
 }

--- a/builder/simplify.cc
+++ b/builder/simplify.cc
@@ -895,8 +895,8 @@ expr simplify(const call* op, std::vector<expr> args) {
   if (op->intrinsic == intrinsic::buffer_at) {
     // Trailing undefined indices can be removed.
     for (index_t d = 1; d < static_cast<index_t>(args.size()); ++d) {
-      // buffer_at(b, 0) is equivalent to buffer_base(b)
-      if (args[d].defined() && is_zero(args[d])) {
+      // buffer_at(b, buffer_min(b, 0)) is equivalent to buffer_base(b)
+      if (args[d].defined() && match(args[d], buffer_min(args[0], d - 1))) {
         args[d] = expr();
         changed = true;
       }
@@ -1438,46 +1438,40 @@ public:
     }
 
     if (const call* bc = base.as<call>()) {
-      // Check if this make_buffer is equivalent to a crop, truncate_rank, or clone.
-      if (bc->intrinsic == intrinsic::buffer_base && match(elem_size, buffer_elem_size(bc->args[0]))) {
-        expr buf = bc->args[0];
-        const symbol_id* buf_sym = as_variable(buf);
-        assert(buf_sym);
-        bool is_clone = true;
-        bool is_crop = true;
-        for (index_t d = 0; d < static_cast<index_t>(dims.size()); ++d) {
-          // To be a crop, the strides and fold factors must match.
-          is_crop = is_crop && match(dims[d].stride, buffer_stride(buf, d));
-          is_crop = is_crop && match(dims[d].stride, buffer_fold_factor(buf, d));
-          is_clone = is_clone && match(dims[d], buffer_dim(buf, d));
-        }
-        if (is_clone) {
-          stmt result = truncate_rank::make(op->sym, dims.size(), std::move(body));
-          if (op->sym != *buf_sym) {
-            result = clone_buffer::make(op->sym, *buf_sym, result);
+      if (bc->intrinsic == intrinsic::buffer_base) {
+        // Check if this make_buffer is truncate_rank, or a clone.
+        const symbol_id* src_buf = as_variable(bc->args[0]);
+        if (src_buf) {
+          var buf(*src_buf);
+          if (match(elem_size, buffer_elem_size(buf))) {
+            bool is_clone = true;
+            for (index_t d = 0; d < static_cast<index_t>(dims.size()); ++d) {
+              is_clone = is_clone && match(dims[d], buffer_dim(buf, d));
+            }
+            if (is_clone) {
+              if (*src_buf == op->sym) {
+                set_result(mutate(truncate_rank::make(op->sym, dims.size(), std::move(body))));
+                return;
+              }
+              const std::optional<box_expr>& src_bounds = buffer_bounds[*src_buf];
+              if (src_bounds && src_bounds->size() == dims.size()) {
+                if (!is_buffer_mutated(op->sym, body) && !is_buffer_mutated(*src_buf, body)) {
+                  // This is a clone of src_buf, and we never mutate either buffer, we can just re-use it.
+                  set_result(let_stmt::make(op->sym, buf, std::move(body)));
+                } else {
+                  // This is a clone of src_buf, but we've mutated one of them. Use clone_buffer instead.
+                  set_result(clone_buffer::make(op->sym, *src_buf, std::move(body)));
+                }
+                return;
+              }
+            }
           }
-          set_result(mutate(result));
-          return;
-        }
-        if (is_crop) {
-          box_expr crop_bounds(dims.size());
-          for (index_t d = 0; d < static_cast<index_t>(dims.size()); ++d) {
-            crop_bounds[d] = dims[d].bounds;
-          }
-          stmt result = crop_buffer::make(op->sym, std::move(crop_bounds), std::move(body));
-          if (op->sym != *buf_sym) {
-            result = clone_buffer::make(op->sym, *buf_sym, result);
-          }
-          set_result(mutate(result));
-          return;
         }
       }
 
-      // Check if this make_buffer is equivalent to slice_buffer
-      if (bc->intrinsic == intrinsic::buffer_at && match(elem_size, buffer_elem_size(bc->args[0]))) {
-        expr buf = bc->args[0];
-        const symbol_id* buf_sym = as_variable(buf);
-        assert(buf_sym);
+      // Check if this make_buffer is equivalent to slice_buffer or crop_buffer
+      var buf(op->sym);
+      if (bc->intrinsic == intrinsic::buffer_at && match(bc->args[0], buf) && match(elem_size, buffer_elem_size(buf))) {
         // To be a slice, we need every dimension that is present in the buffer_at call to be skipped, and the rest of
         // the dimensions to be identity.
         std::size_t dim = 0;
@@ -1495,11 +1489,33 @@ public:
         }
         if (is_slice && slice_rank == dims.size()) {
           std::vector<expr> at(bc->args.begin() + 1, bc->args.end());
-          stmt result = slice_buffer::make(op->sym, std::move(at), std::move(body));
-          if (op->sym != *buf_sym) {
-            result = clone_buffer::make(op->sym, *buf_sym, result);
+          set_result(slice_buffer::make(op->sym, std::move(at), std::move(body)));
+          return;
+        }
+
+        // To be a crop, we need dimensions to either be identity, or the buffer_at argument is the same as the min.
+        bool is_crop = bc->args.size() <= dims.size() + 1;
+        box_expr crop_bounds(dims.size());
+        for (index_t d = 0; d < static_cast<index_t>(dims.size()); ++d) {
+          if (!match(dims[d].stride, buffer_stride(buf, d)) ||
+              !match(dims[d].fold_factor, buffer_fold_factor(buf, d))) {
+            is_crop = false;
+            break;
           }
-          set_result(mutate(result));
+
+          // If the argument is defined, we need the min to be the same as the argument.
+          // If it is not defined, it must be buffer_min(buf, d).
+          bool has_at_d = d + 1 < static_cast<index_t>(bc->args.size()) && bc->args[d + 1].defined();
+          expr crop_min = has_at_d ? bc->args[d + 1] : buffer_min(buf, d);
+          if (match(dims[d].bounds.min, crop_min)) {
+            crop_bounds[d] = dims[d].bounds;
+          } else {
+            is_crop = false;
+            break;
+          }
+        }
+        if (is_crop) {
+          set_result(mutate(crop_buffer::make(op->sym, std::move(crop_bounds), std::move(body))));
           return;
         }
       }

--- a/runtime/buffer.h
+++ b/runtime/buffer.h
@@ -64,13 +64,17 @@ public:
   void set_stride(index_t stride) { stride_ = stride; }
   void set_fold_factor(index_t fold_factor) { fold_factor_ = fold_factor; }
 
+  void translate(index_t offset) { min_ += offset; }
+
   bool contains(index_t x) const { return min() <= x && x <= max(); }
 
   std::ptrdiff_t flat_offset_bytes(index_t i) const {
+    assert(i >= min_);
+    assert(i <= max());
     if (fold_factor_ == unfolded) {
-      return i * stride_;
+      return (i - min_) * stride_;
     } else {
-      return euclidean_mod(i, fold_factor_) * stride_;
+      return euclidean_mod(i - min_, fold_factor_) * stride_;
     }
   }
 };
@@ -111,14 +115,11 @@ protected:
     return dims->contains(i0) && contains_impl(dims + 1, indices...);
   }
 
-  void translate_impl(dim* dim, index_t o0) {
-    base = offset_bytes(base, -dim->flat_offset_bytes(o0));
-    dim->set_min_extent(dim->min() + o0, dim->extent());
-  }
+  static void translate_impl(dim* dims, index_t o0) { dims->translate(o0); }
 
   template <typename... Offsets>
-  void translate_impl(dim* dims, index_t o0, Offsets... offsets) {
-    translate_impl(dims, o0);
+  static void translate_impl(dim* dims, index_t o0, Offsets... offsets) {
+    dims->translate(o0);
     translate_impl(dims + 1, offsets...);
   }
 
@@ -191,13 +192,11 @@ public:
   void translate(span<const index_t> offsets) {
     assert(offsets.size() <= rank);
     for (std::size_t i = 0; i < offsets.size(); ++i) {
-      translate_impl(&dims[i], offsets[i]);
+      dims[i].translate(offsets[i]);
     }
   }
 
   std::size_t size_bytes() const;
-  // This returns the offset that should be added to an allocation to get to the base pointer for this buffer.
-  std::ptrdiff_t allocation_offset_bytes() const;
 
   // Does not call constructor or destructor of T!
   void allocate();

--- a/runtime/evaluate.cc
+++ b/runtime/evaluate.cc
@@ -106,11 +106,7 @@ void copy_stmt_impl(eval_context& ctx, const raw_buffer& src, const raw_buffer& 
     assert(src.rank == 0);
     memcpy(dst.base, src.base, dst.elem_size);
   } else {
-    void* dst_base = dst.base;
-    for (std::size_t d = 0; d < dst.rank; ++d) {
-      dst_base = offset_bytes(dst_base, dst.dim(d).flat_offset_bytes(dst.dim(d).min()));
-    }
-    copy_stmt_impl(ctx, src, dst.dims, dst_base, c, dst.rank - 1);
+    copy_stmt_impl(ctx, src, dst.dims, dst.base, c, dst.rank - 1);
   }
 }
 
@@ -392,7 +388,6 @@ public:
 
     if (op->storage == memory_type::stack) {
       buffer->base = alloca(buffer->size_bytes());
-      buffer->base = offset_bytes(buffer->base, buffer->allocation_offset_bytes());
     } else {
       assert(op->storage == memory_type::heap);
       buffer->allocation = nullptr;
@@ -462,6 +457,7 @@ public:
     std::size_t crop_rank = op->bounds.size();
     interval* old_bounds = SLINKY_ALLOCA(interval, crop_rank);
 
+    void* old_base = buffer->base;
     for (std::size_t d = 0; d < crop_rank; ++d) {
       slinky::dim& dim = buffer->dims[d];
       index_t old_min = dim.min();
@@ -472,11 +468,20 @@ public:
       // Allow these expressions to be undefined, and if so, they default to their existing values.
       index_t min = std::max(old_min, eval_expr(op->bounds[d].min, old_min));
       index_t max = std::min(old_max, eval_expr(op->bounds[d].max, old_max));
+
+      if (max >= min) {
+        index_t offset = dim.flat_offset_bytes(min);
+        // Crops can't span a folding boundary if they move the base pointer.
+        assert(offset == 0 || (max - old_min) / dim.fold_factor() == (min - old_min) / dim.fold_factor());
+        buffer->base = offset_bytes(buffer->base, offset);
+      }
+
       dim.set_bounds(min, max);
     }
 
     visit(op->body);
 
+    buffer->base = old_base;
     for (std::size_t d = 0; d < crop_rank; ++d) {
       slinky::dim& dim = buffer->dims[d];
       dim.set_bounds(old_bounds[d].min, old_bounds[d].max);
@@ -492,10 +497,19 @@ public:
 
     index_t min = std::max(old_min, eval_expr(op->bounds.min, old_min));
     index_t max = std::min(old_max, eval_expr(op->bounds.max, old_max));
+
+    void* old_base = buffer->base;
+    if (max >= min) {
+      buffer->base = offset_bytes(buffer->base, dim.flat_offset_bytes(min));
+      // Crops can't span a folding boundary if they move the base pointer.
+      assert(buffer->base == old_base || (max - old_min) / dim.fold_factor() == (min - old_min) / dim.fold_factor());
+    }
+
     dim.set_bounds(min, max);
 
     visit(op->body);
 
+    buffer->base = old_base;
     dim.set_bounds(old_min, old_max);
   }
 

--- a/runtime/visualize.cc
+++ b/runtime/visualize.cc
@@ -149,8 +149,8 @@ public:
   void visit(const add* op) override { visit_bin_op(op, " + "); }
   void visit(const sub* op) override { visit_bin_op(op, " - "); }
   void visit(const mul* op) override { visit_bin_op(op, " * "); }
-  void visit(const div* op) override { *this << "euclidean_div(" << op->a << ", " << op->b << ")"; }
-  void visit(const mod* op) override { *this << "euclidean_mod(" << op->a << ", " << op->b << ")"; }
+  void visit(const div* op) override { visit_bin_op(op, " / "); }
+  void visit(const mod* op) override { visit_bin_op(op, " % "); }
   void visit(const equal* op) override { visit_bin_op(op, " == "); }
   void visit(const not_equal* op) override { visit_bin_op(op, " != "); }
   void visit(const less* op) override { visit_bin_op(op, " < "); }
@@ -215,32 +215,28 @@ public:
   }
 
   void visit(const allocate* n) override {
-    *this << indent() << "__dims = [\n";
+    *this << indent() << "{ let " << n->sym << " = allocate('" << name(n->sym) << "', "
+          << static_cast<index_t>(n->elem_size) << ", [\n";
     *this << indent(2);
     print_vector(n->dims, ",\n" + indent(2));
     *this << "\n";
-    *this << indent() << "];\n";
-    *this << indent() << "__elem_size = " << static_cast<index_t>(n->elem_size) << ";\n";
-    *this << indent() << "{ let " << n->sym << " = allocate('" << name(n->sym) << "', __elem_size, __dims);\n";
+    *this << indent(1) << "]);\n";
     *this << n->body;
     *this << indent(1) << "free(" << n->sym << ");\n";
     *this << indent() << "}\n";
   }
 
   void visit(const make_buffer* n) override {
-    *this << indent() << "__dims = [";
+    *this << indent() << "{ let " << n->sym << " = make_buffer('" << name(n->sym) << "', " << n->base << ", "
+          << n->elem_size << ", [";
     if (!n->dims.empty()) {
       *this << "\n";
       *this << indent(2);
       print_vector(n->dims, ",\n" + indent(2));
       *this << "\n";
-      *this << indent();
+      *this << indent(1);
     }
-    *this << "];\n";
-    *this << indent() << "__elem_size = " << n->elem_size << ";\n";
-    *this << indent() << "__base = " << n->base << ";\n";
-    *this << indent() << "{ let " << n->sym << " = make_buffer('" << name(n->sym)
-          << "', __base, __elem_size, __dims);\n";
+    *this << "]);\n";
     *this << n->body;
     *this << indent() << "}\n";
   }
@@ -362,8 +358,6 @@ var __buffers = document.getElementById('buffers');
 let __template = document.getElementById('template');
 var __heap_map = [];
 var __event_t = 1;
-function euclidean_div(a, b) { return Math.floor(a / b); }
-function euclidean_mod(a, b) { return Math.round(a - b * euclidean_div(a, b)); }
 function min(a, b) { return Math.min(a, b); }
 function max(a, b) { return Math.max(a, b); }
 function clamp(x, a, b) { return min(max(x, a), b); }
@@ -378,33 +372,9 @@ function unpack_dim(at, dim) {
   if (dim.stride == 0) {
     return 0;
   } else {
-    return euclidean_mod(euclidean_div(at, dim.stride), dim.bounds.max - dim.bounds.min + 1);
+    return Math.floor(at / dim.stride) % (dim.bounds.max - dim.bounds.min + 1);
   }
 }
-function buffer_min(b, d) { return b.dims[d].bounds.min; }
-function buffer_max(b, d) { return b.dims[d].bounds.max; }
-function buffer_extent(b, d) { return b.dims[d].bounds.max - b.dims[d].bounds.min + 1; }
-function buffer_stride(b, d) { return b.dims[d].stride; }
-function buffer_fold_factor(b, d) { return b.dims[d].fold_factor; }
-function buffer_rank(b) { return b.dims.length; }
-function buffer_base(b) { return b.base; }
-function buffer_elem_size(b) { return b.elem_size; }
-function is_folded(d) { return d.fold_factor < (1 << 30); }
-function flat_offset_dim(d, x) { 
-  if (is_folded(d)) {
-    return euclidean_mod(x, d.fold_factor) * d.stride; 
-  } else {
-    return x * d.stride; 
-  }
-}
-function buffer_at(b, ...at) {
-  let result = b.base;
-  for (let d = 0; d < at.length; ++d) {
-    result = result + flat_offset_dim(b.dims[d], at[d]);
-  }
-  return result;
-}
-function select(c, t, f) { return c ? t : f; }
 function add_label(buf, name, dims, color) {
   let label = name + ': ' + dims.map(i => '[' + i.bounds.min + ',' + i.bounds.max + ']').toString();
   let p = document.createElement('p');
@@ -428,34 +398,35 @@ function define_mapping(buffer) {
       return [unpack_dim(at, sorted_dims[0]), unpack_dim(at, sorted_dims[1])];
     }
   }
-  buf.mem.mapping = closure(buffer.flat_begin, buffer.elem_size, buffer.dims);
+  buf.mem.mapping = closure(buffer.base, buffer.elem_size, buffer.dims);
   buf.mem.elem_size = buffer.elem_size;
   buf.mem.productions = [];
   __buffers.appendChild(buf);
-  __heap_map.push({begin: buffer.flat_begin, end: buffer.flat_end, element: buf});
+  __heap_map.push({begin: buffer.base, end: buffer.base + buffer.size, element: buf})
   window.requestAnimationFrame(function(t) { draw(buf.mem, __current_t); });
 }
-function find_mapping(addr) {
+function find_mapping(base) {
   for (let m of __heap_map) {
-    if (m.begin <= addr && addr < m.end) {
+    if (m.begin <= base && base < m.end) {
       return m;
     }
   }
   return 0;
 }
-function add_mapping(b) {
-  let m = find_mapping(buffer_at(b, ...b.dims.map(i => i.bounds.min)));
+function add_mapping(buffer) {
+  let m = find_mapping(buffer.base);
   if (m) {
-    add_label(m.element, b.name, b.dims, b.color);
+    add_label(m.element, buffer.name, buffer.dims, buffer.color);
   }
 }
 function for_each_offset_dim(buf, at, dim, fn) {
-  let d = buf.dims[dim];
-  for (let i = d.bounds.min; i <= d.bounds.max; ++i) {
+  for (let i = buf.dims[dim].bounds.min; i <= buf.dims[dim].bounds.max; ++i) {
     if (dim == 0) {
-      fn(at + flat_offset_dim(d, i));
+      fn(at);
+      at += buf.dims[dim].stride;
     } else {
-      for_each_offset_dim(buf, at + flat_offset_dim(d, i), dim - 1, fn);
+      for_each_offset_dim(buf, at, dim - 1, fn);
+      at += buf.dims[dim].stride;
     }
   }
 }
@@ -481,6 +452,23 @@ function draw(mem, t) {
   window.requestAnimationFrame(function(t) { draw(mem, __current_t); });
 }
 function check(condition) {}
+function buffer_min(b, d) { return b.dims[d].bounds.min; }
+function buffer_max(b, d) { return b.dims[d].bounds.max; }
+function buffer_extent(b, d) { return b.dims[d].bounds.max - b.dims[d].bounds.min + 1; }
+function buffer_stride(b, d) { return b.dims[d].stride; }
+function buffer_fold_factor(b, d) { return b.dims[d].fold_factor; }
+function buffer_rank(b) { return b.dims.length; }
+function buffer_base(b) { return b.base; }
+function buffer_elem_size(b) { return b.elem_size; }
+function flat_offset_dim(d, x) { return ((x - d.bounds.min) % d.fold_factor) * d.stride; }
+function buffer_at(b, ...at) {
+  let result = b.base;
+  for (let d = 0; d < at.length; ++d) {
+    result = result + flat_offset_dim(b.dims[d], at[d]);
+  }
+  return result;
+}
+function select(c, t, f) { return c ? t : f; }
 function flat_allocate(size) {
   if (typeof flat_allocate.heap == 'undefined') {
     flat_allocate.heap = 0;
@@ -499,19 +487,14 @@ function next_color() {
 function allocate(name, elem_size, dims, hidden = false) {
   let flat_min = 0;
   let flat_max = 0;
-  let offset = 0;
   for (let i = 0; i < dims.length; ++i) {
-    let extent = is_folded(dims[i]) ? dims[i].fold_factor : dims[i].bounds.max - dims[i].bounds.min + 1;
+    let extent = min(dims[i].bounds.max - dims[i].bounds.min + 1, dims[i].fold_factor);
     flat_min += (extent - 1) * min(0, dims[i].stride);
     flat_max += (extent - 1) * max(0, dims[i].stride);
-    if (!is_folded(dims[i])) {
-      offset -= dims[i].bounds.min * dims[i].stride;
-    }
   }
   let size = flat_max - flat_min + elem_size;
-  let allocation = flat_allocate(size);
-  let base = allocation + offset;
-  let buffer = {name: name, base: base, flat_begin: allocation, flat_end: allocation + size, elem_size: elem_size, dims: dims, color: next_color()};
+  let base = flat_allocate(size);
+  let buffer = {name: name, base: base, size: size, elem_size: elem_size, dims: dims, color: next_color()};
   if (!hidden) {
     define_mapping(buffer);
   }
@@ -528,6 +511,7 @@ function crop_dim(b, d, bounds) {
   let result = clone_buffer(b);
   let new_min = max(b.dims[d].bounds.min, bounds.min);
   let new_max = min(b.dims[d].bounds.max, bounds.max);
+  b.base += flat_offset_dim(b.dims[d], new_min);
   b.dims[d].bounds.min = new_min;
   b.dims[d].bounds.max = new_max;
   return result;
@@ -558,7 +542,7 @@ function truncate_rank(b, rank) {
   return result;
 }
 function produce(b) {
-  m = find_mapping(buffer_at(b, ...b.dims.map(i => i.bounds.min)));
+  m = find_mapping(b.base);
   if (m) {
     m.element.mem.productions.push({t: __event_t++, buf: clone_buffer(b)});
   }


### PR DESCRIPTION
After working with buffer mins at 0 for a while, I think maybe the old way was better:
- Folding did work better with mins at 0, but only as long as callbacks compute the address of each output element independently (basically #41). If they don't, both approaches need the same work to support folding.
- With the base at the min, we can lift more work out of the callbacks (innermost loop) for crops.
