### PR TITLE
Add missing overrides

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,5 +1,5 @@
 common --enable_bzlmod
-build --action_env=BAZEL_CXXOPTS="-std=c++17:-fstrict-aliasing:-Wall"
+build --action_env=BAZEL_CXXOPTS="-std=c++17:-fstrict-aliasing:-Wall:-Wsuggest-override"
 build --copt=-fdiagnostics-color=always
 run --copt=-fdiagnostics-color=always
 test --copt=-fdiagnostics-color=always

--- a/builder/infer_bounds.cc
+++ b/builder/infer_bounds.cc
@@ -54,13 +54,13 @@ class input_crop_remover : public node_mutator {
   symbol_map<bool> used_as_output;
 
 public:
-  void visit(const call_stmt* op) {
+  void visit(const call_stmt* op) override {
     for (symbol_id i : op->outputs) {
       used_as_output[i] = true;
     }
     set_result(op);
   }
-  void visit(const copy_stmt* op) {
+  void visit(const copy_stmt* op) override {
     used_as_output[op->dst] = true;
     set_result(op);
   }
@@ -85,8 +85,8 @@ public:
     }
   }
 
-  void visit(const crop_buffer* op) { visit_crop(op); }
-  void visit(const crop_dim* op) { visit_crop(op); }
+  void visit(const crop_buffer* op) override { visit_crop(op); }
+  void visit(const crop_dim* op) override { visit_crop(op); }
 };
 
 // Keep substituting substitutions until nothing happens.

--- a/builder/optimizations.cc
+++ b/builder/optimizations.cc
@@ -104,7 +104,7 @@ class replace_copy_with_pad : public node_mutator {
 public:
   replace_copy_with_pad(symbol_id src, symbol_id dst) : src(src), dst(dst) {}
 
-  void visit(const copy_stmt* op) {
+  void visit(const copy_stmt* op) override {
     if (op->src == src && op->dst == dst) {
       if (op->padding.empty()) {
         set_result(stmt());

--- a/builder/simplify.cc
+++ b/builder/simplify.cc
@@ -969,9 +969,9 @@ interval_expr where_true(const expr& condition, symbol_id var) {
   public:
     std::vector<expr> leaves;
 
-    void visit(const variable* op) { leaves.push_back(op); }
-    void visit(const constant* op) { leaves.push_back(op); }
-    void visit(const call* op) {
+    void visit(const variable* op) override { leaves.push_back(op); }
+    void visit(const constant* op) override { leaves.push_back(op); }
+    void visit(const call* op) override {
       if (is_buffer_intrinsic(op->intrinsic)) leaves.push_back(op);
     }
   };

--- a/builder/simplify_exprs.cc
+++ b/builder/simplify_exprs.cc
@@ -61,14 +61,14 @@ public:
     op->b.accept(this);
   }
 
-  void visit(const add* op) { check(op); };
-  void visit(const mul* op) { check(op); };
-  void visit(const class min* op) { check(op); };
-  void visit(const class max* op) { check(op); };
-  void visit(const equal* op) { check(op); };
-  void visit(const not_equal* op) { check(op); };
-  void visit(const logical_and* op) { check(op); };
-  void visit(const logical_or* op) { check(op); };
+  void visit(const add* op) override { check(op); };
+  void visit(const mul* op) override { check(op); };
+  void visit(const class min* op) override { check(op); };
+  void visit(const class max* op) override { check(op); };
+  void visit(const equal* op) override { check(op); };
+  void visit(const not_equal* op) override { check(op); };
+  void visit(const logical_and* op) override { check(op); };
+  void visit(const logical_or* op) override { check(op); };
 };
 
 // We need to generate a lot of rules that are equivalent except for commutation.

--- a/runtime/expr.cc
+++ b/runtime/expr.cc
@@ -593,7 +593,6 @@ var::operator expr() const {
   return expr(variable::make(sym_));
 }
 
-
 void recursive_node_visitor::visit(const variable*) {}
 void recursive_node_visitor::visit(const wildcard*) {}
 void recursive_node_visitor::visit(const constant*) {}

--- a/runtime/expr.h
+++ b/runtime/expr.h
@@ -343,7 +343,7 @@ public:
   std::vector<std::pair<symbol_id, expr>> lets;
   expr body;
 
-  void accept(node_visitor* v) const;
+  void accept(node_visitor* v) const override;
 
   static expr make(std::vector<std::pair<symbol_id, expr>> lets, expr body);
 
@@ -356,7 +356,7 @@ class variable : public expr_node<variable> {
 public:
   symbol_id sym;
 
-  void accept(node_visitor* v) const;
+  void accept(node_visitor* v) const override;
 
   static expr make(symbol_id sym);
 
@@ -373,7 +373,7 @@ public:
   symbol_id sym;
   std::function<bool(const expr&)> matches;
 
-  void accept(node_visitor* v) const;
+  void accept(node_visitor* v) const override;
 
   static expr make(symbol_id sym, std::function<bool(const expr&)> matches);
 
@@ -384,7 +384,7 @@ class constant : public expr_node<constant> {
 public:
   index_t value;
 
-  void accept(node_visitor* v) const;
+  void accept(node_visitor* v) const override;
 
   static expr make(index_t value);
   static expr make(const void* value);
@@ -396,7 +396,7 @@ public:
   class op : public expr_node<class op> {                                                                              \
   public:                                                                                                              \
     expr a, b;                                                                                                         \
-    void accept(node_visitor* v) const;                                                                                \
+    void accept(node_visitor* v) const override;                                                                       \
     static expr make(expr a, expr b);                                                                                  \
     static constexpr node_type static_type = node_type::op;                                                            \
   };
@@ -421,7 +421,7 @@ class logical_not : public expr_node<logical_not> {
 public:
   expr a;
 
-  void accept(node_visitor* v) const;
+  void accept(node_visitor* v) const override;
 
   static expr make(expr a);
 
@@ -436,7 +436,7 @@ public:
   expr true_value;
   expr false_value;
 
-  void accept(node_visitor* v) const;
+  void accept(node_visitor* v) const override;
 
   static expr make(expr condition, expr true_value, expr false_value);
 
@@ -448,7 +448,7 @@ public:
   slinky::intrinsic intrinsic;
   std::vector<expr> args;
 
-  void accept(node_visitor* v) const;
+  void accept(node_visitor* v) const override;
 
   static expr make(slinky::intrinsic i, std::vector<expr> args);
 
@@ -469,7 +469,7 @@ public:
   symbol_list inputs;
   symbol_list outputs;
 
-  void accept(node_visitor* v) const;
+  void accept(node_visitor* v) const override;
 
   static stmt make(callable target, symbol_list inputs, symbol_list outputs);
 
@@ -484,7 +484,7 @@ public:
   std::vector<symbol_id> dst_x;
   std::vector<char> padding;
 
-  void accept(node_visitor* v) const;
+  void accept(node_visitor* v) const override;
 
   static stmt make(
       symbol_id src, std::vector<expr> src_x, symbol_id dst, std::vector<symbol_id> dst_x, std::vector<char> padding);
@@ -501,7 +501,7 @@ public:
   std::vector<std::pair<symbol_id, expr>> lets;
   stmt body;
 
-  void accept(node_visitor* v) const;
+  void accept(node_visitor* v) const override;
 
   static stmt make(std::vector<std::pair<symbol_id, expr>> lets, stmt body);
 
@@ -514,7 +514,7 @@ class block : public stmt_node<block> {
 public:
   std::vector<stmt> stmts;
 
-  void accept(node_visitor* v) const;
+  void accept(node_visitor* v) const override;
 
   // Create a single block to contain all of the `stmts`.
   // Nested block statements are flattened, and undef stmts are removed.
@@ -537,7 +537,7 @@ public:
   expr step;
   stmt body;
 
-  void accept(node_visitor* v) const;
+  void accept(node_visitor* v) const override;
 
   static stmt make(symbol_id sym, loop_mode mode, interval_expr bounds, expr step, stmt body);
 
@@ -570,7 +570,7 @@ public:
   std::vector<dim_expr> dims;
   stmt body;
 
-  void accept(node_visitor* v) const;
+  void accept(node_visitor* v) const override;
 
   static stmt make(symbol_id sym, memory_type storage, std::size_t elem_size, std::vector<dim_expr> dims, stmt body);
 
@@ -587,7 +587,7 @@ public:
   std::vector<dim_expr> dims;
   stmt body;
 
-  void accept(node_visitor* v) const;
+  void accept(node_visitor* v) const override;
 
   static stmt make(symbol_id sym, expr base, expr elem_size, std::vector<dim_expr> dims, stmt body);
 
@@ -603,7 +603,7 @@ public:
   symbol_id src;
   stmt body;
 
-  void accept(node_visitor* v) const;
+  void accept(node_visitor* v) const override;
 
   static stmt make(symbol_id sym, symbol_id src, stmt body);
 
@@ -619,7 +619,7 @@ public:
   std::vector<interval_expr> bounds;
   stmt body;
 
-  void accept(node_visitor* v) const;
+  void accept(node_visitor* v) const override;
 
   static stmt make(symbol_id sym, std::vector<interval_expr> bounds, stmt body);
 
@@ -634,7 +634,7 @@ public:
   interval_expr bounds;
   stmt body;
 
-  void accept(node_visitor* v) const;
+  void accept(node_visitor* v) const override;
 
   static stmt make(symbol_id sym, int dim, interval_expr bounds, stmt body);
 
@@ -651,7 +651,7 @@ public:
   std::vector<expr> at;
   stmt body;
 
-  void accept(node_visitor* v) const;
+  void accept(node_visitor* v) const override;
 
   static stmt make(symbol_id sym, std::vector<expr> at, stmt body);
 
@@ -667,7 +667,7 @@ public:
   expr at;
   stmt body;
 
-  void accept(node_visitor* v) const;
+  void accept(node_visitor* v) const override;
 
   static stmt make(symbol_id sym, int dim, expr at, stmt body);
 
@@ -681,7 +681,7 @@ public:
   int rank;
   stmt body;
 
-  void accept(node_visitor* v) const;
+  void accept(node_visitor* v) const override;
 
   static stmt make(symbol_id sym, int rank, stmt body);
 
@@ -693,7 +693,7 @@ class check : public stmt_node<check> {
 public:
   expr condition;
 
-  void accept(node_visitor* v) const;
+  void accept(node_visitor* v) const override;
 
   static stmt make(expr condition);
 


### PR DESCRIPTION
Minor syntax tweak to add missing overrides and enable the warning about it being missing.