### PR TITLE
Clean up buffer types (fixes #81)

### DIFF
--- a/builder/elementwise_test.cc
+++ b/builder/elementwise_test.cc
@@ -150,7 +150,7 @@ template <typename T, std::size_t Rank>
 class elementwise_pipeline_evaluator : public node_visitor {
 public:
   std::vector<index_t> extents;
-  symbol_map<buffer<T>*> vars;
+  symbol_map<buffer<T, Rank>*> vars;
 
   buffer<T, Rank> result;
 
@@ -166,7 +166,7 @@ public:
   }
 
   void visit(const variable* v) override {
-    const std::optional<buffer<T>*>& i = vars[v->sym];
+    const std::optional<buffer<T, Rank>*>& i = vars[v->sym];
     assert(i);
     result.free();
     index_t stride = sizeof(T);
@@ -289,7 +289,7 @@ void test_expr_pipeline(node_context& ctx, const expr& e) {
   elementwise_pipeline_evaluator<T, Rank> eval;
   eval.extents = extents;
   for (std::size_t i = 0; i < inputs.size(); ++i) {
-    eval.vars[p.inputs()[i]] = &input_bufs[i].template cast<T>();
+    eval.vars[p.inputs()[i]] = &input_bufs[i];
   }
   e.accept(&eval);
 

--- a/builder/pipeline_test.cc
+++ b/builder/pipeline_test.cc
@@ -46,11 +46,12 @@ public:
 
   test_context() {
     allocate = [this](symbol_id, raw_buffer* b) {
-      b->allocate();
+      void* allocation = b->allocate();
       heap.track_allocate(b->size_bytes());
+      return allocation;
     };
-    free = [this](symbol_id, raw_buffer* b) {
-      b->free();
+    free = [this](symbol_id, raw_buffer* b, void* allocation) {
+      ::free(allocation);
       heap.track_free(b->size_bytes());
     };
 

--- a/builder/simplify_test.cc
+++ b/builder/simplify_test.cc
@@ -326,12 +326,9 @@ TEST(simplify, fuzz) {
 
   eval_context ctx;
 
-  std::vector<raw_buffer_ptr> buffers;
+  std::vector<buffer<int, max_rank>> buffers(bufs.size());
   for (int i = 0; i < static_cast<int>(bufs.size()); ++i) {
-    buffers.emplace_back(raw_buffer::make(max_rank, 4));
-  }
-  for (int i = 0; i < static_cast<int>(bufs.size()); ++i) {
-    ctx[bufs[i]] = reinterpret_cast<index_t>(&*buffers[i]);
+    ctx[bufs[i]] = reinterpret_cast<index_t>(&buffers[i]);
   }
 
   symbol_map<interval_expr> var_bounds;
@@ -356,7 +353,7 @@ TEST(simplify, fuzz) {
           // correct in the case of empty buffers. But do we need to handle empty buffers...?
           index_t min = random_constant();
           index_t max = std::max(min + 1, random_constant());
-          b->dim(d).set_bounds(min, max);
+          b.dim(d).set_bounds(min, max);
         }
       }
       index_t eval_test = evaluate(test, ctx);

--- a/runtime/buffer.cc
+++ b/runtime/buffer.cc
@@ -10,7 +10,9 @@
 
 namespace slinky {
 
-std::size_t raw_buffer::size_bytes() const {
+namespace {
+
+std::size_t alloc_size(std::size_t elem_size, std::size_t rank, const dim* dims) {
   index_t flat_min = 0;
   index_t flat_max = 0;
   for (std::size_t i = 0; i < rank; ++i) {
@@ -20,6 +22,10 @@ std::size_t raw_buffer::size_bytes() const {
   }
   return flat_max - flat_min + elem_size;
 }
+
+}  // namespace
+
+std::size_t raw_buffer::size_bytes() const { return alloc_size(elem_size, rank, dims); }
 
 // Does not call constructor or destructor of T!
 void raw_buffer::allocate() {
@@ -35,33 +41,32 @@ void raw_buffer::free() {
   base = nullptr;
 }
 
-raw_buffer_ptr raw_buffer::make(std::size_t rank, std::size_t elem_size) {
-  char* buf_and_dims = new char[sizeof(raw_buffer) + sizeof(slinky::dim) * rank];
-  raw_buffer* buf = new (buf_and_dims) raw_buffer();
+namespace {
+
+void delete_raw_buffer(raw_buffer* p) { delete[] reinterpret_cast<char*>(p); }
+
+}  // namespace
+
+raw_buffer_ptr raw_buffer::make_allocated(std::size_t elem_size, std::size_t rank, const class dim* dims) {
+  char* mem = new char[sizeof(raw_buffer) + sizeof(slinky::dim) * rank + alloc_size(elem_size, rank, dims)];
+  raw_buffer* buf = new (mem) raw_buffer();
+  mem += sizeof(raw_buffer);
   buf->base = nullptr;
   buf->allocation = nullptr;
   buf->rank = rank;
   buf->elem_size = elem_size;
-  buf->dims = reinterpret_cast<slinky::dim*>(buf_and_dims + sizeof(raw_buffer));
-  new (buf->dims) slinky::dim[rank];
+  buf->dims = reinterpret_cast<slinky::dim*>(mem);
+  memcpy(buf->dims, dims, sizeof(slinky::dim) * rank);
+  mem += sizeof(slinky::dim) * rank;
+  buf->base = mem;
+  return {buf, delete_raw_buffer};
+}
+
+raw_buffer_ptr raw_buffer::make_copy(const raw_buffer& src) {
+  assert(src.base);
+  auto buf = make_allocated(src.elem_size, src.rank, src.dims);
+  copy(src, *buf);
   return buf;
-}
-
-void raw_buffer::destroy(raw_buffer* buf) {
-  buf->~raw_buffer();
-  delete[] (char*)buf;
-}
-
-raw_buffer_ptr raw_buffer::make(const raw_buffer& src) {
-  raw_buffer_ptr result = make(src.rank, src.elem_size);
-  for (std::size_t d = 0; d < src.rank; ++d) {
-    result->dims[d] = src.dims[d];
-  }
-  if (src.base) {
-    result->allocate();
-    copy(src, *result);
-  }
-  return result;
 }
 
 namespace {

--- a/runtime/buffer.cc
+++ b/runtime/buffer.cc
@@ -41,14 +41,9 @@ void raw_buffer::free() {
   base = nullptr;
 }
 
-namespace {
-
-void delete_raw_buffer(raw_buffer* p) { delete[] reinterpret_cast<char*>(p); }
-
-}  // namespace
-
 raw_buffer_ptr raw_buffer::make_allocated(std::size_t elem_size, std::size_t rank, const class dim* dims) {
-  char* mem = new char[sizeof(raw_buffer) + sizeof(slinky::dim) * rank + alloc_size(elem_size, rank, dims)];
+  char* mem = reinterpret_cast<char*>(
+      malloc(sizeof(raw_buffer) + sizeof(slinky::dim) * rank + alloc_size(elem_size, rank, dims)));
   raw_buffer* buf = new (mem) raw_buffer();
   mem += sizeof(raw_buffer);
   buf->base = nullptr;
@@ -59,7 +54,7 @@ raw_buffer_ptr raw_buffer::make_allocated(std::size_t elem_size, std::size_t ran
   memcpy(buf->dims, dims, sizeof(slinky::dim) * rank);
   mem += sizeof(slinky::dim) * rank;
   buf->base = mem;
-  return {buf, delete_raw_buffer};
+  return raw_buffer_ptr(buf);
 }
 
 raw_buffer_ptr raw_buffer::make_copy(const raw_buffer& src) {

--- a/runtime/buffer.cc
+++ b/runtime/buffer.cc
@@ -52,17 +52,6 @@ void raw_buffer::destroy(raw_buffer* buf) {
   delete[] (char*)buf;
 }
 
-raw_buffer_ptr raw_buffer::make(std::size_t elem_size, span<const index_t> extents) {
-  raw_buffer_ptr result = make(extents.size(), elem_size);
-  index_t stride = elem_size;
-  for (std::size_t d = 0; d < extents.size(); ++d) {
-    result->dims[d].set_min_extent(0, extents[d]);
-    result->dims[d].set_stride(stride);
-    stride *= extents[d];
-  }
-  return result;
-}
-
 raw_buffer_ptr raw_buffer::make(const raw_buffer& src) {
   raw_buffer_ptr result = make(src.rank, src.elem_size);
   for (std::size_t d = 0; d < src.rank; ++d) {

--- a/runtime/buffer.cc
+++ b/runtime/buffer.cc
@@ -46,7 +46,6 @@ raw_buffer_ptr raw_buffer::make_allocated(std::size_t elem_size, std::size_t ran
       malloc(sizeof(raw_buffer) + sizeof(slinky::dim) * rank + alloc_size(elem_size, rank, dims)));
   raw_buffer* buf = new (mem) raw_buffer();
   mem += sizeof(raw_buffer);
-  buf->base = nullptr;
   buf->allocation = nullptr;
   buf->rank = rank;
   buf->elem_size = elem_size;
@@ -58,7 +57,6 @@ raw_buffer_ptr raw_buffer::make_allocated(std::size_t elem_size, std::size_t ran
 }
 
 raw_buffer_ptr raw_buffer::make_copy(const raw_buffer& src) {
-  assert(src.base);
   auto buf = make_allocated(src.elem_size, src.rank, src.dims);
   copy(src, *buf);
   return buf;

--- a/runtime/buffer.h
+++ b/runtime/buffer.h
@@ -251,6 +251,11 @@ public:
   buffer(std::initializer_list<index_t> extents) : buffer({extents.begin(), extents.end()}) {}
   ~buffer() { free(); }
 
+  buffer(const buffer&) = delete;
+  buffer(buffer&& m) = delete;
+  void operator=(const buffer&) = delete;
+  void operator=(buffer&& m) = delete;
+
   T* base() const { return reinterpret_cast<T*>(raw_buffer::base); }
 
   // These accessors are not designed to be fast. They exist to facilitate testing,

--- a/runtime/buffer.h
+++ b/runtime/buffer.h
@@ -202,8 +202,6 @@ public:
 
   template <typename NewT>
   const buffer<NewT>& cast() const;
-  template <typename NewT>
-  buffer<NewT>& cast();
 
   // Make a pointer to a buffer with an allocation for the buffer in the same allocation.
   static raw_buffer_ptr make_allocated(std::size_t elem_size, std::size_t rank, const class dim* dims);
@@ -282,11 +280,6 @@ public:
 template <typename NewT>
 const buffer<NewT>& raw_buffer::cast() const {
   return *reinterpret_cast<const buffer<NewT>*>(this);
-}
-
-template <typename NewT>
-buffer<NewT>& raw_buffer::cast() {
-  return *reinterpret_cast<buffer<NewT>*>(this);
 }
 
 // Copy the contents of `src` to `dst`. When the `src` is out of bounds of `dst`, fill with `padding`.

--- a/runtime/buffer.h
+++ b/runtime/buffer.h
@@ -240,7 +240,6 @@ public:
     elem_size = sizeof(T);
     if (DimsSize > 0) {
       dims = &dims_storage[0];
-      new (dims) slinky::dim[rank];
     } else {
       dims = nullptr;
     }

--- a/runtime/buffer.h
+++ b/runtime/buffer.h
@@ -299,16 +299,16 @@ static constexpr index_t all = std::numeric_limits<index_t>::max();
 namespace internal {
 
 template <typename F>
-void for_each_index(span<const dim> dims, int d, index_t* is, std::size_t rank, const F& f) {
+void for_each_index(span<const dim> dims, int d, index_t* is, const F& f) {
   if (d == 0) {
     for (index_t i = dims[0].begin(); i < dims[0].end(); ++i) {
       is[0] = i;
-      f(span<const index_t>(is, is + rank));
+      f(span<const index_t>(is, is + dims.size()));
     }
   } else {
     for (index_t i = dims[d].begin(); i < dims[d].end(); ++i) {
       is[d] = i;
-      for_each_index(dims, d - 1, is, rank, f);
+      for_each_index(dims, d - 1, is, f);
     }
   }
 }
@@ -430,7 +430,7 @@ template <typename F>
 void for_each_index(span<const dim> dims, const F& f) {
   // Not using alloca for performance, but to avoid including <vector>
   index_t* i = SLINKY_ALLOCA(index_t, dims.size());
-  internal::for_each_index(dims, dims.size() - 1, i, dims.size(), f);
+  internal::for_each_index(dims, dims.size() - 1, i, f);
 }
 template <typename F>
 void for_each_index(const raw_buffer& buf, const F& f) {

--- a/runtime/buffer.h
+++ b/runtime/buffer.h
@@ -210,9 +210,6 @@ public:
   // Make a buffer and space for dims in the same object.
   static raw_buffer_ptr make(std::size_t rank, std::size_t elem_size);
 
-  // Make a new buffer of rank extents.size(), with dim d having extent extents[d].
-  static raw_buffer_ptr make(std::size_t elem_size, span<const index_t> extents);
-
   // Make a deep copy of another buffer, including allocating and copying the data if src is allocated.
   static raw_buffer_ptr make(const raw_buffer& src);
 

--- a/runtime/buffer.h
+++ b/runtime/buffer.h
@@ -84,7 +84,11 @@ class buffer;
 
 class raw_buffer;
 
-using raw_buffer_ptr = std::unique_ptr<raw_buffer, void(*)(raw_buffer*)>;
+struct free_deleter {
+  void operator()(void* p) { free(p); }
+};
+
+using raw_buffer_ptr = std::unique_ptr<raw_buffer, free_deleter>;
 
 // We have some difficult requirements for this buffer object:
 // 1. We want type safety in user code, but we also want to be able to treat buffers as generic.
@@ -203,10 +207,12 @@ public:
   template <typename NewT>
   const buffer<NewT>& cast() const;
 
-  // Make a pointer to a buffer with an allocation for the buffer in the same allocation.
+  // Make a pointer to a buffer with an allocation for the buffer in the same allocation. The buffer can be freed with
+  // `free`.
   static raw_buffer_ptr make_allocated(std::size_t elem_size, std::size_t rank, const class dim* dims);
 
-  // Make a deep copy of another buffer, including allocating and copying the data if src is allocated.
+  // Make a deep copy of another buffer, including allocating and copying the data if src is allocated. The buffer can
+  // be freed with `free`.
   static raw_buffer_ptr make_copy(const raw_buffer& src);
 };
 

--- a/runtime/evaluate.cc
+++ b/runtime/evaluate.cc
@@ -390,16 +390,16 @@ public:
       dim.set_fold_factor(eval_expr(op->dims[i].fold_factor, dim::unfolded));
     }
 
+    void* heap_allocation = nullptr;
     if (op->storage == memory_type::stack) {
       buffer->base = alloca(buffer->size_bytes());
     } else {
       assert(op->storage == memory_type::heap);
-      buffer->allocation = nullptr;
       if (context.allocate) {
         assert(context.free);
-        context.allocate(op->sym, buffer);
+        heap_allocation = context.allocate(op->sym, buffer);
       } else {
-        buffer->allocate();
+        heap_allocation = buffer->allocate();
       }
     }
 
@@ -409,9 +409,9 @@ public:
     if (op->storage == memory_type::heap) {
       if (context.free) {
         assert(context.allocate);
-        context.free(op->sym, buffer);
+        context.free(op->sym, buffer, heap_allocation);
       } else {
-        buffer->free();
+        free(heap_allocation);
       }
     }
   }

--- a/runtime/evaluate.h
+++ b/runtime/evaluate.h
@@ -9,11 +9,13 @@ namespace slinky {
 class eval_context : public symbol_map<index_t> {
 public:
   // These two functions implement allocation. `allocate` is called before
-  // running the body, and `free` is called after.
+  // running the body, and should assign `base` of the buffer to the address
+  // of the min in each dimension. `free` is called after running the body,
+  // passing the result of `allocate` in addition to the buffer.
   // If these functions are not defined, the default handler will call
-  // raw_buffer::allocate and raw_buffer::free.
-  std::function<void(symbol_id, raw_buffer*)> allocate;
-  std::function<void(symbol_id, raw_buffer*)> free;
+  // `raw_buffer::allocate` and `::free`.
+  std::function<void*(symbol_id, raw_buffer*)> allocate;
+  std::function<void(symbol_id, raw_buffer*, void*)> free;
 
   // Functions called when there is a failure in the pipeline.
   // If these functions are not defined, the default handler will write a


### PR DESCRIPTION
I realized that we could avoid tricky lifetime issues for `raw_buffer::make` helpers by allocating the buffer and data all in one `malloc`ed buffer. Now the result can simply be freed to clean up.

This PR also changes `raw_buffer::allocate` to return a pointer to be freed manually, instead of storing it in the class. `buffer<T, N>` now keeps a pointer to be freed, and automatically manages lifetime.