### PR TITLE
Speed up tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,3 @@ jobs:
         
       - name: Build and test with ASAN
         run: bazel test -c opt --config=asan --test_output=errors ...
-
-      - name: Build and run performance app
-        run: bazel run -c opt apps/performance

--- a/apps/BUILD
+++ b/apps/BUILD
@@ -3,7 +3,7 @@ package(
     default_visibility = ["//visibility:private"],
 )
 
-cc_binary(
+cc_test(
     name = "memcpy",
     srcs = [
         "benchmark.h",
@@ -11,7 +11,7 @@ cc_binary(
     ],
 )
 
-cc_binary(
+cc_test(
     name = "performance",
     srcs = [
         "benchmark.h",

--- a/apps/benchmark.h
+++ b/apps/benchmark.h
@@ -4,6 +4,12 @@
 #include <algorithm>
 #include <chrono>
 #include <cmath>
+#include <cstring>
+
+inline bool is_bazel_test() {
+  const char* bazel_test = getenv("BAZEL_TEST");
+  return bazel_test && strcmp(bazel_test, "1") == 0;
+}
 
 // Benchmark a call.
 template <class F>
@@ -11,7 +17,7 @@ double benchmark(F op) {
   op();
 
   const int max_trials = 10;
-  const double min_time_s = 0.5;
+  const double min_time_s = is_bazel_test() ? 0.0 : 0.5;
   double time_per_iteration_s = 0;
   long iterations = 1;
   for (int trials = 0; trials < max_trials; trials++) {

--- a/builder/simplify_test.cc
+++ b/builder/simplify_test.cc
@@ -321,7 +321,7 @@ expr make_random_expr(int depth) {
 TEST(simplify, fuzz) {
   const int seed = time(nullptr);
   srand(seed);
-  constexpr int tests = 10000;
+  constexpr int tests = 1000;
   constexpr int checks = 10;
 
   eval_context ctx;


### PR DESCRIPTION
- Don't actually benchmark the performance apps when testing
- Don't fuzz test as many expressions. I can't remember the last time this failed

This should save a few minutes for the github CI tests.