### PR TITLE
Don't try to move out of a const container

### DIFF
--- a/runtime/expr.cc
+++ b/runtime/expr.cc
@@ -337,10 +337,9 @@ void flatten_blocks(std::vector<stmt>& v) {
   for (auto it = v.begin(); it != v.end();) {
     if (it->defined()) {
       if (const block* b = it->as<block>()) {
-        auto stmts = std::move(b->stmts);
+        const auto& stmts = b->stmts;
+        it = v.insert(it, stmts.begin(), stmts.end()) + stmts.size();
         it = v.erase(it);
-        it = v.insert(it, stmts.begin(), stmts.end());
-        it += stmts.size();
         continue;
       }
     }


### PR DESCRIPTION
It's a no-op and makes an unnecessary copy.