### PR TITLE
Tiles are span<> instead of tuple<>

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,2 +1,3 @@
 bazel_dep(name = "googletest", version = "1.14.0")
+bazel_dep(name = "google_benchmark", version = "1.8.3")
 bazel_dep(name = "rules_license", version = "0.0.7")

--- a/runtime/BUILD
+++ b/runtime/BUILD
@@ -71,3 +71,12 @@ cc_test(
         "@googletest//:gtest_main",
     ],
 )
+
+cc_binary(
+    name = "buffer_benchmark",
+    srcs = ["buffer_benchmark.cc"],
+    deps = [
+        ":runtime",
+        "@google_benchmark//:benchmark_main",
+    ],
+)

--- a/runtime/buffer.cc
+++ b/runtime/buffer.cc
@@ -345,6 +345,17 @@ void fill(const raw_buffer& dst, const void* value) {
 
 namespace internal {
 
+namespace {
+
+bool can_fuse(const dim& inner, const dim& outer) {
+  if (inner.fold_factor() != dim::unfolded || outer.fold_factor() != dim::unfolded) {
+    return false;
+  }
+  return inner.stride() * inner.extent() == outer.stride();
+}
+
+}  // namespace
+
 void make_for_each_contiguous_slice_dims(const raw_buffer& buf, for_each_contiguous_slice_dim* dims) {
   for_each_contiguous_slice_dim* next = dims;
   index_t slice_extent = 1;

--- a/runtime/buffer.h
+++ b/runtime/buffer.h
@@ -335,21 +335,21 @@ inline bool can_fuse(const dim& inner, const dim& outer) {
 }
 
 template <typename F>
-void for_each_contiguous_slice(
-    void* base, const dim* dims, int d, index_t elem_size, const F& f, index_t slice_extent = 1, index_t outer_extent = 1) {
+void for_each_contiguous_slice(void* base, const dim* dims, int d, index_t elem_size, const F& f,
+    index_t slice_extent = 1, index_t outer_extent = 1) {
   if (d == -1) {
     // We've handled all the loops, call the function.
     f(base, slice_extent);
     return;
   }
-  
+
   const slinky::dim& dim = dims[d];
   index_t extent = dim.extent() * outer_extent;
   if (extent <= 0) {
     // Don't want to worry about empty dimensions in the cases below.
     return;
   }
-  
+
   index_t stride = dim.stride();
   if (stride == elem_size) {
     // This is the dense dimension, pass this dimension through.

--- a/runtime/buffer.h
+++ b/runtime/buffer.h
@@ -364,13 +364,6 @@ void for_each_slice(std::size_t slice_rank, raw_buffer& buf, const F& f) {
   buf.rank += 1;
 }
 
-inline bool can_fuse(const dim& inner, const dim& outer) {
-  if (inner.fold_factor() != dim::unfolded || outer.fold_factor() != dim::unfolded) {
-    return false;
-  }
-  return inner.stride() * inner.extent() == outer.stride();
-}
-
 struct for_each_contiguous_slice_dim {
   union {
     // For loop_folded to call flat_offset_bytes

--- a/runtime/buffer.h
+++ b/runtime/buffer.h
@@ -470,16 +470,15 @@ void for_each_slice(std::size_t slice_rank, const raw_buffer& const_buf, const F
 
   buf.rank -= 1;
   void* old_base = buf.base;
-  // Extent 1 dimensions are likely very common here. We can handle that case more efficiently first because the
-  // base already points to the min.
-  for_each_slice(slice_rank, buf, f);
   if (dim.fold_factor() == dim::unfolded) {
     index_t stride = dim.stride();
-    for (index_t i = min + 1; i <= max; ++i) {
-      buf.base = offset_bytes(buf.base, stride);
+    for (index_t i = min; i <= max; ++i, buf.base = offset_bytes(buf.base, stride)) {
       for_each_slice(slice_rank, buf, f);
     }
   } else {
+    // Extent 1 dimensions are likely very common here. We can handle that case more efficiently first because the
+    // base already points to the min.
+    for_each_slice(slice_rank, buf, f);
     for (index_t i = min + 1; i <= max; ++i) {
       buf.base = offset_bytes(old_base, dim.flat_offset_bytes(i));
       for_each_slice(slice_rank, buf, f);

--- a/runtime/buffer.h
+++ b/runtime/buffer.h
@@ -336,7 +336,7 @@ inline bool can_fuse(const dim& inner, const dim& outer) {
 
 template <typename F>
 void for_each_contiguous_slice(void* base, const dim* dims, int d, index_t elem_size, const F& f,
-    index_t slice_extent = 1, index_t outer_extent = 1) {
+    index_t slice_extent = 1, index_t extent = 1) {
   if (d == -1) {
     // We've handled all the loops, call the function.
     f(base, slice_extent);
@@ -344,7 +344,7 @@ void for_each_contiguous_slice(void* base, const dim* dims, int d, index_t elem_
   }
 
   const slinky::dim& dim = dims[d];
-  index_t extent = dim.extent() * outer_extent;
+  extent *= dim.extent();
   if (extent <= 0) {
     // Don't want to worry about empty dimensions in the cases below.
     return;
@@ -368,7 +368,6 @@ void for_each_contiguous_slice(void* base, const dim* dims, int d, index_t elem_
       for_each_contiguous_slice(base, dims, d - 1, elem_size, f, slice_extent);
     }
   } else {
-    assert(outer_extent == 1);
     index_t begin = dim.begin();
     index_t end = begin + extent;
     // Extent 1 dimensions are likely very common here. We can handle that case more efficiently first because the base

--- a/runtime/buffer.h
+++ b/runtime/buffer.h
@@ -492,8 +492,7 @@ void for_each_slice(std::size_t slice_rank, const raw_buffer& buf, const F& f) {
 // dimension.
 template <typename F>
 void for_each_tile(span<const index_t> tile, const raw_buffer& buf, const F& f) {
-  std::size_t tile_rank = tile.size();
-  assert(buf.rank == tile_rank);
+  assert(buf.rank == tile.size());
 
   // Copy the buffer so we can mutate it.
   // TODO: We restore the buffer to its original state, so if we can guarantee that this thread has its own copy, it

--- a/runtime/buffer.h
+++ b/runtime/buffer.h
@@ -468,7 +468,7 @@ void for_each_tile(span<const index_t> tile, const raw_buffer& buf, const F& f) 
   // TODO: Should we make a copy of the buffer here? We const_cast it so we can modify it, but we
   // also restore it to its original state... not thread safe though in case buf is being shared
   // with another thread.
-  internal::for_each_tile(tile, const_cast<raw_buffer&>(buf), buf.rank - 1, f);
+  internal::for_each_tile(tile.data(), const_cast<raw_buffer&>(buf), buf.rank - 1, f);
 }
 
 }  // namespace slinky

--- a/runtime/buffer.h
+++ b/runtime/buffer.h
@@ -364,12 +364,7 @@ void for_each_contiguous_slice(void* base, const dim* dims, int d, index_t elem_
     // This dimension can be fused with the next dimension.
     for_each_contiguous_slice(base, dims, d - 1, elem_size, f, slice_extent, extent);
   } else if (dim.fold_factor() == dim::unfolded) {
-    // We can traverse this dimension with pointer arithmetic.
-    // Extent 1 dimensions are likely very common here. We can handle that case more efficiently first because the base
-    // already points to begin.
-    for_each_contiguous_slice(base, dims, d - 1, elem_size, f, slice_extent);
-    for (index_t i = 1; i < extent; ++i) {
-      base = offset_bytes(base, stride);
+    for (index_t i = 0; i < extent; ++i, base = offset_bytes(base, stride)) {
       for_each_contiguous_slice(base, dims, d - 1, elem_size, f, slice_extent);
     }
   } else {

--- a/runtime/buffer.h
+++ b/runtime/buffer.h
@@ -254,6 +254,7 @@ public:
   // dimension is "innermost".
   buffer(span<const index_t> extents) : buffer() {
     assert(extents.size() <= rank);
+    rank = extents.size();
     index_t stride = elem_size;
     slinky::dim* d = dims;
     for (index_t extent : extents) {

--- a/runtime/buffer.h
+++ b/runtime/buffer.h
@@ -473,9 +473,17 @@ void for_each_slice(std::size_t slice_rank, const raw_buffer& const_buf, const F
   // Extent 1 dimensions are likely very common here. We can handle that case more efficiently first because the
   // base already points to the min.
   for_each_slice(slice_rank, buf, f);
-  for (index_t i = min + 1; i <= max; ++i) {
-    buf.base = offset_bytes(old_base, dim.flat_offset_bytes(i));
-    for_each_slice(slice_rank, buf, f);
+  if (dim.fold_factor() == dim::unfolded) {
+    index_t stride = dim.stride();
+    for (index_t i = min + 1; i <= max; ++i) {
+      buf.base = offset_bytes(buf.base, stride);
+      for_each_slice(slice_rank, buf, f);
+    }
+  } else {
+    for (index_t i = min + 1; i <= max; ++i) {
+      buf.base = offset_bytes(old_base, dim.flat_offset_bytes(i));
+      for_each_slice(slice_rank, buf, f);
+    }
   }
   buf.base = old_base;
   buf.rank += 1;

--- a/runtime/buffer_benchmark.cc
+++ b/runtime/buffer_benchmark.cc
@@ -7,8 +7,7 @@
 
 namespace slinky {
 
-__attribute__((noinline)) void no_op_slice(void*, index_t) {}
-__attribute__((noinline)) void memset_slice(void* base, index_t extent) { memset(base, 0, extent); }
+void memset_slice(void* base, index_t extent) { memset(base, 0, extent); }
 
 template <typename Fn>
 void BM_for_each_contiguous_slice(benchmark::State& state, Fn fn) {
@@ -47,14 +46,11 @@ void BM_for_each_slice_hardcoded(benchmark::State& state, Fn fn) {
 
 // The difference between these two benchmarks on the same size buffer gives an indication of how much time is spent in
 // overhead inside for_each_contiguous_slice.
-void BM_for_each_contiguous_slice_no_op(benchmark::State& state) { BM_for_each_contiguous_slice(state, no_op_slice); }
 void BM_for_each_contiguous_slice_memset(benchmark::State& state) { BM_for_each_contiguous_slice(state, memset_slice); }
 void BM_for_each_slice_hardcoded_memset(benchmark::State& state) { BM_for_each_slice_hardcoded(state, memset_slice); }
 
-BENCHMARK(BM_for_each_contiguous_slice_no_op)->Args({1024, 16, 1});
 BENCHMARK(BM_for_each_contiguous_slice_memset)->Args({1024, 16, 1});
 BENCHMARK(BM_for_each_slice_hardcoded_memset)->Args({1024, 16, 1});
-BENCHMARK(BM_for_each_contiguous_slice_no_op)->Args({1024, 4, 4});
 BENCHMARK(BM_for_each_contiguous_slice_memset)->Args({1024, 4, 4});
 BENCHMARK(BM_for_each_slice_hardcoded_memset)->Args({1024, 4, 4});
 

--- a/runtime/buffer_benchmark.cc
+++ b/runtime/buffer_benchmark.cc
@@ -7,7 +7,7 @@
 
 namespace slinky {
 
-__attribute__((noinline)) void no_op_slice(void* base, index_t extent) {}
+__attribute__((noinline)) void no_op_slice(void*, index_t) {}
 __attribute__((noinline)) void memset_slice(void* base, index_t extent) { memset(base, 0, extent); }
 
 template <typename Fn>

--- a/runtime/buffer_benchmark.cc
+++ b/runtime/buffer_benchmark.cc
@@ -13,7 +13,7 @@ __attribute__((noinline)) void memset_slice(void* base, index_t extent) { memset
 template <typename Fn>
 void BM_for_each_contiguous_slice(benchmark::State& state, Fn fn) {
   std::vector<index_t> extents = {state.range(0) + 16, state.range(1), state.range(2)};
-  while (extents.back() == 0) {
+  while (extents.back() == 1) {
     extents.pop_back();
   }
   buffer<char, 3> buf(extents);
@@ -25,14 +25,37 @@ void BM_for_each_contiguous_slice(benchmark::State& state, Fn fn) {
   }
 }
 
+template <typename Fn>
+void BM_for_each_slice_hardcoded(benchmark::State& state, Fn fn) {
+  std::vector<index_t> extents = {state.range(0) + 16, state.range(1), state.range(2)};
+  buffer<char, 3> buf(extents);
+  buf.allocate();
+  buf.dim(0).set_extent(state.range(0));
+
+  for (auto _ : state) {
+    char* base_i = buf.base();
+    for (index_t i = 0; i < buf.dim(2).extent(); ++i) {
+      char* base_j = base_i;
+      for (index_t j = 0; j < buf.dim(1).extent(); ++j) {
+        fn(base_j, buf.dim(0).extent());
+        base_j += buf.dim(1).stride();
+      }
+      base_i += buf.dim(2).stride();
+    }
+  }
+}
+
 // The difference between these two benchmarks on the same size buffer gives an indication of how much time is spent in
 // overhead inside for_each_contiguous_slice.
 void BM_for_each_contiguous_slice_no_op(benchmark::State& state) { BM_for_each_contiguous_slice(state, no_op_slice); }
 void BM_for_each_contiguous_slice_memset(benchmark::State& state) { BM_for_each_contiguous_slice(state, memset_slice); }
+void BM_for_each_slice_hardcoded_memset(benchmark::State& state) { BM_for_each_slice_hardcoded(state, memset_slice); }
 
-BENCHMARK(BM_for_each_contiguous_slice_no_op)->Args({1024, 16, 0});
-BENCHMARK(BM_for_each_contiguous_slice_memset)->Args({1024, 16, 0});
+BENCHMARK(BM_for_each_contiguous_slice_no_op)->Args({1024, 16, 1});
+BENCHMARK(BM_for_each_contiguous_slice_memset)->Args({1024, 16, 1});
+BENCHMARK(BM_for_each_slice_hardcoded_memset)->Args({1024, 16, 1});
 BENCHMARK(BM_for_each_contiguous_slice_no_op)->Args({1024, 4, 4});
 BENCHMARK(BM_for_each_contiguous_slice_memset)->Args({1024, 4, 4});
+BENCHMARK(BM_for_each_slice_hardcoded_memset)->Args({1024, 4, 4});
 
 }  // namespace slinky

--- a/runtime/buffer_benchmark.cc
+++ b/runtime/buffer_benchmark.cc
@@ -7,7 +7,7 @@
 
 namespace slinky {
 
-__attribute__((noinline)) void no_op_slice(void* base, index_t extent) {  }
+__attribute__((noinline)) void no_op_slice(void* base, index_t extent) {}
 __attribute__((noinline)) void memset_slice(void* base, index_t extent) { memset(base, 0, extent); }
 
 template <typename Fn>
@@ -25,6 +25,8 @@ void BM_for_each_contiguous_slice(benchmark::State& state, Fn fn) {
   }
 }
 
+// The difference between these two benchmarks on the same size buffer gives an indication of how much time is spent in
+// overhead inside for_each_contiguous_slice.
 void BM_for_each_contiguous_slice_no_op(benchmark::State& state) { BM_for_each_contiguous_slice(state, no_op_slice); }
 void BM_for_each_contiguous_slice_memset(benchmark::State& state) { BM_for_each_contiguous_slice(state, memset_slice); }
 

--- a/runtime/buffer_benchmark.cc
+++ b/runtime/buffer_benchmark.cc
@@ -11,7 +11,7 @@ void memset_slice(void* base, index_t extent) { memset(base, 0, extent); }
 
 template <typename Fn>
 void BM_for_each_contiguous_slice(benchmark::State& state, Fn fn) {
-  std::vector<index_t> extents = {state.range(0) + 16, state.range(1), state.range(2)};
+  std::vector<index_t> extents = {state.range(0) + 64, state.range(1), state.range(2)};
   while (extents.back() == 1) {
     extents.pop_back();
   }
@@ -26,7 +26,7 @@ void BM_for_each_contiguous_slice(benchmark::State& state, Fn fn) {
 
 template <typename Fn>
 void BM_for_each_slice_hardcoded(benchmark::State& state, Fn fn) {
-  std::vector<index_t> extents = {state.range(0) + 16, state.range(1), state.range(2)};
+  std::vector<index_t> extents = {state.range(0) + 64, state.range(1), state.range(2)};
   buffer<char, 3> buf(extents);
   buf.allocate();
   buf.dim(0).set_extent(state.range(0));
@@ -47,9 +47,9 @@ void BM_for_each_slice_hardcoded(benchmark::State& state, Fn fn) {
 void BM_for_each_contiguous_slice(benchmark::State& state) { BM_for_each_contiguous_slice(state, memset_slice); }
 void BM_for_each_slice_hardcoded(benchmark::State& state) { BM_for_each_slice_hardcoded(state, memset_slice); }
 
-BENCHMARK(BM_for_each_contiguous_slice)->Args({1024, 16, 1});
-BENCHMARK(BM_for_each_slice_hardcoded)->Args({1024, 16, 1});
-BENCHMARK(BM_for_each_contiguous_slice)->Args({1024, 4, 4});
-BENCHMARK(BM_for_each_slice_hardcoded)->Args({1024, 4, 4});
+BENCHMARK(BM_for_each_contiguous_slice)->Args({64, 16, 1});
+BENCHMARK(BM_for_each_slice_hardcoded)->Args({64, 16, 1});
+BENCHMARK(BM_for_each_contiguous_slice)->Args({64, 4, 4});
+BENCHMARK(BM_for_each_slice_hardcoded)->Args({64, 4, 4});
 
 }  // namespace slinky

--- a/runtime/buffer_benchmark.cc
+++ b/runtime/buffer_benchmark.cc
@@ -1,0 +1,36 @@
+#include <benchmark/benchmark.h>
+
+#include <cstddef>
+#include <cstdint>
+
+#include "runtime/buffer.h"
+
+namespace slinky {
+
+__attribute__((noinline)) void no_op_slice(void* base, index_t extent) {  }
+__attribute__((noinline)) void memset_slice(void* base, index_t extent) { memset(base, 0, extent); }
+
+template <typename Fn>
+void BM_for_each_contiguous_slice(benchmark::State& state, Fn fn) {
+  std::vector<index_t> extents = {state.range(0) + 16, state.range(1), state.range(2)};
+  while (extents.back() == 0) {
+    extents.pop_back();
+  }
+  buffer<char, 3> buf(extents);
+  buf.allocate();
+  buf.dim(0).set_extent(state.range(0));
+
+  for (auto _ : state) {
+    for_each_contiguous_slice(buf, fn);
+  }
+}
+
+void BM_for_each_contiguous_slice_no_op(benchmark::State& state) { BM_for_each_contiguous_slice(state, no_op_slice); }
+void BM_for_each_contiguous_slice_memset(benchmark::State& state) { BM_for_each_contiguous_slice(state, memset_slice); }
+
+BENCHMARK(BM_for_each_contiguous_slice_no_op)->Args({1024, 16, 0});
+BENCHMARK(BM_for_each_contiguous_slice_memset)->Args({1024, 16, 0});
+BENCHMARK(BM_for_each_contiguous_slice_no_op)->Args({1024, 4, 4});
+BENCHMARK(BM_for_each_contiguous_slice_memset)->Args({1024, 4, 4});
+
+}  // namespace slinky

--- a/runtime/buffer_benchmark.cc
+++ b/runtime/buffer_benchmark.cc
@@ -46,12 +46,12 @@ void BM_for_each_slice_hardcoded(benchmark::State& state, Fn fn) {
 
 // The difference between these two benchmarks on the same size buffer gives an indication of how much time is spent in
 // overhead inside for_each_contiguous_slice.
-void BM_for_each_contiguous_slice_memset(benchmark::State& state) { BM_for_each_contiguous_slice(state, memset_slice); }
-void BM_for_each_slice_hardcoded_memset(benchmark::State& state) { BM_for_each_slice_hardcoded(state, memset_slice); }
+void BM_for_each_contiguous_slice(benchmark::State& state) { BM_for_each_contiguous_slice(state, memset_slice); }
+void BM_for_each_slice_hardcoded(benchmark::State& state) { BM_for_each_slice_hardcoded(state, memset_slice); }
 
-BENCHMARK(BM_for_each_contiguous_slice_memset)->Args({1024, 16, 1});
-BENCHMARK(BM_for_each_slice_hardcoded_memset)->Args({1024, 16, 1});
-BENCHMARK(BM_for_each_contiguous_slice_memset)->Args({1024, 4, 4});
-BENCHMARK(BM_for_each_slice_hardcoded_memset)->Args({1024, 4, 4});
+BENCHMARK(BM_for_each_contiguous_slice)->Args({1024, 16, 1});
+BENCHMARK(BM_for_each_slice_hardcoded)->Args({1024, 16, 1});
+BENCHMARK(BM_for_each_contiguous_slice)->Args({1024, 4, 4});
+BENCHMARK(BM_for_each_slice_hardcoded)->Args({1024, 4, 4});
 
 }  // namespace slinky

--- a/runtime/buffer_benchmark.cc
+++ b/runtime/buffer_benchmark.cc
@@ -33,13 +33,11 @@ void BM_for_each_slice_hardcoded(benchmark::State& state, Fn fn) {
 
   for (auto _ : state) {
     char* base_i = buf.base();
-    for (index_t i = 0; i < buf.dim(2).extent(); ++i) {
+    for (index_t i = 0; i < buf.dim(2).extent(); ++i, base_i += buf.dim(2).stride()) {
       char* base_j = base_i;
-      for (index_t j = 0; j < buf.dim(1).extent(); ++j) {
+      for (index_t j = 0; j < buf.dim(1).extent(); ++j, base_j += buf.dim(1).stride()) {
         fn(base_j, buf.dim(0).extent());
-        base_j += buf.dim(1).stride();
       }
-      base_i += buf.dim(2).stride();
     }
   }
 }

--- a/runtime/buffer_test.cc
+++ b/runtime/buffer_test.cc
@@ -172,7 +172,7 @@ TEST(buffer, for_each_slice) {
         fill(slice, &seven);
         slices++;
         int elements_slice = 1;
-        for (int d = 0; d < slice.rank; ++d) {
+        for (std::size_t d = 0; d < slice.rank; ++d) {
           elements_slice *= slice.dim(d).extent();
         }
         elements += elements_slice;

--- a/runtime/buffer_test.cc
+++ b/runtime/buffer_test.cc
@@ -110,7 +110,7 @@ TEST(buffer, for_each_contiguous_slice_non_innermost) {
 }
 
 TEST(buffer, for_each_tile_1x1) {
-  buffer<int, 3> buf({10, 20, 5});
+  buffer<int, 2> buf({10, 20});
   buf.allocate();
 
   int tiles = 0;
@@ -121,11 +121,11 @@ TEST(buffer, for_each_tile_1x1) {
     ASSERT_EQ(i.dim(1).extent(), all[1]);
     tiles++;
   });
-  ASSERT_EQ(tiles, buf.dim(2).extent());
+  ASSERT_EQ(tiles, 1);
 }
 
 TEST(buffer, for_each_tile_uneven) {
-  buffer<int, 3> buf({10, 20, 5});
+  buffer<int, 2> buf({10, 20});
   buf.allocate();
 
   int tiles = 0;
@@ -136,12 +136,11 @@ TEST(buffer, for_each_tile_uneven) {
     ASSERT_LE(i.dim(1).extent(), tile[1]);
     tiles++;
   });
-  ASSERT_EQ(tiles, ceil_div<index_t>(buf.dim(0).extent(), tile[0]) * ceil_div<index_t>(buf.dim(1).extent(), tile[1]) *
-                       buf.dim(2).extent());
+  ASSERT_EQ(tiles, ceil_div<index_t>(buf.dim(0).extent(), tile[0]) * ceil_div<index_t>(buf.dim(1).extent(), tile[1]));
 }
 
 TEST(buffer, for_each_tile_all) {
-  buffer<int, 3> buf({10, 20, 5});
+  buffer<int, 2> buf({10, 20});
   buf.allocate();
 
   int tiles = 0;
@@ -152,7 +151,7 @@ TEST(buffer, for_each_tile_all) {
     ASSERT_EQ(i.dim(1).extent(), slice[1]);
     tiles++;
   });
-  ASSERT_EQ(tiles, ceil_div<index_t>(buf.dim(1).extent(), slice[1]) * buf.dim(2).extent());
+  ASSERT_EQ(tiles, ceil_div<index_t>(buf.dim(1).extent(), slice[1]));
 }
 
 // A non-standard size type that acts like an integer for testing.

--- a/runtime/buffer_test.cc
+++ b/runtime/buffer_test.cc
@@ -155,33 +155,41 @@ TEST(buffer, for_each_tile_all) {
 }
 
 TEST(buffer, for_each_slice) {
-  for (int slice_rank : {0, 1, 2}) {
-    buffer<int, 2> buf({10, 20});
-    buf.allocate();
-    int slices = 0;
-    int elements = 0;
-    for_each_slice(slice_rank, buf, [&](const raw_buffer& slice) {
-      const int seven = 7;
-      fill(slice, &seven);
-      slices++;
-      int elements_slice = 1;
-      for (int d = 0; d < slice.rank; ++d) {
-        elements_slice *= slice.dim(d).extent();
+  for (std::size_t slice_rank : {0, 1, 2}) {
+    for (index_t fold_factor : {dim::unfolded, static_cast<index_t>(4)}) {
+      buffer<int, 2> buf({10, 20});
+      if (slice_rank <= 0) {
+        buf.dim(0).set_fold_factor(fold_factor);
       }
-      elements += elements_slice;
-    });
-    int expected_slices = 1;
-    int expected_elements = 1;
-    for (int d = 0; d < buf.rank; ++d) {
-      if (d >= slice_rank) {
-        expected_slices *= buf.dim(d).extent();
+      if (slice_rank <= 1) {
+        buf.dim(1).set_fold_factor(fold_factor);
       }
-      expected_elements *= buf.dim(d).extent();
-    }
-    ASSERT_EQ(slices, expected_slices);
-    ASSERT_EQ(elements, expected_elements);
+      buf.allocate();
+      int slices = 0;
+      int elements = 0;
+      for_each_slice(slice_rank, buf, [&](const raw_buffer& slice) {
+        const int seven = 7;
+        fill(slice, &seven);
+        slices++;
+        int elements_slice = 1;
+        for (int d = 0; d < slice.rank; ++d) {
+          elements_slice *= slice.dim(d).extent();
+        }
+        elements += elements_slice;
+      });
+      int expected_slices = 1;
+      int expected_elements = 1;
+      for (std::size_t d = 0; d < buf.rank; ++d) {
+        if (d >= slice_rank) {
+          expected_slices *= buf.dim(d).extent();
+        }
+        expected_elements *= buf.dim(d).extent();
+      }
+      ASSERT_EQ(slices, expected_slices);
+      ASSERT_EQ(elements, expected_elements);
 
-    for_each_index(buf, [&](auto i) { ASSERT_EQ(buf(i), 7); });
+      for_each_index(buf, [&](auto i) { ASSERT_EQ(buf(i), 7); });
+    }
   }
 }
 

--- a/runtime/buffer_test.cc
+++ b/runtime/buffer_test.cc
@@ -160,7 +160,7 @@ TEST(buffer, for_each_slice) {
     buf.allocate();
     int slices = 0;
     int elements = 0;
-    for_each_slice(slice_rank, buf, [&](const raw_buffer& slice) { 
+    for_each_slice(slice_rank, buf, [&](const raw_buffer& slice) {
       const int seven = 7;
       fill(slice, &seven);
       slices++;

--- a/runtime/buffer_test.cc
+++ b/runtime/buffer_test.cc
@@ -154,6 +154,37 @@ TEST(buffer, for_each_tile_all) {
   ASSERT_EQ(tiles, ceil_div<index_t>(buf.dim(1).extent(), slice[1]));
 }
 
+TEST(buffer, for_each_slice) {
+  for (int slice_rank : {0, 1, 2}) {
+    buffer<int, 2> buf({10, 20});
+    buf.allocate();
+    int slices = 0;
+    int elements = 0;
+    for_each_slice(slice_rank, buf, [&](const raw_buffer& slice) { 
+      const int seven = 7;
+      fill(slice, &seven);
+      slices++;
+      int elements_slice = 1;
+      for (int d = 0; d < slice.rank; ++d) {
+        elements_slice *= slice.dim(d).extent();
+      }
+      elements += elements_slice;
+    });
+    int expected_slices = 1;
+    int expected_elements = 1;
+    for (int d = 0; d < buf.rank; ++d) {
+      if (d >= slice_rank) {
+        expected_slices *= buf.dim(d).extent();
+      }
+      expected_elements *= buf.dim(d).extent();
+    }
+    ASSERT_EQ(slices, expected_slices);
+    ASSERT_EQ(elements, expected_elements);
+
+    for_each_index(buf, [&](auto i) { ASSERT_EQ(buf(i), 7); });
+  }
+}
+
 // A non-standard size type that acts like an integer for testing.
 struct big {
   uint64_t a, b;

--- a/runtime/buffer_test.cc
+++ b/runtime/buffer_test.cc
@@ -92,9 +92,7 @@ TEST(buffer, for_each_contiguous_slice_padded) {
     buffer<char, 3> buf({10, 20, 30});
     buf.allocate();
     buf.dim(padded_dim).set_bounds(0, 8);
-    for_each_contiguous_slice(buf, [&](void* slice, index_t slice_extent) {
-      memset(slice, 7, slice_extent);
-    });
+    for_each_contiguous_slice(buf, [&](void* slice, index_t slice_extent) { memset(slice, 7, slice_extent); });
     for_each_index(buf, [&](auto i) { ASSERT_EQ(buf(i), 7); });
   }
 }
@@ -116,11 +114,11 @@ TEST(buffer, for_each_tile_1x1) {
   buf.allocate();
 
   int tiles = 0;
-  const auto all = std::make_tuple(buf.dim(0).extent(), buf.dim(1).extent());
+  const index_t all[] = {buf.dim(0).extent(), buf.dim(1).extent()};
   for_each_tile(all, buf, [&](const raw_buffer& i) {
     ASSERT_EQ(i.rank, 2);
-    ASSERT_EQ(i.dim(0).extent(), std::get<0>(all));
-    ASSERT_EQ(i.dim(1).extent(), std::get<1>(all));
+    ASSERT_EQ(i.dim(0).extent(), all[0]);
+    ASSERT_EQ(i.dim(1).extent(), all[1]);
     tiles++;
   });
   ASSERT_EQ(tiles, buf.dim(2).extent());
@@ -131,15 +129,15 @@ TEST(buffer, for_each_tile_uneven) {
   buf.allocate();
 
   int tiles = 0;
-  const auto tile = std::make_tuple(3, 6);
+  const index_t tile[] = {3, 6};
   for_each_tile(tile, buf, [&](const raw_buffer& i) {
     ASSERT_EQ(i.rank, 2);
-    ASSERT_LE(i.dim(0).extent(), std::get<0>(tile));
-    ASSERT_LE(i.dim(1).extent(), std::get<1>(tile));
+    ASSERT_LE(i.dim(0).extent(), tile[0]);
+    ASSERT_LE(i.dim(1).extent(), tile[1]);
     tiles++;
   });
-  ASSERT_EQ(tiles, ceil_div<index_t>(buf.dim(0).extent(), std::get<0>(tile)) *
-                       ceil_div<index_t>(buf.dim(1).extent(), std::get<1>(tile)) * buf.dim(2).extent());
+  ASSERT_EQ(tiles, ceil_div<index_t>(buf.dim(0).extent(), tile[0]) * ceil_div<index_t>(buf.dim(1).extent(), tile[1]) *
+                       buf.dim(2).extent());
 }
 
 TEST(buffer, for_each_tile_all) {
@@ -147,14 +145,14 @@ TEST(buffer, for_each_tile_all) {
   buf.allocate();
 
   int tiles = 0;
-  const auto slice = std::tuple<slinky::all, std::integral_constant<int, 5>>();
+  const index_t slice[] = {slinky::all, 5};
   for_each_tile(slice, buf, [&](const raw_buffer& i) {
     ASSERT_EQ(i.rank, 2);
     ASSERT_EQ(i.dim(0).extent(), buf.dim(0).extent());
-    ASSERT_EQ(i.dim(1).extent(), std::get<1>(slice));
+    ASSERT_EQ(i.dim(1).extent(), slice[1]);
     tiles++;
   });
-  ASSERT_EQ(tiles, ceil_div<index_t>(buf.dim(1).extent(), std::get<1>(slice)) * buf.dim(2).extent());
+  ASSERT_EQ(tiles, ceil_div<index_t>(buf.dim(1).extent(), slice[1]) * buf.dim(2).extent());
 }
 
 // A non-standard size type that acts like an integer for testing.


### PR DESCRIPTION
This was probably a premature optimization. This PR also adds a benchmark of `for_each_contiguous_slice`