### PR TITLE
Add benchmarks of copy/fill/pad

### DIFF
--- a/runtime/buffer_benchmark.cc
+++ b/runtime/buffer_benchmark.cc
@@ -7,6 +7,17 @@
 
 namespace slinky {
 
+std::vector<index_t> state_to_vector(std::size_t max_size, const benchmark::State& state) {
+  std::vector<index_t> vec(max_size);
+  for (std::size_t i = 0; i < max_size; ++i) {
+    vec[i] = state.range(i);
+  }
+  while (vec.back() == -1) {
+    vec.pop_back();
+  }
+  return vec;
+}
+
 void BM_memcpy(benchmark::State& state) {
   std::size_t size = state.range(0);
   char* src = new char[size];
@@ -23,17 +34,6 @@ void BM_memcpy(benchmark::State& state) {
 }
 
 BENCHMARK(BM_memcpy)->Arg(1024 * 1024);
-
-std::vector<index_t> state_to_vector(std::size_t max_size, const benchmark::State& state) {
-  std::vector<index_t> vec(max_size);
-  for (std::size_t i = 0; i < max_size; ++i) {
-    vec[i] = state.range(i);
-  }
-  while (vec.back() == -1) {
-    vec.pop_back();
-  }
-  return vec;
-}
 
 void BM_copy(benchmark::State& state) {
   std::vector<index_t> extents = state_to_vector(4, state);
@@ -65,6 +65,19 @@ void BM_copy_padded(benchmark::State& state) {
 
 BENCHMARK(BM_copy_padded)->Args({1024, 256, 4, -1});
 BENCHMARK(BM_copy_padded)->Args({32, 32, 256, 4});
+
+void BM_memset(benchmark::State& state) {
+  std::size_t size = state.range(0);
+  char* dst = new char[size];
+
+  for (auto _ : state) {
+    memset(dst, 0, size);
+  }
+
+  delete[] dst;
+}
+
+BENCHMARK(BM_memset)->Arg(1024 * 1024);
 
 void BM_fill(benchmark::State& state) {
   std::vector<index_t> extents = state_to_vector(4, state);

--- a/runtime/buffer_benchmark.cc
+++ b/runtime/buffer_benchmark.cc
@@ -18,15 +18,19 @@ std::vector<index_t> state_to_vector(std::size_t max_size, const benchmark::Stat
   return vec;
 }
 
+template <typename Fn>
+__attribute__((noinline)) void no_inline(Fn&& fn) { fn(); }
+
 void BM_memcpy(benchmark::State& state) {
   std::size_t size = state.range(0);
   char* src = new char[size];
   char* dst = new char[size];
 
   memset(src, 0, size);
+  memset(dst, 0, size);
 
   for (auto _ : state) {
-    memcpy(dst, src, size);
+    no_inline([=]() { memcpy(dst, src, size); });
   }
 
   delete[] src;
@@ -71,7 +75,7 @@ void BM_memset(benchmark::State& state) {
   char* dst = new char[size];
 
   for (auto _ : state) {
-    memset(dst, 0, size);
+    no_inline([=]() { memset(dst, 0, size); });
   }
 
   delete[] dst;

--- a/runtime/buffer_benchmark.cc
+++ b/runtime/buffer_benchmark.cc
@@ -7,14 +7,122 @@
 
 namespace slinky {
 
+void BM_memcpy(benchmark::State& state) {
+  std::size_t size = state.range(0);
+  char* src = new char[size];
+  char* dst = new char[size];
+
+  memset(src, 0, size);
+
+  for (auto _ : state) {
+    memcpy(dst, src, size);
+  }
+
+  delete[] src;
+  delete[] dst;
+}
+
+BENCHMARK(BM_memcpy)->Arg(1024 * 1024);
+
+std::vector<index_t> state_to_vector(std::size_t max_size, const benchmark::State& state) {
+  std::vector<index_t> vec(max_size);
+  for (std::size_t i = 0; i < max_size; ++i) {
+    vec[i] = state.range(i);
+  }
+  while (vec.back() == -1) {
+    vec.pop_back();
+  }
+  return vec;
+}
+
+void BM_copy(benchmark::State& state) {
+  std::vector<index_t> extents = state_to_vector(4, state);
+  buffer<char, 4> src(extents);
+  buffer<char, 4> dst(extents);
+  src.allocate();
+  dst.allocate();
+
+  for (auto _ : state) {
+    copy(src, dst);
+  }
+}
+
+BENCHMARK(BM_copy)->Args({1024, 256, -1, -1});
+BENCHMARK(BM_copy)->Args({32, 32, 256, -1});
+
+void BM_copy_padded(benchmark::State& state) {
+  std::vector<index_t> extents = state_to_vector(4, state);
+  buffer<char, 4> src(extents);
+  buffer<char, 4> dst(extents);
+  dst.dim(0).set_min_extent(0, extents[0] + 16);
+  src.allocate();
+  dst.allocate();
+
+  for (auto _ : state) {
+    copy(src, dst);
+  }
+}
+
+BENCHMARK(BM_copy_padded)->Args({1024, 256, 4, -1});
+BENCHMARK(BM_copy_padded)->Args({32, 32, 256, 4});
+
+void BM_fill(benchmark::State& state) {
+  std::vector<index_t> extents = state_to_vector(4, state);
+  buffer<char, 4> dst(extents);
+  dst.allocate();
+
+  char five = 0;
+
+  for (auto _ : state) {
+    fill(dst, &five);
+  }
+}
+
+BENCHMARK(BM_fill)->Args({1024, 256, -1, -1});
+BENCHMARK(BM_fill)->Args({32, 32, 256, -1});
+
+void BM_fill_padded(benchmark::State& state) {
+  std::vector<index_t> extents = state_to_vector(4, state);
+  buffer<char, 4> dst(extents);
+  dst.dim(0).set_stride(dst.dim(0).stride() + 16);
+  dst.allocate();
+
+  char five = 0;
+
+  for (auto _ : state) {
+    fill(dst, &five);
+  }
+}
+
+BENCHMARK(BM_fill_padded)->Args({1024, 256, -1, -1});
+BENCHMARK(BM_fill_padded)->Args({32, 32, 256, -1});
+
+void BM_pad(benchmark::State& state) {
+  std::vector<index_t> extents = state_to_vector(4, state);
+  buffer<char, 4> dst(extents);
+  dst.allocate();
+
+  buffer<char, 4> src(extents);
+  for (std::size_t d = 0; d < src.rank; ++d) {
+    src.dim(d).set_bounds(1, extents[d] - 1);
+  }
+
+  char five = 0;
+
+  for (auto _ : state) {
+    pad(src.dims, dst, &five);
+  }
+}
+
+BENCHMARK(BM_pad)->Args({1024, 256, -1, -1});
+BENCHMARK(BM_pad)->Args({32, 32, 256, -1});
+
 void memset_slice(void* base, index_t extent) { memset(base, 0, extent); }
 
 template <typename Fn>
 void BM_for_each_contiguous_slice(benchmark::State& state, Fn fn) {
-  std::vector<index_t> extents = {state.range(0) + 64, state.range(1), state.range(2)};
-  while (extents.back() == 1) {
-    extents.pop_back();
-  }
+  std::vector<index_t> extents = state_to_vector(3, state);
+  extents[0] += 64;  // Insert padding after the first dimension.
   buffer<char, 3> buf(extents);
   buf.allocate();
   buf.dim(0).set_extent(state.range(0));
@@ -26,7 +134,8 @@ void BM_for_each_contiguous_slice(benchmark::State& state, Fn fn) {
 
 template <typename Fn>
 void BM_for_each_slice_hardcoded(benchmark::State& state, Fn fn) {
-  std::vector<index_t> extents = {state.range(0) + 64, state.range(1), state.range(2)};
+  std::vector<index_t> extents = state_to_vector(3, state);
+  extents[0] += 64;  // Insert padding after the first dimension.
   buffer<char, 3> buf(extents);
   buf.allocate();
   buf.dim(0).set_extent(state.range(0));

--- a/runtime/buffer_benchmark.cc
+++ b/runtime/buffer_benchmark.cc
@@ -47,8 +47,8 @@ void BM_copy(benchmark::State& state) {
   }
 }
 
-BENCHMARK(BM_copy)->Args({1024, 256, -1, -1});
-BENCHMARK(BM_copy)->Args({32, 32, 256, -1});
+BENCHMARK(BM_copy)->Args({1024, 256, 4, -1});
+BENCHMARK(BM_copy)->Args({32, 32, 256, 4});
 
 void BM_copy_padded(benchmark::State& state) {
   std::vector<index_t> extents = state_to_vector(4, state);
@@ -78,8 +78,8 @@ void BM_fill(benchmark::State& state) {
   }
 }
 
-BENCHMARK(BM_fill)->Args({1024, 256, -1, -1});
-BENCHMARK(BM_fill)->Args({32, 32, 256, -1});
+BENCHMARK(BM_fill)->Args({1024, 256, 4, -1});
+BENCHMARK(BM_fill)->Args({32, 32, 256, 4});
 
 void BM_fill_padded(benchmark::State& state) {
   std::vector<index_t> extents = state_to_vector(4, state);
@@ -94,8 +94,8 @@ void BM_fill_padded(benchmark::State& state) {
   }
 }
 
-BENCHMARK(BM_fill_padded)->Args({1024, 256, -1, -1});
-BENCHMARK(BM_fill_padded)->Args({32, 32, 256, -1});
+BENCHMARK(BM_fill_padded)->Args({1024, 256, 4, -1});
+BENCHMARK(BM_fill_padded)->Args({32, 32, 256, 4});
 
 void BM_pad(benchmark::State& state) {
   std::vector<index_t> extents = state_to_vector(4, state);
@@ -114,8 +114,8 @@ void BM_pad(benchmark::State& state) {
   }
 }
 
-BENCHMARK(BM_pad)->Args({1024, 256, -1, -1});
-BENCHMARK(BM_pad)->Args({32, 32, 256, -1});
+BENCHMARK(BM_pad)->Args({1024, 256, 4, -1});
+BENCHMARK(BM_pad)->Args({32, 32, 256, 4});
 
 void memset_slice(void* base, index_t extent) { memset(base, 0, extent); }
 


### PR DESCRIPTION
Unfortunately my CPU is affected by this hardware bug: https://bugs.launchpad.net/ubuntu/+source/glibc/+bug/2030515

Which means I can't really tell if these benchmarks are tuned quite right to be useful, but I think they should be.