### PR TITLE
move ctor/op= should be marked `noexcept`

### DIFF
--- a/builder/pipeline.cc
+++ b/builder/pipeline.cc
@@ -83,8 +83,8 @@ func::func(std::vector<input> inputs, output out) : func(nullptr, std::move(inpu
   padding_ = std::vector<char>{};
 }
 
-func::func(func&& m) { *this = std::move(m); }
-func& func::operator=(func&& m) {
+func::func(func&& m) noexcept { *this = std::move(m); }
+func& func::operator=(func&& m) noexcept {
   if (this == &m) return *this;
   m.remove_this_from_buffers();
   impl_ = std::move(m.impl_);

--- a/builder/pipeline.h
+++ b/builder/pipeline.h
@@ -146,8 +146,8 @@ public:
   func(call_stmt::callable impl, std::vector<input> inputs, std::vector<output> outputs);
   func(std::vector<input> inputs, output out);
   func(input input, output out, std::optional<std::vector<char>> padding);
-  func(func&&);
-  func& operator=(func&&);
+  func(func&&) noexcept;
+  func& operator=(func&&) noexcept;
   ~func();
   func(const func&) = delete;
   func& operator=(const func&) = delete;

--- a/runtime/expr.h
+++ b/runtime/expr.h
@@ -311,7 +311,7 @@ public:
   stmt(const base_stmt_node* n) : n_(n) {}
 
   stmt& operator=(const stmt&) = default;
-  stmt& operator=(stmt&&) = default;
+  stmt& operator=(stmt&&) noexcept = default;
 
   void accept(node_visitor* v) const {
     assert(defined());
@@ -1008,14 +1008,14 @@ public:
     ctx_value = std::move(value);
   }
 
-  scoped_value_in_symbol_map(scoped_value_in_symbol_map&& other)
+  scoped_value_in_symbol_map(scoped_value_in_symbol_map&& other) noexcept
       : context_(other.context_), sym_(other.sym_), old_value_(std::move(other.old_value_)) {
     // Don't let other.~scoped_value() unset this value.
     other.context_ = nullptr;
   }
   scoped_value_in_symbol_map(const scoped_value_in_symbol_map&) = delete;
   scoped_value_in_symbol_map& operator=(const scoped_value_in_symbol_map&) = delete;
-  scoped_value_in_symbol_map& operator=(scoped_value_in_symbol_map&& other) {
+  scoped_value_in_symbol_map& operator=(scoped_value_in_symbol_map&& other) noexcept {
     context_ = other.context_;
     sym_ = other.sym_;
     old_value_ = std::move(other.old_value_);

--- a/runtime/util.h
+++ b/runtime/util.h
@@ -189,7 +189,7 @@ public:
     if (value) value->add_ref();
   }
   ref_count(const ref_count& other) : ref_count(other.value) {}
-  ref_count(ref_count&& other) : value(other.value) { other.value = nullptr; }
+  ref_count(ref_count&& other) noexcept : value(other.value) { other.value = nullptr; }
   ~ref_count() {
     if (value) value->release();
   }
@@ -205,7 +205,7 @@ public:
 
   ref_count& operator=(const ref_count& other) { return operator=(other.value); }
 
-  ref_count& operator=(ref_count&& other) {
+  ref_count& operator=(ref_count&& other) noexcept {
     std::swap(value, other.value);
     other = nullptr;
     return *this;


### PR DESCRIPTION
Nit suggested by clang-tidy