### PR TITLE
Don't use 'virtual' and 'override' on the same func

### DIFF
--- a/builder/node_mutator.h
+++ b/builder/node_mutator.h
@@ -40,42 +40,42 @@ public:
     }
   }
 
-  virtual void visit(const variable* op) override { set_result(op); }
-  virtual void visit(const wildcard* op) override { set_result(op); }
-  virtual void visit(const constant* op) override { set_result(op); }
+  void visit(const variable* op) override { set_result(op); }
+  void visit(const wildcard* op) override { set_result(op); }
+  void visit(const constant* op) override { set_result(op); }
 
-  virtual void visit(const let*) override;
-  virtual void visit(const let_stmt*) override;
-  virtual void visit(const add*) override;
-  virtual void visit(const sub*) override;
-  virtual void visit(const mul*) override;
-  virtual void visit(const div*) override;
-  virtual void visit(const mod*) override;
-  virtual void visit(const class min*) override;
-  virtual void visit(const class max*) override;
-  virtual void visit(const equal*) override;
-  virtual void visit(const not_equal*) override;
-  virtual void visit(const less*) override;
-  virtual void visit(const less_equal*) override;
-  virtual void visit(const logical_and*) override;
-  virtual void visit(const logical_or*) override;
-  virtual void visit(const logical_not*) override;
-  virtual void visit(const class select*) override;
-  virtual void visit(const call*) override;
+  void visit(const let*) override;
+  void visit(const let_stmt*) override;
+  void visit(const add*) override;
+  void visit(const sub*) override;
+  void visit(const mul*) override;
+  void visit(const div*) override;
+  void visit(const mod*) override;
+  void visit(const class min*) override;
+  void visit(const class max*) override;
+  void visit(const equal*) override;
+  void visit(const not_equal*) override;
+  void visit(const less*) override;
+  void visit(const less_equal*) override;
+  void visit(const logical_and*) override;
+  void visit(const logical_or*) override;
+  void visit(const logical_not*) override;
+  void visit(const class select*) override;
+  void visit(const call*) override;
 
-  virtual void visit(const block*) override;
-  virtual void visit(const loop*) override;
-  virtual void visit(const call_stmt*) override;
-  virtual void visit(const copy_stmt*) override;
-  virtual void visit(const allocate*) override;
-  virtual void visit(const make_buffer*) override;
-  virtual void visit(const clone_buffer*) override;
-  virtual void visit(const crop_buffer*) override;
-  virtual void visit(const crop_dim*) override;
-  virtual void visit(const slice_buffer*) override;
-  virtual void visit(const slice_dim*) override;
-  virtual void visit(const truncate_rank*) override;
-  virtual void visit(const check*) override;
+  void visit(const block*) override;
+  void visit(const loop*) override;
+  void visit(const call_stmt*) override;
+  void visit(const copy_stmt*) override;
+  void visit(const allocate*) override;
+  void visit(const make_buffer*) override;
+  void visit(const clone_buffer*) override;
+  void visit(const crop_buffer*) override;
+  void visit(const crop_dim*) override;
+  void visit(const slice_buffer*) override;
+  void visit(const slice_dim*) override;
+  void visit(const truncate_rank*) override;
+  void visit(const check*) override;
 };
 
 // This is helpful for writing templated mutators.

--- a/runtime/buffer.h
+++ b/runtime/buffer.h
@@ -135,7 +135,7 @@ public:
   raw_buffer(raw_buffer&&) = delete;
   void operator=(const raw_buffer&) = delete;
   void operator=(raw_buffer&&) = delete;
-  ~raw_buffer() { free(); }
+  ~raw_buffer() override { free(); }
 
   slinky::dim& dim(std::size_t i) {
     assert(i < rank);

--- a/runtime/expr.h
+++ b/runtime/expr.h
@@ -746,42 +746,42 @@ public:
 
 class recursive_node_visitor : public node_visitor {
 public:
-  virtual void visit(const variable*) override;
-  virtual void visit(const wildcard*) override;
-  virtual void visit(const constant*) override;
-  virtual void visit(const let* op) override;
+  void visit(const variable*) override;
+  void visit(const wildcard*) override;
+  void visit(const constant*) override;
+  void visit(const let* op) override;
 
-  virtual void visit(const add* op) override;
-  virtual void visit(const sub* op) override;
-  virtual void visit(const mul* op) override;
-  virtual void visit(const div* op) override;
-  virtual void visit(const mod* op) override;
-  virtual void visit(const class min* op) override;
-  virtual void visit(const class max* op) override;
-  virtual void visit(const equal* op) override;
-  virtual void visit(const not_equal* op) override;
-  virtual void visit(const less* op) override;
-  virtual void visit(const less_equal* op) override;
-  virtual void visit(const logical_and* op) override;
-  virtual void visit(const logical_or* op) override;
-  virtual void visit(const logical_not* op) override;
-  virtual void visit(const class select* op) override;
-  virtual void visit(const call* op) override;
+  void visit(const add* op) override;
+  void visit(const sub* op) override;
+  void visit(const mul* op) override;
+  void visit(const div* op) override;
+  void visit(const mod* op) override;
+  void visit(const class min* op) override;
+  void visit(const class max* op) override;
+  void visit(const equal* op) override;
+  void visit(const not_equal* op) override;
+  void visit(const less* op) override;
+  void visit(const less_equal* op) override;
+  void visit(const logical_and* op) override;
+  void visit(const logical_or* op) override;
+  void visit(const logical_not* op) override;
+  void visit(const class select* op) override;
+  void visit(const call* op) override;
 
-  virtual void visit(const let_stmt* op) override;
-  virtual void visit(const block* op) override;
-  virtual void visit(const loop* op) override;
-  virtual void visit(const call_stmt* op) override;
-  virtual void visit(const copy_stmt* op) override;
-  virtual void visit(const allocate* op) override;
-  virtual void visit(const make_buffer* op) override;
-  virtual void visit(const clone_buffer* op) override;
-  virtual void visit(const crop_buffer* op) override;
-  virtual void visit(const crop_dim* op) override;
-  virtual void visit(const slice_buffer* op) override;
-  virtual void visit(const slice_dim* op) override;
-  virtual void visit(const truncate_rank* op) override;
-  virtual void visit(const check* op) override;
+  void visit(const let_stmt* op) override;
+  void visit(const block* op) override;
+  void visit(const loop* op) override;
+  void visit(const call_stmt* op) override;
+  void visit(const copy_stmt* op) override;
+  void visit(const allocate* op) override;
+  void visit(const make_buffer* op) override;
+  void visit(const clone_buffer* op) override;
+  void visit(const crop_buffer* op) override;
+  void visit(const crop_dim* op) override;
+  void visit(const slice_buffer* op) override;
+  void visit(const slice_dim* op) override;
+  void visit(const truncate_rank* op) override;
+  void visit(const check* op) override;
 };
 
 inline void variable::accept(node_visitor* v) const { v->visit(this); }


### PR DESCRIPTION
Nit suggested by clang-tidy: when using 'override' don't also use 'virtual'