### PR TITLE
Prefer `=default` to `{]` for empty ctor/dtor bodies

### DIFF
--- a/builder/pipeline.h
+++ b/builder/pipeline.h
@@ -120,7 +120,7 @@ public:
     expr step;
     loop_mode mode;
 
-    loop_info() {}
+    loop_info() = default;
     loop_info(slinky::var var, expr step = 1, loop_mode mode = loop_mode::serial) : var(var), step(step), mode(mode) {}
 
     symbol_id sym() const { return var.sym(); }
@@ -142,7 +142,7 @@ private:
   void remove_this_from_buffers();
 
 public:
-  func() {}
+  func() = default;
   func(call_stmt::callable impl, std::vector<input> inputs, std::vector<output> outputs);
   func(std::vector<input> inputs, output out);
   func(input input, output out, std::optional<std::vector<char>> padding);

--- a/runtime/expr.h
+++ b/runtime/expr.h
@@ -244,7 +244,7 @@ expr max(span<expr> x);
 struct interval_expr {
   expr min, max;
 
-  interval_expr() {}
+  interval_expr() = default;
   explicit interval_expr(const expr& point) : min(point), max(point) {}
   interval_expr(expr min, expr max) : min(std::move(min)), max(std::move(max)) {}
 
@@ -705,7 +705,7 @@ public:
 
 class node_visitor {
 public:
-  virtual ~node_visitor() {}
+  virtual ~node_visitor() = default;
 
   virtual void visit(const variable*) = 0;
   virtual void visit(const wildcard*) = 0;
@@ -941,7 +941,7 @@ class symbol_map {
   }
 
 public:
-  symbol_map() {}
+  symbol_map() = default;
   symbol_map(std::initializer_list<std::pair<symbol_id, T>> init) {
     for (const std::pair<symbol_id, T>& i : init) {
       operator[](i.first) = i.second;

--- a/runtime/util.h
+++ b/runtime/util.h
@@ -176,7 +176,7 @@ public:
     }
   }
 
-  virtual ~ref_counted() {}
+  virtual ~ref_counted() = default;
 };
 
 // A smart pointer to a ref_counted base.


### PR DESCRIPTION
Yet another nit found by clang-tidy. YMMV.