### PR TITLE
Make copy and pad calls customizable via evaluate callbacks

### DIFF
--- a/builder/optimizations.cc
+++ b/builder/optimizations.cc
@@ -113,7 +113,11 @@ public:
             [src = op->src, dst = op->dst, padding = *op->padding](const eval_context& ctx) -> index_t {
               const raw_buffer* src_buf = ctx.lookup_buffer(src);
               const raw_buffer* dst_buf = ctx.lookup_buffer(dst);
-              pad(src_buf->dims, *dst_buf, padding.data());
+              if (ctx.pad) {
+                ctx.pad(src_buf->dims, *dst_buf, padding.data());
+              } else {
+                pad(src_buf->dims, *dst_buf, padding.data());
+              }
               return 0;
             },
             {src}, {dst}));
@@ -431,7 +435,12 @@ public:
         [src = op->src, dst = op->dst, padding = op->padding](const eval_context& ctx) -> index_t {
           const raw_buffer* src_buf = ctx.lookup_buffer(src);
           const raw_buffer* dst_buf = ctx.lookup_buffer(dst);
-          copy(*src_buf, *dst_buf, (!padding || padding->empty()) ? nullptr : padding->data());
+          const void* pad_value = (!padding || padding->empty()) ? nullptr : padding->data();
+          if (ctx.copy) {
+            ctx.copy(*src_buf, *dst_buf, pad_value);
+          } else {
+            copy(*src_buf, *dst_buf, pad_value);
+          }
           return 0;
         },
         {op->src}, {op->dst});

--- a/builder/optimizations.cc
+++ b/builder/optimizations.cc
@@ -188,11 +188,7 @@ public:
             [src, dst, padding = *op->padding](const eval_context& ctx) -> index_t {
               const raw_buffer* src_buf = ctx.lookup_buffer(src);
               const raw_buffer* dst_buf = ctx.lookup_buffer(dst);
-              if (ctx.pad) {
-                ctx.pad(src_buf->dims, *dst_buf, padding.data());
-              } else {
-                pad(src_buf->dims, *dst_buf, padding.data());
-              }
+              ctx.pad(src_buf->dims, *dst_buf, padding.data());
               return 0;
             },
             {src}, {dst});
@@ -419,11 +415,7 @@ stmt implement_copy(const copy_stmt* op, node_context& ctx) {
         const raw_buffer* src_buf = ctx.lookup_buffer(src);
         const raw_buffer* dst_buf = ctx.lookup_buffer(dst);
         const void* pad_value = (!padding || padding->empty()) ? nullptr : padding->data();
-        if (ctx.copy) {
-          ctx.copy(*src_buf, *dst_buf, pad_value);
-        } else {
-          copy(*src_buf, *dst_buf, pad_value);
-        }
+        ctx.copy(*src_buf, *dst_buf, pad_value);
         return 0;
       },
       {op->src}, {op->dst});

--- a/builder/optimizations.cc
+++ b/builder/optimizations.cc
@@ -96,38 +96,6 @@ bool is_copy(const copy_stmt* op, std::vector<expr>& offset) {
   return true;
 }
 
-// Replaces `copy_stmt` with a call to `pad`.
-class replace_copy_with_pad : public node_mutator {
-  symbol_id src;
-  symbol_id dst;
-
-public:
-  replace_copy_with_pad(symbol_id src, symbol_id dst) : src(src), dst(dst) {}
-
-  void visit(const copy_stmt* op) override {
-    if (op->src == src && op->dst == dst) {
-      if (!op->padding || op->padding->empty()) {
-        set_result(stmt());
-      } else {
-        set_result(call_stmt::make(
-            [src = op->src, dst = op->dst, padding = *op->padding](const eval_context& ctx) -> index_t {
-              const raw_buffer* src_buf = ctx.lookup_buffer(src);
-              const raw_buffer* dst_buf = ctx.lookup_buffer(dst);
-              if (ctx.pad) {
-                ctx.pad(src_buf->dims, *dst_buf, padding.data());
-              } else {
-                pad(src_buf->dims, *dst_buf, padding.data());
-              }
-              return 0;
-            },
-            {src}, {dst}));
-      }
-    } else {
-      set_result(op);
-    }
-  }
-};
-
 class buffer_aliaser : public node_mutator {
   struct buffer_alias {
     std::vector<expr> offset;
@@ -206,7 +174,30 @@ public:
       stmt result = make_buffer::make(
           op->sym, buffer_at(target_var, at), static_cast<index_t>(op->elem_size), std::move(dims), std::move(body));
       // If we aliased the source and destination of a copy, replace the copy with a pad.
-      stmt pad_result = replace_copy_with_pad(op->sym, target.first).mutate(result);
+      stmt pad_result = recursive_mutate<copy_stmt>(result, [src = op->sym, dst = target.first](const copy_stmt* op) {
+        if (op->src != src || op->dst != dst) {
+          // Not this copy.
+          return stmt(op);
+        }
+        if (!op->padding || op->padding->empty()) {
+          // No padding, this copy is now a no-op.
+          return stmt();
+        }
+        // Make a call to `pad`.
+        return call_stmt::make(
+            [src, dst, padding = *op->padding](const eval_context& ctx) -> index_t {
+              const raw_buffer* src_buf = ctx.lookup_buffer(src);
+              const raw_buffer* dst_buf = ctx.lookup_buffer(dst);
+              if (ctx.pad) {
+                ctx.pad(src_buf->dims, *dst_buf, padding.data());
+              } else {
+                pad(src_buf->dims, *dst_buf, padding.data());
+              }
+              return 0;
+            },
+            {src}, {dst});
+      });
+      
       if (pad_result.same_as(result)) {
         // This wasn't a copy, we actually did some computation in place. We can't alias another buffer to this target
         // without understanding the lifetimes more carefully.
@@ -421,114 +412,103 @@ public:
 
 stmt alias_buffers(const stmt& s) { return buffer_aliaser().mutate(s); }
 
-namespace {
-
-class copy_optimizer : public node_mutator {
-  node_context& ctx;
-
-public:
-  copy_optimizer(node_context& ctx) : ctx(ctx) {}
-
-  void visit(const copy_stmt* op) override {
-    // Start by making a call to copy.
-    stmt result = call_stmt::make(
-        [src = op->src, dst = op->dst, padding = op->padding](const eval_context& ctx) -> index_t {
-          const raw_buffer* src_buf = ctx.lookup_buffer(src);
-          const raw_buffer* dst_buf = ctx.lookup_buffer(dst);
-          const void* pad_value = (!padding || padding->empty()) ? nullptr : padding->data();
-          if (ctx.copy) {
-            ctx.copy(*src_buf, *dst_buf, pad_value);
-          } else {
-            copy(*src_buf, *dst_buf, pad_value);
-          }
-          return 0;
-        },
-        {op->src}, {op->dst});
-
-    var src_var(op->src);
-    var dst_var(op->dst);
-
-    std::vector<expr> src_x = op->src_x;
-    std::vector<dim_expr> src_dims;
-    std::vector<std::pair<symbol_id, int>> dst_x;
-
-    // If we just leave these two arrays alone, the copy will be correct, but slow.
-    // We can speed it up by finding dimensions we can let pass through to the copy.
-    for (int d = 0; d < static_cast<int>(op->dst_x.size()); ++d) {
-      int dep_count = 0;
-      int src_d = -1;
-      for (int sd = 0; sd < static_cast<int>(src_x.size()); ++sd) {
-        if (depends_on(src_x[sd], op->dst_x[d]).any()) {
-          ++dep_count;
-          src_d = sd;
+stmt implement_copy(const copy_stmt* op, node_context& ctx) {
+  // Start by making a call to copy.
+  stmt result = call_stmt::make(
+      [src = op->src, dst = op->dst, padding = op->padding](const eval_context& ctx) -> index_t {
+        const raw_buffer* src_buf = ctx.lookup_buffer(src);
+        const raw_buffer* dst_buf = ctx.lookup_buffer(dst);
+        const void* pad_value = (!padding || padding->empty()) ? nullptr : padding->data();
+        if (ctx.copy) {
+          ctx.copy(*src_buf, *dst_buf, pad_value);
+        } else {
+          copy(*src_buf, *dst_buf, pad_value);
         }
+        return 0;
+      },
+      {op->src}, {op->dst});
+
+  var src_var(op->src);
+  var dst_var(op->dst);
+
+  std::vector<expr> src_x = op->src_x;
+  std::vector<dim_expr> src_dims;
+  std::vector<std::pair<symbol_id, int>> dst_x;
+
+  // If we just leave these two arrays alone, the copy will be correct, but slow.
+  // We can speed it up by finding dimensions we can let pass through to the copy.
+  for (int d = 0; d < static_cast<int>(op->dst_x.size()); ++d) {
+    int dep_count = 0;
+    int src_d = -1;
+    for (int sd = 0; sd < static_cast<int>(src_x.size()); ++sd) {
+      if (depends_on(src_x[sd], op->dst_x[d]).any()) {
+        ++dep_count;
+        src_d = sd;
       }
-      bool handled = false;
-      if (dep_count == 0) {
-        // This dimension is a broadcast. To handle this, we're going to add a dummy dimension to the input.
-        // We can just always do this, regardless of whether this broadcast is implicit (the input has fewer
-        // dimensions than the output) or not.
-        src_dims.push_back({buffer_bounds(dst_var, d), 0, expr()});
+    }
+    bool handled = false;
+    if (dep_count == 0) {
+      // This dimension is a broadcast. To handle this, we're going to add a dummy dimension to the input.
+      // We can just always do this, regardless of whether this broadcast is implicit (the input has fewer
+      // dimensions than the output) or not.
+      src_dims.push_back({buffer_bounds(dst_var, d), 0, expr()});
+      handled = true;
+    } else if (dep_count == 1) {
+      expr offset;
+      if (is_copy(src_x[src_d], op->dst_x[d], offset)) {
+        interval_expr dst_bounds = buffer_bounds(dst_var, d);
+        interval_expr src_bounds = buffer_bounds(src_var, src_d) - offset;
+        src_dims.push_back(
+            {dst_bounds & src_bounds, buffer_stride(src_var, src_d), buffer_fold_factor(src_var, src_d)});
+        src_x[src_d] = max(buffer_min(dst_var, d) + offset, buffer_min(src_var, src_d));
         handled = true;
-      } else if (dep_count == 1) {
-        expr offset;
-        if (is_copy(src_x[src_d], op->dst_x[d], offset)) {
-          interval_expr dst_bounds = buffer_bounds(dst_var, d);
-          interval_expr src_bounds = buffer_bounds(src_var, src_d) - offset;
-          src_dims.push_back(
-              {dst_bounds & src_bounds, buffer_stride(src_var, src_d), buffer_fold_factor(src_var, src_d)});
-          src_x[src_d] = max(buffer_min(dst_var, d) + offset, buffer_min(src_var, src_d));
-          handled = true;
-        }
-      }
-      if (!handled) {
-        dst_x.emplace_back(op->dst_x[d], d);
       }
     }
-
-    // TODO: Try to optimize reshapes, where the index of the input is an "unpacking" of a flat index of the output.
-    // This will require the simplifier to understand the constraints implied by the checks on the buffer metadata
-    // at the beginning of the pipeline, e.g. that buffer_stride(dst_var, d) == buffer_stride(dst_var, d - 1) *
-    // buffer_extent(dst_var, d - 1).
-
-    // Rewrite the source buffer to be only the dimensions of the src we want to pass to copy.
-    result = make_buffer::make(op->src, buffer_at(src_var, src_x), buffer_elem_size(src_var), src_dims, result);
-
-    // Any dimensions left need loops and slices.
-    // We're going to make slices here, which invalidates buffer metadata calls in the body. To avoid breaking
-    // the body, we'll make lets of the buffer metadata outside the loops.
-    // TODO: Is this really the right thing to do, or is it an artifact of a bad idea/implementation?
-    std::vector<std::pair<symbol_id, expr>> lets;
-    symbol_id let_id = ctx.insert_unique();
-    auto do_substitute = [&](const expr& value) {
-      stmt new_result = substitute(result, value, variable::make(let_id));
-      if (!new_result.same_as(result)) {
-        lets.push_back({let_id, value});
-        let_id = ctx.insert_unique();
-        result = std::move(new_result);
-      }
-    };
-    for (int d = 0; d < static_cast<index_t>(op->dst_x.size()); ++d) {
-      do_substitute(buffer_min(dst_var, d));
-      do_substitute(buffer_max(dst_var, d));
-      do_substitute(buffer_extent(dst_var, d));
-      do_substitute(buffer_stride(dst_var, d));
-      do_substitute(buffer_fold_factor(dst_var, d));
+    if (!handled) {
+      dst_x.emplace_back(op->dst_x[d], d);
     }
-
-    for (const std::pair<symbol_id, int>& d : dst_x) {
-      result = slice_dim::make(op->dst, d.second, var(d.first), result);
-      result = loop::make(d.first, loop_mode::serial, buffer_bounds(dst_var, d.second), 1, result);
-    }
-    result = let_stmt::make(std::move(lets), result);
-
-    set_result(result);
   }
-};
 
-}  // namespace
+  // TODO: Try to optimize reshapes, where the index of the input is an "unpacking" of a flat index of the output.
+  // This will require the simplifier to understand the constraints implied by the checks on the buffer metadata
+  // at the beginning of the pipeline, e.g. that buffer_stride(dst_var, d) == buffer_stride(dst_var, d - 1) *
+  // buffer_extent(dst_var, d - 1).
 
-stmt optimize_copies(const stmt& s, node_context& ctx) { return copy_optimizer(ctx).mutate(s); }
+  // Rewrite the source buffer to be only the dimensions of the src we want to pass to copy.
+  result = make_buffer::make(op->src, buffer_at(src_var, src_x), buffer_elem_size(src_var), src_dims, result);
+
+  // Any dimensions left need loops and slices.
+  // We're going to make slices here, which invalidates buffer metadata calls in the body. To avoid breaking
+  // the body, we'll make lets of the buffer metadata outside the loops.
+  // TODO: Is this really the right thing to do, or is it an artifact of a bad idea/implementation?
+  std::vector<std::pair<symbol_id, expr>> lets;
+  symbol_id let_id = ctx.insert_unique();
+  auto do_substitute = [&](const expr& value) {
+    stmt new_result = substitute(result, value, variable::make(let_id));
+    if (!new_result.same_as(result)) {
+      lets.push_back({let_id, value});
+      let_id = ctx.insert_unique();
+      result = std::move(new_result);
+    }
+  };
+  for (int d = 0; d < static_cast<index_t>(op->dst_x.size()); ++d) {
+    do_substitute(buffer_min(dst_var, d));
+    do_substitute(buffer_max(dst_var, d));
+    do_substitute(buffer_extent(dst_var, d));
+    do_substitute(buffer_stride(dst_var, d));
+    do_substitute(buffer_fold_factor(dst_var, d));
+  }
+
+  for (const std::pair<symbol_id, int>& d : dst_x) {
+    result = slice_dim::make(op->dst, d.second, var(d.first), result);
+    result = loop::make(d.first, loop_mode::serial, buffer_bounds(dst_var, d.second), 1, result);
+  }
+  return let_stmt::make(std::move(lets), result);
+}
+
+stmt implement_copies(const stmt& s, node_context& ctx) {
+  return recursive_mutate<copy_stmt>(s, [&](const copy_stmt* op) { return implement_copy(op, ctx); });
+}
 
 namespace {
 

--- a/builder/optimizations.h
+++ b/builder/optimizations.h
@@ -8,8 +8,12 @@ namespace slinky {
 // Where possible, rewrite copies as buffer metadata rewrites.
 stmt alias_buffers(const stmt& s);
 
-// Find copy operations that can be implemented with calls to copy.
-stmt optimize_copies(const stmt& s, node_context& ctx);
+// Given a copy_stmt, produce an implementation that calls `slinky::copy`, possibly inside loops that implement copy
+// operations that `slinky::copy` cannot express.
+stmt implement_copy(const copy_stmt* c, node_context& ctx);
+
+// Replace every `copy_stmt` with the result of `implement_copy`
+stmt implement_copies(const stmt& s, node_context& ctx);
 
 // Attempt to reduce the scope of statements to only the operations required.
 stmt reduce_scopes(const stmt& s);

--- a/builder/pipeline.cc
+++ b/builder/pipeline.cc
@@ -556,6 +556,8 @@ stmt build_pipeline(node_context& ctx, const std::vector<buffer_expr_ptr>& input
   if (!options.no_alias_buffers) {
     result = alias_buffers(result);
   }
+
+  // `evaluate` currently can't handle `copy_stmt`, so this is required.
   result = implement_copies(result, ctx);
 
   result = simplify(result);

--- a/builder/pipeline.cc
+++ b/builder/pipeline.cc
@@ -556,7 +556,7 @@ stmt build_pipeline(node_context& ctx, const std::vector<buffer_expr_ptr>& input
   if (!options.no_alias_buffers) {
     result = alias_buffers(result);
   }
-  result = optimize_copies(result, ctx);
+  result = implement_copies(result, ctx);
 
   result = simplify(result);
   result = reduce_scopes(result);
@@ -564,12 +564,7 @@ stmt build_pipeline(node_context& ctx, const std::vector<buffer_expr_ptr>& input
   result = fix_buffer_races(result);
 
   if (options.no_checks) {
-    class remove_checks : public node_mutator {
-    public:
-      void visit(const check* op) override { set_result(stmt()); }
-    };
-
-    result = remove_checks().mutate(result);
+    result = recursive_mutate<check>(result, [](const check* op) { return stmt(); });
   }
 
   std::cout << std::tie(result, ctx) << std::endl;

--- a/runtime/evaluate.cc
+++ b/runtime/evaluate.cc
@@ -62,55 +62,6 @@ void dump_context_for_expr(
 
 namespace {
 
-// This is a very slow implementation of copy_stmt. The expectation is that copies will have been lowered to aliases or
-// calls to `copy` in buffer.h/cc instead of relying on this implementation.
-void copy_stmt_impl(
-    eval_context& ctx, const raw_buffer& src, const dim* dst_dims, void* dst_base, const copy_stmt& c, int dim) {
-  const class dim& dst_dim = dst_dims[dim];
-  index_t dst_stride = dst_dim.stride();
-  for (index_t dst_x = dst_dim.begin(); dst_x < dst_dim.end(); ++dst_x) {
-    auto s = set_value_in_scope(ctx, c.dst_x[dim], dst_x);
-    if (dim == 0) {
-      const void* src_base = src.base;
-      for (std::size_t d = 0; d < src.rank; ++d) {
-        const class dim& src_dim = src.dims[d];
-
-        index_t src_x = evaluate(c.src_x[d], ctx);
-        if (src_dim.contains(src_x)) {
-          src_base = offset_bytes(src_base, src_dim.flat_offset_bytes(src_x));
-        } else {
-          src_base = nullptr;
-          break;
-        }
-      }
-      if (src_base) {
-        memcpy(dst_base, src_base, src.elem_size);
-      } else if (c.padding && !c.padding->empty()) {
-        memcpy(dst_base, c.padding->data(), src.elem_size);
-      } else {
-        // Leave unmodified.
-      }
-    } else {
-      copy_stmt_impl(ctx, src, dst_dims, dst_base, c, dim - 1);
-    }
-    dst_base = offset_bytes(dst_base, dst_stride);
-  }
-}
-
-void copy_stmt_impl(eval_context& ctx, const raw_buffer& src, const raw_buffer& dst, const copy_stmt& c) {
-  assert(c.src_x.size() == src.rank);
-  assert(c.dst_x.size() == dst.rank);
-  assert(dst.elem_size == src.elem_size);
-  assert(!c.padding || c.padding->empty() || dst.elem_size == c.padding->size());
-  if (dst.rank == 0) {
-    // The buffer is scalar.
-    assert(src.rank == 0);
-    memcpy(dst.base, src.base, dst.elem_size);
-  } else {
-    copy_stmt_impl(ctx, src, dst.dims, dst.base, c, dst.rank - 1);
-  }
-}
-
 // TODO(https://github.com/dsharlet/slinky/issues/2): I think the T::accept/node_visitor::visit
 // overhead (two virtual function calls per node) might be significant. This could be implemented
 // as a switch statement instead.
@@ -363,10 +314,8 @@ public:
   }
 
   void visit(const copy_stmt* op) override {
-    const raw_buffer* src = reinterpret_cast<raw_buffer*>(context.lookup(op->src, 0));
-    const raw_buffer* dst = reinterpret_cast<raw_buffer*>(context.lookup(op->dst, 0));
-
-    copy_stmt_impl(context, *src, *dst, *op);
+    std::cerr << "copy_stmt should have been implemented by calls to copy/pad." << std::endl;
+    std::abort();
   }
 
   void visit(const allocate* op) override {

--- a/runtime/evaluate.h
+++ b/runtime/evaluate.h
@@ -34,6 +34,12 @@ public:
   std::function<void(task)> enqueue_one;
   std::function<void(std::function<bool()>)> wait_for;
 
+  // Functions implementing buffer data movement:
+  // - `copy` should copy from `src` to `dst`, filling `dst` with `padding` when out of bounds of `src`. Can be set to `slinky::copy`.
+  // - `pad` should fill the area out of bounds of `src_dims` with `padding` in `dst`. Can be set to `slinky::pad`.
+  std::function<void(const raw_buffer& src, const raw_buffer& dst, const void* padding)> copy;
+  std::function<void(const dim* in_bounds, const raw_buffer& dst, const void* padding)> pad;
+
   const raw_buffer* lookup_buffer(symbol_id id) const { return reinterpret_cast<const raw_buffer*>(*lookup(id)); }
 };
 

--- a/runtime/evaluate.h
+++ b/runtime/evaluate.h
@@ -35,10 +35,10 @@ public:
   std::function<void(std::function<bool()>)> wait_for;
 
   // Functions implementing buffer data movement:
-  // - `copy` should copy from `src` to `dst`, filling `dst` with `padding` when out of bounds of `src`. Can be set to `slinky::copy`.
-  // - `pad` should fill the area out of bounds of `src_dims` with `padding` in `dst`. Can be set to `slinky::pad`.
-  std::function<void(const raw_buffer& src, const raw_buffer& dst, const void* padding)> copy;
-  std::function<void(const dim* in_bounds, const raw_buffer& dst, const void* padding)> pad;
+  // - `copy` should copy from `src` to `dst`, filling `dst` with `padding` when out of bounds of `src`.
+  // - `pad` should fill the area out of bounds of `src_dims` with `padding` in `dst`.
+  std::function<void(const raw_buffer& src, const raw_buffer& dst, const void* padding)> copy = slinky::copy;
+  std::function<void(const dim* in_bounds, const raw_buffer& dst, const void* padding)> pad = slinky::pad;
 
   const raw_buffer* lookup_buffer(symbol_id id) const { return reinterpret_cast<const raw_buffer*>(*lookup(id)); }
 };


### PR DESCRIPTION
There's an issue I've been thinking about for a while: if we wanted to use slinky to drive GPU dispatches instead of CPU work, that could "just work" by doing GPU dispatches in callbacks... except for copy/pad, which call `copy` and `pad`, which assume the buffer is on the CPU.

This PR maybe addresses that by making `copy` and `pad` callbacks in `eval_context` that can be customized.

This also makes it so we can test copy optimization is working as intended (much like the allocation callbacks enable testing of storage folding).