### PR TITLE
Add "no padding" as an option for copies

### DIFF
--- a/builder/optimizations.cc
+++ b/builder/optimizations.cc
@@ -106,11 +106,11 @@ public:
 
   void visit(const copy_stmt* op) {
     if (op->src == src && op->dst == dst) {
-      if (op->padding.empty()) {
+      if (!op->padding || op->padding->empty()) {
         set_result(stmt());
       } else {
         set_result(call_stmt::make(
-            [src = op->src, dst = op->dst, padding = op->padding](const eval_context& ctx) -> index_t {
+            [src = op->src, dst = op->dst, padding = *op->padding](const eval_context& ctx) -> index_t {
               const raw_buffer* src_buf = ctx.lookup_buffer(src);
               const raw_buffer* dst_buf = ctx.lookup_buffer(dst);
               pad(src_buf->dims, *dst_buf, padding.data());
@@ -346,7 +346,7 @@ public:
         [src = op->src, dst = op->dst, padding = op->padding](const eval_context& ctx) -> index_t {
           const raw_buffer* src_buf = ctx.lookup_buffer(src);
           const raw_buffer* dst_buf = ctx.lookup_buffer(dst);
-          copy(*src_buf, *dst_buf, padding.empty() ? nullptr : padding.data());
+          copy(*src_buf, *dst_buf, (!padding || padding->empty()) ? nullptr : padding->data());
           return 0;
         },
         {op->src}, {op->dst});

--- a/builder/pipeline.h
+++ b/builder/pipeline.h
@@ -136,7 +136,7 @@ private:
   std::vector<loop_info> loops_;
   std::optional<loop_id> compute_at_;
 
-  std::vector<char> padding_;
+  std::optional<std::vector<char>> padding_;
 
   void add_this_to_buffers();
   void remove_this_from_buffers();
@@ -145,7 +145,7 @@ public:
   func() {}
   func(call_stmt::callable impl, std::vector<input> inputs, std::vector<output> outputs);
   func(std::vector<input> inputs, output out);
-  func(input input, output out, std::vector<char> padding);
+  func(input input, output out, std::optional<std::vector<char>> padding);
   func(func&&);
   func& operator=(func&&);
   ~func();
@@ -231,7 +231,7 @@ public:
   }
 
   static func make_copy(std::vector<input> in, output out) { return func(std::move(in), {std::move(out)}); }
-  static func make_copy(input in, output out, std::vector<char> padding = {}) {
+  static func make_copy(input in, output out, std::optional<std::vector<char>> padding = {}) {
     return func(std::move(in), {std::move(out)}, std::move(padding));
   }
   static func make_copy(input in1, input in2, output out) {
@@ -241,7 +241,7 @@ public:
   const call_stmt::callable& impl() const { return impl_; }
   const std::vector<input>& inputs() const { return inputs_; }
   const std::vector<output>& outputs() const { return outputs_; }
-  const std::vector<char>& padding() const { return padding_; }
+  const std::optional<std::vector<char>>& padding() const { return padding_; }
 
   stmt make_call() const;
 };

--- a/builder/pipeline.h
+++ b/builder/pipeline.h
@@ -230,12 +230,14 @@ public:
     return make(std::move(impl), std::move(inputs), std::move(outputs));
   }
 
+  // Make a copy from multiple inputs with undefined padding.
   static func make_copy(std::vector<input> in, output out) { return func(std::move(in), {std::move(out)}); }
-  static func make_copy(input in, output out, std::optional<std::vector<char>> padding = {}) {
-    return func(std::move(in), {std::move(out)}, std::move(padding));
-  }
   static func make_copy(input in1, input in2, output out) {
     return func({std::move(in1), std::move(in2)}, {std::move(out)});
+  }
+  // Make a copy from a single input to a single output, with no padding by default.
+  static func make_copy(input in, output out, std::optional<std::vector<char>> padding = {}) {
+    return func(std::move(in), {std::move(out)}, std::move(padding));
   }
 
   const call_stmt::callable& impl() const { return impl_; }

--- a/builder/pipeline_test.cc
+++ b/builder/pipeline_test.cc
@@ -1081,7 +1081,7 @@ TEST(pipeline, padded_stencil) {
     var y(ctx, "y");
 
     func add = func::make(add_1<short>, {{in, {point(x), point(y)}}}, {{intm, {x, y}}});
-    func padded = func::make_copy({intm, {point(x), point(y)}}, {padded_intm, {x, y}}, {6, 0});
+    func padded = func::make_copy({intm, {point(x), point(y)}}, {padded_intm, {x, y}}, {{6, 0}});
     func stencil = func::make(sum3x3<short>, {{padded_intm, {bounds(-1, 1) + x, bounds(-1, 1) + y}}}, {{out, {x, y}}});
 
     switch (schedule) {

--- a/runtime/evaluate.cc
+++ b/runtime/evaluate.cc
@@ -85,8 +85,8 @@ void copy_stmt_impl(
       }
       if (src_base) {
         memcpy(dst_base, src_base, src.elem_size);
-      } else if (!c.padding.empty()) {
-        memcpy(dst_base, c.padding.data(), src.elem_size);
+      } else if (c.padding && !c.padding->empty()) {
+        memcpy(dst_base, c.padding->data(), src.elem_size);
       } else {
         // Leave unmodified.
       }
@@ -101,7 +101,7 @@ void copy_stmt_impl(eval_context& ctx, const raw_buffer& src, const raw_buffer& 
   assert(c.src_x.size() == src.rank);
   assert(c.dst_x.size() == dst.rank);
   assert(dst.elem_size == src.elem_size);
-  assert(c.padding.empty() || dst.elem_size == c.padding.size());
+  assert(!c.padding || c.padding->empty() || dst.elem_size == c.padding->size());
   if (dst.rank == 0) {
     // The buffer is scalar.
     assert(src.rank == 0);

--- a/runtime/expr.cc
+++ b/runtime/expr.cc
@@ -317,7 +317,7 @@ stmt call_stmt::make(call_stmt::callable target, symbol_list inputs, symbol_list
 }
 
 stmt copy_stmt::make(
-    symbol_id src, std::vector<expr> src_x, symbol_id dst, std::vector<symbol_id> dst_x, std::vector<char> padding) {
+    symbol_id src, std::vector<expr> src_x, symbol_id dst, std::vector<symbol_id> dst_x, std::optional<std::vector<char>> padding) {
   auto n = new copy_stmt();
   n->src = src;
   n->src_x = std::move(src_x);

--- a/runtime/expr.h
+++ b/runtime/expr.h
@@ -482,12 +482,15 @@ public:
   std::vector<expr> src_x;
   symbol_id dst;
   std::vector<symbol_id> dst_x;
-  std::vector<char> padding;
+  // padding = nullopt => no padding
+  // padding = {} => padding is uninitialized
+  // padding = <elem_size bytes> => value to put in padding
+  std::optional<std::vector<char>> padding;
 
   void accept(node_visitor* v) const;
 
   static stmt make(
-      symbol_id src, std::vector<expr> src_x, symbol_id dst, std::vector<symbol_id> dst_x, std::vector<char> padding);
+      symbol_id src, std::vector<expr> src_x, symbol_id dst, std::vector<symbol_id> dst_x, std::optional<std::vector<char>> padding);
 
   static constexpr node_type static_type = node_type::copy_stmt;
 };

--- a/runtime/print.cc
+++ b/runtime/print.cc
@@ -198,8 +198,11 @@ public:
   }
 
   void visit(const copy_stmt* n) override {
-    *this << indent() << "copy(" << n->src << ", {" << n->src_x << "}, " << n->dst << ", {" << n->dst_x << "}, {"
-          << n->padding << "})\n";
+    *this << indent() << "copy(" << n->src << ", {" << n->src_x << "}, " << n->dst << ", {" << n->dst_x << "}";
+    if (n->padding) {
+      *this << ", { " << *n->padding << " }";
+    }
+    *this << ")\n";
   }
 
   void visit(const allocate* n) override {

--- a/runtime/print.cc
+++ b/runtime/print.cc
@@ -200,7 +200,7 @@ public:
   void visit(const copy_stmt* n) override {
     *this << indent() << "copy(" << n->src << ", {" << n->src_x << "}, " << n->dst << ", {" << n->dst_x << "}";
     if (n->padding) {
-      *this << ", { " << *n->padding << " }";
+      *this << ", {" << *n->padding << "}";
     }
     *this << ")\n";
   }


### PR DESCRIPTION
This is a step towards cleaning up bounds inference for copies, which is currently broken (#21).