### PR TITLE
Remove if_then_else node

### DIFF
--- a/builder/elementwise_test.cc
+++ b/builder/elementwise_test.cc
@@ -129,7 +129,6 @@ public:
   void visit(const let_stmt*) override { std::abort(); }
   void visit(const block*) override { std::abort(); }
   void visit(const loop*) override { std::abort(); }
-  void visit(const if_then_else*) override { std::abort(); }
   void visit(const call_stmt*) override { std::abort(); }
   void visit(const copy_stmt*) override { std::abort(); }
   void visit(const allocate*) override { std::abort(); }
@@ -234,7 +233,6 @@ public:
   void visit(const let_stmt*) override { std::abort(); }
   void visit(const block*) override { std::abort(); }
   void visit(const loop*) override { std::abort(); }
-  void visit(const if_then_else*) override { std::abort(); }
   void visit(const call_stmt*) override { std::abort(); }
   void visit(const copy_stmt*) override { std::abort(); }
   void visit(const allocate*) override { std::abort(); }

--- a/builder/node_mutator.cc
+++ b/builder/node_mutator.cc
@@ -143,16 +143,6 @@ void node_mutator::visit(const loop* op) {
     set_result(loop::make(op->sym, op->mode, std::move(bounds), std::move(step), std::move(body)));
   }
 }
-void node_mutator::visit(const if_then_else* op) {
-  expr cond = mutate(op->condition);
-  stmt true_body = mutate(op->true_body);
-  stmt false_body = mutate(op->false_body);
-  if (cond.same_as(op->condition) && true_body.same_as(op->true_body) && false_body.same_as(op->false_body)) {
-    set_result(op);
-  } else {
-    set_result(if_then_else::make(std::move(cond), std::move(true_body), std::move(false_body)));
-  }
-}
 void node_mutator::visit(const call_stmt* op) { set_result(op); }
 void node_mutator::visit(const copy_stmt* op) {
   std::vector<expr> src_x;

--- a/builder/node_mutator.h
+++ b/builder/node_mutator.h
@@ -65,7 +65,6 @@ public:
 
   virtual void visit(const block*) override;
   virtual void visit(const loop*) override;
-  virtual void visit(const if_then_else*) override;
   virtual void visit(const call_stmt*) override;
   virtual void visit(const copy_stmt*) override;
   virtual void visit(const allocate*) override;

--- a/builder/simplify_test.cc
+++ b/builder/simplify_test.cc
@@ -138,11 +138,6 @@ TEST(simplify, buffer_intrinsics) {
   test_simplify(max(buffer_max(x, y) + 1, buffer_min(x, y) - 1), buffer_max(x, y) + 1);
 }
 
-TEST(simplify, if_then_else) {
-  test_simplify(if_then_else::make(x == x, check::make(y), check::make(z)), check::make(y));
-  test_simplify(if_then_else::make(x != x, check::make(y), check::make(z)), check::make(z));
-}
-
 TEST(simplify, bounds) {
   test_simplify(
       loop::make(x.sym(), loop_mode::serial, bounds(y - 2, z), 2, check::make(y - 2 <= x)),

--- a/builder/substitute.cc
+++ b/builder/substitute.cc
@@ -269,16 +269,6 @@ public:
     if (!try_match(ls->body, op->body)) return;
   }
 
-  void visit(const if_then_else* op) override {
-    if (match) return;
-    const if_then_else* is = match_self_as(op);
-    if (!is) return;
-
-    if (!try_match(is->condition, op->condition)) return;
-    if (!try_match(is->true_body, op->true_body)) return;
-    if (!try_match(is->false_body, op->false_body)) return;
-  }
-
   void visit(const call_stmt* op) override {
     if (match) return;
     const call_stmt* cs = match_self_as(op);

--- a/runtime/evaluate.cc
+++ b/runtime/evaluate.cc
@@ -357,18 +357,6 @@ public:
     }
   }
 
-  void visit(const if_then_else* op) override {
-    if (eval_expr(op->condition)) {
-      if (op->true_body.defined()) {
-        visit(op->true_body);
-      }
-    } else {
-      if (op->false_body.defined()) {
-        visit(op->false_body);
-      }
-    }
-  }
-
   void visit(const call_stmt* op) override {
     result = op->target(context);
     if (result) {

--- a/runtime/expr.cc
+++ b/runtime/expr.cc
@@ -390,14 +390,6 @@ stmt loop::make(symbol_id sym, loop_mode mode, interval_expr bounds, expr step, 
   return l;
 }
 
-stmt if_then_else::make(expr condition, stmt true_body, stmt false_body) {
-  auto n = new if_then_else();
-  n->condition = std::move(condition);
-  n->true_body = std::move(true_body);
-  n->false_body = std::move(false_body);
-  return n;
-}
-
 stmt allocate::make(symbol_id sym, memory_type storage, std::size_t elem_size, std::vector<dim_expr> dims, stmt body) {
   auto n = new allocate();
   n->sym = sym;

--- a/runtime/expr.h
+++ b/runtime/expr.h
@@ -60,7 +60,6 @@ enum class node_type {
   let_stmt,
   block,
   loop,
-  if_then_else,
   allocate,
   make_buffer,
   clone_buffer,
@@ -545,21 +544,6 @@ public:
   static constexpr node_type static_type = node_type::loop;
 };
 
-// Run `true_body` if `condition` is true, or `false_body` otherwise. Either body can be undefined, indicating that
-// nothing should happen in that case.
-class if_then_else : public stmt_node<if_then_else> {
-public:
-  expr condition;
-  stmt true_body;
-  stmt false_body;
-
-  void accept(node_visitor* v) const;
-
-  static stmt make(expr condition, stmt true_body, stmt false_body = stmt());
-
-  static constexpr node_type static_type = node_type::if_then_else;
-};
-
 // A helper containing sub-expressions that describe a dimension of a buffer, corresponding to `dim`.
 struct dim_expr {
   interval_expr bounds;
@@ -744,7 +728,6 @@ public:
   virtual void visit(const let_stmt*) = 0;
   virtual void visit(const block*) = 0;
   virtual void visit(const loop*) = 0;
-  virtual void visit(const if_then_else*) = 0;
   virtual void visit(const call_stmt*) = 0;
   virtual void visit(const copy_stmt*) = 0;
   virtual void visit(const allocate*) = 0;
@@ -817,11 +800,6 @@ public:
     op->bounds.max.accept(this);
     if (op->step.defined()) op->step.accept(this);
     if (op->body.defined()) op->body.accept(this);
-  }
-  virtual void visit(const if_then_else* op) override {
-    op->condition.accept(this);
-    if (op->true_body.defined()) op->true_body.accept(this);
-    if (op->false_body.defined()) op->false_body.accept(this);
   }
   virtual void visit(const call_stmt* op) override {}
   virtual void visit(const copy_stmt* op) override {
@@ -902,7 +880,6 @@ inline void call::accept(node_visitor* v) const { v->visit(this); }
 inline void let_stmt::accept(node_visitor* v) const { v->visit(this); }
 inline void block::accept(node_visitor* v) const { v->visit(this); }
 inline void loop::accept(node_visitor* v) const { v->visit(this); }
-inline void if_then_else::accept(node_visitor* v) const { v->visit(this); }
 inline void call_stmt::accept(node_visitor* v) const { v->visit(this); }
 inline void copy_stmt::accept(node_visitor* v) const { v->visit(this); }
 inline void allocate::accept(node_visitor* v) const { v->visit(this); }

--- a/runtime/print.cc
+++ b/runtime/print.cc
@@ -193,16 +193,6 @@ public:
     *this << indent() << "}\n";
   }
 
-  void visit(const if_then_else* n) override {
-    *this << indent() << "if(" << n->condition << ") {\n";
-    *this << n->true_body;
-    if (n->false_body.defined()) {
-      *this << indent() << "} else {\n";
-      *this << n->false_body;
-    }
-    *this << indent() << "}\n";
-  }
-
   void visit(const call_stmt* n) override {
     *this << indent() << "call(<fn>, {" << n->inputs << "}, {" << n->outputs << "})\n";
   }

--- a/runtime/visualize.cc
+++ b/runtime/visualize.cc
@@ -199,16 +199,6 @@ public:
     *this << indent() << "}\n";
   }
 
-  void visit(const if_then_else* n) override {
-    *this << indent() << "if(" << n->condition << ") {\n";
-    *this << n->true_body;
-    if (n->false_body.defined()) {
-      *this << indent() << "} else {\n";
-      *this << n->false_body;
-    }
-    *this << indent() << "}\n";
-  }
-
   void visit(const call_stmt* n) override {
     for (symbol_id i : n->inputs) {
       *this << indent() << "consume(" << i << ");\n";


### PR DESCRIPTION
Now that we allow crops to produce empty buffers, and expect callbacks to handle that, we have no use for if_then_else nodes.

We'll probably bring this back at some point, but we should remove it until then.