### PR TITLE
Add `for_each_contiguous_slice`, `for_each_slice`, and `for_each_tile`

### DIFF
--- a/builder/copy_test.cc
+++ b/builder/copy_test.cc
@@ -12,7 +12,7 @@ namespace slinky {
 template <typename T, std::size_t N>
 void init_random(buffer<T, N>& x) {
   x.allocate();
-  for_each_slice(x, [&](void* base, index_t extent) {
+  for_each_contiguous_slice(x, [&](void* base, index_t extent) {
     for (index_t i = 0; i < extent; ++i) {
       reinterpret_cast<T*>(base)[i] = (rand() % 20) - 10;
     }

--- a/builder/copy_test.cc
+++ b/builder/copy_test.cc
@@ -12,7 +12,11 @@ namespace slinky {
 template <typename T, std::size_t N>
 void init_random(buffer<T, N>& x) {
   x.allocate();
-  for_each_index(x, [&](auto i) { x(i) = (rand() % 20) - 10; });
+  for_each_slice(x, [&](void* base, index_t extent) {
+    for (index_t i = 0; i < extent; ++i) {
+      reinterpret_cast<T*>(base)[i] = (rand() % 20) - 10;
+    }
+  });
 }
 
 TEST(copy, trivial_1d) {

--- a/builder/elementwise_test.cc
+++ b/builder/elementwise_test.cc
@@ -16,7 +16,7 @@ namespace slinky {
 template <typename T, std::size_t N>
 void init_random(buffer<T, N>& x) {
   x.allocate();
-  for_each_slice(x, [&](void* base, index_t extent) {
+  for_each_contiguous_slice(x, [&](void* base, index_t extent) {
     for (index_t i = 0; i < extent; ++i) {
       reinterpret_cast<T*>(base)[i] = (rand() % 20) - 10;
     }

--- a/builder/elementwise_test.cc
+++ b/builder/elementwise_test.cc
@@ -16,7 +16,11 @@ namespace slinky {
 template <typename T, std::size_t N>
 void init_random(buffer<T, N>& x) {
   x.allocate();
-  for_each_index(x, [&](auto i) { x(i) = (rand() % 20) - 10; });
+  for_each_slice(x, [&](void* base, index_t extent) {
+    for (index_t i = 0; i < extent; ++i) {
+      reinterpret_cast<T*>(base)[i] = (rand() % 20) - 10;
+    }
+  });
 }
 
 // (Ab)use our expression mechanism to make an elementwise "calculator", for the purposes of testing.

--- a/runtime/buffer.h
+++ b/runtime/buffer.h
@@ -341,19 +341,20 @@ void for_each_contiguous_slice(void* base, const dim* dims, int d, index_t elem_
     // already points to the min.
     for_each_contiguous_slice(base, dims, d - 1, elem_size, f, slice_extent);
     for (index_t i = dims[d].begin() + 1; i < dims[d].end(); ++i) {
-      for_each_contiguous_slice(offset_bytes(base, dims[d].flat_offset_bytes(i)), dims, d - 1, elem_size, f, slice_extent);
+      for_each_contiguous_slice(
+          offset_bytes(base, dims[d].flat_offset_bytes(i)), dims, d - 1, elem_size, f, slice_extent);
     }
   }
 }
 
 // Implements the cropping part of a loop over tiles.
 template <int D, typename Tile, typename F>
-void for_each_tile_crop(const Tile& tile, raw_buffer& buf, F&& f) {
+void for_each_tile(const Tile& tile, raw_buffer& buf, F&& f) {
   if constexpr (D == -1) {
     f(buf);
   } else if constexpr (std::is_same_v<std::tuple_element<D, Tile>, all>) {
     // Don't want to tile this dimension.
-    for_each_tile_crop<D - 1>(tile, buf, f);
+    for_each_tile<D - 1>(tile, buf, f);
   } else {
     slinky::dim& dim = buf.dim(D);
 
@@ -361,7 +362,7 @@ void for_each_tile_crop(const Tile& tile, raw_buffer& buf, F&& f) {
     index_t step = std::get<D>(tile);
     if (dim.extent() <= step) {
       // There's nothing to crop here, just move on.
-      for_each_tile_crop<D - 1>(tile, buf, f);
+      for_each_tile<D - 1>(tile, buf, f);
     } else {
       // TODO: Supporting folding here should be possible.
       assert(dim.fold_factor() == dim::unfolded);
@@ -374,42 +375,17 @@ void for_each_tile_crop(const Tile& tile, raw_buffer& buf, F&& f) {
 
       // Handle the first tile.
       dim.set_bounds(old_min, std::min(old_max, old_min + step - 1));
-      for_each_tile_crop<D - 1>(tile, buf, f);
+      for_each_tile<D - 1>(tile, buf, f);
       for (index_t i = old_min + step; i <= old_max; i += step) {
         buf.base = offset_bytes(buf.base, stride);
         dim.set_bounds(i, std::min(old_max, i + step - 1));
-        for_each_tile_crop<D - 1>(tile, buf, f);
+        for_each_tile<D - 1>(tile, buf, f);
       }
 
       // Restore the old base and bounds.
       buf.base = old_base;
       dim.set_bounds(old_min, old_max);
     }
-  }
-}
-
-// Implements the slicing part of a loop over tiles. Dimensions after the tile are sliced.
-template <typename Tile, typename F>
-void for_each_tile_slice(const Tile& tile, raw_buffer& buf, F&& f) {
-  constexpr int tile_rank = std::tuple_size_v<Tile>;
-  int d = buf.rank - 1;
-  assert(d >= tile_rank - 1);
-  if (d < tile_rank) {
-    for_each_tile_crop<tile_rank - 1>(tile, buf, f);
-  } else {
-    const slinky::dim& dim = buf.dim(d);
-
-    buf.rank -= 1;
-    void* old_base = buf.base;
-    // Extent 1 dimensions are likely very common here. We can handle that case more efficiently first because the base
-    // already points to the min.
-    internal::for_each_tile_slice(tile, buf, f);
-    for (index_t i = dim.begin() + 1; i < dim.end(); ++i) {
-      buf.base = offset_bytes(old_base, dim.flat_offset_bytes(i));
-      internal::for_each_tile_slice(tile, buf, f);
-    }
-    buf.base = old_base;
-    buf.rank += 1;
   }
 }
 
@@ -436,15 +412,47 @@ void for_each_contiguous_slice(const raw_buffer& buf, F&& f) {
   internal::for_each_contiguous_slice(buf.base, buf.dims, buf.rank - 1, buf.elem_size, f);
 }
 
+// Call `f` for each slice of the first `slice_rank` dimensions of buf.
+template <typename F>
+void for_each_slice(int slice_rank, const raw_buffer& const_buf, F&& f) {
+  // TODO: Should we make a copy of the buffer here? We const_cast it so we can modify it, but we
+  // also restore it to its original state... not thread safe though in case buf is being shared
+  // with another thread.
+  raw_buffer& buf = const_cast<raw_buffer&>(const_buf);
+  if (buf.rank <= slice_rank) {
+    f(buf);
+  } else {
+    const slinky::dim& dim = buf.dim(buf.rank - 1);
+    buf.rank -= 1;
+
+    void* old_base = buf.base;
+    // Extent 1 dimensions are likely very common here. We can handle that case more efficiently first because the base
+    // already points to the min.
+    for_each_slice(slice_rank, buf, f);
+    for (index_t i = dim.begin() + 1; i < dim.end(); ++i) {
+      buf.base = offset_bytes(old_base, dim.flat_offset_bytes(i));
+      for_each_slice(slice_rank, buf, f);
+    }
+    buf.base = old_base;
+    buf.rank += 1;
+  }
+}
+
 // Call `f(buf)` for each tile of size `tile` in the domain of `buf`. `tile` is a tuple, where each
 // element can be an integer (or `std::integral_constant`), or `all`, indicating that the dimension
 // should be passed unmodified to `f`. Dimensions after the size of the tuple are sliced.
 template <typename Tile, typename F>
-void for_each_tile(const Tile& tile, const raw_buffer& buf, F&& f) {
+void for_each_tile(const Tile& tile, const raw_buffer& buf, const F& f) {
+  constexpr int tile_rank = std::tuple_size_v<Tile>;
+  assert(buf.rank >= tile_rank);
   // TODO: Should we make a copy of the buffer here? We const_cast it so we can modify it, but we
   // also restore it to its original state... not thread safe though in case buf is being shared
   // with another thread.
-  internal::for_each_tile_slice(tile, const_cast<raw_buffer&>(buf), f);
+  for_each_slice(tile_rank, buf, [&f, &tile](const raw_buffer& buf) {
+    // GCC struggles with capturing constexprs.
+    constexpr int tile_rank = std::tuple_size_v<Tile>;
+    internal::for_each_tile<tile_rank - 1>(tile, const_cast<raw_buffer&>(buf), f);
+  });
 }
 
 }  // namespace slinky

--- a/runtime/buffer_test.cc
+++ b/runtime/buffer_test.cc
@@ -130,7 +130,11 @@ void test_copy() {
             }
             set_strides(src, src_permutation, src_padding, broadcast);
             src.allocate();
-            for_each_index(src, [&](auto i) { src(i) = rand(); });
+            for_each_slice(src, [&](void* base, index_t extent) {
+              for (index_t i = 0; i < extent; ++i) {
+                reinterpret_cast<T*>(base)[i] = rand();
+              }
+            });
 
             for (int dmin : {-1, 0, 1}) {
               for (int dmax : {-1, 0, 1}) {
@@ -150,7 +154,11 @@ void test_copy() {
                   }
                 });
 
-                for_each_index(src, [&](auto i) { src(i) += 1; });
+                for_each_slice(src, [&](void* base, index_t extent) {
+                  for (index_t i = 0; i < extent; ++i) {
+                    reinterpret_cast<T*>(base)[i] += 1;
+                  }
+                });
 
                 copy(src, dst, nullptr);
                 for_each_index(dst, [&](auto i) {
@@ -163,7 +171,11 @@ void test_copy() {
                   }
                 });
 
-                for_each_index(src, [&](auto i) { src(i) += -1; });
+                for_each_slice(src, [&](void* base, index_t extent) {
+                  for (index_t i = 0; i < extent; ++i) {
+                    reinterpret_cast<T*>(base)[i] += -1;
+                  }
+                });
 
                 T new_padding = 3;
                 pad(src.dims, dst, &new_padding);


### PR DESCRIPTION
These helpers make it easier to implement callbacks with other libraries that do not have arbitrary rank/stride APIs.