### PR TITLE
Add benchmarks of evaluation of various stmt types

### DIFF
--- a/runtime/BUILD
+++ b/runtime/BUILD
@@ -80,3 +80,13 @@ cc_binary(
         "@google_benchmark//:benchmark_main",
     ],
 )
+
+cc_binary(
+    name = "evaluate_benchmark",
+    srcs = ["evaluate_benchmark.cc"],
+    deps = [
+        ":runtime",
+        ":thread_pool",
+        "@google_benchmark//:benchmark_main",
+    ],
+)

--- a/runtime/evaluate_benchmark.cc
+++ b/runtime/evaluate_benchmark.cc
@@ -56,7 +56,7 @@ BENCHMARK(BM_call);
 
 void BM_let(benchmark::State& state) {
   std::atomic<int> calls = 0;
-  std::vector<std::pair<symbol_id, expr>> values = {{y.sym(), 0}, {z.sym(), y}, {w.sym(), z}};
+  std::vector<std::pair<symbol_id, expr>> values = {{y.sym(), x}, {z.sym(), y}, {w.sym(), z}};
   values.resize(state.range(0));
   stmt body = make_loop(let_stmt::make(values, make_call_counter(calls)));
 

--- a/runtime/evaluate_benchmark.cc
+++ b/runtime/evaluate_benchmark.cc
@@ -1,0 +1,189 @@
+#include <benchmark/benchmark.h>
+
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+
+#include "runtime/evaluate.h"
+#include "runtime/expr.h"
+#include "runtime/thread_pool.h"
+
+namespace slinky {
+
+node_context ctx;
+var buf(ctx, "buf");
+var x(ctx, "x");
+var y(ctx, "y");
+var z(ctx, "z");
+
+constexpr index_t iterations = 100000;
+
+// These benchmarks mostly work by generating nodes around a call counter, and wrapping that node with a loop.
+stmt make_call_counter(std::atomic<int>& calls) {
+  return call_stmt::make(
+      [&](eval_context& ctx) -> index_t {
+        ++calls;
+        return 0;
+      },
+      {}, {});
+}
+
+stmt make_loop(stmt body) { return loop::make(x.sym(), loop_mode::serial, range(0, iterations), 1, body); }
+
+// For nodes that need a buffer, we can add a buffer outside that loop, the cost of constructing it will be negligible.
+stmt make_buf(int rank, stmt body) {
+  std::vector<dim_expr> dims;
+  for (int i = 0; i < rank; ++i) {
+    dims.push_back({{0, 100}, i, dim::unfolded});
+  }
+  return make_buffer::make(buf.sym(), 0, 1, dims, body);
+}
+
+void BM_call(benchmark::State& state) {
+  std::atomic<int> calls = 0;
+  stmt body = make_loop(make_call_counter(calls));
+
+  for (auto _ : state) {
+    evaluate(body);
+  }
+
+  state.SetItemsProcessed(calls);
+}
+
+BENCHMARK(BM_call);
+
+void BM_let(benchmark::State& state) {
+  std::atomic<int> calls = 0;
+  stmt body = make_loop(let_stmt::make({{y.sym(), 0}, {z.sym(), y}}, make_call_counter(calls)));
+
+  for (auto _ : state) {
+    evaluate(body);
+  }
+
+  state.SetItemsProcessed(calls);
+}
+
+BENCHMARK(BM_let);
+
+void BM_block(benchmark::State& state) {
+  std::atomic<int> calls = 0;
+  std::vector<stmt> call_counters(state.range(0), make_call_counter(calls));
+  stmt body = make_loop(block::make(call_counters));
+
+  for (auto _ : state) {
+    evaluate(body);
+  }
+
+  state.SetItemsProcessed(calls);
+}
+
+BENCHMARK(BM_block)->RangeMultiplier(2)->Range(2, 16);
+
+void BM_make_buffer(benchmark::State& state) {
+  std::atomic<int> calls = 0;
+  stmt body = make_loop(make_buf(3, make_call_counter(calls)));
+
+  for (auto _ : state) {
+    evaluate(body);
+  }
+
+  state.SetItemsProcessed(calls);
+}
+
+BENCHMARK(BM_make_buffer);
+
+void BM_crop_dim(benchmark::State& state) {
+  std::atomic<int> calls = 0;
+  stmt c = crop_dim::make(buf.sym(), 0, {1, 10}, make_call_counter(calls));
+  stmt l = make_loop(c);
+  stmt body = make_buf(3, l);
+
+  for (auto _ : state) {
+    evaluate(body);
+  }
+
+  state.SetItemsProcessed(calls);
+}
+
+BENCHMARK(BM_crop_dim);
+
+void BM_crop_buffer(benchmark::State& state) {
+  std::atomic<int> calls = 0;
+  stmt c = crop_buffer::make(buf.sym(), {{1, 10}, {}, {2, 20}}, make_call_counter(calls));
+  stmt l = make_loop(c);
+  stmt body = make_buf(3, l);
+
+  for (auto _ : state) {
+    evaluate(body);
+  }
+
+  state.SetItemsProcessed(calls);
+}
+
+BENCHMARK(BM_crop_buffer);
+
+void BM_slice_dim(benchmark::State& state) {
+  std::atomic<int> calls = 0;
+  stmt c = slice_dim::make(buf.sym(), 1, 10, make_call_counter(calls));
+  stmt l = make_loop(c);
+  stmt body = make_buf(3, l);
+
+  for (auto _ : state) {
+    evaluate(body);
+  }
+
+  state.SetItemsProcessed(calls);
+}
+
+BENCHMARK(BM_slice_dim);
+
+void BM_slice_buffer(benchmark::State& state) {
+  std::atomic<int> calls = 0;
+  stmt c = slice_buffer::make(buf.sym(), {10, {}, 20}, make_call_counter(calls));
+  stmt l = make_loop(c);
+  stmt body = make_buf(3, l);
+
+  for (auto _ : state) {
+    evaluate(body);
+  }
+
+  state.SetItemsProcessed(calls);
+}
+
+BENCHMARK(BM_slice_buffer);
+
+void BM_allocate(benchmark::State& state) {
+  std::atomic<int> calls = 0;
+  stmt c = allocate::make(buf.sym(), memory_type::stack, 1, {{{0, 100}, 1, dim::unfolded}}, make_call_counter(calls));
+  stmt body = make_loop(c);
+
+  for (auto _ : state) {
+    evaluate(body);
+  }
+
+  state.SetItemsProcessed(calls);
+}
+
+BENCHMARK(BM_allocate);
+
+void BM_parallel_loop(benchmark::State& state) {
+  std::atomic<int> calls = 0;
+  stmt body = loop::make(x.sym(), loop_mode::parallel, range(0, iterations), 1, make_call_counter(calls));
+
+  thread_pool t(state.range(0));
+
+  eval_context eval_ctx;
+  eval_ctx.enqueue_many = [&](const thread_pool::task& f) { t.enqueue(t.thread_count(), f); };
+  eval_ctx.enqueue_one = [&](thread_pool::task f) { t.enqueue(std::move(f)); };
+  eval_ctx.wait_for = [&](std::function<bool()> f) { t.wait_for(std::move(f)); };
+
+  for (auto _ : state) {
+    evaluate(body, eval_ctx);
+  }
+
+  state.SetItemsProcessed(calls);
+}
+
+BENCHMARK(BM_parallel_loop)->RangeMultiplier(2)->Range(2, 16);
+
+}  // namespace slinky

--- a/runtime/evaluate_benchmark.cc
+++ b/runtime/evaluate_benchmark.cc
@@ -12,6 +12,7 @@ namespace slinky {
 
 node_context ctx;
 var buf(ctx, "buf");
+var buf2(ctx, "buf2");
 var x(ctx, "x");
 var y(ctx, "y");
 var z(ctx, "z");
@@ -91,6 +92,21 @@ void BM_make_buffer(benchmark::State& state) {
 }
 
 BENCHMARK(BM_make_buffer);
+
+void BM_make_buffer_clone(benchmark::State& state) {
+  std::atomic<int> calls = 0;
+  std::vector<dim_expr> dims = {buffer_dim(buf, 0), buffer_dim(buf, 1), buffer_dim(buf, 2)};
+  stmt clone = make_buffer::make(buf2.sym(), buffer_base(buf), buffer_elem_size(buf), dims, make_call_counter(calls));
+  stmt body = make_buf(3, make_loop(clone));
+
+  for (auto _ : state) {
+    evaluate(body);
+  }
+
+  state.SetItemsProcessed(calls);
+}
+
+BENCHMARK(BM_make_buffer_clone);
 
 void BM_crop_dim(benchmark::State& state) {
   std::atomic<int> calls = 0;

--- a/runtime/evaluate_benchmark.cc
+++ b/runtime/evaluate_benchmark.cc
@@ -93,7 +93,7 @@ void BM_make_buffer(benchmark::State& state) {
 
 BENCHMARK(BM_make_buffer);
 
-void BM_make_buffer_clone(benchmark::State& state) {
+void BM_buffer_metadata(benchmark::State& state) {
   std::atomic<int> calls = 0;
   std::vector<dim_expr> dims = {buffer_dim(buf, 0), buffer_dim(buf, 1), buffer_dim(buf, 2)};
   stmt clone = make_buffer::make(buf2.sym(), buffer_base(buf), buffer_elem_size(buf), dims, make_call_counter(calls));

--- a/runtime/evaluate_benchmark.cc
+++ b/runtime/evaluate_benchmark.cc
@@ -106,7 +106,7 @@ void BM_buffer_metadata(benchmark::State& state) {
   state.SetItemsProcessed(calls);
 }
 
-BENCHMARK(BM_make_buffer_clone);
+BENCHMARK(BM_buffer_metadata);
 
 void BM_crop_dim(benchmark::State& state) {
   std::atomic<int> calls = 0;

--- a/runtime/evaluate_benchmark.cc
+++ b/runtime/evaluate_benchmark.cc
@@ -16,6 +16,7 @@ var buf2(ctx, "buf2");
 var x(ctx, "x");
 var y(ctx, "y");
 var z(ctx, "z");
+var w(ctx, "w");
 
 constexpr index_t iterations = 100000;
 
@@ -55,7 +56,9 @@ BENCHMARK(BM_call);
 
 void BM_let(benchmark::State& state) {
   std::atomic<int> calls = 0;
-  stmt body = make_loop(let_stmt::make({{y.sym(), 0}, {z.sym(), y}}, make_call_counter(calls)));
+  std::vector<std::pair<symbol_id, expr>> values = {{y.sym(), 0}, {z.sym(), y}, {w.sym(), z}};
+  values.resize(state.range(0));
+  stmt body = make_loop(let_stmt::make(values, make_call_counter(calls)));
 
   for (auto _ : state) {
     evaluate(body);
@@ -64,7 +67,7 @@ void BM_let(benchmark::State& state) {
   state.SetItemsProcessed(calls);
 }
 
-BENCHMARK(BM_let);
+BENCHMARK(BM_let)->DenseRange(1, 3);
 
 void BM_block(benchmark::State& state) {
   std::atomic<int> calls = 0;

--- a/runtime/evaluate_benchmark.cc
+++ b/runtime/evaluate_benchmark.cc
@@ -80,34 +80,6 @@ void BM_block(benchmark::State& state) {
 
 BENCHMARK(BM_block)->RangeMultiplier(2)->Range(2, 16);
 
-void BM_make_buffer(benchmark::State& state) {
-  std::atomic<int> calls = 0;
-  stmt body = make_loop(make_buf(3, make_call_counter(calls)));
-
-  for (auto _ : state) {
-    evaluate(body);
-  }
-
-  state.SetItemsProcessed(calls);
-}
-
-BENCHMARK(BM_make_buffer);
-
-void BM_buffer_metadata(benchmark::State& state) {
-  std::atomic<int> calls = 0;
-  std::vector<dim_expr> dims = {buffer_dim(buf, 0), buffer_dim(buf, 1), buffer_dim(buf, 2)};
-  stmt clone = make_buffer::make(buf2.sym(), buffer_base(buf), buffer_elem_size(buf), dims, make_call_counter(calls));
-  stmt body = make_buf(3, make_loop(clone));
-
-  for (auto _ : state) {
-    evaluate(body);
-  }
-
-  state.SetItemsProcessed(calls);
-}
-
-BENCHMARK(BM_buffer_metadata);
-
 void BM_crop_dim(benchmark::State& state) {
   std::atomic<int> calls = 0;
   stmt c = crop_dim::make(buf.sym(), 0, {1, 10}, make_call_counter(calls));
@@ -181,6 +153,34 @@ void BM_allocate(benchmark::State& state) {
 }
 
 BENCHMARK(BM_allocate);
+
+void BM_make_buffer(benchmark::State& state) {
+  std::atomic<int> calls = 0;
+  stmt body = make_loop(make_buf(3, make_call_counter(calls)));
+
+  for (auto _ : state) {
+    evaluate(body);
+  }
+
+  state.SetItemsProcessed(calls);
+}
+
+BENCHMARK(BM_make_buffer);
+
+void BM_buffer_metadata(benchmark::State& state) {
+  std::atomic<int> calls = 0;
+  std::vector<dim_expr> dims = {buffer_dim(buf, 0), buffer_dim(buf, 1), buffer_dim(buf, 2)};
+  stmt clone = make_buffer::make(buf2.sym(), buffer_base(buf), buffer_elem_size(buf), dims, make_call_counter(calls));
+  stmt body = make_buf(3, make_loop(clone));
+
+  for (auto _ : state) {
+    evaluate(body);
+  }
+
+  state.SetItemsProcessed(calls);
+}
+
+BENCHMARK(BM_buffer_metadata);
 
 void BM_parallel_loop(benchmark::State& state) {
   std::atomic<int> calls = 0;

--- a/runtime/thread_pool.cc
+++ b/runtime/thread_pool.cc
@@ -34,7 +34,7 @@ void thread_pool::wait_for(std::function<bool()> condition) {
       // This is pretty inefficient. It is here to wake up threads that are waiting for a condition to become true, that
       // may have become true due to the task completing. There may be a better way to do this.
       cv_.notify_all();
-    } else {
+    } else if (!stop_) {
       cv_.wait(l);
     }
   }


### PR DESCRIPTION
I realized we could pretty easily have some benchmarks of evaluating various types of nodes. These benchmarks aren't very useful in getting an absolute sense of performance, but if one were to attempt to optimize `evaluate`, the impact would hopefully be visible in these benchmarks.

The current output looks like this:
```
------------------------------------------------------------------------------
Benchmark                    Time             CPU   Iterations UserCounters...
------------------------------------------------------------------------------
BM_call                 305734 ns       305730 ns         2281 items_per_second=327.086M/s
BM_let/1                997022 ns       986753 ns          718 items_per_second=101.343M/s
BM_let/2               1257601 ns      1257603 ns          553 items_per_second=79.5164M/s
BM_let/3               1599969 ns      1599972 ns          440 items_per_second=62.5011M/s
BM_block/2              801240 ns       801235 ns          867 items_per_second=249.615M/s
BM_block/4             1337473 ns      1337475 ns          529 items_per_second=299.071M/s
BM_block/8             2431433 ns      2431438 ns          285 items_per_second=329.023M/s
BM_block/16            4745688 ns      4745699 ns          147 items_per_second=337.147M/s
BM_crop_dim             761575 ns       761577 ns          916 items_per_second=131.307M/s
BM_crop_buffer         1535819 ns      1535821 ns          453 items_per_second=65.1117M/s
BM_slice_dim            883828 ns       883830 ns          799 items_per_second=113.144M/s
BM_slice_buffer        1107524 ns      1107525 ns          630 items_per_second=90.2914M/s
BM_allocate            1342411 ns      1342413 ns          511 items_per_second=74.4927M/s
BM_make_buffer         1719626 ns      1719629 ns          409 items_per_second=58.1521M/s
BM_buffer_metadata     7362997 ns      7363003 ns           94 items_per_second=13.5814M/s
BM_parallel_loop/2     3881079 ns      3875385 ns          144 items_per_second=25.8039M/s
BM_parallel_loop/4     5617294 ns      5596193 ns          127 items_per_second=17.8693M/s
BM_parallel_loop/8     5313559 ns      5235499 ns          142 items_per_second=19.1004M/s
BM_parallel_loop/16    4350476 ns      4175685 ns          170 items_per_second=23.9482M/s
```
Where `items_per_second` is a measure of the rate we could evaluate that node.