### PR TITLE
Implement simplifier rules with compile time pattern matching

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -3,6 +3,10 @@ build --action_env=BAZEL_CXXOPTS="-std=c++17:-fstrict-aliasing:-Wall:-Wsuggest-o
 build --copt=-fdiagnostics-color=always
 run --copt=-fdiagnostics-color=always
 test --copt=-fdiagnostics-color=always
+# Without --force_pic, bazel compiles a lot of cc files twice, if they are used by PIC and non-PIC targets.
+build --force_pic
+run --force_pic
+test --force_pic
 
 # Allow us to run with --config=asan
 build:asan --strip=never

--- a/builder/BUILD
+++ b/builder/BUILD
@@ -12,6 +12,7 @@ cc_library(
         "infer_bounds.cc",
         "node_mutator.cc",
         "optimizations.cc",
+        "rewrite.h",
         "simplify.cc",
         "simplify_bounds.cc",
         "simplify_exprs.cc",

--- a/builder/elementwise_test.cc
+++ b/builder/elementwise_test.cc
@@ -125,7 +125,6 @@ public:
     result_funcs.push_back(std::move(r));
   }
 
-  void visit(const wildcard*) override { std::abort(); }
   void visit(const let*) override { std::abort(); }
   void visit(const call*) override { std::abort(); }
   void visit(const logical_not*) override { std::abort(); }
@@ -229,7 +228,6 @@ public:
     for_each_index(result, [&](auto i) { result(i) = c_buf(i) ? t_buf(i) : result(i); });
   }
 
-  void visit(const wildcard*) override { std::abort(); }
   void visit(const let*) override { std::abort(); }
   void visit(const call*) override { std::abort(); }
   void visit(const logical_not*) override { std::abort(); }

--- a/builder/node_mutator.h
+++ b/builder/node_mutator.h
@@ -41,7 +41,6 @@ public:
   }
 
   void visit(const variable* op) override { set_result(op); }
-  void visit(const wildcard* op) override { set_result(op); }
   void visit(const constant* op) override { set_result(op); }
 
   void visit(const let*) override;

--- a/builder/rewrite.h
+++ b/builder/rewrite.h
@@ -25,13 +25,13 @@ struct match_context {
   }
 };
 
-inline bool match(index_t p, const expr& x, match_context& m) { return is_constant(x, p); }
-inline bool match(const expr& p, const expr& x, match_context& m) { return p.same_as(x); }
-inline expr substitute(int p, const match_context& m) { return p; }
-inline expr substitute(const expr& p, const match_context& m) { return p; }
+SLINKY_ALWAYS_INLINE inline bool match(index_t p, const expr& x, match_context& m) { return is_constant(x, p); }
+SLINKY_ALWAYS_INLINE inline bool match(const expr& p, const expr& x, match_context& m) { return p.same_as(x); }
+SLINKY_ALWAYS_INLINE inline expr substitute(int p, const match_context& m) { return p; }
+SLINKY_ALWAYS_INLINE inline expr substitute(const expr& p, const match_context& m) { return p; }
 
-inline node_type static_type(index_t) { return node_type::constant; }
-inline node_type static_type(const expr& e) { return e.type(); }
+SLINKY_ALWAYS_INLINE inline node_type static_type(index_t) { return node_type::constant; }
+SLINKY_ALWAYS_INLINE inline node_type static_type(const expr& e) { return e.type(); }
 
 class pattern_wildcard {
 public:

--- a/builder/rewrite.h
+++ b/builder/rewrite.h
@@ -7,6 +7,8 @@
 
 #include "runtime/print.h"
 
+// This pattern matching engine is heavily inspired by https://github.com/halide/Halide/blob/main/src/IRMatch.h.
+
 namespace slinky {
 namespace rewrite {
 

--- a/builder/rewrite.h
+++ b/builder/rewrite.h
@@ -84,10 +84,10 @@ template <typename T, typename A, typename B>
 class pattern_binary {
 public:
   using is_pattern = std::true_type;
-  const A& a;
-  const B& b;
+  A a;
+  B b;
 
-  pattern_binary(const A& a, const B& b) : a(a), b(b) {
+  pattern_binary(A a, B b) : a(a), b(b) {
     if (T::commutative) {
       assert(!should_commute(static_type(this->a), static_type(this->b)));
     }
@@ -116,7 +116,8 @@ bool match(const pattern_binary<T, A, B>& p, const expr& x, match_context& m) {
       // We should commute in this variant.
       return match(p.a, t->b, m) && match(p.b, t->a, m);
     }
-    return match(p.a, t->a, m) && match(p.b, t->b, m);
+    if (!match(p.a, t->a, m)) return false;
+    return match(p.b, t->b, m);
   } else {
     return false;
   }
@@ -131,7 +132,7 @@ template <typename T, typename A>
 class pattern_unary {
 public:
   using is_pattern = std::true_type;
-  const A& a;
+  A a;
 };
 
 template <typename T, typename A>
@@ -157,9 +158,9 @@ template <typename C, typename T, typename F>
 class pattern_select {
 public:
   using is_pattern = std::true_type;
-  const C& c;
-  const T& t;
-  const F& f;
+  C c;
+  T t;
+  F f;
 };
 
 template <typename C, typename T, typename F>
@@ -223,7 +224,7 @@ expr substitute(const pattern_call<Args...>& p, const match_context& m) {
 template <typename T>
 class replacement_is_finite {
 public:
-  const T& a;
+  T a;
 };
 
 template <typename T>
@@ -239,7 +240,7 @@ bool substitute(const replacement_is_finite<T>& r, const match_context& m) {
 template <typename T>
 class replacement_eval {
 public:
-  const T& a;
+  T a;
 };
 
 template <typename T>

--- a/builder/rewrite.h
+++ b/builder/rewrite.h
@@ -27,7 +27,7 @@ struct match_context {
 
 SLINKY_ALWAYS_INLINE inline bool match(index_t p, const expr& x, match_context& m) { return is_constant(x, p); }
 SLINKY_ALWAYS_INLINE inline bool match(const expr& p, const expr& x, match_context& m) { return p.same_as(x); }
-SLINKY_ALWAYS_INLINE inline expr substitute(int p, const match_context& m) { return p; }
+SLINKY_ALWAYS_INLINE inline expr substitute(index_t p, const match_context& m) { return p; }
 SLINKY_ALWAYS_INLINE inline expr substitute(const expr& p, const match_context& m) { return p; }
 
 SLINKY_ALWAYS_INLINE inline node_type static_type(index_t) { return node_type::constant; }

--- a/builder/rewrite.h
+++ b/builder/rewrite.h
@@ -5,8 +5,6 @@
 #include "runtime/evaluate.h"
 #include "runtime/expr.h"
 
-#include "runtime/print.h"
-
 // This pattern matching engine is heavily inspired by https://github.com/halide/Halide/blob/main/src/IRMatch.h.
 
 namespace slinky {

--- a/builder/rewrite.h
+++ b/builder/rewrite.h
@@ -370,7 +370,7 @@ class rewriter {
   const expr& x;
 
   template <typename Pattern>
-  bool variant_match(const Pattern& p, const expr& x, match_context& ctx) {
+  bool variant_match(const Pattern& p, match_context& ctx) {
     for (int variant = 0;; ++variant) {
       ctx.variant = variant;
       ctx.variant_bits = 0;
@@ -395,7 +395,7 @@ public:
   template <typename Pattern, typename Replacement>
   bool rewrite(const Pattern& p, const Replacement& r) {
     match_context ctx;
-    if (!variant_match(p, x, ctx)) return false;
+    if (!variant_match(p, ctx)) return false;
 
     result = substitute(r, ctx);
     return true;
@@ -404,7 +404,7 @@ public:
   template <typename Pattern, typename Replacement, typename Predicate>
   bool rewrite(const Pattern& p, const Replacement& r, const Predicate& pr) {
     match_context ctx;
-    if (!variant_match(p, x, ctx)) return false;
+    if (!variant_match(p, ctx)) return false;
 
     if (!substitute(pr, ctx)) return false;
 

--- a/builder/rewrite.h
+++ b/builder/rewrite.h
@@ -1,0 +1,369 @@
+#ifndef SLINKY_BUILDER_REWRITE_H
+#define SLINKY_BUILDER_REWRITE_H
+
+#include "builder/substitute.h"
+#include "runtime/evaluate.h"
+#include "runtime/expr.h"
+
+#include "runtime/print.h"
+
+namespace slinky {
+namespace rewrite {
+
+constexpr int max_symbol = 4;
+
+struct match_context {
+  std::array<expr, max_symbol> vars;
+  std::array<std::optional<index_t>, max_symbol> constants;
+};
+
+inline bool match(index_t p, const expr& x, match_context& m) { return is_constant(x, p); }
+inline bool match(const expr& p, const expr& x, match_context& m) { return p.same_as(x); }
+inline expr substitute(int p, const match_context& m) { return p; }
+inline expr substitute(const expr& p, const match_context& m) { return p; }
+
+inline node_type static_type(index_t) { return node_type::constant; }
+inline node_type static_type(const expr& e) { return e.type(); }
+
+class pattern_variable {
+public:
+  using is_pattern = std::true_type;
+  int sym;
+};
+
+inline node_type static_type(const pattern_variable&) { return node_type::variable; }
+
+inline bool match(const pattern_variable& p, const expr& x, match_context& m) {
+  if (m.vars[p.sym].defined()) {
+    return slinky::match(x, m.vars[p.sym]);
+  } else {
+    m.vars[p.sym] = x;
+    return true;
+  }
+}
+
+inline expr substitute(const pattern_variable& p, const match_context& m) { return m.vars[p.sym]; }
+
+class pattern_constant {
+public:
+  using is_pattern = std::true_type;
+  int sym;
+};
+
+inline node_type static_type(const pattern_constant&) { return node_type::constant; }
+
+inline bool match(const pattern_constant& p, const expr& x, match_context& m) {
+  if (const constant* c = x.as<constant>()) {
+    if (m.constants[p.sym]) {
+      return *m.constants[p.sym] == c->value;
+    } else {
+      m.constants[p.sym] = c->value;
+      return true;
+    }
+  }
+  return false;
+}
+
+expr substitute(const pattern_constant& p, const match_context& m) {
+  assert(m.constants[p.sym]);
+  return *m.constants[p.sym];
+}
+
+template <typename T, typename A, typename B>
+class pattern_binary {
+public:
+  using is_pattern = std::true_type;
+  A a;
+  B b;
+
+  pattern_binary(A a, B b) : a(std::move(a)), b(std::move(b)) {
+    if (typename T::commutative()) {
+      assert(static_type(this->a) <= static_type(this->b));
+    }
+  }
+};
+
+template <typename T, typename A, typename B>
+inline node_type static_type(const pattern_binary<T, A, B>&) {
+  return T::static_type;
+}
+
+template <typename T, typename A, typename B>
+bool match(const pattern_binary<T, A, B>& p, const expr& x, match_context& m) {
+  if (const T* t = x.as<T>()) {
+    return match(p.a, t->a, m) && match(p.b, t->b, m);
+  } else {
+    return false;
+  }
+}
+
+template <typename T, typename A, typename B>
+expr substitute(const pattern_binary<T, A, B>& p, const match_context& m) {
+  return T::make(substitute(p.a, m), substitute(p.b, m));
+}
+
+template <typename T, typename A>
+class pattern_unary {
+public:
+  using is_pattern = std::true_type;
+  A a;
+};
+
+template <typename T, typename A>
+inline node_type static_type(const pattern_unary<T, A>&) {
+  return T::static_type;
+}
+
+template <typename T, typename A>
+bool match(const pattern_unary<T, A>& p, const expr& x, match_context& m) {
+  if (const T* t = x.as<T>()) {
+    return match(p.a, t->a, m);
+  } else {
+    return false;
+  }
+}
+
+template <typename T, typename A>
+expr substitute(const pattern_unary<T, A>& p, const match_context& m) {
+  return T::make(substitute(p.a, m));
+}
+
+template <typename C, typename T, typename F>
+class pattern_select {
+public:
+  using is_pattern = std::true_type;
+  C c;
+  T t;
+  F f;
+};
+
+template <typename C, typename T, typename F>
+inline node_type static_type(const pattern_select<C, T, F>&) {
+  return node_type::select;
+}
+
+template <typename C, typename T, typename F>
+bool match(const pattern_select<C, T, F>& p, const expr& x, match_context& m) {
+  if (const class select* s = x.as<class select>()) {
+    return match(p.c, s->condition, m) && match(p.t, s->true_value, m) && match(p.f, s->false_value, m);
+  } else {
+    return false;
+  }
+}
+
+template <typename C, typename T, typename F>
+expr substitute(const pattern_select<C, T, F>& p, const match_context& m) {
+  return select::make(substitute(p.c, m), substitute(p.t, m), substitute(p.f, m));
+}
+
+template <typename... Args>
+class pattern_call {
+public:
+  using is_pattern = std::true_type;
+  slinky::intrinsic fn;
+  std::tuple<Args...> args;
+};
+
+template <typename... Args>
+inline node_type static_type(const pattern_call<Args...>&) {
+  return node_type::call;
+}
+
+template <typename T, std::size_t... Is>
+bool match_tuple(const T& t, const std::vector<expr>& x, match_context& m, std::index_sequence<Is...>) {
+  return (... && match(std::get<Is>(t), x[Is], m));
+}
+
+template <typename T, std::size_t... Is>
+std::vector<expr> substitute_tuple(const T& t, const match_context& m, std::index_sequence<Is...>) {
+  return {substitute(std::get<Is>(t), m)...};
+}
+
+template <typename... Args>
+bool match(const pattern_call<Args...>& p, const expr& x, match_context& m) {
+  if (const call* c = x.as<call>()) {
+    if (c->intrinsic == p.fn) {
+      assert(c->args.size() == sizeof...(Args));
+      return match_tuple(p.args, c->args, m, std::make_index_sequence<sizeof...(Args)>());
+    }
+  }
+  return false;
+}
+
+template <typename... Args>
+expr substitute(const pattern_call<Args...>& p, const match_context& m) {
+  return call::make(p.fn, substitute_tuple(p.args, m, std::make_index_sequence<sizeof...(Args)>()));
+}
+
+template <typename T>
+class replacement_is_finite {
+public:
+  T a;
+};
+
+template <typename T>
+inline node_type static_type(const replacement_is_finite<T>&) {
+  return node_type::call;
+}
+
+template <typename T>
+bool substitute(const replacement_is_finite<T>& r, const match_context& m) {
+  return is_finite(substitute(r.a, m));
+}
+
+template <typename T>
+class replacement_eval {
+public:
+  T a;
+};
+
+template <typename T>
+inline node_type static_type(const replacement_eval<T>&) {
+  return node_type::call;
+}
+
+template <typename T>
+index_t substitute(const replacement_eval<T>& r, const match_context& m) {
+  return evaluate(substitute(r.a, m));
+}
+
+template <typename A>
+auto operator!(const A& a) {
+  return pattern_unary<logical_not, A>{a};
+}
+template <typename A>
+auto operator-(const A& a) {
+  return pattern_binary<sub, index_t, A>{0, a};
+}
+template <typename A, typename B>
+auto operator+(const A& a, const B& b) {
+  return pattern_binary<add, A, B>{a, b};
+}
+template <typename A, typename B>
+auto operator-(const A& a, const B& b) {
+  return pattern_binary<sub, A, B>{a, b};
+}
+template <typename A, typename B>
+auto operator*(const A& a, const B& b) {
+  return pattern_binary<mul, A, B>{a, b};
+}
+template <typename A, typename B>
+auto operator/(const A& a, const B& b) {
+  return pattern_binary<div, A, B>{a, b};
+}
+template <typename A, typename B>
+auto operator%(const A& a, const B& b) {
+  return pattern_binary<mod, A, B>{a, b};
+}
+template <typename A, typename B, typename = typename A::is_pattern>
+auto operator==(const A& a, const B& b) {
+  return pattern_binary<equal, A, B>{a, b};
+}
+template <typename A, typename B, typename = typename A::is_pattern>
+auto operator!=(const A& a, const B& b) {
+  return pattern_binary<not_equal, A, B>{a, b};
+}
+template <typename A, typename B>
+auto operator<(const A& a, const B& b) {
+  return pattern_binary<less, A, B>{a, b};
+}
+template <typename A, typename B>
+auto operator<=(const A& a, const B& b) {
+  return pattern_binary<less_equal, A, B>{a, b};
+}
+template <typename A, typename B>
+auto operator>(const A& a, const B& b) {
+  return pattern_binary<less, B, A>{b, a};
+}
+template <typename A, typename B>
+auto operator>=(const A& a, const B& b) {
+  return pattern_binary<less_equal, B, A>{b, a};
+}
+template <typename A, typename B, typename = typename A::is_pattern>
+auto operator&&(const A& a, const B& b) {
+  return pattern_binary<logical_and, A, B>{a, b};
+}
+template <typename A, typename B, typename = typename A::is_pattern>
+auto operator||(const A& a, const B& b) {
+  return pattern_binary<logical_or, A, B>{a, b};
+}
+template <typename A, typename B>
+auto min(const A& a, const B& b) {
+  return pattern_binary<class min, A, B>{a, b};
+}
+template <typename A, typename B>
+auto max(const A& a, const B& b) {
+  return pattern_binary<class max, A, B>{a, b};
+}
+template <typename C, typename T, typename F>
+auto select(const C& c, const T& t, const F& f) {
+  return pattern_select<C, T, F>{c, t, f};
+}
+template <typename T>
+auto abs(const T& x) {
+  return pattern_call<T>{intrinsic::abs, {x}};
+}
+template <typename T>
+auto is_finite(const T& x) {
+  return replacement_is_finite<T>{x};
+}
+
+using buffer_dim_meta = pattern_call<pattern_variable, pattern_variable>;
+
+inline auto buffer_min(const pattern_variable& buf, const pattern_variable& dim) {
+  return buffer_dim_meta{intrinsic::buffer_min, {buf, dim}};
+}
+inline auto buffer_max(const pattern_variable& buf, const pattern_variable& dim) {
+  return buffer_dim_meta{intrinsic::buffer_max, {buf, dim}};
+}
+inline auto buffer_extent(const pattern_variable& buf, const pattern_variable& dim) {
+  return buffer_dim_meta{intrinsic::buffer_extent, {buf, dim}};
+}
+
+template <typename T>
+auto eval(const T& x) {
+  return replacement_eval<T>{x};
+}
+
+class rewriter {
+  const expr& x;
+
+public:
+  expr result;
+
+  rewriter(const expr& x) : x(x) {}
+
+  template <typename Pattern, typename Replacement>
+  bool rewrite(const Pattern& p, const Replacement& r) {
+    match_context m;
+    if (!match(p, x, m)) return false;
+
+    result = substitute(r, m);
+    return true;
+  }
+
+  template <typename Pattern, typename Replacement, typename Predicate>
+  bool rewrite(const Pattern& p, const Replacement& r, const Predicate& pr) {
+    match_context m;
+    if (!match(p, x, m)) return false;
+
+    if (!substitute(eval(pr), m)) return false;
+
+    result = substitute(r, m);
+    return true;
+  }
+};
+
+static pattern_variable x{0};
+static pattern_variable y{1};
+static pattern_variable z{2};
+static pattern_variable w{3};
+
+static pattern_constant c0{0};
+static pattern_constant c1{1};
+static pattern_constant c2{2};
+
+}  // namespace rewrite
+}  // namespace slinky
+
+#endif  // SLINKY_BUILDER_REWRITE_H

--- a/builder/rewrite.h
+++ b/builder/rewrite.h
@@ -44,7 +44,7 @@ SLINKY_ALWAYS_INLINE inline node_type static_type(const pattern_wildcard&) { ret
 inline bool match(const pattern_wildcard& p, const expr& x, match_context& m) {
   if (m.vars[p.sym]) {
     // Try pointer comparison first to short circuit the full match.
-    return x.get() == m.vars[p.sym] || slinky::match(x, m.vars[p.sym]);
+    return x.get() == m.vars[p.sym] || slinky::compare(x, m.vars[p.sym]) == 0;
   } else if (x.get()) {
     m.vars[p.sym] = x.get();
     return true;

--- a/builder/rewrite.h
+++ b/builder/rewrite.h
@@ -10,6 +10,7 @@
 namespace slinky {
 namespace rewrite {
 
+// The maximum number of values pattern_wildcard::idx and pattern_constant::idx can have, starting from 0.
 constexpr int symbol_count = 4;
 constexpr int constant_count = 3;
 
@@ -18,18 +19,12 @@ struct match_context {
   const index_t* constants[constant_count];
   int variant;
   int variant_bits;
-
-  void clear() {
-    // Memset initializing these makes debug builds significantly faster.
-    memset(vars, 0, sizeof(vars));
-    memset(constants, 0, sizeof(constants));
-  }
 };
 
 SLINKY_ALWAYS_INLINE inline bool match(index_t p, const expr& x, match_context& ctx) { return is_constant(x, p); }
-SLINKY_ALWAYS_INLINE inline bool match(const expr& p, const expr& x, match_context& ctx) { 
+SLINKY_ALWAYS_INLINE inline bool match(const expr& p, const expr& x, match_context& ctx) {
   // We can use same_as here because expressions used in patterns should be canonical constants.
-  return p.same_as(x); 
+  return p.same_as(x);
 }
 SLINKY_ALWAYS_INLINE inline expr substitute(index_t p, const match_context& ctx) { return p; }
 SLINKY_ALWAYS_INLINE inline expr substitute(const expr& p, const match_context& ctx) { return p; }
@@ -59,7 +54,7 @@ inline bool match(const pattern_wildcard& p, const expr& x, match_context& ctx) 
 
 inline expr substitute(const pattern_wildcard& p, const match_context& ctx) {
   assert(ctx.vars[p.idx]);
-  return ctx.vars[p.idx]; 
+  return ctx.vars[p.idx];
 }
 
 class pattern_constant {
@@ -372,9 +367,8 @@ class rewriter {
   template <typename Pattern>
   bool variant_match(const Pattern& p, match_context& ctx) {
     for (int variant = 0;; ++variant) {
+      memset(&ctx, 0, sizeof(ctx));
       ctx.variant = variant;
-      ctx.variant_bits = 0;
-      ctx.clear();
       if (match(p, x, ctx)) {
         return true;
       }

--- a/builder/simplify.cc
+++ b/builder/simplify.cc
@@ -267,7 +267,7 @@ public:
       args_bounds.push_back(std::move(i_bounds));
     }
 
-    expr e = simplify(op, std::move(args));
+    expr e = simplify(op, op->intrinsic, std::move(args));
     if (e.same_as(op)) {
       set_result(e, bounds_of(op, std::move(args_bounds)));
     } else {

--- a/builder/simplify.h
+++ b/builder/simplify.h
@@ -40,7 +40,7 @@ expr simplify(const logical_and* op, expr a, expr b);
 expr simplify(const logical_or* op, expr a, expr b);
 expr simplify(const logical_not* op, expr a);
 expr simplify(const class select* op, expr c, expr t, expr f);
-expr simplify(const call* op, std::vector<expr> args);
+expr simplify(const call* op, intrinsic fn, std::vector<expr> args);
 
 // Helpers for producing the bounds of ops.
 interval_expr bounds_of(const class min* op, interval_expr a, interval_expr b);

--- a/builder/simplify_bounds.cc
+++ b/builder/simplify_bounds.cc
@@ -100,7 +100,11 @@ interval_expr bounds_of(const div* op, interval_expr a, interval_expr b) {
     return a | -a;
   }
 }
-interval_expr bounds_of(const mod* op, interval_expr a, interval_expr b) { return {0, max(abs(b.min), abs(b.max))}; }
+interval_expr bounds_of(const mod* op, interval_expr a, interval_expr b) {
+  return {0, simplify(static_cast<const class max*>(nullptr),
+                 simplify(static_cast<const class call*>(nullptr), intrinsic::abs, {b.min}),
+                 simplify(static_cast<const class call*>(nullptr), intrinsic::abs, {b.max}))};
+  }
 
 interval_expr bounds_of(const class min* op, interval_expr a, interval_expr b) {
   return bounds_of_linear(op, std::move(a), std::move(b));
@@ -153,8 +157,8 @@ interval_expr bounds_of(const call* op, std::vector<interval_expr> args) {
     if (is_positive(args[0].min)) {
       return {args[0].min, args[0].max};
     } else {
-      expr abs_min = simplify(op, {args[0].min});
-      expr abs_max = simplify(op, {args[0].max});
+      expr abs_min = simplify(op, intrinsic::abs, {args[0].min});
+      expr abs_max = simplify(op, intrinsic::abs, {args[0].max});
       return {0, simplify(static_cast<const class max*>(nullptr), std::move(abs_min), std::move(abs_max))};
     }
   default: return {op, op};

--- a/builder/simplify_exprs.cc
+++ b/builder/simplify_exprs.cc
@@ -7,7 +7,6 @@
 #include "builder/rewrite.h"
 #include "builder/substitute.h"
 #include "runtime/evaluate.h"
-#include "runtime/print.h"
 
 namespace slinky {
 

--- a/builder/simplify_exprs.cc
+++ b/builder/simplify_exprs.cc
@@ -476,8 +476,8 @@ expr simplify(const less_equal* op, expr a, expr b) {
       r.rewrite(x <= c1 - y, x + y <= c1) ||
       r.rewrite(x + c0 <= y + c1, x - y <= eval(c1 - c0)) ||
 
-      r.rewrite((x + c0) / c1 <= x / c1, c0 <= 0) ||
-      r.rewrite(x / c1 <= (x + c0) / c1, 0 <= c0) ||
+      r.rewrite((x + c0) / c1 <= x / c1, eval(c0 <= 0)) ||
+      r.rewrite(x / c1 <= (x + c0) / c1, eval(0 <= c0)) ||
 
       r.rewrite(x <= x + y, 0 <= y) ||
       r.rewrite(x + y <= x, y <= 0) ||
@@ -495,13 +495,13 @@ expr simplify(const less_equal* op, expr a, expr b) {
       r.rewrite(min(x, y) <= max(x, y), true) ||
       r.rewrite(max(x, y) <= min(x, y), x == y) ||
 
-      r.rewrite(c0 <= max(x, c1), c0 <= x || c0 <= c1) ||
-      r.rewrite(c0 <= min(x, c1), c0 <= x && c0 <= c1) ||
-      r.rewrite(max(x, c0) <= c1, x <= c1 && c0 <= c1) ||
-      r.rewrite(min(x, c0) <= c1, x <= c1 || c0 <= c1) ||
+      r.rewrite(c0 <= max(x, c1), c0 <= x || eval(c0 <= c1)) ||
+      r.rewrite(c0 <= min(x, c1), c0 <= x && eval(c0 <= c1)) ||
+      r.rewrite(max(x, c0) <= c1, x <= c1 && eval(c0 <= c1)) ||
+      r.rewrite(min(x, c0) <= c1, x <= c1 || eval(c0 <= c1)) ||
 
-      r.rewrite(buffer_extent(x, y) <= c0, false, c0 <= 0) ||
-      r.rewrite(c0 <= buffer_extent(x, y), true, c0 <= 0) ||
+      r.rewrite(buffer_extent(x, y) <= c0, false, eval(c0 <= 0)) ||
+      r.rewrite(c0 <= buffer_extent(x, y), true, eval(c0 <= 0)) ||
       false) {
     return r.result;
   }
@@ -528,7 +528,7 @@ expr simplify(const equal* op, expr a, expr b) {
   rewriter r(e);
   if (r.rewrite(x == x, true) ||
       r.rewrite(x + c0 == c1, x == eval(c1 - c0)) ||
-      r.rewrite(c0 - x == c1, -x == eval(c1 - c0), c0 != 0) ||
+      r.rewrite(c0 - x == c1, -x == eval(c1 - c0), eval(c0 != 0)) ||
       false) {
     return r.result;
   }
@@ -555,7 +555,7 @@ expr simplify(const not_equal* op, expr a, expr b) {
   rewriter r(e);
   if (r.rewrite(x != x, false) ||
       r.rewrite(x + c0 != c1, x != eval(c1 - c0)) ||
-      r.rewrite(c0 - x != c1, -x != eval(c1 - c0), c0 != 0) ||
+      r.rewrite(c0 - x != c1, -x != eval(c1 - c0), eval(c0 != 0)) ||
       false) {
     return r.result;
   }

--- a/builder/simplify_exprs.cc
+++ b/builder/simplify_exprs.cc
@@ -4,232 +4,14 @@
 #include <cassert>
 #include <iostream>
 
+#include "builder/rewrite.h"
 #include "builder/substitute.h"
 #include "runtime/evaluate.h"
 #include "runtime/print.h"
 
 namespace slinky {
 
-namespace {
-
-expr x = variable::make(0);
-expr y = variable::make(1);
-expr z = variable::make(2);
-expr w = variable::make(3);
-
-expr c0 = wildcard::make(10, as_constant);
-expr c1 = wildcard::make(11, as_constant);
-expr c2 = wildcard::make(12, as_constant);
-
-expr finite_x = wildcard::make(20, is_finite);
-
-// Check if a and b are out of (canonical) order.
-bool should_commute(const expr& a, const expr& b) {
-  auto order = [](node_type t) {
-    switch (t) {
-    case node_type::constant: return 100;
-    case node_type::wildcard: return 99;
-    case node_type::variable: return 0;
-    case node_type::call: return -1;
-    default: return 1;
-    }
-  };
-  int ra = order(a.type());
-  int rb = order(b.type());
-  if (ra > rb) return true;
-
-  const call* ca = a.as<call>();
-  const call* cb = b.as<call>();
-  if (ca && cb) {
-    if (ca->intrinsic > cb->intrinsic) return true;
-  }
-
-  return false;
-}
-
-// Rules that are not in canonical order are unnecessary or may cause infinite loops.
-// This visitor checks that all commutable operations are in canonical order.
-class assert_canonical : public recursive_node_visitor {
-public:
-  template <typename T>
-  void check(const T* op) {
-    if (should_commute(op->a, op->b)) {
-      std::cerr << "Non-canonical operands: " << expr(op) << std::endl;
-      std::abort();
-    }
-    op->a.accept(this);
-    op->b.accept(this);
-  }
-
-  void visit(const add* op) override { check(op); };
-  void visit(const mul* op) override { check(op); };
-  void visit(const class min* op) override { check(op); };
-  void visit(const class max* op) override { check(op); };
-  void visit(const equal* op) override { check(op); };
-  void visit(const not_equal* op) override { check(op); };
-  void visit(const logical_and* op) override { check(op); };
-  void visit(const logical_or* op) override { check(op); };
-};
-
-// We need to generate a lot of rules that are equivalent except for commutation.
-// To avoid repetitive error-prone code, we can generate all the valid commutative
-// equivalents of an expression.
-class commute_variants : public node_visitor {
-public:
-  std::vector<expr> results;
-
-  void visit(const variable* op) override { results = {op}; }
-  void visit(const wildcard* op) override { results = {op}; }
-  void visit(const constant* op) override { results = {op}; }
-  void visit(const let* op) override { std::abort(); }
-
-  template <typename T>
-  void visit_binary(bool commutative, const T* op) {
-    // TODO: I think some of these patterns are redundant, but finding them is tricky.
-
-    op->a.accept(this);
-    std::vector<expr> a = std::move(results);
-    op->b.accept(this);
-    std::vector<expr> b = std::move(results);
-
-    results.clear();
-    results.reserve(a.size() * b.size());
-    for (const expr& i : a) {
-      for (const expr& j : b) {
-        if (match(i, j)) {
-          results.push_back(T::make(i, j));
-        } else {
-          results.push_back(T::make(i, j));
-          if (commutative) {
-            results.push_back(T::make(j, i));
-          }
-        }
-      }
-    }
-  }
-
-  void visit(const add* op) override { visit_binary(true, op); }
-  void visit(const sub* op) override { visit_binary(false, op); }
-  void visit(const mul* op) override { visit_binary(true, op); }
-  void visit(const div* op) override { visit_binary(false, op); }
-  void visit(const mod* op) override { visit_binary(false, op); }
-  void visit(const class min* op) override { visit_binary(true, op); }
-  void visit(const class max* op) override { visit_binary(true, op); }
-  void visit(const equal* op) override { visit_binary(true, op); }
-  void visit(const not_equal* op) override { visit_binary(true, op); }
-  void visit(const less* op) override { visit_binary(false, op); }
-  void visit(const less_equal* op) override { visit_binary(false, op); }
-  void visit(const logical_and* op) override { visit_binary(true, op); }
-  void visit(const logical_or* op) override { visit_binary(true, op); }
-  void visit(const logical_not* op) override {
-    op->a.accept(this);
-    for (expr& i : results) {
-      i = !i;
-    }
-  }
-  void visit(const class select* op) override {
-    op->condition.accept(this);
-    std::vector<expr> c = std::move(results);
-    op->true_value.accept(this);
-    std::vector<expr> t = std::move(results);
-    op->false_value.accept(this);
-    std::vector<expr> f = std::move(results);
-
-    results.clear();
-    results.reserve(c.size() * t.size() * f.size());
-    for (const expr& i : c) {
-      for (const expr& j : t) {
-        for (const expr& k : f) {
-          results.push_back(select::make(i, j, k));
-        }
-      }
-    }
-  }
-
-  void visit(const call* op) override {
-    if (op->args.size() == 1) {
-      op->args.front().accept(this);
-      for (expr& i : results) {
-        i = call::make(op->intrinsic, {i});
-      }
-    } else {
-      results = {op};
-    }
-  }
-
-  void visit(const let_stmt* op) override { std::abort(); }
-  void visit(const block* op) override { std::abort(); }
-  void visit(const loop* op) override { std::abort(); }
-  void visit(const call_stmt* op) override { std::abort(); }
-  void visit(const copy_stmt* op) override { std::abort(); }
-  void visit(const allocate* op) override { std::abort(); }
-  void visit(const make_buffer* op) override { std::abort(); }
-  void visit(const clone_buffer* op) override { std::abort(); }
-  void visit(const crop_buffer* op) override { std::abort(); }
-  void visit(const crop_dim* op) override { std::abort(); }
-  void visit(const slice_buffer* op) override { std::abort(); }
-  void visit(const slice_dim* op) override { std::abort(); }
-  void visit(const truncate_rank* op) override { std::abort(); }
-  void visit(const check* op) override { std::abort(); }
-};
-
-class rule_set {
-public:
-  struct rule {
-    expr pattern;
-    expr replacement;
-    expr predicate;
-
-    rule(expr p, expr r, expr pr = expr())
-        : pattern(std::move(p)), replacement(std::move(r)), predicate(std::move(pr)) {
-      assert_canonical v;
-      replacement.accept(&v);
-    }
-  };
-
-private:
-  std::vector<rule> rules_;
-
-public:
-  rule_set(std::initializer_list<rule> rules) {
-    for (const rule& i : rules) {
-      commute_variants v;
-      i.pattern.accept(&v);
-
-      for (expr& p : v.results) {
-        rules_.emplace_back(std::move(p), i.replacement, i.predicate);
-      }
-    }
-  }
-
-  expr apply(expr op) {
-    // std::cerr << "apply_rules: " << op << std::endl;
-    symbol_map<expr> matches;
-    for (const rule& r : rules_) {
-      matches.clear();
-      // std::cerr << "  Considering " << r.pattern << std::endl;
-      if (match(r.pattern, op, matches)) {
-        // std::cerr << "  Matched:" << std::endl;
-        // for (const auto& i : matches) {
-        //   std::cerr << "    " << i.first << ": " << i.second << std::endl;
-        // }
-
-        if (!r.predicate.defined() || prove_true(substitute(r.predicate, matches))) {
-          // std::cerr << "  Applied " << r.pattern << " -> " << r.replacement << std::endl;
-          op = substitute(r.replacement, matches);
-          // std::cerr << "  Result: " << op << std::endl;
-          return op;
-        } else {
-          // std::cerr << "  Failed predicate: " << r.predicate << std::endl;
-        }
-      }
-    }
-    // std::cerr << "  Failed" << std::endl;
-    return op;
-  }
-};
-
-}  // namespace
+using namespace rewrite;
 
 expr simplify(const class min* op, expr a, expr b) {
   if (should_commute(a, b)) {
@@ -247,51 +29,53 @@ expr simplify(const class min* op, expr a, expr b) {
     e = min::make(std::move(a), std::move(b));
   }
 
-  static rule_set rules = {
-      // Constant simplifications
-      {min(x, indeterminate()), indeterminate()},
-      {min(x, std::numeric_limits<index_t>::max()), x},
-      {min(x, positive_infinity()), x},
-      {min(x, std::numeric_limits<index_t>::min()), std::numeric_limits<index_t>::min()},
-      {min(x, negative_infinity()), negative_infinity()},
-      {min(min(x, c0), c1), min(x, min(c0, c1))},
-      {min(x, x + c0), x, c0 > 0},
-      {min(x, x + c0), x + c0, c0 < 0},
-      {min(x + c0, c1), min(x, c1 - c0) + c0},
-      {min(c0 - x, c0 - y), c0 - max(x, y)},
-      {min(x, -x), -abs(x)},
-      {min(x + c0, c0 - x), c0 - abs(x)},
+  rewriter r(e);
+  if (// Constant simplifications
+      r.rewrite(min(x, indeterminate()), indeterminate()) ||
+      r.rewrite(min(x, std::numeric_limits<index_t>::max()), x) ||
+      r.rewrite(min(x, positive_infinity()), x) ||
+      r.rewrite(min(x, std::numeric_limits<index_t>::min()), std::numeric_limits<index_t>::min()) ||
+      r.rewrite(min(x, negative_infinity()), negative_infinity()) ||
+      r.rewrite(min(min(x, c0), c1), min(x, min(c0, c1))) ||
+      r.rewrite(min(x, x + c0), x, c0 > 0) ||
+      r.rewrite(min(x, x + c0), x + c0, c0 < 0) ||
+      r.rewrite(min(x + c0, c1), min(x, c1 - c0) + c0) ||
+      r.rewrite(min(c0 - x, c0 - y), c0 - max(x, y)) ||
+      r.rewrite(min(x, -x), -abs(x)) ||
+      r.rewrite(min(x + c0, c0 - x), c0 - abs(x)) ||
 
       // Algebraic simplifications
-      {min(x, x), x},
-      {min(x, max(x, y)), x},
-      {min(x, min(x, y)), min(x, y)},
-      {min(min(x, y), y + c0), min(x, min(y, y + c0))},
-      {min(min(x, y + c0), y), min(x, min(y, y + c0))},
-      {min(max(x, y), min(x, z)), min(x, z)},
-      {min(min(x, y), min(x, z)), min(x, min(y, z))},
-      {min(max(x, y), max(x, z)), max(x, min(y, z))},
-      {min(x, min(y, x + z)), min(y, min(x, x + z))},
-      {min(x, min(y, x - z)), min(y, min(x, x - z))},
-      {min(min(x, (y + z)), (y + w)), min(x, min(y + z, y + w))},
-      {min(x / z, y / z), min(x, y) / z, z > 0},
-      {min(x / z, y / z), max(x, y) / z, z < 0},
-      {min(x * z, y * z), z * min(x, y), z > 0},
-      {min(x * z, y * z), z * max(x, y), z < 0},
-      {min(x + z, y + z), z + min(x, y)},
-      {min(x - z, y - z), min(x, y) - z},
-      {min(z - x, z - y), z - max(x, y)},
-      {min(x + z, z - y), z + min(x, -y)},
+      r.rewrite(min(x, x), x) ||
+      r.rewrite(min(x, max(x, y)), x) ||
+      r.rewrite(min(x, min(x, y)), min(x, y)) ||
+      r.rewrite(min(y + c0, min(x, y)), min(x, min(y, y + c0))) ||
+      r.rewrite(min(y, min(x, y + c0)), min(x, min(y, y + c0))) ||
+      r.rewrite(min(min(x, y), max(x, z)), min(x, y)) ||
+      r.rewrite(min(min(x, y), min(x, z)), min(x, min(y, z))) ||
+      r.rewrite(min(max(x, y), max(x, z)), max(x, min(y, z))) ||
+      r.rewrite(min(x, min(y, x + z)), min(y, min(x, x + z))) ||
+      r.rewrite(min(x, min(y, x - z)), min(y, min(x, x - z))) ||
+      r.rewrite(min((y + w), min(x, (y + z))), min(x, min(y + z, y + w))) ||
+      r.rewrite(min(x / z, y / z), min(x, y) / z, z > 0) ||
+      r.rewrite(min(x / z, y / z), max(x, y) / z, z < 0) ||
+      r.rewrite(min(x * z, y * z), z * min(x, y), z > 0) ||
+      r.rewrite(min(x * z, y * z), z * max(x, y), z < 0) ||
+      r.rewrite(min(x + z, y + z), z + min(x, y)) ||
+      r.rewrite(min(x - z, y - z), min(x, y) - z) ||
+      r.rewrite(min(z - x, z - y), z - max(x, y)) ||
+      r.rewrite(min(x + z, z - y), z + min(x, -y)) ||
 
       // Buffer meta simplifications
       // TODO: These rules are sketchy, they assume buffer_max(x, y) > buffer_min(x, y), which
       // is true if we disallow empty buffers...
-      {min(buffer_min(x, y), buffer_max(x, y)), buffer_min(x, y)},
-      {min(buffer_min(x, y), buffer_max(x, y) + c0), buffer_min(x, y), c0 > 0},
-      {min(buffer_max(x, y), buffer_min(x, y) + c0), buffer_min(x, y) + c0, c0 < 0},
-      {min(buffer_max(x, y) + c0, buffer_min(x, y) + c1), buffer_min(x, y) + c1, c0 > c1},
-  };
-  return rules.apply(e);
+      r.rewrite(min(buffer_min(x, y), buffer_max(x, y)), buffer_min(x, y)) ||
+      r.rewrite(min(buffer_max(x, y) + c0, buffer_min(x, y)), buffer_min(x, y), c0 > 0) ||
+      r.rewrite(min(buffer_min(x, y) + c0, buffer_max(x, y)), buffer_min(x, y) + c0, c0 < 0) ||
+      r.rewrite(min(buffer_max(x, y) + c0, buffer_min(x, y) + c1), buffer_min(x, y) + c1, c0 > c1) || 
+      false) {
+    return r.result;
+  }
+  return e;
 }
 
 expr simplify(const class max* op, expr a, expr b) {
@@ -310,47 +94,49 @@ expr simplify(const class max* op, expr a, expr b) {
     e = max::make(std::move(a), std::move(b));
   }
 
-  static rule_set rules = {
-      // Constant simplifications
-      {max(x, indeterminate()), indeterminate()},
-      {max(x, std::numeric_limits<index_t>::min()), x},
-      {max(x, negative_infinity()), x},
-      {max(x, std::numeric_limits<index_t>::max()), std::numeric_limits<index_t>::max()},
-      {max(x, positive_infinity()), positive_infinity()},
-      {max(max(x, c0), c1), max(x, max(c0, c1))},
-      {max(x, x + c0), x + c0, c0 > 0},
-      {max(x, x + c0), x, c0 < 0},
-      {max(x + c0, c1), max(x, c1 - c0) + c0},
-      {max(c0 - x, c0 - y), c0 - min(x, y)},
-      {max(x, -x), abs(x)},
-      {max(x + c0, c0 - x), abs(x) + c0},
+  rewriter r(e);
+  if (// Constant simplifications
+      r.rewrite(max(x, indeterminate()), indeterminate()) ||
+      r.rewrite(max(x, std::numeric_limits<index_t>::min()), x) ||
+      r.rewrite(max(x, negative_infinity()), x) ||
+      r.rewrite(max(x, std::numeric_limits<index_t>::max()), std::numeric_limits<index_t>::max()) ||
+      r.rewrite(max(x, positive_infinity()), positive_infinity()) ||
+      r.rewrite(max(max(x, c0), c1), max(x, max(c0, c1))) ||
+      r.rewrite(max(x, x + c0), x + c0, c0 > 0) ||
+      r.rewrite(max(x, x + c0), x, c0 < 0) ||
+      r.rewrite(max(x + c0, c1), max(x, c1 - c0) + c0) ||
+      r.rewrite(max(c0 - x, c0 - y), c0 - min(x, y)) ||
+      r.rewrite(max(x, -x), abs(x)) ||
+      r.rewrite(max(x + c0, c0 - x), abs(x) + c0) ||
 
       // Algebraic simplifications
-      {max(x, x), x},
-      {max(x, min(x, y)), x},
-      {max(x, max(x, y)), max(x, y)},
-      {max(max(x, y), y + c0), max(x, max(y, y + c0))},
-      {max(max(x, y + c0), y), max(x, max(y, y + c0))},
-      {max(min(x, y), max(x, z)), max(x, z)},
-      {max(max(x, y), max(x, z)), max(x, max(y, z))},
-      {max(min(x, y), min(x, z)), min(x, max(y, z))},
-      {max(x, max(y, x + z)), max(y, max(x, x + z))},
-      {max(x, max(y, x - z)), max(y, max(x, x - z))},
-      {max(x / z, y / z), max(x, y) / z, z > 0},
-      {max(x / z, y / z), min(x, y) / z, z < 0},
-      {max(x * z, y * z), z * max(x, y), z > 0},
-      {max(x * z, y * z), z * min(x, y), z < 0},
-      {max(x + z, y + z), z + max(x, y)},
-      {max(x - z, y - z), max(x, y) - z},
-      {max(z - x, z - y), z - min(x, y)},
+      r.rewrite(max(x, x), x) ||
+      r.rewrite(max(x, min(x, y)), x) ||
+      r.rewrite(max(x, max(x, y)), max(x, y)) ||
+      r.rewrite(max(y + c0, max(x, y)), max(x, max(y, y + c0))) ||
+      r.rewrite(max(y, max(x, y + c0)), max(x, max(y, y + c0))) ||
+      r.rewrite(max(min(x, y), max(x, z)), max(x, z)) ||
+      r.rewrite(max(max(x, y), max(x, z)), max(x, max(y, z))) ||
+      r.rewrite(max(min(x, y), min(x, z)), min(x, max(y, z))) ||
+      r.rewrite(max(x, max(y, x + z)), max(y, max(x, x + z))) ||
+      r.rewrite(max(x, max(y, x - z)), max(y, max(x, x - z))) ||
+      r.rewrite(max(x / z, y / z), max(x, y) / z, z > 0) ||
+      r.rewrite(max(x / z, y / z), min(x, y) / z, z < 0) ||
+      r.rewrite(max(x * z, y * z), z * max(x, y), z > 0) ||
+      r.rewrite(max(x * z, y * z), z * min(x, y), z < 0) ||
+      r.rewrite(max(x + z, y + z), z + max(x, y)) ||
+      r.rewrite(max(x - z, y - z), max(x, y) - z) ||
+      r.rewrite(max(z - x, z - y), z - min(x, y)) ||
 
       // Buffer meta simplifications
-      {max(buffer_min(x, y), buffer_max(x, y)), buffer_max(x, y)},
-      {max(buffer_min(x, y), buffer_max(x, y) + c0), buffer_max(x, y) + c0, c0 > 0},
-      {max(buffer_max(x, y), buffer_min(x, y) + c0), buffer_max(x, y), c0 < 0},
-      {max(buffer_max(x, y) + c0, buffer_min(x, y) + c1), buffer_max(x, y) + c0, c0 > c1},
-  };
-  return rules.apply(e);
+      r.rewrite(max(buffer_min(x, y), buffer_max(x, y)), buffer_max(x, y)) ||
+      r.rewrite(max(buffer_max(x, y) + c0, buffer_min(x, y)), buffer_max(x, y) + c0, c0 > 0) ||
+      r.rewrite(max(buffer_min(x, y) + c0, buffer_max(x, y)), buffer_max(x, y), c0 < 0) ||
+      r.rewrite(max(buffer_max(x, y) + c0, buffer_min(x, y) + c1), buffer_max(x, y) + c0, c0 > c1) || 
+      false) {
+    return r.result;
+  }
+  return e;
 }
 
 expr simplify(const add* op, expr a, expr b) {
@@ -369,63 +155,65 @@ expr simplify(const add* op, expr a, expr b) {
     e = add::make(std::move(a), std::move(b));
   }
 
-  static rule_set rules = {
-      {x + indeterminate(), indeterminate()},
-      {positive_infinity() + indeterminate(), indeterminate()},
-      {negative_infinity() + positive_infinity(), indeterminate()},
-      {finite_x + positive_infinity(), positive_infinity()},
-      {finite_x + negative_infinity(), negative_infinity()},
-      {x + 0, x},
-      {x + x, x * 2},
-      {x + (x + y), y + x * 2},
-      {x + (x - y), x * 2 - y},
-      {x + (y - x), y},
-      //{x + x * y, x * (y + 1)},  // Needs x to be non-constant or it loops with c0 * (x + c1) -> c0 * x + c0 * c1...
+  rewriter r(e);
+  if (r.rewrite(x + indeterminate(), indeterminate()) ||
+      r.rewrite(positive_infinity() + indeterminate(), indeterminate()) ||
+      r.rewrite(negative_infinity() + positive_infinity(), indeterminate()) ||
+      r.rewrite(x + positive_infinity(), positive_infinity(), is_finite(x)) ||
+      r.rewrite(x + negative_infinity(), negative_infinity(), is_finite(x)) ||
+      r.rewrite(x + 0, x) ||
+      r.rewrite(x + x, x * 2) ||
+      r.rewrite(x + (x + y), y + x * 2) ||
+      r.rewrite(x + (x - y), x * 2 - y) ||
+      r.rewrite(x + (y - x), y) ||
+      //r.rewrite(x + x * y, x * (y + 1)) ||  // Needs x to be non-constant or it loops with c0 * (x + c1) -> c0 * x + c0 * c1...
       // how?
-      {x * y + x * z, x * (y + z)},
-      {(x + y) + (x + z), x * 2 + (y + z)},
-      {(x - y) + (x + z), x * 2 + (z - y)},
-      {(y - x) + (x + z), y + z},
-      {(x + y) + (x - z), x * 2 + (y - z)},
-      {(x + y) + (z - x), y + z},
-      {(x - y) + (x - z), x * 2 - (y + z)},
-      {(y - x) + (x - z), y - z},
-      {(x - y) + (z - x), z - y},
-      {(y - x) + (z - x), (y + z) + x * -2},
+      r.rewrite(x * y + x * z, x * (y + z)) ||
+      r.rewrite((x + y) + (x + z), (y + z) + x * 2) ||
+      r.rewrite((x + z) + (x - y), (z - y) + x * 2) ||
+      r.rewrite((x + z) + (y - x), y + z) ||
+      r.rewrite((x + y) + (x - z), (y - z) + x * 2) ||
+      r.rewrite((x + y) + (z - x), y + z) ||
+      r.rewrite((x - y) + (x - z), x * 2 - (y + z)) ||
+      r.rewrite((y - x) + (x - z), y - z) ||
+      r.rewrite((x - y) + (z - x), z - y) ||
+      r.rewrite((y - x) + (z - x), (y + z) + x * -2) ||
 
-      {(x + c0) + c1, x + (c0 + c1)},
-      {(c0 - x) + c1, (c0 + c1) - x},
-      {x + (c0 - y), (x - y) + c0},
-      {x + (y + c0), (x + y) + c0},
-      {(x + c0) + (y + c1), (x + y) + (c0 + c1)},
+      r.rewrite((x + c0) + c1, x + (c0 + c1)) ||
+      r.rewrite((c0 - x) + c1, (c0 + c1) - x) ||
+      r.rewrite(x + (c0 - y), (x - y) + c0) ||
+      r.rewrite(x + (y + c0), (x + y) + c0) ||
+      r.rewrite((x + c0) + (y + c1), (x + y) + (c0 + c1)) ||
 
-      {min(x, y - z) + z, min(y, x + z)},
-      {max(x, y - z) + z, max(y, x + z)},
+      r.rewrite(z + min(x, y - z), min(y, x + z)) ||
+      r.rewrite(z + max(x, y - z), max(y, x + z)) ||
 
-      {min(x + c0, y + c1) + c2, min(x + (c0 + c2), y + (c1 + c2))},
-      {max(x + c0, y + c1) + c2, max(x + (c0 + c2), y + (c1 + c2))},
-      {min(c0 - x, y + c1) + c2, min((c0 + c2) - x, y + (c1 + c2))},
-      {max(c0 - x, y + c1) + c2, max((c0 + c2) - x, y + (c1 + c2))},
-      {min(c0 - x, c1 - y) + c2, min((c0 + c2) - x, (c1 + c2) - y)},
-      {max(c0 - x, c1 - y) + c2, max((c0 + c2) - x, (c1 + c2) - y)},
-      {min(x, y + c0) + c1, min(x + c1, y + (c0 + c1))},
-      {max(x, y + c0) + c1, max(x + c1, y + (c0 + c1))},
+      r.rewrite(min(x + c0, y + c1) + c2, min(x + (c0 + c2), y + (c1 + c2))) ||
+      r.rewrite(max(x + c0, y + c1) + c2, max(x + (c0 + c2), y + (c1 + c2))) ||
+      r.rewrite(min(y + c1, c0 - x) + c2, min(y + (c1 + c2), (c0 + c2) - x)) ||
+      r.rewrite(max(y + c1, c0 - x) + c2, max(y + (c1 + c2), (c0 + c2) - x)) ||
+      r.rewrite(min(c0 - x, c1 - y) + c2, min((c0 + c2) - x, (c1 + c2) - y)) ||
+      r.rewrite(max(c0 - x, c1 - y) + c2, max((c0 + c2) - x, (c1 + c2) - y)) ||
+      r.rewrite(min(x, y + c0) + c1, min(x + c1, y + (c0 + c1))) ||
+      r.rewrite(max(x, y + c0) + c1, max(x + c1, y + (c0 + c1))) ||
 
-      {select(x, c0, c1) + c2, select(x, c0 + c2, c1 + c2)},
-      {select(x, y + c0, c1) + c2, select(x, y + (c0 + c2), c1 + c2)},
-      {select(x, c0 - y, c1) + c2, select(x, (c0 + c2) - y, c1 + c2)},
-      {select(x, c0, y + c1) + c2, select(x, c0 + c2, y + (c1 + c2))},
-      {select(x, c0, c1 - y) + c2, select(x, c0 + c2, (c1 + c2) - y)},
-      {select(x, y + c0, z + c1) + c2, select(x, y + (c0 + c2), z + (c1 + c2))},
-      {select(x, c0 - y, z + c1) + c2, select(x, (c0 + c2) - y, z + (c1 + c2))},
-      {select(x, y + c0, c1 - z) + c2, select(x, y + (c0 + c2), (c1 + c2) - z)},
-      {select(x, c0 - y, c1 - z) + c2, select(x, (c0 + c2) - y, (c1 + c2) - z)},
+      r.rewrite(select(x, c0, c1) + c2, select(x, c0 + c2, c1 + c2)) ||
+      r.rewrite(select(x, y + c0, c1) + c2, select(x, y + (c0 + c2), c1 + c2)) ||
+      r.rewrite(select(x, c0 - y, c1) + c2, select(x, (c0 + c2) - y, c1 + c2)) ||
+      r.rewrite(select(x, c0, y + c1) + c2, select(x, c0 + c2, y + (c1 + c2))) ||
+      r.rewrite(select(x, c0, c1 - y) + c2, select(x, c0 + c2, (c1 + c2) - y)) ||
+      r.rewrite(select(x, y + c0, z + c1) + c2, select(x, y + (c0 + c2), z + (c1 + c2))) ||
+      r.rewrite(select(x, c0 - y, z + c1) + c2, select(x, (c0 + c2) - y, z + (c1 + c2))) ||
+      r.rewrite(select(x, y + c0, c1 - z) + c2, select(x, y + (c0 + c2), (c1 + c2) - z)) ||
+      r.rewrite(select(x, c0 - y, c1 - z) + c2, select(x, (c0 + c2) - y, (c1 + c2) - z)) ||
 
-      {buffer_min(x, y) + buffer_extent(x, y), buffer_max(x, y) + 1},
-      {buffer_min(x, y) + (z - buffer_max(x, y)), (z - buffer_extent(x, y)) + 1},
-      {buffer_max(x, y) + (z - buffer_min(x, y)), (buffer_extent(x, y) + z) + -1},
-  };
-  return rules.apply(e);
+      r.rewrite(buffer_min(x, y) + buffer_extent(x, y), buffer_max(x, y) + 1) ||
+      r.rewrite((z - buffer_max(x, y)) + buffer_min(x, y), (z - buffer_extent(x, y)) + 1) ||
+      r.rewrite((z - buffer_min(x, y)) + buffer_max(x, y), (z + buffer_extent(x, y)) + -1) || 
+      false) {
+    return r.result;
+  }
+  return e;
 }
 
 expr simplify(const sub* op, expr a, expr b) {
@@ -447,53 +235,55 @@ expr simplify(const sub* op, expr a, expr b) {
     e = sub::make(std::move(a), std::move(b));
   }
 
-  static rule_set rules = {
-      {x - indeterminate(), indeterminate()},
-      {indeterminate() - x, indeterminate()},
-      {positive_infinity() - positive_infinity(), indeterminate()},
-      {positive_infinity() - negative_infinity(), positive_infinity()},
-      {negative_infinity() - negative_infinity(), indeterminate()},
-      {negative_infinity() - positive_infinity(), negative_infinity()},
-      {finite_x - positive_infinity(), negative_infinity()},
-      {finite_x - negative_infinity(), positive_infinity()},
-      {x - x, 0},
-      {x - 0, x},
-      {x - c0 * y, x + y * (-c0)},
-      {x - (c0 - y), (x + y) - c0},
-      {c0 - (x - y), (y - x) + c0},
-      {x - (y + c0), (x - y) - c0},
-      {(c0 - x) - y, c0 - (x + y)},
-      {(x + c0) - y, (x - y) + c0},
-      {(x + y) - x, y},
-      {(x - y) - x, -y},
-      {x - (x + y), -y},
-      {x - (x - y), y},
-      {(x + y) - (x + z), y - z},
-      {(x - y) - (z - y), x - z},
-      {(x - y) - (x - z), z - y},
-      {(c0 - x) - (y - z), ((z - x) - y) + c0},
-      {(x + c0) - (y + c1), (x - y) + (c0 - c1)},
+  rewriter r(e);
+  if (r.rewrite(x - indeterminate(), indeterminate()) ||
+      r.rewrite(indeterminate() - x, indeterminate()) ||
+      r.rewrite(positive_infinity() - positive_infinity(), indeterminate()) ||
+      r.rewrite(positive_infinity() - negative_infinity(), positive_infinity()) ||
+      r.rewrite(negative_infinity() - negative_infinity(), indeterminate()) ||
+      r.rewrite(negative_infinity() - positive_infinity(), negative_infinity()) ||
+      r.rewrite(x - positive_infinity(), negative_infinity(), is_finite(x)) ||
+      r.rewrite(x - negative_infinity(), positive_infinity(), is_finite(x)) ||
+      r.rewrite(x - x, 0) ||
+      r.rewrite(x - 0, x) ||
+      r.rewrite(x - y * c0, x + y * (-c0)) ||
+      r.rewrite(x - (c0 - y), (x + y) - c0) ||
+      r.rewrite(c0 - (x - y), (y - x) + c0) ||
+      r.rewrite(x - (y + c0), (x - y) - c0) ||
+      r.rewrite((c0 - x) - y, c0 - (x + y)) ||
+      r.rewrite((x + c0) - y, (x - y) + c0) ||
+      r.rewrite((x + y) - x, y) ||
+      r.rewrite((x - y) - x, -y) ||
+      r.rewrite(x - (x + y), -y) ||
+      r.rewrite(x - (x - y), y) ||
+      r.rewrite((x + y) - (x + z), y - z) ||
+      r.rewrite((x - y) - (z - y), x - z) ||
+      r.rewrite((x - y) - (x - z), z - y) ||
+      r.rewrite((c0 - x) - (y - z), ((z - x) - y) + c0) ||
+      r.rewrite((x + c0) - (y + c1), (x - y) + (c0 - c1)) ||
 
-      {(x + y) / c0 - x / c0, (y + (x % c0)) / c0, c0 > 0},
+      r.rewrite((x + y) / c0 - x / c0, (y + (x % c0)) / c0, c0 > 0) ||
 
-      {min(x, y + z) - z, min(y, x - z)},
-      {max(x, y + z) - z, max(y, x - z)},
+      r.rewrite(min(x, y + z) - z, min(y, x - z)) ||
+      r.rewrite(max(x, y + z) - z, max(y, x - z)) ||
 
-      {c2 - select(x, c0, c1), select(x, c2 - c0, c2 - c1)},
-      {c2 - select(x, y + c0, c1), select(x, (c2 - c0) - y, c2 - c1)},
-      {c2 - select(x, c0 - y, c1), select(x, y + (c2 - c0), c2 - c1)},
-      {c2 - select(x, c0, y + c1), select(x, c2 - c0, (c2 - c1) - y)},
-      {c2 - select(x, c0, c1 - y), select(x, c2 - c0, y + (c2 - c1))},
-      {c2 - select(x, y + c0, z + c1), select(x, (c2 - c0) - y, (c2 - c1) - z)},
-      {c2 - select(x, c0 - y, z + c1), select(x, y + (c2 - c0), (c2 - c1) - z)},
-      {c2 - select(x, y + c0, c1 - z), select(x, (c2 - c0) - y, z + (c2 - c1))},
-      {c2 - select(x, c0 - y, c1 - z), select(x, y + (c2 - c0), z + (c2 - c1))},
+      r.rewrite(c2 - select(x, c0, c1), select(x, c2 - c0, c2 - c1)) ||
+      r.rewrite(c2 - select(x, y + c0, c1), select(x, (c2 - c0) - y, c2 - c1)) ||
+      r.rewrite(c2 - select(x, c0 - y, c1), select(x, y + (c2 - c0), c2 - c1)) ||
+      r.rewrite(c2 - select(x, c0, y + c1), select(x, c2 - c0, (c2 - c1) - y)) ||
+      r.rewrite(c2 - select(x, c0, c1 - y), select(x, c2 - c0, y + (c2 - c1))) ||
+      r.rewrite(c2 - select(x, y + c0, z + c1), select(x, (c2 - c0) - y, (c2 - c1) - z)) ||
+      r.rewrite(c2 - select(x, c0 - y, z + c1), select(x, y + (c2 - c0), (c2 - c1) - z)) ||
+      r.rewrite(c2 - select(x, y + c0, c1 - z), select(x, (c2 - c0) - y, z + (c2 - c1))) ||
+      r.rewrite(c2 - select(x, c0 - y, c1 - z), select(x, y + (c2 - c0), z + (c2 - c1))) ||
 
-      {buffer_max(x, y) - buffer_min(x, y), buffer_extent(x, y) + -1},
-      {buffer_max(x, y) - (buffer_min(x, y) + z), (buffer_extent(x, y) - z) + -1},
-      {(buffer_max(x, y) + z) - buffer_min(x, y), (buffer_extent(x, y) + z) + -1},
-  };
-  return rules.apply(e);
+      r.rewrite(buffer_max(x, y) - buffer_min(x, y), buffer_extent(x, y) + -1) ||
+      r.rewrite(buffer_max(x, y) - (z + buffer_min(x, y)), (buffer_extent(x, y) - z) + -1) ||
+      r.rewrite((z + buffer_max(x, y)) - buffer_min(x, y), (z + buffer_extent(x, y)) + -1) ||
+      false) {
+    return r.result;
+  }
+  return e;
 }
 
 expr simplify(const mul* op, expr a, expr b) {
@@ -512,23 +302,25 @@ expr simplify(const mul* op, expr a, expr b) {
     e = mul::make(std::move(a), std::move(b));
   }
 
-  static rule_set rules = {
-      {x * indeterminate(), indeterminate()},
-      {positive_infinity() * positive_infinity(), positive_infinity()},
-      {negative_infinity() * positive_infinity(), negative_infinity()},
-      {negative_infinity() * negative_infinity(), positive_infinity()},
-      {c0 * positive_infinity(), positive_infinity(), c0 > 0},
-      {c0 * negative_infinity(), negative_infinity(), c0 > 0},
-      {c0 * positive_infinity(), negative_infinity(), c0 < 0},
-      {c0 * negative_infinity(), positive_infinity(), c0 < 0},
-      {x * 0, 0},
-      {x * 1, x},
-      {(x * c0) * c1, x * (c0 * c1)},
-      {(x + c0) * c1, x * c1 + c0 * c1},
-      {(0 - x) * c1, x * (-c1)},
-      {(c0 - x) * c1, c0 * c1 - x * c1},
-  };
-  return rules.apply(e);
+  rewriter r(e);
+  if (r.rewrite(x * indeterminate(), indeterminate()) ||
+      r.rewrite(positive_infinity() * positive_infinity(), positive_infinity()) ||
+      r.rewrite(negative_infinity() * positive_infinity(), negative_infinity()) ||
+      r.rewrite(negative_infinity() * negative_infinity(), positive_infinity()) ||
+      r.rewrite(positive_infinity() * c0, positive_infinity(), c0 > 0) ||
+      r.rewrite(negative_infinity() * c0, negative_infinity(), c0 > 0) ||
+      r.rewrite(positive_infinity() * c0, negative_infinity(), c0 < 0) ||
+      r.rewrite(negative_infinity() * c0, positive_infinity(), c0 < 0) ||
+      r.rewrite(x * 0, 0) ||
+      r.rewrite(x * 1, x) ||
+      r.rewrite((x * c0) * c1, x * eval(c0 * c1)) ||
+      r.rewrite((x + c0) * c1, x * c1 + c0 * c1) ||
+      r.rewrite((0 - x) * c1, x * (-c1)) ||
+      r.rewrite((c0 - x) * c1, c0 * c1 - x * c1) ||
+      false) {
+    return r.result;
+  }
+  return e;
 }
 
 expr simplify(const div* op, expr a, expr b) {
@@ -544,33 +336,35 @@ expr simplify(const div* op, expr a, expr b) {
     e = div::make(std::move(a), std::move(b));
   }
 
-  static rule_set rules = {
-      {x / indeterminate(), indeterminate()},
-      {indeterminate() / x, indeterminate()},
-      {positive_infinity() / positive_infinity(), indeterminate()},
-      {positive_infinity() / negative_infinity(), indeterminate()},
-      {negative_infinity() / positive_infinity(), indeterminate()},
-      {negative_infinity() / negative_infinity(), indeterminate()},
-      {finite_x / positive_infinity(), 0},
-      {finite_x / negative_infinity(), 0},
-      {positive_infinity() / c0, positive_infinity(), c0 > 0},
-      {negative_infinity() / c0, negative_infinity(), c0 > 0},
-      {positive_infinity() / c0, negative_infinity(), c0 < 0},
-      {negative_infinity() / c0, positive_infinity(), c0 < 0},
-      {x / 0, 0},
-      {0 / x, 0},
-      {x / 1, x},
-      {x / -1, -x},
-      {x / x, x != 0},
+  rewriter r(e);
+  if (r.rewrite(x / indeterminate(), indeterminate()) ||
+      r.rewrite(indeterminate() / x, indeterminate()) ||
+      r.rewrite(positive_infinity() / positive_infinity(), indeterminate()) ||
+      r.rewrite(positive_infinity() / negative_infinity(), indeterminate()) ||
+      r.rewrite(negative_infinity() / positive_infinity(), indeterminate()) ||
+      r.rewrite(negative_infinity() / negative_infinity(), indeterminate()) ||
+      r.rewrite(x / positive_infinity(), 0, is_finite(x)) ||
+      r.rewrite(x / negative_infinity(), 0, is_finite(x)) ||
+      r.rewrite(positive_infinity() / c0, positive_infinity(), c0 > 0) ||
+      r.rewrite(negative_infinity() / c0, negative_infinity(), c0 > 0) ||
+      r.rewrite(positive_infinity() / c0, negative_infinity(), c0 < 0) ||
+      r.rewrite(negative_infinity() / c0, positive_infinity(), c0 < 0) ||
+      r.rewrite(x / 0, 0) ||
+      r.rewrite(0 / x, 0) ||
+      r.rewrite(x / 1, x) ||
+      r.rewrite(x / -1, -x) ||
+      r.rewrite(x / x, x != 0) ||
 
-      {(x / c0) / c1, x / (c0 * c1), c0 > 0 && c1 > 0},
-      {(x / c0 + c1) / c2, (x + (c1 * c0)) / (c0 * c2), c0 > 0 && c2 > 0},
-      {(x * c0) / c1, x * (c0 / c1), c0 % c1 == 0 && c1 > 0},
+      r.rewrite((x / c0) / c1, x / eval(c0 * c1), c0 > 0 && c1 > 0) ||
+      r.rewrite((x / c0 + c1) / c2, (x + eval(c1 * c0)) / eval(c0 * c2), c0 > 0 && c2 > 0) ||
+      r.rewrite((x * c0) / c1, x * eval(c0 / c1), c0 % c1 == 0 && c1 > 0) ||
 
-      {(x + c0) / c1, x / c1 + c0 / c1, c0 % c1 == 0},
-      {(c0 - x) / c1, c0 / c1 + (-x / c1), c0 != 0 && c0 % c1 == 0},
-  };
-  return rules.apply(e);
+      r.rewrite((x + c0) / c1, x / c1 + eval(c0 / c1), c0 % c1 == 0) ||
+      r.rewrite((c0 - x) / c1, (-x / c1) + eval(c0 / c1), c0 % c1 == 0 && c0 != 0) ||
+      false) {
+    return r.result;
+  }
+  return e;
 }
 
 expr simplify(const mod* op, expr a, expr b) {
@@ -586,12 +380,14 @@ expr simplify(const mod* op, expr a, expr b) {
     e = mod::make(std::move(a), std::move(b));
   }
 
-  static rule_set rules = {
-      {x % 1, 0},
-      {x % 0, 0},
-      {x % x, 0},
-  };
-  return rules.apply(e);
+  rewriter r(e);
+  if (r.rewrite(x % 1, 0) || 
+      r.rewrite(x % 0, 0) || 
+      r.rewrite(x % x, 0) ||
+      false) {
+    return r.result;
+  }
+  return e;
 }
 
 expr simplify(const less* op, expr a, expr b) {
@@ -608,46 +404,48 @@ expr simplify(const less* op, expr a, expr b) {
     e = less::make(std::move(a), std::move(b));
   }
 
-  static rule_set rules = {
-      {positive_infinity() < finite_x, false},
-      {negative_infinity() < finite_x, true},
-      {finite_x < positive_infinity(), true},
-      {finite_x < negative_infinity(), false},
-      {x < x, false},
-      {x + c0 < c1, x < c1 - c0},
-      {x < x + y, 0 < y},
-      {x + y < x, y < 0},
-      {x - y < x, 0 < y},
-      {0 - x < c0, -c0 < x},
-      {c0 - x < c1, c0 - c1 < x},
-      {c0 < c1 - x, x < c1 - c0},
+  rewriter r(e);
+  if (r.rewrite(positive_infinity() < x, false, is_finite(x)) ||
+      r.rewrite(negative_infinity() < x, true, is_finite(x)) ||
+      r.rewrite(x < positive_infinity(), true, is_finite(x)) ||
+      r.rewrite(x < negative_infinity(), false, is_finite(x)) ||
+      r.rewrite(x < x, false) ||
+      r.rewrite(x + c0 < c1, x < c1 - c0) ||
+      r.rewrite(x < x + y, 0 < y) ||
+      r.rewrite(x + y < x, y < 0) ||
+      r.rewrite(x - y < x, 0 < y) ||
+      r.rewrite(0 - x < c0, -c0 < x) ||
+      r.rewrite(c0 - x < c1, c0 - c1 < x) ||
+      r.rewrite(c0 < c1 - x, x < c1 - c0) ||
 
-      {x < x + y, 0 < y},
-      {x + y < x, y < 0},
-      {x < x - y, y < 0},
-      {x - y < x, 0 < y},
-      {x + y < x + z, y < z},
-      {x - y < x - z, z < y},
-      {x - y < z - y, x < z},
+      r.rewrite(x < x + y, 0 < y) ||
+      r.rewrite(x + y < x, y < 0) ||
+      r.rewrite(x < x - y, y < 0) ||
+      r.rewrite(x - y < x, 0 < y) ||
+      r.rewrite(x + y < x + z, y < z) ||
+      r.rewrite(x - y < x - z, z < y) ||
+      r.rewrite(x - y < z - y, x < z) ||
 
-      {min(x, y) < x, y < x},
-      {min(x, min(y, z)) < y, min(x, z) < y},
-      {max(x, y) < x, false},
-      {x < max(x, y), x < y},
-      {x < min(x, y), false},
-      {min(x, y) < max(x, y), x != y},
-      {max(x, y) < min(x, y), false},
-      {min(x, y) < min(x, z), y < min(x, z)},
+      r.rewrite(min(x, y) < x, y < x) ||
+      r.rewrite(min(x, min(y, z)) < y, min(x, z) < y) ||
+      r.rewrite(max(x, y) < x, false) ||
+      r.rewrite(x < max(x, y), x < y) ||
+      r.rewrite(x < min(x, y), false) ||
+      r.rewrite(min(x, y) < max(x, y), x != y) ||
+      r.rewrite(max(x, y) < min(x, y), false) ||
+      r.rewrite(min(x, y) < min(x, z), y < min(x, z)) ||
 
-      {c0 < max(x, c1), c0 < x || c0 < c1},
-      {c0 < min(x, c1), c0 < x && c0 < c1},
-      {max(x, c0) < c1, x < c1 && c0 < c1},
-      {min(x, c0) < c1, x < c1 || c0 < c1},
+      r.rewrite(c0 < max(x, c1), c0 < x || c0 < c1) ||
+      r.rewrite(c0 < min(x, c1), c0 < x && c0 < c1) ||
+      r.rewrite(max(x, c0) < c1, x < c1 && c0 < c1) ||
+      r.rewrite(min(x, c0) < c1, x < c1 || c0 < c1) ||
 
-      {buffer_extent(x, y) < c0, false, c0 < 0},
-      {c0 < buffer_extent(x, y), true, c0 < 0},
-  };
-  return rules.apply(e);
+      r.rewrite(buffer_extent(x, y) < c0, false, c0 < 0) ||
+      r.rewrite(c0 < buffer_extent(x, y), true, c0 < 0) ||
+      false) {
+    return r.result;
+  }
+  return e;
 }
 
 expr simplify(const less_equal* op, expr a, expr b) {
@@ -664,48 +462,50 @@ expr simplify(const less_equal* op, expr a, expr b) {
     e = less_equal::make(std::move(a), std::move(b));
   }
 
-  static rule_set rules = {
-      {positive_infinity() <= finite_x, false},
-      {negative_infinity() <= finite_x, true},
-      {finite_x <= positive_infinity(), true},
-      {finite_x <= negative_infinity(), false},
-      {x <= x, true},
-      {x <= x + y, 0 <= y},
-      {x + y <= x, y <= 0},
-      {x - y <= x, 0 <= y},
-      {0 - x <= c0, -c0 <= x},
-      {c0 - x <= y, c0 <= y + x},
-      {x <= c1 - y, x + y <= c1},
-      {x + c0 <= y + c1, x - y <= c1 - c0},
+  rewriter r(e);
+  if (r.rewrite(positive_infinity() <= x, false, is_finite(x)) ||
+      r.rewrite(negative_infinity() <= x, true, is_finite(x)) ||
+      r.rewrite(x <= positive_infinity(), true, is_finite(x)) ||
+      r.rewrite(x <= negative_infinity(), false, is_finite(x)) ||
+      r.rewrite(x <= x, true) ||
+      r.rewrite(x <= x + y, 0 <= y) ||
+      r.rewrite(x + y <= x, y <= 0) ||
+      r.rewrite(x - y <= x, 0 <= y) ||
+      r.rewrite(0 - x <= c0, -c0 <= x) ||
+      r.rewrite(c0 - x <= y, c0 <= y + x) ||
+      r.rewrite(x <= c1 - y, x + y <= c1) ||
+      r.rewrite(x + c0 <= y + c1, x - y <= c1 - c0) ||
 
-      {(x + c0) / c1 <= x / c1, c0 <= 0},
-      {x / c1 <= (x + c0) / c1, 0 <= c0},
+      r.rewrite((x + c0) / c1 <= x / c1, c0 <= 0) ||
+      r.rewrite(x / c1 <= (x + c0) / c1, 0 <= c0) ||
 
-      {x <= x + y, 0 <= y},
-      {x + y <= x, y <= 0},
-      {x <= x - y, y <= 0},
-      {x - y <= x, 0 <= y},
-      {x + y <= x + z, y <= z},
-      {x - y <= x - z, z <= y},
-      {x - y <= z - y, x <= z},
+      r.rewrite(x <= x + y, 0 <= y) ||
+      r.rewrite(x + y <= x, y <= 0) ||
+      r.rewrite(x <= x - y, y <= 0) ||
+      r.rewrite(x - y <= x, 0 <= y) ||
+      r.rewrite(x + y <= x + z, y <= z) ||
+      r.rewrite(x - y <= x - z, z <= y) ||
+      r.rewrite(x - y <= z - y, x <= z) ||
 
-      {min(x, y) <= x, true},
-      {min(x, min(y, z)) <= y, true},
-      {max(x, y) <= x, y <= x},
-      {x <= max(x, y), true},
-      {x <= min(x, y), x <= y},
-      {min(x, y) <= max(x, y), true},
-      {max(x, y) <= min(x, y), x == y},
+      r.rewrite(min(x, y) <= x, true) ||
+      r.rewrite(min(x, min(y, z)) <= y, true) ||
+      r.rewrite(max(x, y) <= x, y <= x) ||
+      r.rewrite(x <= max(x, y), true) ||
+      r.rewrite(x <= min(x, y), x <= y) ||
+      r.rewrite(min(x, y) <= max(x, y), true) ||
+      r.rewrite(max(x, y) <= min(x, y), x == y) ||
 
-      {c0 <= max(x, c1), c0 <= x || c0 <= c1},
-      {c0 <= min(x, c1), c0 <= x && c0 <= c1},
-      {max(x, c0) <= c1, x <= c1 && c0 <= c1},
-      {min(x, c0) <= c1, x <= c1 || c0 <= c1},
+      r.rewrite(c0 <= max(x, c1), c0 <= x || c0 <= c1) ||
+      r.rewrite(c0 <= min(x, c1), c0 <= x && c0 <= c1) ||
+      r.rewrite(max(x, c0) <= c1, x <= c1 && c0 <= c1) ||
+      r.rewrite(min(x, c0) <= c1, x <= c1 || c0 <= c1) ||
 
-      {buffer_extent(x, y) <= c0, false, c0 <= 0},
-      {c0 <= buffer_extent(x, y), true, c0 <= 0},
-  };
-  return rules.apply(e);
+      r.rewrite(buffer_extent(x, y) <= c0, false, c0 <= 0) ||
+      r.rewrite(c0 <= buffer_extent(x, y), true, c0 <= 0) ||
+      false) {
+    return r.result;
+  }
+  return e;
 }
 
 expr simplify(const equal* op, expr a, expr b) {
@@ -724,13 +524,15 @@ expr simplify(const equal* op, expr a, expr b) {
   } else {
     e = equal::make(std::move(a), std::move(b));
   }
-
-  static rule_set rules = {
-      {x == x, true},
-      {x + c0 == c1, x == c1 - c0},
-      {c0 - x == c1, -x == c1 - c0, c0 != 0},
-  };
-  return rules.apply(e);
+  
+  rewriter r(e);
+  if (r.rewrite(x == x, true) ||
+      r.rewrite(x + c0 == c1, x == c1 - c0) ||
+      r.rewrite(c0 - x == c1, -x == c1 - c0, c0 != 0) ||
+      false) {
+    return r.result;
+  }
+  return e;
 }
 
 expr simplify(const not_equal* op, expr a, expr b) {
@@ -750,12 +552,14 @@ expr simplify(const not_equal* op, expr a, expr b) {
     e = not_equal::make(std::move(a), std::move(b));
   }
 
-  static rule_set rules = {
-      {x != x, false},
-      {x + c0 != c1, x != c1 - c0},
-      {c0 - x != c1, -x != c1 - c0, c0 != 0},
-  };
-  return rules.apply(e);
+  rewriter r(e);
+  if (r.rewrite(x != x, false) ||
+      r.rewrite(x + c0 != c1, x != c1 - c0) ||
+      r.rewrite(c0 - x != c1, -x != c1 - c0, c0 != 0) ||
+      false) {
+    return r.result;
+  }
+  return e;
 }
 
 expr simplify(const logical_and* op, expr a, expr b) {
@@ -778,14 +582,16 @@ expr simplify(const logical_and* op, expr a, expr b) {
     e = logical_and::make(std::move(a), std::move(b));
   }
 
-  static rule_set rules = {
-      {x && x, x},
-      {x && !x, false},
-      {!x && !y, !(x || y)},
-      {x && (x && y), x && y},
-      {x && (x || y), x},
-  };
-  return rules.apply(e);
+  rewriter r(e);
+  if (r.rewrite(x && x, x) ||
+      r.rewrite(x && !x, false) ||
+      r.rewrite(!x && !y, !(x || y)) ||
+      r.rewrite(x && (x && y), x && y) ||
+      r.rewrite(x && (x || y), x) ||
+      false) {
+    return r.result;
+  }
+  return e;
 }
 
 expr simplify(const logical_or* op, expr a, expr b) {
@@ -808,14 +614,16 @@ expr simplify(const logical_or* op, expr a, expr b) {
     e = logical_or::make(std::move(a), std::move(b));
   }
 
-  static rule_set rules = {
-      {x || x, x},
-      {x || !x, true},
-      {!x || !y, !(x && y)},
-      {x || (x && y), x},
-      {x || (x || y), x || y},
+  rewriter r(e);
+  if (r.rewrite(x || x, x) ||
+      r.rewrite(x || !x, true) ||
+      r.rewrite(!x || !y, !(x && y)) ||
+      r.rewrite(x || (x && y), x) ||
+      r.rewrite(x || (x || y), x || y) ||
+      false) {
+    return r.result;
   };
-  return rules.apply(e);
+  return e;
 }
 
 expr simplify(const logical_not* op, expr a) {
@@ -831,14 +639,16 @@ expr simplify(const logical_not* op, expr a) {
     e = logical_not::make(std::move(a));
   }
 
-  static rule_set rules = {
-      {!!x, x},
-      {!(x == y), x != y},
-      {!(x != y), x == y},
-      {!(x < y), y <= x},
-      {!(x <= y), y < x},
-  };
-  return rules.apply(e);
+  rewriter r(e);
+  if (r.rewrite(!!x, x) ||
+      r.rewrite(!(x == y), x != y) ||
+      r.rewrite(!(x != y), x == y) ||
+      r.rewrite(!(x < y), y <= x) ||
+      r.rewrite(!(x <= y), y < x) ||
+      false) {
+    return r.result;
+  }
+  return e;
 }
 
 expr simplify(const class select* op, expr c, expr t, expr f) {
@@ -859,16 +669,19 @@ expr simplify(const class select* op, expr c, expr t, expr f) {
   } else {
     e = select::make(std::move(c), std::move(t), std::move(f));
   }
-  static rule_set rules = {
-      {select(!x, y, z), select(x, z, y)},
+
+  rewriter r(e);
+  if (r.rewrite(select(!x, y, z), select(x, z, y)) ||
 
       // Pull common expressions out
-      {select(x, y, y + z), y + select(x, 0, z)},
-      {select(x, y + z, y), y + select(x, z, 0)},
-      {select(x, y + z, y + w), y + select(x, z, w)},
-      {select(x, z - y, w - y), select(x, z, w) - y},
-  };
-  return rules.apply(e);
+      r.rewrite(select(x, y, y + z), y + select(x, 0, z)) ||
+      r.rewrite(select(x, y + z, y), y + select(x, z, 0)) ||
+      r.rewrite(select(x, y + z, y + w), y + select(x, z, w)) ||
+      r.rewrite(select(x, z - y, w - y), select(x, z, w) - y) ||
+      false) {
+    return r.result;
+  }
+  return e;
 }
 
 expr simplify(const call* op, std::vector<expr> args) {
@@ -911,12 +724,14 @@ expr simplify(const call* op, std::vector<expr> args) {
     return evaluate(e);
   }
 
-  static rule_set rules = {
-      {abs(negative_infinity()), positive_infinity()},
-      {abs(-x), abs(x)},
-      {abs(abs(x)), abs(x)},
-  };
-  return rules.apply(e);
+  rewriter r(e);
+  if (r.rewrite(abs(negative_infinity()), positive_infinity()) || 
+      r.rewrite(abs(-x), abs(x)) ||
+      r.rewrite(abs(abs(x)), abs(x)) ||
+      false) {
+    return r.result;
+  }
+  return e;
 }
 
 }  // namespace slinky

--- a/builder/simplify_exprs.cc
+++ b/builder/simplify_exprs.cc
@@ -36,10 +36,10 @@ expr simplify(const class min* op, expr a, expr b) {
       r.rewrite(min(x, positive_infinity()), x) ||
       r.rewrite(min(x, std::numeric_limits<index_t>::min()), std::numeric_limits<index_t>::min()) ||
       r.rewrite(min(x, negative_infinity()), negative_infinity()) ||
-      r.rewrite(min(min(x, c0), c1), min(x, min(c0, c1))) ||
-      r.rewrite(min(x, x + c0), x, c0 > 0) ||
-      r.rewrite(min(x, x + c0), x + c0, c0 < 0) ||
-      r.rewrite(min(x + c0, c1), min(x, c1 - c0) + c0) ||
+      r.rewrite(min(min(x, c0), c1), min(x, eval(min(c0, c1)))) ||
+      r.rewrite(min(x, x + c0), x, eval(c0 > 0)) ||
+      r.rewrite(min(x, x + c0), x + c0, eval(c0 < 0)) ||
+      r.rewrite(min(x + c0, c1), min(x, eval(c1 - c0)) + c0) ||
       r.rewrite(min(c0 - x, c0 - y), c0 - max(x, y)) ||
       r.rewrite(min(x, -x), -abs(x)) ||
       r.rewrite(min(x + c0, c0 - x), c0 - abs(x)) ||
@@ -56,10 +56,10 @@ expr simplify(const class min* op, expr a, expr b) {
       r.rewrite(min(x, min(y, x + z)), min(y, min(x, x + z))) ||
       r.rewrite(min(x, min(y, x - z)), min(y, min(x, x - z))) ||
       r.rewrite(min((y + w), min(x, (y + z))), min(x, min(y + z, y + w))) ||
-      r.rewrite(min(x / z, y / z), min(x, y) / z, z > 0) ||
-      r.rewrite(min(x / z, y / z), max(x, y) / z, z < 0) ||
-      r.rewrite(min(x * z, y * z), z * min(x, y), z > 0) ||
-      r.rewrite(min(x * z, y * z), z * max(x, y), z < 0) ||
+      r.rewrite(min(x / c0, y / c0), min(x, y) / c0, eval(c0 > 0)) ||
+      r.rewrite(min(x / c0, y / c0), max(x, y) / c0, eval(c0 < 0)) ||
+      r.rewrite(min(x * c0, y * c0), min(x, y) * c0, eval(c0 > 0)) ||
+      r.rewrite(min(x * c0, y * c0), max(x, y) * c0, eval(c0 < 0)) ||
       r.rewrite(min(x + z, y + z), z + min(x, y)) ||
       r.rewrite(min(x - z, y - z), min(x, y) - z) ||
       r.rewrite(min(z - x, z - y), z - max(x, y)) ||
@@ -69,9 +69,9 @@ expr simplify(const class min* op, expr a, expr b) {
       // TODO: These rules are sketchy, they assume buffer_max(x, y) > buffer_min(x, y), which
       // is true if we disallow empty buffers...
       r.rewrite(min(buffer_min(x, y), buffer_max(x, y)), buffer_min(x, y)) ||
-      r.rewrite(min(buffer_max(x, y) + c0, buffer_min(x, y)), buffer_min(x, y), c0 > 0) ||
-      r.rewrite(min(buffer_min(x, y) + c0, buffer_max(x, y)), buffer_min(x, y) + c0, c0 < 0) ||
-      r.rewrite(min(buffer_max(x, y) + c0, buffer_min(x, y) + c1), buffer_min(x, y) + c1, c0 > c1) || 
+      r.rewrite(min(buffer_max(x, y) + c0, buffer_min(x, y)), buffer_min(x, y), eval(c0 > 0)) ||
+      r.rewrite(min(buffer_min(x, y) + c0, buffer_max(x, y)), buffer_min(x, y) + c0, eval(c0 < 0)) ||
+      r.rewrite(min(buffer_max(x, y) + c0, buffer_min(x, y) + c1), buffer_min(x, y) + c1, eval(c0 > c1)) || 
       false) {
     return r.result;
   }
@@ -101,10 +101,10 @@ expr simplify(const class max* op, expr a, expr b) {
       r.rewrite(max(x, negative_infinity()), x) ||
       r.rewrite(max(x, std::numeric_limits<index_t>::max()), std::numeric_limits<index_t>::max()) ||
       r.rewrite(max(x, positive_infinity()), positive_infinity()) ||
-      r.rewrite(max(max(x, c0), c1), max(x, max(c0, c1))) ||
-      r.rewrite(max(x, x + c0), x + c0, c0 > 0) ||
-      r.rewrite(max(x, x + c0), x, c0 < 0) ||
-      r.rewrite(max(x + c0, c1), max(x, c1 - c0) + c0) ||
+      r.rewrite(max(max(x, c0), c1), max(x, eval(max(c0, c1)))) ||
+      r.rewrite(max(x, x + c0), x + c0, eval(c0 > 0)) ||
+      r.rewrite(max(x, x + c0), x, eval(c0 < 0)) ||
+      r.rewrite(max(x + c0, c1), max(x, eval(c1 - c0)) + c0) ||
       r.rewrite(max(c0 - x, c0 - y), c0 - min(x, y)) ||
       r.rewrite(max(x, -x), abs(x)) ||
       r.rewrite(max(x + c0, c0 - x), abs(x) + c0) ||
@@ -120,19 +120,19 @@ expr simplify(const class max* op, expr a, expr b) {
       r.rewrite(max(min(x, y), min(x, z)), min(x, max(y, z))) ||
       r.rewrite(max(x, max(y, x + z)), max(y, max(x, x + z))) ||
       r.rewrite(max(x, max(y, x - z)), max(y, max(x, x - z))) ||
-      r.rewrite(max(x / z, y / z), max(x, y) / z, z > 0) ||
-      r.rewrite(max(x / z, y / z), min(x, y) / z, z < 0) ||
-      r.rewrite(max(x * z, y * z), z * max(x, y), z > 0) ||
-      r.rewrite(max(x * z, y * z), z * min(x, y), z < 0) ||
+      r.rewrite(max(x / c0, y / c0), max(x, y) / c0, eval(c0 > 0)) ||
+      r.rewrite(max(x / c0, y / c0), min(x, y) / c0, eval(c0 < 0)) ||
+      r.rewrite(max(x * c0, y * c0), max(x, y) * c0, eval(c0 > 0)) ||
+      r.rewrite(max(x * c0, y * c0), min(x, y) * c0, eval(c0 < 0)) ||
       r.rewrite(max(x + z, y + z), z + max(x, y)) ||
       r.rewrite(max(x - z, y - z), max(x, y) - z) ||
       r.rewrite(max(z - x, z - y), z - min(x, y)) ||
 
       // Buffer meta simplifications
       r.rewrite(max(buffer_min(x, y), buffer_max(x, y)), buffer_max(x, y)) ||
-      r.rewrite(max(buffer_max(x, y) + c0, buffer_min(x, y)), buffer_max(x, y) + c0, c0 > 0) ||
-      r.rewrite(max(buffer_min(x, y) + c0, buffer_max(x, y)), buffer_max(x, y), c0 < 0) ||
-      r.rewrite(max(buffer_max(x, y) + c0, buffer_min(x, y) + c1), buffer_max(x, y) + c0, c0 > c1) || 
+      r.rewrite(max(buffer_max(x, y) + c0, buffer_min(x, y)), buffer_max(x, y) + c0, eval(c0 > 0)) ||
+      r.rewrite(max(buffer_min(x, y) + c0, buffer_max(x, y)), buffer_max(x, y), eval(c0 < 0)) ||
+      r.rewrite(max(buffer_max(x, y) + c0, buffer_min(x, y) + c1), buffer_max(x, y) + c0, eval(c0 > c1)) || 
       false) {
     return r.result;
   }
@@ -179,33 +179,33 @@ expr simplify(const add* op, expr a, expr b) {
       r.rewrite((x - y) + (z - x), z - y) ||
       r.rewrite((y - x) + (z - x), (y + z) + x * -2) ||
 
-      r.rewrite((x + c0) + c1, x + (c0 + c1)) ||
-      r.rewrite((c0 - x) + c1, (c0 + c1) - x) ||
+      r.rewrite((x + c0) + c1, x + eval(c0 + c1)) ||
+      r.rewrite((c0 - x) + c1, eval(c0 + c1) - x) ||
       r.rewrite(x + (c0 - y), (x - y) + c0) ||
       r.rewrite(x + (y + c0), (x + y) + c0) ||
-      r.rewrite((x + c0) + (y + c1), (x + y) + (c0 + c1)) ||
+      r.rewrite((x + c0) + (y + c1), (x + y) + eval(c0 + c1)) ||
 
       r.rewrite(z + min(x, y - z), min(y, x + z)) ||
       r.rewrite(z + max(x, y - z), max(y, x + z)) ||
 
-      r.rewrite(min(x + c0, y + c1) + c2, min(x + (c0 + c2), y + (c1 + c2))) ||
-      r.rewrite(max(x + c0, y + c1) + c2, max(x + (c0 + c2), y + (c1 + c2))) ||
-      r.rewrite(min(y + c1, c0 - x) + c2, min(y + (c1 + c2), (c0 + c2) - x)) ||
-      r.rewrite(max(y + c1, c0 - x) + c2, max(y + (c1 + c2), (c0 + c2) - x)) ||
-      r.rewrite(min(c0 - x, c1 - y) + c2, min((c0 + c2) - x, (c1 + c2) - y)) ||
-      r.rewrite(max(c0 - x, c1 - y) + c2, max((c0 + c2) - x, (c1 + c2) - y)) ||
-      r.rewrite(min(x, y + c0) + c1, min(x + c1, y + (c0 + c1))) ||
-      r.rewrite(max(x, y + c0) + c1, max(x + c1, y + (c0 + c1))) ||
+      r.rewrite(min(x + c0, y + c1) + c2, min(x + eval(c0 + c2), y + eval(c1 + c2))) ||
+      r.rewrite(max(x + c0, y + c1) + c2, max(x + eval(c0 + c2), y + eval(c1 + c2))) ||
+      r.rewrite(min(y + c1, c0 - x) + c2, min(y + eval(c1 + c2), eval(c0 + c2) - x)) ||
+      r.rewrite(max(y + c1, c0 - x) + c2, max(y + eval(c1 + c2), eval(c0 + c2) - x)) ||
+      r.rewrite(min(c0 - x, c1 - y) + c2, min(eval(c0 + c2) - x, eval(c1 + c2) - y)) ||
+      r.rewrite(max(c0 - x, c1 - y) + c2, max(eval(c0 + c2) - x, eval(c1 + c2) - y)) ||
+      r.rewrite(min(x, y + c0) + c1, min(x + c1, y + eval(c0 + c1))) ||
+      r.rewrite(max(x, y + c0) + c1, max(x + c1, y + eval(c0 + c1))) ||
 
-      r.rewrite(select(x, c0, c1) + c2, select(x, c0 + c2, c1 + c2)) ||
-      r.rewrite(select(x, y + c0, c1) + c2, select(x, y + (c0 + c2), c1 + c2)) ||
-      r.rewrite(select(x, c0 - y, c1) + c2, select(x, (c0 + c2) - y, c1 + c2)) ||
-      r.rewrite(select(x, c0, y + c1) + c2, select(x, c0 + c2, y + (c1 + c2))) ||
-      r.rewrite(select(x, c0, c1 - y) + c2, select(x, c0 + c2, (c1 + c2) - y)) ||
-      r.rewrite(select(x, y + c0, z + c1) + c2, select(x, y + (c0 + c2), z + (c1 + c2))) ||
-      r.rewrite(select(x, c0 - y, z + c1) + c2, select(x, (c0 + c2) - y, z + (c1 + c2))) ||
-      r.rewrite(select(x, y + c0, c1 - z) + c2, select(x, y + (c0 + c2), (c1 + c2) - z)) ||
-      r.rewrite(select(x, c0 - y, c1 - z) + c2, select(x, (c0 + c2) - y, (c1 + c2) - z)) ||
+      r.rewrite(select(x, c0, c1) + c2, select(x, eval(c0 + c2), eval(c1 + c2))) ||
+      r.rewrite(select(x, y + c0, c1) + c2, select(x, y + eval(c0 + c2), eval(c1 + c2))) ||
+      r.rewrite(select(x, c0 - y, c1) + c2, select(x, eval(c0 + c2) - y, eval(c1 + c2))) ||
+      r.rewrite(select(x, c0, y + c1) + c2, select(x, eval(c0 + c2), y + eval(c1 + c2))) ||
+      r.rewrite(select(x, c0, c1 - y) + c2, select(x, eval(c0 + c2), eval(c1 + c2) - y)) ||
+      r.rewrite(select(x, y + c0, z + c1) + c2, select(x, y + eval(c0 + c2), z + eval(c1 + c2))) ||
+      r.rewrite(select(x, c0 - y, z + c1) + c2, select(x, eval(c0 + c2) - y, z + eval(c1 + c2))) ||
+      r.rewrite(select(x, y + c0, c1 - z) + c2, select(x, y + eval(c0 + c2), eval(c1 + c2) - z)) ||
+      r.rewrite(select(x, c0 - y, c1 - z) + c2, select(x, eval(c0 + c2) - y, eval(c1 + c2) - z)) ||
 
       r.rewrite(buffer_min(x, y) + buffer_extent(x, y), buffer_max(x, y) + 1) ||
       r.rewrite((z - buffer_max(x, y)) + buffer_min(x, y), (z - buffer_extent(x, y)) + 1) ||
@@ -260,22 +260,22 @@ expr simplify(const sub* op, expr a, expr b) {
       r.rewrite((x - y) - (z - y), x - z) ||
       r.rewrite((x - y) - (x - z), z - y) ||
       r.rewrite((c0 - x) - (y - z), ((z - x) - y) + c0) ||
-      r.rewrite((x + c0) - (y + c1), (x - y) + (c0 - c1)) ||
+      r.rewrite((x + c0) - (y + c1), (x - y) + eval(c0 - c1)) ||
 
-      r.rewrite((x + y) / c0 - x / c0, (y + (x % c0)) / c0, c0 > 0) ||
+      r.rewrite((x + y) / c0 - x / c0, (y + (x % c0)) / c0, eval(c0 > 0)) ||
 
       r.rewrite(min(x, y + z) - z, min(y, x - z)) ||
       r.rewrite(max(x, y + z) - z, max(y, x - z)) ||
 
-      r.rewrite(c2 - select(x, c0, c1), select(x, c2 - c0, c2 - c1)) ||
-      r.rewrite(c2 - select(x, y + c0, c1), select(x, (c2 - c0) - y, c2 - c1)) ||
-      r.rewrite(c2 - select(x, c0 - y, c1), select(x, y + (c2 - c0), c2 - c1)) ||
-      r.rewrite(c2 - select(x, c0, y + c1), select(x, c2 - c0, (c2 - c1) - y)) ||
-      r.rewrite(c2 - select(x, c0, c1 - y), select(x, c2 - c0, y + (c2 - c1))) ||
-      r.rewrite(c2 - select(x, y + c0, z + c1), select(x, (c2 - c0) - y, (c2 - c1) - z)) ||
-      r.rewrite(c2 - select(x, c0 - y, z + c1), select(x, y + (c2 - c0), (c2 - c1) - z)) ||
-      r.rewrite(c2 - select(x, y + c0, c1 - z), select(x, (c2 - c0) - y, z + (c2 - c1))) ||
-      r.rewrite(c2 - select(x, c0 - y, c1 - z), select(x, y + (c2 - c0), z + (c2 - c1))) ||
+      r.rewrite(c2 - select(x, c0, c1), select(x, eval(c2 - c0), eval(c2 - c1))) ||
+      r.rewrite(c2 - select(x, y + c0, c1), select(x, eval(c2 - c0) - y, eval(c2 - c1))) ||
+      r.rewrite(c2 - select(x, c0 - y, c1), select(x, y + eval(c2 - c0), eval(c2 - c1))) ||
+      r.rewrite(c2 - select(x, c0, y + c1), select(x, eval(c2 - c0), eval(c2 - c1) - y)) ||
+      r.rewrite(c2 - select(x, c0, c1 - y), select(x, eval(c2 - c0), y + eval(c2 - c1))) ||
+      r.rewrite(c2 - select(x, y + c0, z + c1), select(x, eval(c2 - c0) - y, eval(c2 - c1) - z)) ||
+      r.rewrite(c2 - select(x, c0 - y, z + c1), select(x, y + eval(c2 - c0), eval(c2 - c1) - z)) ||
+      r.rewrite(c2 - select(x, y + c0, c1 - z), select(x, eval(c2 - c0) - y, z + eval(c2 - c1))) ||
+      r.rewrite(c2 - select(x, c0 - y, c1 - z), select(x, y + eval(c2 - c0), z + eval(c2 - c1))) ||
 
       r.rewrite(buffer_max(x, y) - buffer_min(x, y), buffer_extent(x, y) + -1) ||
       r.rewrite(buffer_max(x, y) - (z + buffer_min(x, y)), (buffer_extent(x, y) - z) + -1) ||
@@ -307,16 +307,16 @@ expr simplify(const mul* op, expr a, expr b) {
       r.rewrite(positive_infinity() * positive_infinity(), positive_infinity()) ||
       r.rewrite(negative_infinity() * positive_infinity(), negative_infinity()) ||
       r.rewrite(negative_infinity() * negative_infinity(), positive_infinity()) ||
-      r.rewrite(positive_infinity() * c0, positive_infinity(), c0 > 0) ||
-      r.rewrite(negative_infinity() * c0, negative_infinity(), c0 > 0) ||
-      r.rewrite(positive_infinity() * c0, negative_infinity(), c0 < 0) ||
-      r.rewrite(negative_infinity() * c0, positive_infinity(), c0 < 0) ||
+      r.rewrite(positive_infinity() * c0, positive_infinity(), eval(c0 > 0)) ||
+      r.rewrite(negative_infinity() * c0, negative_infinity(), eval(c0 > 0)) ||
+      r.rewrite(positive_infinity() * c0, negative_infinity(), eval(c0 < 0)) ||
+      r.rewrite(negative_infinity() * c0, positive_infinity(), eval(c0 < 0)) ||
       r.rewrite(x * 0, 0) ||
       r.rewrite(x * 1, x) ||
       r.rewrite((x * c0) * c1, x * eval(c0 * c1)) ||
-      r.rewrite((x + c0) * c1, x * c1 + c0 * c1) ||
-      r.rewrite((0 - x) * c1, x * (-c1)) ||
-      r.rewrite((c0 - x) * c1, c0 * c1 - x * c1) ||
+      r.rewrite((x + c0) * c1, x * c1 + eval(c0 * c1)) ||
+      r.rewrite((0 - x) * c1, x * eval(-c1)) ||
+      r.rewrite((c0 - x) * c1, eval(c0 * c1) - x * c1) ||
       false) {
     return r.result;
   }
@@ -345,22 +345,22 @@ expr simplify(const div* op, expr a, expr b) {
       r.rewrite(negative_infinity() / negative_infinity(), indeterminate()) ||
       r.rewrite(x / positive_infinity(), 0, is_finite(x)) ||
       r.rewrite(x / negative_infinity(), 0, is_finite(x)) ||
-      r.rewrite(positive_infinity() / c0, positive_infinity(), c0 > 0) ||
-      r.rewrite(negative_infinity() / c0, negative_infinity(), c0 > 0) ||
-      r.rewrite(positive_infinity() / c0, negative_infinity(), c0 < 0) ||
-      r.rewrite(negative_infinity() / c0, positive_infinity(), c0 < 0) ||
+      r.rewrite(positive_infinity() / c0, positive_infinity(), eval(c0 > 0)) ||
+      r.rewrite(negative_infinity() / c0, negative_infinity(), eval(c0 > 0)) ||
+      r.rewrite(positive_infinity() / c0, negative_infinity(), eval(c0 < 0)) ||
+      r.rewrite(negative_infinity() / c0, positive_infinity(), eval(c0 < 0)) ||
       r.rewrite(x / 0, 0) ||
       r.rewrite(0 / x, 0) ||
       r.rewrite(x / 1, x) ||
       r.rewrite(x / -1, -x) ||
       r.rewrite(x / x, x != 0) ||
 
-      r.rewrite((x / c0) / c1, x / eval(c0 * c1), c0 > 0 && c1 > 0) ||
-      r.rewrite((x / c0 + c1) / c2, (x + eval(c1 * c0)) / eval(c0 * c2), c0 > 0 && c2 > 0) ||
-      r.rewrite((x * c0) / c1, x * eval(c0 / c1), c0 % c1 == 0 && c1 > 0) ||
+      r.rewrite((x / c0) / c1, x / eval(c0 * c1), eval(c0 > 0 && c1 > 0)) ||
+      r.rewrite((x / c0 + c1) / c2, (x + eval(c1 * c0)) / eval(c0 * c2), eval(c0 > 0 && c2 > 0)) ||
+      r.rewrite((x * c0) / c1, x * eval(c0 / c1), eval(c1 > 0 && c0 % c1 == 0)) ||
 
-      r.rewrite((x + c0) / c1, x / c1 + eval(c0 / c1), c0 % c1 == 0) ||
-      r.rewrite((c0 - x) / c1, (-x / c1) + eval(c0 / c1), c0 % c1 == 0 && c0 != 0) ||
+      r.rewrite((x + c0) / c1, x / c1 + eval(c0 / c1), eval(c0 % c1 == 0)) ||
+      r.rewrite((c0 - x) / c1, (-x / c1) + eval(c0 / c1), eval(c0 != 0 && c0 % c1 == 0)) ||
       false) {
     return r.result;
   }
@@ -410,13 +410,13 @@ expr simplify(const less* op, expr a, expr b) {
       r.rewrite(x < positive_infinity(), true, is_finite(x)) ||
       r.rewrite(x < negative_infinity(), false, is_finite(x)) ||
       r.rewrite(x < x, false) ||
-      r.rewrite(x + c0 < c1, x < c1 - c0) ||
+      r.rewrite(x + c0 < c1, x < eval(c1 - c0)) ||
       r.rewrite(x < x + y, 0 < y) ||
       r.rewrite(x + y < x, y < 0) ||
       r.rewrite(x - y < x, 0 < y) ||
       r.rewrite(0 - x < c0, -c0 < x) ||
-      r.rewrite(c0 - x < c1, c0 - c1 < x) ||
-      r.rewrite(c0 < c1 - x, x < c1 - c0) ||
+      r.rewrite(c0 - x < c1, eval(c0 - c1) < x) ||
+      r.rewrite(c0 < c1 - x, x < eval(c1 - c0)) ||
 
       r.rewrite(x < x + y, 0 < y) ||
       r.rewrite(x + y < x, y < 0) ||
@@ -435,13 +435,13 @@ expr simplify(const less* op, expr a, expr b) {
       r.rewrite(max(x, y) < min(x, y), false) ||
       r.rewrite(min(x, y) < min(x, z), y < min(x, z)) ||
 
-      r.rewrite(c0 < max(x, c1), c0 < x || c0 < c1) ||
-      r.rewrite(c0 < min(x, c1), c0 < x && c0 < c1) ||
-      r.rewrite(max(x, c0) < c1, x < c1 && c0 < c1) ||
-      r.rewrite(min(x, c0) < c1, x < c1 || c0 < c1) ||
+      r.rewrite(c0 < max(x, c1), c0 < x || eval(c0 < c1)) ||
+      r.rewrite(c0 < min(x, c1), c0 < x && eval(c0 < c1)) ||
+      r.rewrite(max(x, c0) < c1, x < c1 && eval(c0 < c1)) ||
+      r.rewrite(min(x, c0) < c1, x < c1 || eval(c0 < c1)) ||
 
-      r.rewrite(buffer_extent(x, y) < c0, false, c0 < 0) ||
-      r.rewrite(c0 < buffer_extent(x, y), true, c0 < 0) ||
+      r.rewrite(buffer_extent(x, y) < c0, false, eval(c0 < 0)) ||
+      r.rewrite(c0 < buffer_extent(x, y), true, eval(c0 < 0)) ||
       false) {
     return r.result;
   }
@@ -474,7 +474,7 @@ expr simplify(const less_equal* op, expr a, expr b) {
       r.rewrite(0 - x <= c0, -c0 <= x) ||
       r.rewrite(c0 - x <= y, c0 <= y + x) ||
       r.rewrite(x <= c1 - y, x + y <= c1) ||
-      r.rewrite(x + c0 <= y + c1, x - y <= c1 - c0) ||
+      r.rewrite(x + c0 <= y + c1, x - y <= eval(c1 - c0)) ||
 
       r.rewrite((x + c0) / c1 <= x / c1, c0 <= 0) ||
       r.rewrite(x / c1 <= (x + c0) / c1, 0 <= c0) ||
@@ -527,8 +527,8 @@ expr simplify(const equal* op, expr a, expr b) {
   
   rewriter r(e);
   if (r.rewrite(x == x, true) ||
-      r.rewrite(x + c0 == c1, x == c1 - c0) ||
-      r.rewrite(c0 - x == c1, -x == c1 - c0, c0 != 0) ||
+      r.rewrite(x + c0 == c1, x == eval(c1 - c0)) ||
+      r.rewrite(c0 - x == c1, -x == eval(c1 - c0), c0 != 0) ||
       false) {
     return r.result;
   }
@@ -554,8 +554,8 @@ expr simplify(const not_equal* op, expr a, expr b) {
 
   rewriter r(e);
   if (r.rewrite(x != x, false) ||
-      r.rewrite(x + c0 != c1, x != c1 - c0) ||
-      r.rewrite(c0 - x != c1, -x != c1 - c0, c0 != 0) ||
+      r.rewrite(x + c0 != c1, x != eval(c1 - c0)) ||
+      r.rewrite(c0 - x != c1, -x != eval(c1 - c0), c0 != 0) ||
       false) {
     return r.result;
   }
@@ -585,9 +585,12 @@ expr simplify(const logical_and* op, expr a, expr b) {
   rewriter r(e);
   if (r.rewrite(x && x, x) ||
       r.rewrite(x && !x, false) ||
+      r.rewrite(!x && x, false) ||
       r.rewrite(!x && !y, !(x || y)) ||
       r.rewrite(x && (x && y), x && y) ||
+      r.rewrite((x && y) && x, x && y) ||
       r.rewrite(x && (x || y), x) ||
+      r.rewrite((x || y) && x, x) ||
       false) {
     return r.result;
   }
@@ -617,9 +620,12 @@ expr simplify(const logical_or* op, expr a, expr b) {
   rewriter r(e);
   if (r.rewrite(x || x, x) ||
       r.rewrite(x || !x, true) ||
+      r.rewrite(!x || x, true) ||
       r.rewrite(!x || !y, !(x && y)) ||
       r.rewrite(x || (x && y), x) ||
+      r.rewrite((x && y) || x, x) ||
       r.rewrite(x || (x || y), x || y) ||
+      r.rewrite((x || y) || x, x || y) ||
       false) {
     return r.result;
   };

--- a/builder/simplify_exprs.cc
+++ b/builder/simplify_exprs.cc
@@ -166,8 +166,7 @@ expr simplify(const add* op, expr a, expr b) {
       r.rewrite(x + (x + y), y + x * 2) ||
       r.rewrite(x + (x - y), x * 2 - y) ||
       r.rewrite(x + (y - x), y) ||
-      //r.rewrite(x + x * y, x * (y + 1)) ||  // Needs x to be non-constant or it loops with c0 * (x + c1) -> c0 * x + c0 * c1...
-      // how?
+      r.rewrite(x + x * y, x * (y + 1), eval(!is_constant(x))) ||
       r.rewrite(x * y + x * z, x * (y + z)) ||
       r.rewrite((x + y) + (x + z), (y + z) + x * 2) ||
       r.rewrite((x + z) + (x - y), (z - y) + x * 2) ||

--- a/builder/simplify_test.cc
+++ b/builder/simplify_test.cc
@@ -68,6 +68,8 @@ TEST(simplify, basic) {
   test_simplify(expr(1) - 2, -1);
   test_simplify(expr(1) < 2, 1);
   test_simplify(expr(1) > 2, 0);
+  test_simplify(negative_infinity() + 3, negative_infinity());
+  test_simplify(3 + negative_infinity(), negative_infinity());
 
   test_simplify(min(1, 2), 1);
   test_simplify(max(1, 2), 2);

--- a/builder/simplify_test.cc
+++ b/builder/simplify_test.cc
@@ -64,6 +64,7 @@ void test_simplify(const stmt& test, const stmt& expected) {
 }
 
 TEST(simplify, basic) {
+  test_simplify(expr() == 1, expr() == 1);
   test_simplify(expr(1) + 2, 3);
   test_simplify(expr(1) - 2, -1);
   test_simplify(expr(1) < 2, 1);
@@ -137,6 +138,7 @@ TEST(simplify, let) {
 
 TEST(simplify, buffer_intrinsics) {
   test_simplify(buffer_extent(x, y) >= 0, true);
+  test_simplify((buffer_max(x, y) - buffer_min(x, y) + 1) * 4, buffer_extent(x, y) * 4);
   test_simplify(max(buffer_max(x, y) + 1, buffer_min(x, y) - 1), buffer_max(x, y) + 1);
 }
 
@@ -323,7 +325,7 @@ expr make_random_expr(int depth) {
 TEST(simplify, fuzz) {
   const int seed = time(nullptr);
   srand(seed);
-  constexpr int tests = 1000;
+  constexpr int tests = 10000;
   constexpr int checks = 10;
 
   eval_context ctx;

--- a/builder/substitute.cc
+++ b/builder/substitute.cc
@@ -144,46 +144,27 @@ public:
     if (!try_match(ex->b, op->b)) return;
   }
 
-  void match_wildcard(symbol_id sym, std::function<bool(const expr&)> predicate) {
-    if (match) return;
-
-    std::optional<expr>& matched = (*matches)[sym];
-    if (matched) {
-      // We already matched this variable. The expression must match.
-      if (!matched->same_as(static_cast<const base_expr_node*>(self))) {
-        symbol_map<expr>* old_matches = matches;
-        matches = nullptr;
-        matched->accept(this);
-        matches = old_matches;
-      }
-    } else if (!predicate || predicate(static_cast<const base_expr_node*>(self))) {
-      // This is a new match.
-      matched = static_cast<const base_expr_node*>(self);
-      match = 0;
-    } else {
-      // The predicate failed, we can't match this.
-      match = 1;
-    }
-  }
-
   void visit(const variable* op) override {
+    if (match) return;
     if (matches) {
-      match_wildcard(op->sym, nullptr);
+      std::optional<expr>& matched = (*matches)[op->sym];
+      if (matched) {
+        // We already matched this variable. The expression must match.
+        if (!matched->same_as(static_cast<const base_expr_node*>(self))) {
+          symbol_map<expr>* old_matches = matches;
+          matches = nullptr;
+          matched->accept(this);
+          matches = old_matches;
+        }
+      } else {
+        // This is a new match.
+        matched = static_cast<const base_expr_node*>(self);
+        match = 0;
+      }
     } else {
       const variable* ev = match_self_as(op);
       if (ev) {
         try_match(ev->sym, op->sym);
-      }
-    }
-  }
-
-  void visit(const wildcard* op) override {
-    if (matches) {
-      match_wildcard(op->sym, op->matches);
-    } else {
-      const wildcard* ew = match_self_as(op);
-      if (ew) {
-        try_match(ew->sym, op->sym);
       }
     }
   }
@@ -442,8 +423,7 @@ public:
   }
   using node_mutator::mutate;
 
-  template <typename T>
-  void visit_variable(const T* v) {
+  void visit(const variable* v) override {
     if (shadowed.contains(v->sym)) {
       // This variable has been shadowed, don't substitute it.
       set_result(v);
@@ -455,8 +435,6 @@ public:
     }
   }
 
-  void visit(const variable* v) override { visit_variable(v); }
-  void visit(const wildcard* v) override { visit_variable(v); }
 
   template <typename T>
   T mutate_decl_body(symbol_id sym, const T& x) {

--- a/builder/substitute.h
+++ b/builder/substitute.h
@@ -27,6 +27,7 @@ stmt substitute_bounds(const stmt& s, symbol_id buffer, int dim, const interval_
 
 // Compute a sort ordering of two nodes based on their structure (not their values).
 int compare(const expr& a, const expr& b);
+int compare(const base_expr_node* a, const base_expr_node* b);
 int compare(const stmt& a, const stmt& b);
 
 // A comparator suitable for using expr/stmt as keys in an std::map/std::set.

--- a/builder/substitute_test.cc
+++ b/builder/substitute_test.cc
@@ -50,7 +50,7 @@ void test_substitute(const stmt& test, T target, const expr& replacement, const 
 
 TEST(substitute, basic) {
   test_substitute(x + y, x.sym(), z, z + y);
-  test_substitute(check::make(buffer_min(x, 3) == y), buffer_min(x, 3), z, check::make(z == y));
+  test_substitute(check::make(y == buffer_min(x, 3)), buffer_min(x, 3), z, check::make(y == z));
 }
 
 TEST(substitute, shadowed) {

--- a/runtime/depends_on.cc
+++ b/runtime/depends_on.cc
@@ -45,7 +45,6 @@ public:
   }
 
   void visit(const variable* op) override { visit_var(op->sym); }
-  void visit(const wildcard* op) override { visit_var(op->sym); }
   void visit(const call* op) override {
     if (is_buffer_intrinsic(op->intrinsic)) {
       assert(op->args.size() >= 1);

--- a/runtime/evaluate.cc
+++ b/runtime/evaluate.cc
@@ -163,13 +163,6 @@ public:
     result = *value;
   }
 
-  void visit(const wildcard* op) override {
-    // Maybe evaluating this should just be an error.
-    auto value = context.lookup(op->sym);
-    assert(value);
-    result = *value;
-  }
-
   void visit(const constant* op) override { result = op->value; }
 
   template <typename T>

--- a/runtime/expr.cc
+++ b/runtime/expr.cc
@@ -80,9 +80,6 @@ stmt let_stmt::make(std::vector<std::pair<symbol_id, expr>> lets, stmt body) {
   return make_let<let_stmt>(std::move(lets), std::move(body));
 }
 
-// TODO(https://github.com/dsharlet/slinky/issues/4): At this time, the top CPU user
-// of simplify_fuzz is malloc/free. Perhaps caching common values of variables (yes
-// we can cache variables!) would be worth doing.
 const variable* make_variable(symbol_id sym) {
   auto n = new variable();
   n->sym = sym;

--- a/runtime/expr.cc
+++ b/runtime/expr.cc
@@ -48,9 +48,26 @@ std::optional<symbol_id> node_context::lookup(const std::string& name) const {
   return {};
 }
 
+bool should_commute(const expr& a, const expr& b) {
+  if (a.type() > b.type()) return true;
+
+  const call* call_a = a.as<call>();
+  const call* call_b = b.as<call>();
+  if (call_a && call_b && call_a->intrinsic > call_b->intrinsic) return true;
+
+  return false;
+}
+
+bool can_commute(const expr& a, const expr& b) {
+  return !should_commute(b, a);
+}
+
 template <typename T>
 const T* make_bin_op(expr a, expr b) {
   auto n = new T();
+  if (typename T::commutative() && should_commute(a, b)) {
+    std::swap(a, b);
+  }
   n->a = std::move(a);
   n->b = std::move(b);
   return n;

--- a/runtime/expr.cc
+++ b/runtime/expr.cc
@@ -52,6 +52,7 @@ template <typename T>
 const T* make_bin_op(expr a, expr b) {
   auto n = new T();
   if (T::commutative && should_commute(a, b)) {
+    // Aggressively canonicalizing the order is a big speedup by avoiding unnecessary simplifier rewrites.
     std::swap(a, b);
   }
   n->a = std::move(a);
@@ -309,8 +310,8 @@ stmt call_stmt::make(call_stmt::callable target, symbol_list inputs, symbol_list
   return n;
 }
 
-stmt copy_stmt::make(
-    symbol_id src, std::vector<expr> src_x, symbol_id dst, std::vector<symbol_id> dst_x, std::optional<std::vector<char>> padding) {
+stmt copy_stmt::make(symbol_id src, std::vector<expr> src_x, symbol_id dst, std::vector<symbol_id> dst_x,
+    std::optional<std::vector<char>> padding) {
   auto n = new copy_stmt();
   n->src = src;
   n->src_x = std::move(src_x);

--- a/runtime/expr.cc
+++ b/runtime/expr.cc
@@ -48,24 +48,10 @@ std::optional<symbol_id> node_context::lookup(const std::string& name) const {
   return {};
 }
 
-bool should_commute(const expr& a, const expr& b) {
-  if (a.type() > b.type()) return true;
-
-  const call* call_a = a.as<call>();
-  const call* call_b = b.as<call>();
-  if (call_a && call_b && call_a->intrinsic > call_b->intrinsic) return true;
-
-  return false;
-}
-
-bool can_commute(const expr& a, const expr& b) {
-  return !should_commute(b, a);
-}
-
 template <typename T>
 const T* make_bin_op(expr a, expr b) {
   auto n = new T();
-  if (typename T::commutative() && should_commute(a, b)) {
+  if (T::commutative && should_commute(a, b)) {
     std::swap(a, b);
   }
   n->a = std::move(a);

--- a/runtime/expr.cc
+++ b/runtime/expr.cc
@@ -99,13 +99,6 @@ expr::expr(index_t x) : expr(make_constant(x)) {}
 
 expr variable::make(symbol_id sym) { return make_variable(sym); }
 
-expr wildcard::make(symbol_id sym, std::function<bool(const expr&)> matches) {
-  auto n = new wildcard();
-  n->sym = sym;
-  n->matches = std::move(matches);
-  return n;
-}
-
 expr constant::make(index_t value) { return make_constant(value); }
 expr constant::make(const void* value) { return make(reinterpret_cast<index_t>(value)); }
 
@@ -596,7 +589,6 @@ var::operator expr() const {
 }
 
 void recursive_node_visitor::visit(const variable*) {}
-void recursive_node_visitor::visit(const wildcard*) {}
 void recursive_node_visitor::visit(const constant*) {}
 
 void recursive_node_visitor::visit(const let* op) {

--- a/runtime/expr.cc
+++ b/runtime/expr.cc
@@ -459,20 +459,17 @@ stmt check::make(expr condition) {
   return n;
 }
 
-const expr& positive_infinity() {
-  static expr e = call::make(intrinsic::positive_infinity, {});
-  return e;
-}
+namespace {
 
-const expr& negative_infinity() {
-  static expr e = call::make(intrinsic::negative_infinity, {});
-  return e;
-}
+expr global_positive_infinity = call::make(intrinsic::positive_infinity, {});
+expr global_negative_infinity = call::make(intrinsic::negative_infinity, {});
+expr global_indeterminate = call::make(intrinsic::indeterminate, {});
 
-const expr& indeterminate() {
-  static expr e = call::make(intrinsic::indeterminate, {});
-  return e;
-}
+}  // namespace
+
+const expr& positive_infinity() { return global_positive_infinity; }
+const expr& negative_infinity() { return global_negative_infinity; }
+const expr& indeterminate() { return global_indeterminate; }
 
 expr abs(expr x) { return call::make(intrinsic::abs, {std::move(x)}); }
 

--- a/runtime/expr.h
+++ b/runtime/expr.h
@@ -805,35 +805,35 @@ inline void truncate_rank::accept(node_visitor* v) const { v->visit(this); }
 inline void check::accept(node_visitor* v) const { v->visit(this); }
 
 // If `x` is a constant, returns the value of the constant, otherwise `nullptr`.
-inline const index_t* as_constant(const expr& x) {
+SLINKY_ALWAYS_INLINE inline const index_t* as_constant(const expr& x) {
   const constant* cx = x.as<constant>();
   return cx ? &cx->value : nullptr;
 }
 
 // If `x` is a variable, returns the `symbol_id` of the variable, otherwise `nullptr`.
-inline const symbol_id* as_variable(const expr& x) {
+SLINKY_ALWAYS_INLINE inline const symbol_id* as_variable(const expr& x) {
   const variable* vx = x.as<variable>();
   return vx ? &vx->sym : nullptr;
 }
 
 // Check if `x` is a variable equal to the symbol `sym`.
-inline bool is_variable(const expr& x, symbol_id sym) {
+SLINKY_ALWAYS_INLINE inline bool is_variable(const expr& x, symbol_id sym) {
   const variable* vx = x.as<variable>();
   return vx ? vx->sym == sym : false;
 }
 
 // Check if `x` is equal to the constant `value`.
-inline bool is_constant(const expr& x, index_t value) {
+SLINKY_ALWAYS_INLINE inline bool is_constant(const expr& x, index_t value) {
   const constant* cx = x.as<constant>();
   return cx ? cx->value == value : false;
 }
-inline bool is_zero(const expr& x) { return is_constant(x, 0); }
-inline bool is_one(const expr& x) { return is_constant(x, 1); }
+SLINKY_ALWAYS_INLINE inline bool is_zero(const expr& x) { return is_constant(x, 0); }
+SLINKY_ALWAYS_INLINE inline bool is_one(const expr& x) { return is_constant(x, 1); }
 inline bool is_true(const expr& x) {
   const constant* cx = x.as<constant>();
   return cx ? cx->value != 0 : false;
 }
-inline bool is_false(const expr& x) { return is_zero(x); }
+SLINKY_ALWAYS_INLINE inline bool is_false(const expr& x) { return is_zero(x); }
 
 // Check if `x` is a call to the intrinsic `fn`.
 inline bool is_intrinsic(const expr& x, intrinsic fn) {

--- a/runtime/expr.h
+++ b/runtime/expr.h
@@ -35,7 +35,6 @@ enum class node_type {
   none,
 
   variable,
-  wildcard,
   let,
   add,
   sub,
@@ -367,23 +366,6 @@ public:
   static constexpr node_type static_type = node_type::variable;
 };
 
-// Similar to a variable, designed for use in pattern matching. A match with x is only
-// accepted if matches(x) returns true.
-// TODO(https://github.com/dsharlet/slinky/issues/6): This is pretty ugly. We should be
-// able to contain this kind of logic to pattern matching only, it shouldn't be polluting
-// the expression mechanism.
-class wildcard : public expr_node<wildcard> {
-public:
-  symbol_id sym;
-  std::function<bool(const expr&)> matches;
-
-  void accept(node_visitor* v) const override;
-
-  static expr make(symbol_id sym, std::function<bool(const expr&)> matches);
-
-  static constexpr node_type static_type = node_type::wildcard;
-};
-
 class constant : public expr_node<constant> {
 public:
   index_t value;
@@ -713,7 +695,6 @@ public:
   virtual ~node_visitor() = default;
 
   virtual void visit(const variable*) = 0;
-  virtual void visit(const wildcard*) = 0;
   virtual void visit(const constant*) = 0;
   virtual void visit(const let*) = 0;
   virtual void visit(const add*) = 0;
@@ -752,7 +733,6 @@ public:
 class recursive_node_visitor : public node_visitor {
 public:
   void visit(const variable*) override;
-  void visit(const wildcard*) override;
   void visit(const constant*) override;
   void visit(const let* op) override;
 
@@ -790,7 +770,6 @@ public:
 };
 
 inline void variable::accept(node_visitor* v) const { v->visit(this); }
-inline void wildcard::accept(node_visitor* v) const { v->visit(this); }
 inline void constant::accept(node_visitor* v) const { v->visit(this); }
 inline void let::accept(node_visitor* v) const { v->visit(this); }
 inline void add::accept(node_visitor* v) const { v->visit(this); }

--- a/runtime/expr.h
+++ b/runtime/expr.h
@@ -152,11 +152,6 @@ public:
 
 class expr;
 
-// Check if a and b should be commuted.
-bool should_commute(const expr& a, const expr& b);
-// Check that a and b can be commuted.
-bool can_commute(const expr& a, const expr& b);
-
 expr operator+(expr a, expr b);
 expr operator-(expr a, expr b);
 expr operator*(expr a, expr b);
@@ -186,19 +181,19 @@ public:
   // Make an `expr` referencing an existing node.
   expr(const base_expr_node* n) : n_(n) {}
 
-  void accept(node_visitor* v) const {
+  SLINKY_ALWAYS_INLINE void accept(node_visitor* v) const {
     assert(defined());
     n_->accept(v);
   }
 
-  bool defined() const { return n_ != nullptr; }
-  bool same_as(const expr& other) const { return n_ == other.n_; }
-  bool same_as(const base_expr_node* other) const { return n_ == other; }
-  node_type type() const { return n_ ? n_->type : node_type::none; }
-  const base_expr_node* get() const { return n_; }
+  SLINKY_ALWAYS_INLINE bool defined() const { return n_ != nullptr; }
+  SLINKY_ALWAYS_INLINE bool same_as(const expr& other) const { return n_ == other.n_; }
+  SLINKY_ALWAYS_INLINE bool same_as(const base_expr_node* other) const { return n_ == other; }
+  SLINKY_ALWAYS_INLINE node_type type() const { return n_ ? n_->type : node_type::none; }
+  SLINKY_ALWAYS_INLINE const base_expr_node* get() const { return n_; }
 
   template <typename T>
-  const T* as() const {
+  SLINKY_ALWAYS_INLINE const T* as() const {
     if (n_ && type() == T::static_type) {
       return reinterpret_cast<const T*>(&*n_);
     } else {
@@ -245,6 +240,10 @@ expr clamp(expr x, expr a, expr b);
 expr select(expr c, expr t, expr f);
 expr min(span<expr> x);
 expr max(span<expr> x);
+
+// Check if a and b should be commuted.
+SLINKY_ALWAYS_INLINE inline bool should_commute(node_type a, node_type b) { return a > b; }
+inline bool should_commute(const expr& a, const expr& b) { return should_commute(a.type(), b.type()); }
 
 struct interval_expr {
   expr min, max;
@@ -318,19 +317,19 @@ public:
   stmt& operator=(const stmt&) = default;
   stmt& operator=(stmt&&) noexcept = default;
 
-  void accept(node_visitor* v) const {
+  SLINKY_ALWAYS_INLINE void accept(node_visitor* v) const {
     assert(defined());
     n_->accept(v);
   }
 
-  bool defined() const { return n_ != nullptr; }
-  bool same_as(const stmt& other) const { return n_ == other.n_; }
-  bool same_as(const base_stmt_node* other) const { return n_ == other; }
-  node_type type() const { return n_ ? n_->type : node_type::none; }
-  const base_stmt_node* get() const { return n_; }
+  SLINKY_ALWAYS_INLINE bool defined() const { return n_ != nullptr; }
+  SLINKY_ALWAYS_INLINE bool same_as(const stmt& other) const { return n_ == other.n_; }
+  SLINKY_ALWAYS_INLINE bool same_as(const base_stmt_node* other) const { return n_ == other; }
+  SLINKY_ALWAYS_INLINE node_type type() const { return n_ ? n_->type : node_type::none; }
+  SLINKY_ALWAYS_INLINE const base_stmt_node* get() const { return n_; }
 
   template <typename T>
-  const T* as() const {
+  SLINKY_ALWAYS_INLINE const T* as() const {
     if (n_ && type() == T::static_type) {
       return reinterpret_cast<const T*>(&*n_);
     } else {
@@ -404,22 +403,22 @@ public:
     void accept(node_visitor* v) const override;                                                                       \
     static expr make(expr a, expr b);                                                                                  \
     static constexpr node_type static_type = node_type::op;                                                            \
-    using commutative = c;                                                                                             \
+    static constexpr bool commutative = c;                                                                             \
   };
 
-DECLARE_BINARY_OP(add, std::true_type)
-DECLARE_BINARY_OP(sub, std::false_type)
-DECLARE_BINARY_OP(mul, std::true_type)
-DECLARE_BINARY_OP(div, std::false_type)
-DECLARE_BINARY_OP(mod, std::false_type)
-DECLARE_BINARY_OP(min, std::true_type)
-DECLARE_BINARY_OP(max, std::true_type)
-DECLARE_BINARY_OP(equal, std::true_type)
-DECLARE_BINARY_OP(not_equal, std::true_type)
-DECLARE_BINARY_OP(less, std::false_type)
-DECLARE_BINARY_OP(less_equal, std::false_type)
-DECLARE_BINARY_OP(logical_and, std::false_type)
-DECLARE_BINARY_OP(logical_or, std::false_type)
+DECLARE_BINARY_OP(add, true)
+DECLARE_BINARY_OP(sub, false)
+DECLARE_BINARY_OP(mul, true)
+DECLARE_BINARY_OP(div, false)
+DECLARE_BINARY_OP(mod, false)
+DECLARE_BINARY_OP(min, true)
+DECLARE_BINARY_OP(max, true)
+DECLARE_BINARY_OP(equal, true)
+DECLARE_BINARY_OP(not_equal, true)
+DECLARE_BINARY_OP(less, false)
+DECLARE_BINARY_OP(less_equal, false)
+DECLARE_BINARY_OP(logical_and, false)
+DECLARE_BINARY_OP(logical_or, false)
 
 #undef DECLARE_BINARY_OP
 

--- a/runtime/expr.h
+++ b/runtime/expr.h
@@ -418,8 +418,8 @@ DECLARE_BINARY_OP(equal, std::true_type)
 DECLARE_BINARY_OP(not_equal, std::true_type)
 DECLARE_BINARY_OP(less, std::false_type)
 DECLARE_BINARY_OP(less_equal, std::false_type)
-DECLARE_BINARY_OP(logical_and, std::true_type)
-DECLARE_BINARY_OP(logical_or, std::true_type)
+DECLARE_BINARY_OP(logical_and, std::false_type)
+DECLARE_BINARY_OP(logical_or, std::false_type)
 
 #undef DECLARE_BINARY_OP
 

--- a/runtime/print.cc
+++ b/runtime/print.cc
@@ -128,7 +128,6 @@ public:
   std::string indent(int extra = 0) const { return std::string(depth + extra, ' '); }
 
   void visit(const variable* v) override { *this << v->sym; }
-  void visit(const wildcard* w) override { *this << w->sym; }
   void visit(const constant* c) override { *this << c->value; }
 
   void visit(const let* l) override {

--- a/runtime/util.h
+++ b/runtime/util.h
@@ -12,6 +12,7 @@
 namespace slinky {
 
 #define SLINKY_ALLOCA(T, N) reinterpret_cast<T*>(alloca((N) * sizeof(T)))
+#define SLINKY_ALWAYS_INLINE __attribute__((always_inline))
 
 // Signed integer division in C/C++ is terrible. These implementations
 // of Euclidean division and mod are taken from:
@@ -211,13 +212,13 @@ public:
     return *this;
   }
 
-  T& operator*() { return *value; }
-  const T& operator*() const { return *value; }
-  T* operator->() { return value; }
-  const T* operator->() const { return value; }
+  SLINKY_ALWAYS_INLINE T& operator*() { return *value; }
+  SLINKY_ALWAYS_INLINE const T& operator*() const { return *value; }
+  SLINKY_ALWAYS_INLINE T* operator->() { return value; }
+  SLINKY_ALWAYS_INLINE const T* operator->() const { return value; }
 
-  operator T*() { return value; }
-  operator const T*() const { return value; }
+  SLINKY_ALWAYS_INLINE operator T*() { return value; }
+  SLINKY_ALWAYS_INLINE operator const T*() const { return value; }
 };
 
 }  // namespace slinky

--- a/runtime/visualize.cc
+++ b/runtime/visualize.cc
@@ -129,7 +129,6 @@ public:
   std::string indent(int extra = 0) const { return std::string((depth + extra) * 2, ' '); }
 
   void visit(const variable* v) override { *this << v->sym; }
-  void visit(const wildcard* w) override { *this << w->sym; }
   void visit(const constant* c) override { *this << c->value; }
 
   void visit(const let* l) override {


### PR DESCRIPTION
- Speeds up `simplify` by ~5x
- Speeds up compile time of `simplify_exprs.cc` by ~2x (80s -> 40s with --config=asan in GitHub Actions)
- The mechanism for predicates is much better than the old `std::function` hack, this allowed enabling a rule that had a TODO before.

This enabled quite a bit of cleanup too, in particular we don't need the `wildcard` node any more, which always felt like a hack.