### PR TITLE
Padded copies must always have crops (fixes #21)

### DIFF
--- a/builder/copy_test.cc
+++ b/builder/copy_test.cc
@@ -30,8 +30,10 @@ TEST(copy, trivial_1d) {
 
   std::vector<char> padding(sizeof(int), 0);
 
+  // Crop the output to the intersection of the input and output buffer.
+  box_expr output_crop = in->bounds() & out->bounds();
   // This copy should be implemented as a single call to copy.
-  func copy = func::make_copy({in, {point(x)}, in->bounds() & out->bounds()}, {out, {x}}, padding);
+  func copy = func::make_copy({in, {point(x)}, output_crop}, {out, {x}}, padding);
 
   pipeline p = build_pipeline(ctx, {in}, {out});
 
@@ -72,8 +74,10 @@ TEST(copy, trivial_2d) {
 
   std::vector<char> padding(sizeof(int), 0);
 
+  // Crop the output to the intersection of the input and output buffer.
+  box_expr output_crop = in->bounds() & out->bounds();
   // This copy should be implemented as a single call to copy.
-  func copy = func::make_copy({in, {point(x), point(y)}, in->bounds() & out->bounds()}, {out, {x, y}}, padding);
+  func copy = func::make_copy({in, {point(x), point(y)}, output_crop}, {out, {x, y}}, padding);
 
   pipeline p = build_pipeline(ctx, {in}, {out});
 

--- a/builder/copy_test.cc
+++ b/builder/copy_test.cc
@@ -31,7 +31,7 @@ TEST(copy, trivial_1d) {
   std::vector<char> padding(sizeof(int), 0);
 
   // This copy should be implemented as a single call to copy.
-  func copy = func::make_copy({in, {point(x)}}, {out, {x}}, in->bounds() & out->bounds(), padding);
+  func copy = func::make_copy({in, {point(x)}, in->bounds() & out->bounds()}, {out, {x}}, padding);
 
   pipeline p = build_pipeline(ctx, {in}, {out});
 
@@ -73,7 +73,7 @@ TEST(copy, trivial_2d) {
   std::vector<char> padding(sizeof(int), 0);
 
   // This copy should be implemented as a single call to copy.
-  func copy = func::make_copy({in, {point(x), point(y)}}, {out, {x, y}}, in->bounds() & out->bounds(), padding);
+  func copy = func::make_copy({in, {point(x), point(y)}, in->bounds() & out->bounds()}, {out, {x, y}}, padding);
 
   pipeline p = build_pipeline(ctx, {in}, {out});
 

--- a/builder/pipeline.cc
+++ b/builder/pipeline.cc
@@ -45,7 +45,7 @@ buffer_expr::buffer_expr(symbol_id sym, const raw_buffer* buffer)
     expr max = buffer->dims[d].max();
     expr stride = buffer->dims[d].stride();
     expr fold_factor = buffer->dims[d].fold_factor();
-    dims_.push_back({bounds(min, max), stride, fold_factor});
+    dims_.push_back({slinky::bounds(min, max), stride, fold_factor});
   }
 }
 
@@ -69,18 +69,30 @@ void buffer_expr::set_producer(func* f) {
   producer_ = f;
 }
 
+box_expr buffer_expr::bounds() const {
+  box_expr result(rank());
+  for (std::size_t d = 0; d < rank(); ++d) {
+    result[d] = dim(d).bounds;
+  }
+  return result;
+}
+
 func::func(call_stmt::callable impl, std::vector<input> inputs, std::vector<output> outputs)
     : impl_(std::move(impl)), inputs_(std::move(inputs)), outputs_(std::move(outputs)) {
   add_this_to_buffers();
 }
 
-func::func(input input, output out, std::optional<std::vector<char>> padding)
+func::func(input input, output out, box_expr crop, std::vector<char> padding)
     : func(nullptr, {std::move(input)}, {std::move(out)}) {
+  output_crops_.push_back(std::move(crop));
   padding_ = std::move(padding);
 }
 
-func::func(std::vector<input> inputs, output out) : func(nullptr, std::move(inputs), {std::move(out)}) {
-  padding_ = std::vector<char>{};
+func::func(input input, output out) : func(nullptr, {std::move(input)}, {std::move(out)}) {}
+
+func::func(std::vector<input> inputs, output out, std::vector<box_expr> out_crops)
+    : func(nullptr, std::move(inputs), {std::move(out)}) {
+  output_crops_ = std::move(out_crops);
 }
 
 func::func(func&& m) noexcept { *this = std::move(m); }
@@ -122,8 +134,6 @@ stmt func::make_call() const {
     }
     return call_stmt::make(impl_, std::move(inputs), std::move(outputs));
   } else {
-    // Only copies that leave padding unmodified can have multiple inputs.
-    assert((padding_ && padding_->empty()) || inputs_.size() == 1);
     std::vector<stmt> copies;
     for (const func::input& input : inputs_) {
       assert(outputs_.size() == 1);
@@ -140,6 +150,37 @@ stmt func::make_call() const {
     }
     return block::make(std::move(copies));
   }
+}
+
+func func::make_concat(std::vector<buffer_expr_ptr> in, output out, std::size_t dim, std::vector<expr> bounds) {
+  assert(in.size() + 1 == bounds.size());
+  std::size_t rank = out.buffer->rank();
+
+  std::vector<box_expr> crops;
+  std::vector<func::input> inputs;
+  for (std::size_t i = 0; i < in.size(); ++i) {
+    // Translate the bounds into the crop needed by make_copy.
+    // We leave the dimensions not concatenated undefined so infer_bounds will require each input to provide the full
+    // output in those dimensions.
+    box_expr crop;
+    crop.resize(dim + 1);
+    crop[dim] = range(bounds[i], bounds[i + 1]);
+    crops.push_back(crop);
+
+    // Prepare the input.
+    assert(in[i]->rank() == rank);
+    func::input input;
+    input.buffer = in[i];
+    input.bounds.resize(rank);
+    for (std::size_t d = 0; d < rank; ++d) {
+      input.bounds[d] = point(out.dims[d]);
+    }
+    // We translate the input by the bounds to make concatenation a bit more natural (the concatenated buffers will
+    // start at index 0 in the concatenated dimension).
+    input.bounds[dim] -= bounds[i];
+    inputs.push_back(std::move(input));
+  }
+  return make_copy(std::move(inputs), std::move(out), std::move(crops));
 }
 
 namespace {
@@ -273,6 +314,7 @@ public:
   stmt add_input_crops(stmt result, const func* f) {
     // Find the bounds of the outputs required in each dimension. This is the union of the all the intervals from each
     // output associated with a particular dimension.
+    assert(!f->outputs().empty());
     symbol_map<expr> output_mins, output_maxs;
     for (const func::output& o : f->outputs()) {
       for (std::size_t d = 0; d < o.dims.size(); ++d) {
@@ -285,17 +327,33 @@ public:
       }
     }
     // Use the output bounds, and the bounds expressions of the inputs, to determine the bounds required of the input.
-    for (const func::input& i : f->inputs()) {
-      box_expr crop(i.buffer->rank());
+    for (std::size_t i = 0; i < f->inputs().size(); ++i) {
+      symbol_map<expr> output_mins_in = output_mins;
+      symbol_map<expr> output_maxs_in = output_maxs;
+      if (i < f->output_crops().size()) {
+        // We have an output crop for this input. Apply it to our bounds.
+        const box_expr& crop = f->output_crops()[i];
+        assert(f->outputs().size() == 1);
+        const func::output& o = f->outputs().front();
+        for (std::size_t d = 0; d < o.dims.size(); ++d) {
+          std::optional<expr>& min = output_mins_in[o.dims[d]];
+          std::optional<expr>& max = output_maxs_in[o.dims[d]];
+          assert(min);
+          assert(max);
+          if (crop[d].min.defined()) min = slinky::max(*min, crop[d].min);
+          if (crop[d].max.defined()) max = slinky::min(*max, crop[d].max);
+        }
+      }
+
+      const func::input& in = f->inputs()[i];
+      box_expr crop(in.buffer->rank());
       for (int d = 0; d < static_cast<int>(crop.size()); ++d) {
-        // TODO (https://github.com/dsharlet/slinky/issues/21): We may have been given bounds on the input that are
-        // smaller than the bounds implied by the output, e.g. in the case of copy with padding.
-        expr min = substitute(i.bounds[d].min, output_mins);
-        expr max = substitute(i.bounds[d].max, output_maxs);
+        expr min = substitute(in.bounds[d].min, output_mins_in);
+        expr max = substitute(in.bounds[d].max, output_maxs_in);
         // The bounds may have been negated.
         crop[d] = simplify(slinky::bounds(min, max) | slinky::bounds(max, min));
       }
-      result = crop_buffer::make(i.sym(), crop, result);
+      result = crop_buffer::make(in.sym(), crop, result);
     }
     return result;
   }

--- a/builder/pipeline.cc
+++ b/builder/pipeline.cc
@@ -332,6 +332,8 @@ public:
       symbol_map<expr> output_maxs_in = output_maxs;
       if (i < f->output_crops().size()) {
         // We have an output crop for this input. Apply it to our bounds.
+        // TODO: It would be nice if this were simply a crop_buffer inserted in the right place. However, that is
+        // difficult to do because it could be used in several places, each with a different output crop to apply.
         const box_expr& crop = f->output_crops()[i];
         assert(f->outputs().size() == 1);
         const func::output& o = f->outputs().front();

--- a/builder/pipeline_test.cc
+++ b/builder/pipeline_test.cc
@@ -1073,7 +1073,7 @@ TEST(pipeline, padded_stencil) {
     var y(ctx, "y");
 
     func add = func::make(add_1<short>, {{in, {point(x), point(y)}}}, {{intm, {x, y}}});
-    func padded = func::make_copy({intm, {point(x), point(y)}}, {padded_intm, {x, y}}, out->bounds(), {{6, 0}});
+    func padded = func::make_copy({intm, {point(x), point(y)}, out->bounds()}, {padded_intm, {x, y}}, {{6, 0}});
     func stencil = func::make(sum3x3<short>, {{padded_intm, {bounds(-1, 1) + x, bounds(-1, 1) + y}}}, {{out, {x, y}}});
 
     switch (schedule) {

--- a/builder/pipeline_test.cc
+++ b/builder/pipeline_test.cc
@@ -1014,22 +1014,17 @@ TEST(pipeline, concatenated_result) {
     auto intm1 = buffer_expr::make(ctx, "intm1", sizeof(short), 2);
     auto intm2 = buffer_expr::make(ctx, "intm2", sizeof(short), 2);
 
-    intm1->dim(1).bounds = in1->dim(1).bounds;
-    intm2->dim(1).bounds = in2->dim(1).bounds;
-
     var x(ctx, "x");
     var y(ctx, "y");
 
     // In this pipeline, the result is copied to the output. We should just compute the result directly in the output.
     func add1 = func::make(add_1<short>, {{{in1, {point(x), point(y)}}}}, {{{intm1, {x, y}}}});
     func add2 = func::make(add_1<short>, {{{in2, {point(x), point(y)}}}}, {{{intm2, {x, y}}}});
-    func concatenated = func::make_copy(
-        {intm1, {point(x), point(y)}}, {intm2, {point(x), point(y - in1->dim(1).extent())}}, {out, {x, y}});
+    func concatenated =
+        func::make_concat({intm1, intm2}, {out, {x, y}}, 1, {0, in1->dim(1).extent(), out->dim(1).extent()});
 
-    // TODO(https://github.com/dsharlet/slinky/issues/21): The checks on the input bounds are overzealous in this case.
-    // We shouldn't need to disable checks.
     pipeline p =
-        build_pipeline(ctx, {in1, in2}, {out}, build_options{.no_checks = true, .no_alias_buffers = no_alias_buffers});
+        build_pipeline(ctx, {in1, in2}, {out}, build_options{.no_alias_buffers = no_alias_buffers});
 
     // Run the pipeline.
     const int W = 20;
@@ -1074,14 +1069,11 @@ TEST(pipeline, padded_stencil) {
     auto intm = buffer_expr::make(ctx, "intm", sizeof(short), 2);
     auto padded_intm = buffer_expr::make(ctx, "padded_intm", sizeof(short), 2);
 
-    intm->dim(0).bounds = out->dim(0).bounds;
-    intm->dim(1).bounds = out->dim(1).bounds;
-
     var x(ctx, "x");
     var y(ctx, "y");
 
     func add = func::make(add_1<short>, {{in, {point(x), point(y)}}}, {{intm, {x, y}}});
-    func padded = func::make_copy({intm, {point(x), point(y)}}, {padded_intm, {x, y}}, {{6, 0}});
+    func padded = func::make_copy({intm, {point(x), point(y)}}, {padded_intm, {x, y}}, out->bounds(), {{6, 0}});
     func stencil = func::make(sum3x3<short>, {{padded_intm, {bounds(-1, 1) + x, bounds(-1, 1) + y}}}, {{out, {x, y}}});
 
     switch (schedule) {


### PR DESCRIPTION
This PR makes it so copies that are padded always have a crop that applies to the output, which defines where the padding will be applied, and more importantly, limits the bounds required of the source buffer we are (potentially) adding padding to.

This exposed some bugs in the design of the existing API, the trivial copy tests become less interesting with this change. What these two tests did (translate by an input parameter, and rely on `copy` to pad as needed) relies on the fact that the inputs to the copy were inputs to the pipeline, and the API that supported that is hard to use if the copy inputs *aren't* pipeline inputs. So, this PR removes that API entirely.