### PR TITLE
Fix patterns that don't use any pattern objects

### DIFF
--- a/builder/simplify_exprs.cc
+++ b/builder/simplify_exprs.cc
@@ -156,8 +156,9 @@ expr simplify(const add* op, expr a, expr b) {
 
   rewriter r(e);
   if (r.rewrite(x + indeterminate(), indeterminate()) ||
-      r.rewrite(positive_infinity() + indeterminate(), indeterminate()) ||
-      r.rewrite(negative_infinity() + positive_infinity(), indeterminate()) ||
+      r.rewrite(rewrite::operator+(positive_infinity(), positive_infinity()), positive_infinity()) ||
+      r.rewrite(rewrite::operator+(negative_infinity(), negative_infinity()), negative_infinity()) ||
+      r.rewrite(rewrite::operator+(negative_infinity(), positive_infinity()), indeterminate()) ||
       r.rewrite(x + positive_infinity(), positive_infinity(), is_finite(x)) ||
       r.rewrite(x + negative_infinity(), negative_infinity(), is_finite(x)) ||
       r.rewrite(x + 0, x) ||
@@ -236,10 +237,10 @@ expr simplify(const sub* op, expr a, expr b) {
   rewriter r(e);
   if (r.rewrite(x - indeterminate(), indeterminate()) ||
       r.rewrite(indeterminate() - x, indeterminate()) ||
-      r.rewrite(positive_infinity() - positive_infinity(), indeterminate()) ||
-      r.rewrite(positive_infinity() - negative_infinity(), positive_infinity()) ||
-      r.rewrite(negative_infinity() - negative_infinity(), indeterminate()) ||
-      r.rewrite(negative_infinity() - positive_infinity(), negative_infinity()) ||
+      r.rewrite(rewrite::operator-(positive_infinity(), positive_infinity()), indeterminate()) ||
+      r.rewrite(rewrite::operator-(positive_infinity(), negative_infinity()), positive_infinity()) ||
+      r.rewrite(rewrite::operator-(negative_infinity(), negative_infinity()), indeterminate()) ||
+      r.rewrite(rewrite::operator-(negative_infinity(), positive_infinity()), negative_infinity()) ||
       r.rewrite(x - positive_infinity(), negative_infinity(), is_finite(x)) ||
       r.rewrite(x - negative_infinity(), positive_infinity(), is_finite(x)) ||
       r.rewrite(x - x, 0) ||
@@ -302,9 +303,9 @@ expr simplify(const mul* op, expr a, expr b) {
 
   rewriter r(e);
   if (r.rewrite(x * indeterminate(), indeterminate()) ||
-      r.rewrite(positive_infinity() * positive_infinity(), positive_infinity()) ||
-      r.rewrite(negative_infinity() * positive_infinity(), negative_infinity()) ||
-      r.rewrite(negative_infinity() * negative_infinity(), positive_infinity()) ||
+      r.rewrite(rewrite::operator*(positive_infinity(), positive_infinity()), positive_infinity()) ||
+      r.rewrite(rewrite::operator*(negative_infinity(), positive_infinity()), negative_infinity()) ||
+      r.rewrite(rewrite::operator*(negative_infinity(), negative_infinity()), positive_infinity()) ||
       r.rewrite(positive_infinity() * c0, positive_infinity(), eval(c0 > 0)) ||
       r.rewrite(negative_infinity() * c0, negative_infinity(), eval(c0 > 0)) ||
       r.rewrite(positive_infinity() * c0, negative_infinity(), eval(c0 < 0)) ||
@@ -337,10 +338,10 @@ expr simplify(const div* op, expr a, expr b) {
   rewriter r(e);
   if (r.rewrite(x / indeterminate(), indeterminate()) ||
       r.rewrite(indeterminate() / x, indeterminate()) ||
-      r.rewrite(positive_infinity() / positive_infinity(), indeterminate()) ||
-      r.rewrite(positive_infinity() / negative_infinity(), indeterminate()) ||
-      r.rewrite(negative_infinity() / positive_infinity(), indeterminate()) ||
-      r.rewrite(negative_infinity() / negative_infinity(), indeterminate()) ||
+      r.rewrite(rewrite::operator/(positive_infinity(), positive_infinity()), indeterminate()) ||
+      r.rewrite(rewrite::operator/(positive_infinity(), negative_infinity()), indeterminate()) ||
+      r.rewrite(rewrite::operator/(negative_infinity(), positive_infinity()), indeterminate()) ||
+      r.rewrite(rewrite::operator/(negative_infinity(), negative_infinity()), indeterminate()) ||
       r.rewrite(x / positive_infinity(), 0, is_finite(x)) ||
       r.rewrite(x / negative_infinity(), 0, is_finite(x)) ||
       r.rewrite(positive_infinity() / c0, positive_infinity(), eval(c0 > 0)) ||

--- a/builder/simplify_test.cc
+++ b/builder/simplify_test.cc
@@ -71,6 +71,10 @@ TEST(simplify, basic) {
   test_simplify(expr(1) > 2, 0);
   test_simplify(negative_infinity() + 3, negative_infinity());
   test_simplify(3 + negative_infinity(), negative_infinity());
+  test_simplify(positive_infinity() + positive_infinity(), positive_infinity());
+  test_simplify(positive_infinity() + negative_infinity(), indeterminate());
+  test_simplify(positive_infinity() * positive_infinity(), positive_infinity());
+  test_simplify(positive_infinity() * negative_infinity(), negative_infinity());
 
   test_simplify(min(1, 2), 1);
   test_simplify(max(1, 2), 2);


### PR DESCRIPTION
Patterns that don't use `rewrite` namespace operands are just regular exprs. This caused two problems: we assume exprs used in patterns are canonical global constants, and this was creating a huge number of exprs unnecessarily.