### PR TITLE
Make for_each_contiguous_slice() a variadic function.

### DIFF
--- a/runtime/BUILD
+++ b/runtime/BUILD
@@ -79,6 +79,7 @@ cc_binary(
         ":runtime",
         "@google_benchmark//:benchmark_main",
     ],
+    testonly = 1,
 )
 
 cc_binary(
@@ -89,4 +90,5 @@ cc_binary(
         ":thread_pool",
         "@google_benchmark//:benchmark_main",
     ],
+    testonly = 1,
 )

--- a/runtime/buffer.cc
+++ b/runtime/buffer.cc
@@ -362,6 +362,15 @@ void make_for_each_contiguous_slice_dims(const raw_buffer& buf, for_each_contigu
   next->extent = slice_extent;
 }
 
+bool other_bufs_ok(const raw_buffer& buf, const raw_buffer& other_buf) {
+  if (other_buf.rank != buf.rank) return false;
+  for (int d = 0; d < buf.rank; d++) {
+    if (other_buf.dims[d].min() > buf.dims[d].min()) return false;
+    if (other_buf.dims[d].max() < buf.dims[d].max()) return false;
+  }
+  return true;
+}
+
 }  // namespace internal
 
 }  // namespace slinky

--- a/runtime/buffer.h
+++ b/runtime/buffer.h
@@ -7,8 +7,6 @@
 #include <cstring>
 #include <memory>
 
-#include <iostream>
-
 #include "runtime/util.h"
 
 namespace slinky {

--- a/runtime/buffer.h
+++ b/runtime/buffer.h
@@ -7,6 +7,8 @@
 #include <cstring>
 #include <memory>
 
+#include <iostream>
+
 #include "runtime/util.h"
 
 namespace slinky {
@@ -483,6 +485,228 @@ void for_each_tile(span<const index_t> tile, const raw_buffer& buf, const F& f) 
   memcpy(buf_.dims, buf.dims, sizeof(dim) * buf.rank);
 
   internal::for_each_tile(tile.data(), buf_, buf_.rank - 1, f);
+}
+
+namespace internal {
+
+struct per_buf_info {
+  union {
+    // For loop_folded to call flat_offset_bytes
+    const slinky::dim* dim;
+    // For loop_linear to offset the base.
+    index_t stride;
+  };
+};
+
+template <int N>
+struct for_each_contiguous_slice_multi_dim {
+  enum {
+    call_f,       // Uses extent
+    loop_linear,  // Uses stride, extent
+    loop_folded,  // Uses dim, extent
+  } impl;
+  index_t extent_here;
+  per_buf_info info[N];  // 0 = main; 1...N-1 = others
+};
+
+inline void assign_stride(int, per_buf_info*) {
+  // nothing
+}
+
+template <typename First, typename... Rest>
+inline void assign_stride(int d, per_buf_info* info, const First& first, const Rest&... rest) {
+  info->stride = first.dim(d).stride();
+  assign_stride(d, info + 1, rest...);
+}
+
+inline void assign_dim(int, per_buf_info*) {
+  // nothing
+}
+
+template <typename First, typename... Rest>
+inline void assign_dim(int d, per_buf_info* info, const First& first, const Rest&... rest) {
+  info->dim = &first.dim(d);
+  assign_dim(d, info + 1, rest...);
+}
+
+inline void add_stride_to_bases(const per_buf_info*) {
+  // nothing
+}
+
+template <typename First, typename... Rest>
+inline void add_stride_to_bases(const per_buf_info* info, First& first, Rest&... rest) {
+  first = offset_bytes(first, info->stride);
+  add_stride_to_bases(info + 1, rest...);
+}
+
+inline bool can_fuse_multi(const dim& inner, const dim& outer) {
+  if (inner.fold_factor() != dim::unfolded || outer.fold_factor() != dim::unfolded) {
+    return false;
+  }
+  return inner.stride() * inner.extent() == outer.stride();
+}
+
+inline bool can_fuse_multi(const raw_buffer& buf, int d) {
+  assert(d > 0);
+  return can_fuse_multi(buf.dim(d - 1), buf.dim(d));
+}
+
+template <typename... Args>
+inline bool others_can_fuse_with(const raw_buffer& buf, int d) {
+  return true;
+}
+
+template <typename First, typename... Rest>
+inline bool others_can_fuse_with(const raw_buffer& buf, int d, const First& first, const Rest&... rest) {
+  assert(d > 0);
+  // Our caller should have filtered out any dim at d that are folded,
+  // but it might not have done so for d-1, so we must do so here:
+  const auto& inner_other = first.dim(d - 1);
+  if (inner_other.fold_factor() != dim::unfolded) {
+    return false;
+  }
+  assert(buf.dim(d - 1).fold_factor() == dim::unfolded && buf.dim(d).fold_factor() == dim::unfolded &&
+         first.dim(d - 1).fold_factor() == dim::unfolded && first.dim(d).fold_factor() == dim::unfolded);
+  // I think this is sufficient:
+  const bool can = inner_other.stride() * inner_other.extent() == buf.dim(d).stride();
+  return can && others_can_fuse_with(buf, d, rest...);
+}
+
+template <int N, typename... Args>
+void make_for_each_contiguous_slice_multi_dims(
+    const raw_buffer& buf, for_each_contiguous_slice_multi_dim<N>* slice_dims, const Args&... other_bufs) {
+  auto* next = slice_dims;
+  index_t slice_extent = 1;
+  index_t extent = 1;
+  for (int d = buf.rank - 1; d >= 0; --d) {
+    extent *= buf.dim(d).extent();
+    const bool any_others_folded = (... || (other_bufs.dim(d).fold_factor() != dim::unfolded));
+    const bool any_folded = buf.dim(d).fold_factor() != dim::unfolded || any_others_folded;
+    if (any_folded) {
+      next->impl = for_each_contiguous_slice_multi_dim<N>::loop_folded;
+      assign_dim(d, next->info, buf, other_bufs...);
+      next->extent_here = extent;
+      extent = 1;  // TODO(srj)
+      ++next;
+    } else if (buf.dim(d).stride() == static_cast<index_t>(buf.elem_size)) {
+      // This is the slice dimension.
+      slice_extent = extent;
+      extent = 1;
+    } else if (extent == 1) {
+      // base already points to the min, we don't need to do anything.
+    } else if (d > 0 && can_fuse_multi(buf, d) && others_can_fuse_with(buf, d, other_bufs...)) {
+      // Let this dimension fuse with the next dimension.
+    } else {
+      // For the "output" buf, we can't cross a fold boundary, which means we can treat it as linear.
+      assert(buf.dim(d).min() / buf.dim(d).fold_factor() == buf.dim(d).max() / buf.dim(d).fold_factor());
+      next->impl = for_each_contiguous_slice_multi_dim<N>::loop_linear;
+      assign_stride(d, next->info, buf, other_bufs...);
+      next->extent_here = extent;
+      extent = 1;
+      ++next;
+    }
+  }
+  next->impl = for_each_contiguous_slice_multi_dim<N>::call_f;
+  next->extent_here = slice_extent;
+}
+
+template <typename... Args, std::size_t... Indices>
+inline void offset_folded_bases(int i, const per_buf_info* info, std::array<void*, sizeof...(Args)>& offset_bases,
+    std::index_sequence<Indices...>, const Args&... other_bases) {
+  ((offset_bases[Indices] = offset_bytes(other_bases, info[Indices].dim->flat_offset_bytes(i))), ...);
+}
+
+template <int N, typename F, std::size_t... Indices>
+void for_each_contiguous_slice_multi_array(void* base, const for_each_contiguous_slice_multi_dim<N>* slice_dim,
+    const F& f, const std::array<void*, sizeof...(Indices)>& other_bases, std::index_sequence<Indices...>) {
+  for_each_contiguous_slice_multi_impl(base, slice_dim, f, other_bases[Indices]...);
+}
+
+template <int N, typename F, typename... Args>
+void for_each_contiguous_slice_multi_impl(
+    void* base, const for_each_contiguous_slice_multi_dim<N>* slice_dim, const F& f, Args... other_bases) {
+  if (slice_dim->impl == for_each_contiguous_slice_multi_dim<N>::call_f) {
+    f(base, slice_dim->extent_here, static_cast<void*>(other_bases)...);
+  } else if (slice_dim->impl == for_each_contiguous_slice_multi_dim<N>::loop_linear) {
+    const auto* next = slice_dim + 1;
+    if (next->impl == for_each_contiguous_slice_multi_dim<N>::call_f) {
+      // If the next step is to call f, do that eagerly here to avoid an extra call.
+      for (index_t i = 0; i < slice_dim->extent_here; ++i) {
+        f(base, next->extent_here, static_cast<void*>(other_bases)...);
+        add_stride_to_bases(slice_dim->info, base, static_cast<void*&>(other_bases)...);
+      }
+    } else {
+      for (index_t i = 0; i < slice_dim->extent_here; ++i) {
+        for_each_contiguous_slice_multi_impl(base, slice_dim + 1, f, static_cast<void*>(other_bases)...);
+        add_stride_to_bases(slice_dim->info, base, static_cast<void*&>(other_bases)...);
+      }
+    }
+  } else {
+    assert(slice_dim->impl == for_each_contiguous_slice_multi_dim<N>::loop_folded);
+
+    std::array<void*, sizeof...(Args)> offset_bases;
+
+    // TODO: If any buffer if folded in a given dimension, we just take the slow path
+    // that handles either folded or unfolded for *all* the buffers in that dimension.
+    // It's possible we could special-case and improve the situation somewhat if we
+    // see common cases (eg main buffer never folded and one 'other' buffer that is folded).
+    index_t begin = slice_dim->info[0].dim->begin();
+    index_t end = begin + slice_dim->extent_here;
+    for (index_t i = begin; i < end; ++i) {
+      offset_folded_bases<Args...>(
+          i, slice_dim->info + 1, offset_bases, std::make_index_sequence<sizeof...(Args)>(), other_bases...);
+      for_each_contiguous_slice_multi_array(offset_bytes(base, slice_dim->info[0].dim->flat_offset_bytes(i)),
+          slice_dim + 1, f, offset_bases, std::make_index_sequence<sizeof...(Args)>());
+    }
+  }
+}
+
+bool other_bufs_ok(const raw_buffer& buf, const raw_buffer& other_buf);
+
+template <int N>
+inline void* offset_base_unfolded(
+    const raw_buffer& buf, const for_each_contiguous_slice_multi_dim<N>* slice_dim, const raw_buffer& other_buf) {
+  void* other_base = other_buf.base;
+  for (int d = 0; d < buf.rank; d++) {
+    if (slice_dim[d].impl != for_each_contiguous_slice_multi_dim<N>::loop_folded) {
+      other_base = offset_bytes(other_base, (buf.dim(d).min() - other_buf.dim(d).min()) * other_buf.dim(d).stride());
+    }
+  }
+  return other_base;
+}
+
+template <int N, typename... Args, std::size_t... Indices>
+void offset_unfolded_dimensions(const raw_buffer& buf, const for_each_contiguous_slice_multi_dim<N>* slice_dim,
+    const std::array<const raw_buffer*, sizeof...(Indices)>& other_bufs,
+    std::array<void*, sizeof...(Indices)>& offset_bases, std::index_sequence<Indices...>) {
+  ((offset_bases[Indices] = offset_base_unfolded(buf, slice_dim, *other_bufs[Indices])), ...);
+}
+
+}  // namespace internal
+
+// Like `for_each_contiguous_slice`, but allows for passing an arbitrary number of additional buffers,
+// which will be sliced in tandem with the 'main' buffer. All additional buffers must be of identical
+// rank to the main, and must cover (at least) the same area in each dimension.
+//
+// TODO: should we also offer a variant that takes std::array<const raw_buffer&, N> instead of variadic?
+template <typename F, typename... Args>
+void for_each_contiguous_slice_multi(const raw_buffer& buf, const F& f, const Args&... other_bufs) {
+  assert(... && internal::other_bufs_ok(buf, other_bufs));
+
+  // +1 to include buf
+  constexpr int N = sizeof...(Args) + 1;
+
+  // We might need a slice dim for each dimension in the buffer, plus one for the call to f.
+  internal::for_each_contiguous_slice_multi_dim<N>* dims =
+      SLINKY_ALLOCA(internal::for_each_contiguous_slice_multi_dim<N>, buf.rank + 1);
+  internal::make_for_each_contiguous_slice_multi_dims<N>(buf, dims, other_bufs...);
+
+  std::array<void*, sizeof...(Args)> offset_bases;
+  internal::offset_unfolded_dimensions<N>(
+      buf, dims, {&other_bufs...}, offset_bases, std::make_index_sequence<sizeof...(Args)>());
+
+  internal::for_each_contiguous_slice_multi_array(
+      buf.base, dims, f, offset_bases, std::make_index_sequence<sizeof...(Args)>());
 }
 
 }  // namespace slinky

--- a/runtime/buffer.h
+++ b/runtime/buffer.h
@@ -469,7 +469,7 @@ void make_for_each_contiguous_slice_dims(
       next->impl = for_each_contiguous_slice_dim<N>::loop_folded;
       assign_dim(d, next->info, buf, other_bufs...);
       next->extent_here = extent;
-      extent = 1;  // TODO(srj)
+      extent = 1;
       ++next;
     } else if (buf.dim(d).stride() == static_cast<index_t>(buf.elem_size)) {
       // This is the slice dimension.

--- a/runtime/buffer_benchmark.cc
+++ b/runtime/buffer_benchmark.cc
@@ -141,7 +141,7 @@ constexpr index_t slice_extent = 64;
 void memset_slice(void* base, index_t extent) { memset(base, 0, slice_extent); }
 
 template <typename Fn>
-void BM_for_each_slice(benchmark::State& state, Fn fn) {
+void BM_for_each_slice_impl(benchmark::State& state, Fn fn) {
   std::vector<index_t> extents = state_to_vector(3, state);
   extents[0] += 64;  // Insert padding after the first dimension.
   buffer<char, 3> buf(extents);
@@ -156,7 +156,7 @@ void BM_for_each_slice(benchmark::State& state, Fn fn) {
 }
 
 template <typename Fn>
-void BM_for_each_contiguous_slice(benchmark::State& state, Fn fn) {
+void BM_for_each_contiguous_slice_impl(benchmark::State& state, Fn fn) {
   std::vector<index_t> extents = state_to_vector(3, state);
   extents[0] += 64;  // Insert padding after the first dimension.
   buffer<char, 3> buf(extents);
@@ -170,7 +170,7 @@ void BM_for_each_contiguous_slice(benchmark::State& state, Fn fn) {
 }
 
 template <typename Fn>
-void BM_for_each_slice_hardcoded(benchmark::State& state, Fn fn) {
+void BM_for_each_slice_hardcoded_impl(benchmark::State& state, Fn fn) {
   std::vector<index_t> extents = state_to_vector(3, state);
   extents[0] += 64;  // Insert padding after the first dimension.
   buffer<char, 3> buf(extents);
@@ -191,9 +191,9 @@ void BM_for_each_slice_hardcoded(benchmark::State& state, Fn fn) {
 
 // The difference between these two benchmarks on the same size buffer gives an indication of how much time is spent in
 // overhead inside for_each_contiguous_slice.
-void BM_for_each_slice(benchmark::State& state) { BM_for_each_slice(state, memset_slice); }
-void BM_for_each_contiguous_slice(benchmark::State& state) { BM_for_each_contiguous_slice(state, memset_slice); }
-void BM_for_each_slice_hardcoded(benchmark::State& state) { BM_for_each_slice_hardcoded(state, memset_slice); }
+void BM_for_each_slice(benchmark::State& state) { BM_for_each_slice_impl(state, memset_slice); }
+void BM_for_each_contiguous_slice(benchmark::State& state) { BM_for_each_contiguous_slice_impl(state, memset_slice); }
+void BM_for_each_slice_hardcoded(benchmark::State& state) { BM_for_each_slice_hardcoded_impl(state, memset_slice); }
 
 BENCHMARK(BM_for_each_slice)->Args({slice_extent, 16, 1});
 BENCHMARK(BM_for_each_contiguous_slice)->Args({slice_extent, 16, 1});
@@ -205,7 +205,7 @@ BENCHMARK(BM_for_each_slice_hardcoded)->Args({slice_extent, 4, 4});
 void memcpy_slices(void* dst, index_t extent, void* src) { memcpy(dst, src, extent); }
 
 template <typename Fn>
-void BM_for_each_contiguous_slice_multi(benchmark::State& state, Fn fn) {
+void BM_for_each_contiguous_slice_multi_impl(benchmark::State& state, Fn fn) {
   std::vector<index_t> extents = state_to_vector(3, state);
   extents[0] += 64;  // Insert padding after the first dimension.
   buffer<char, 3> dst(extents);
@@ -226,7 +226,7 @@ void BM_for_each_contiguous_slice_multi(benchmark::State& state, Fn fn) {
 }
 
 void BM_for_each_contiguous_slice_multi(benchmark::State& state) {
-  BM_for_each_contiguous_slice_multi(state, memcpy_slices);
+  BM_for_each_contiguous_slice_multi_impl(state, memcpy_slices);
 }
 
 BENCHMARK(BM_for_each_contiguous_slice_multi)->Args({slice_extent, 16, 1});
@@ -242,7 +242,7 @@ void add_slices(void* dst, index_t extent, void* src1, void* src2) {
 }
 
 template <typename Fn>
-void BM_for_each_contiguous_slice_multi3(benchmark::State& state, Fn fn) {
+void BM_for_each_contiguous_slice_multi3_impl(benchmark::State& state, Fn fn) {
   std::vector<index_t> extents = state_to_vector(3, state);
   extents[0] += 64;  // Insert padding after the first dimension.
 
@@ -269,7 +269,7 @@ void BM_for_each_contiguous_slice_multi3(benchmark::State& state, Fn fn) {
 }
 
 void BM_for_each_contiguous_slice_multi3(benchmark::State& state) {
-  BM_for_each_contiguous_slice_multi3(state, add_slices);
+  BM_for_each_contiguous_slice_multi3_impl(state, add_slices);
 }
 
 BENCHMARK(BM_for_each_contiguous_slice_multi3)->Args({slice_extent, 16, 1});

--- a/runtime/buffer_benchmark.cc
+++ b/runtime/buffer_benchmark.cc
@@ -202,33 +202,77 @@ BENCHMARK(BM_for_each_slice)->Args({slice_extent, 4, 4});
 BENCHMARK(BM_for_each_contiguous_slice)->Args({slice_extent, 4, 4});
 BENCHMARK(BM_for_each_slice_hardcoded)->Args({slice_extent, 4, 4});
 
-void memset_slices_multi(void* slice, index_t extent, void* slice2) {
-  memset(slice, 0, extent);
-  memset(slice2, 0, extent);
-}
+void memcpy_slices(void* dst, index_t extent, void* src) { memcpy(dst, src, extent); }
 
 template <typename Fn>
 void BM_for_each_contiguous_slice_multi(benchmark::State& state, Fn fn) {
   std::vector<index_t> extents = state_to_vector(3, state);
   extents[0] += 64;  // Insert padding after the first dimension.
-  buffer<char, 3> buf(extents);
-  buf.allocate();
-  buf.dim(0).set_extent(state.range(0));
-  buffer<char, 3> buf2(extents);
-  buf2.allocate();
-  buf2.dim(0).set_extent(state.range(0));
+  buffer<char, 3> dst(extents);
+  dst.allocate();
+  dst.dim(0).set_extent(state.range(0));
+
+  buffer<char, 3> src(extents);
+  src.allocate();
+  src.dim(0).set_extent(state.range(0));
+
+  char x = 42;
+  fill(src, &x);
 
   for (auto _ : state) {
-    for_each_contiguous_slice(buf, fn, buf2);
+    for_each_contiguous_slice(dst, fn, src);
   }
-  state.SetBytesProcessed(static_cast<int64_t>(state.iterations()) * (buf.size_bytes() + buf2.size_bytes()));
+  state.SetBytesProcessed(static_cast<int64_t>(state.iterations()) * (dst.size_bytes() + src.size_bytes()));
 }
 
 void BM_for_each_contiguous_slice_multi(benchmark::State& state) {
-  BM_for_each_contiguous_slice_multi(state, memset_slices_multi);
+  BM_for_each_contiguous_slice_multi(state, memcpy_slices);
 }
 
 BENCHMARK(BM_for_each_contiguous_slice_multi)->Args({slice_extent, 16, 1});
 BENCHMARK(BM_for_each_contiguous_slice_multi)->Args({slice_extent, 4, 4});
+
+void add_slices(void* dst, index_t extent, void* src1, void* src2) {
+  const char* s1 = reinterpret_cast<const char*>(src1);
+  const char* s2 = reinterpret_cast<const char*>(src2);
+  char* d = reinterpret_cast<char*>(dst);
+  for (index_t i = 0; i < extent; i++) {
+    d[i] = s1[i] + s2[i];
+  }
+}
+
+template <typename Fn>
+void BM_for_each_contiguous_slice_multi3(benchmark::State& state, Fn fn) {
+  std::vector<index_t> extents = state_to_vector(3, state);
+  extents[0] += 64;  // Insert padding after the first dimension.
+
+  buffer<char, 3> dst(extents);
+  dst.allocate();
+  dst.dim(0).set_extent(state.range(0));
+
+  buffer<char, 3> src1(extents);
+  src1.allocate();
+  src1.dim(0).set_extent(state.range(0));
+  buffer<char, 3> src2(extents);
+  src2.allocate();
+  src2.dim(0).set_extent(state.range(0));
+
+  char x = 42;
+  fill(src1, &x);
+  fill(src2, &x);
+
+  for (auto _ : state) {
+    for_each_contiguous_slice(dst, fn, src1, src2);
+  }
+  state.SetBytesProcessed(
+      static_cast<int64_t>(state.iterations()) * (dst.size_bytes() + src1.size_bytes() + src2.size_bytes()));
+}
+
+void BM_for_each_contiguous_slice_multi3(benchmark::State& state) {
+  BM_for_each_contiguous_slice_multi3(state, add_slices);
+}
+
+BENCHMARK(BM_for_each_contiguous_slice_multi3)->Args({slice_extent, 16, 1});
+BENCHMARK(BM_for_each_contiguous_slice_multi3)->Args({slice_extent, 4, 4});
 
 }  // namespace slinky

--- a/runtime/buffer_benchmark.cc
+++ b/runtime/buffer_benchmark.cc
@@ -19,7 +19,9 @@ std::vector<index_t> state_to_vector(std::size_t max_size, const benchmark::Stat
 }
 
 template <typename Fn>
-__attribute__((noinline)) void no_inline(Fn&& fn) { fn(); }
+__attribute__((noinline)) void no_inline(Fn&& fn) {
+  fn();
+}
 
 void BM_memcpy(benchmark::State& state) {
   std::size_t size = state.range(0);
@@ -147,6 +149,7 @@ void BM_for_each_contiguous_slice(benchmark::State& state, Fn fn) {
   for (auto _ : state) {
     for_each_contiguous_slice(buf, fn);
   }
+  state.SetBytesProcessed(static_cast<int64_t>(state.iterations()) * buf.size_bytes());
 }
 
 template <typename Fn>
@@ -166,6 +169,7 @@ void BM_for_each_slice_hardcoded(benchmark::State& state, Fn fn) {
       }
     }
   }
+  state.SetBytesProcessed(static_cast<int64_t>(state.iterations()) * buf.size_bytes());
 }
 
 // The difference between these two benchmarks on the same size buffer gives an indication of how much time is spent in
@@ -177,5 +181,61 @@ BENCHMARK(BM_for_each_contiguous_slice)->Args({64, 16, 1});
 BENCHMARK(BM_for_each_slice_hardcoded)->Args({64, 16, 1});
 BENCHMARK(BM_for_each_contiguous_slice)->Args({64, 4, 4});
 BENCHMARK(BM_for_each_slice_hardcoded)->Args({64, 4, 4});
+BENCHMARK(BM_for_each_contiguous_slice)->Args({1024, 256, 4});
+BENCHMARK(BM_for_each_slice_hardcoded)->Args({1024, 256, 4});
+
+void memset_slices_multi(void* slice, index_t extent, void* slice2) {
+  memset(slice, 0, extent);
+  memset(slice2, 0, extent);
+}
+
+template <typename Fn>
+void BM_for_each_contiguous_slice_multi(benchmark::State& state, Fn fn) {
+  std::vector<index_t> extents = state_to_vector(3, state);
+  extents[0] += 64;  // Insert padding after the first dimension.
+  buffer<char, 3> buf(extents);
+  buf.allocate();
+  buf.dim(0).set_extent(state.range(0));
+  buffer<char, 3> buf2(extents);
+  buf2.allocate();
+  buf2.dim(0).set_extent(state.range(0));
+
+  for (auto _ : state) {
+    for_each_contiguous_slice_multi(buf, fn, buf2);
+  }
+  state.SetBytesProcessed(static_cast<int64_t>(state.iterations()) * buf.size_bytes() * 2);
+}
+
+void BM_for_each_contiguous_slice_multi(benchmark::State& state) {
+  BM_for_each_contiguous_slice_multi(state, memset_slices_multi);
+}
+
+BENCHMARK(BM_for_each_contiguous_slice_multi)->Args({64, 16, 1});
+BENCHMARK(BM_for_each_contiguous_slice_multi)->Args({64, 4, 4});
+BENCHMARK(BM_for_each_contiguous_slice_multi)->Args({1024, 256, 4});
+
+template <typename Fn>
+void BM_for_each_contiguous_slice_multi_single(benchmark::State& state, Fn fn) {
+  std::vector<index_t> extents = state_to_vector(3, state);
+  extents[0] += 64;  // Insert padding after the first dimension.
+  buffer<char, 3> buf(extents);
+  buf.allocate();
+  buf.dim(0).set_extent(state.range(0));
+
+  for (auto _ : state) {
+    for_each_contiguous_slice_multi(buf, fn);
+  }
+  state.SetBytesProcessed(static_cast<int64_t>(state.iterations()) * buf.size_bytes());
+}
+
+void BM_for_each_contiguous_slice_multi_single(benchmark::State& state) {
+  BM_for_each_contiguous_slice_multi_single(state, memset_slice);
+}
+
+// These benchmarks are meant to inform how much overhead BM_for_each_contiguous_slice_multi has over the non-multi
+// variant
+BENCHMARK(BM_for_each_contiguous_slice_multi_single)->Args({64, 16, 1});
+BENCHMARK(BM_for_each_contiguous_slice_multi_single)->Args({64, 4, 4});
+BENCHMARK(BM_for_each_contiguous_slice_multi_single)->Args({1024, 256, 4});
 
 }  // namespace slinky

--- a/runtime/buffer_benchmark.cc
+++ b/runtime/buffer_benchmark.cc
@@ -221,7 +221,7 @@ void BM_for_each_contiguous_slice_multi(benchmark::State& state, Fn fn) {
   for (auto _ : state) {
     for_each_contiguous_slice(buf, fn, buf2);
   }
-  state.SetBytesProcessed(static_cast<int64_t>(state.iterations()) * buf.size_bytes() * 2);
+  state.SetBytesProcessed(static_cast<int64_t>(state.iterations()) * (buf.size_bytes() + buf2.size_bytes()));
 }
 
 void BM_for_each_contiguous_slice_multi(benchmark::State& state) {

--- a/runtime/buffer_benchmark.cc
+++ b/runtime/buffer_benchmark.cc
@@ -219,7 +219,7 @@ void BM_for_each_contiguous_slice_multi(benchmark::State& state, Fn fn) {
   buf2.dim(0).set_extent(state.range(0));
 
   for (auto _ : state) {
-    for_each_contiguous_slice_multi(buf, fn, buf2);
+    for_each_contiguous_slice(buf, fn, buf2);
   }
   state.SetBytesProcessed(static_cast<int64_t>(state.iterations()) * buf.size_bytes() * 2);
 }
@@ -230,28 +230,5 @@ void BM_for_each_contiguous_slice_multi(benchmark::State& state) {
 
 BENCHMARK(BM_for_each_contiguous_slice_multi)->Args({slice_extent, 16, 1});
 BENCHMARK(BM_for_each_contiguous_slice_multi)->Args({slice_extent, 4, 4});
-
-template <typename Fn>
-void BM_for_each_contiguous_slice_multi_single(benchmark::State& state, Fn fn) {
-  std::vector<index_t> extents = state_to_vector(3, state);
-  extents[0] += 64;  // Insert padding after the first dimension.
-  buffer<char, 3> buf(extents);
-  buf.allocate();
-  buf.dim(0).set_extent(state.range(0));
-
-  for (auto _ : state) {
-    for_each_contiguous_slice_multi(buf, fn);
-  }
-  state.SetBytesProcessed(static_cast<int64_t>(state.iterations()) * buf.size_bytes());
-}
-
-void BM_for_each_contiguous_slice_multi_single(benchmark::State& state) {
-  BM_for_each_contiguous_slice_multi_single(state, memset_slice);
-}
-
-// These benchmarks are meant to inform how much overhead BM_for_each_contiguous_slice_multi has over the non-multi
-// variant
-BENCHMARK(BM_for_each_contiguous_slice_multi_single)->Args({slice_extent, 16, 1});
-BENCHMARK(BM_for_each_contiguous_slice_multi_single)->Args({slice_extent, 4, 4});
 
 }  // namespace slinky

--- a/runtime/buffer_test.cc
+++ b/runtime/buffer_test.cc
@@ -424,26 +424,13 @@ TEST(buffer, copy) {
   test_copy<big>();
 }
 
-TEST(buffer, for_each_contiguous_slice_multi_single) {
-  buffer<char, 3> buf({10, 20, 30});
-  buf.allocate();
-
-  int slices = 0;
-  for_each_contiguous_slice_multi(buf, [&](void* slice, index_t slice_extent) {
-    memset(slice, 7, slice_extent);
-    slices++;
-  });
-  ASSERT_EQ(slices, 1);
-  for_each_index(buf, [&](auto i) { ASSERT_EQ(buf(i), 7); });
-}
-
 TEST(buffer, for_each_contiguous_slice_multi) {
   buffer<char, 3> buf({10, 20, 30});
   buffer<char, 3> buf2({10, 20, 30});
   buf.allocate();
   buf2.allocate();
   int slices = 0;
-  for_each_contiguous_slice_multi(
+  for_each_contiguous_slice(
       buf,
       [&](void* slice, index_t slice_extent, void* slice2) {
         memset(slice, 7, slice_extent);
@@ -464,7 +451,7 @@ TEST(buffer, for_each_contiguous_slice_multi_padded) {
     buffer<int, 3> buf2({10, 20, 30});
     buf2.allocate();
     int value = 0;
-    for_each_contiguous_slice_multi(
+    for_each_contiguous_slice(
         buf,
         [&](void* slice, index_t slice_extent, void* slice2) {
           int* s = reinterpret_cast<int*>(slice);
@@ -497,7 +484,7 @@ TEST(buffer, for_each_contiguous_slice_multi_non_innermost) {
   buf2.allocate();
   std::swap(buf2.dim(0), buf2.dim(1));
   int value = 0;
-  for_each_contiguous_slice_multi(
+  for_each_contiguous_slice(
       buf,
       [&](void* slice, index_t slice_extent, void* slice2) {
         int* s = reinterpret_cast<int*>(slice);
@@ -529,7 +516,7 @@ TEST(buffer, for_each_contiguous_slice_multi_both_non_zero_min) {
   buf2.allocate();
   buf2.translate(1, 2, 3);
   int slices = 0;
-  for_each_contiguous_slice_multi(
+  for_each_contiguous_slice(
       buf,
       [&](void* slice, index_t slice_extent, void* slice2) {
         memset(slice, 7, slice_extent);
@@ -564,7 +551,7 @@ TEST(buffer, for_each_contiguous_slice_multi_fuse_lots) {
   buf8.allocate();
   buf9.allocate();
   int slices = 0;
-  for_each_contiguous_slice_multi(
+  for_each_contiguous_slice(
       buf1,
       [&](void* slice1, index_t slice_extent, void* slice2, void* slice3, void* slice4, void* slice5, void* slice6,
           void* slice7, void* slice8, void* slice9) {
@@ -601,7 +588,7 @@ TEST(buffer, for_each_contiguous_slice_multi_extra_buf_offset_negative) {
   buf2.translate(-1, -1, -1);
   int slices = 0;
   int value = 0;
-  for_each_contiguous_slice_multi(
+  for_each_contiguous_slice(
       buf,
       [&](void* slice, index_t slice_extent, void* slice2) {
         int* s = reinterpret_cast<int*>(slice);
@@ -638,7 +625,7 @@ TEST(buffer, for_each_contiguous_slice_multi_folded_main_buffer) {
   for (int crop_extent : {1, 2, 3, 4}) {
     buf.dim(1).set_min_extent(8, crop_extent);
     int slices = 0;
-    for_each_contiguous_slice_multi(
+    for_each_contiguous_slice(
         buf,
         [&](void* slice, index_t slice_extent, void* slice2) {
           memset(slice, 7, slice_extent);
@@ -667,7 +654,7 @@ TEST(buffer, for_each_contiguous_slice_multi_folded_other_buffer) {
   buf2.dim(1).set_fold_factor(4);
   buf2.allocate();
   int slices = 0;
-  for_each_contiguous_slice_multi(
+  for_each_contiguous_slice(
       buf,
       [&](void* slice, index_t slice_extent, void* slice2) {
         memset(slice, 7, slice_extent);
@@ -699,7 +686,7 @@ TEST(buffer, for_each_contiguous_slice_multi_folded_all) {
   buf3.dim(1).set_fold_factor(5);
   buf3.allocate();
   int slices = 0;
-  for_each_contiguous_slice_multi(
+  for_each_contiguous_slice(
       buf,
       [&](void* slice, index_t slice_extent, void* slice2, void* slice3) {
         memset(slice, 7, slice_extent);
@@ -748,7 +735,7 @@ TEST(buffer, for_each_contiguous_slice_multi_folded_all_with_offset) {
   buf3.translate(-1, -1, -1);
   fill_slow(buf3, 43);
   int slices = 0;
-  for_each_contiguous_slice_multi(
+  for_each_contiguous_slice(
       buf,
       [&](void* slice, index_t slice_extent, void* slice2, void* slice3) {
         memset(slice, 7, slice_extent);

--- a/runtime/buffer_test.cc
+++ b/runtime/buffer_test.cc
@@ -425,22 +425,25 @@ TEST(buffer, copy) {
 }
 
 TEST(buffer, for_each_contiguous_slice_multi) {
-  buffer<char, 3> buf({10, 20, 30});
-  buffer<char, 3> buf2({10, 20, 30});
-  buf.allocate();
-  buf2.allocate();
+  buffer<char, 3> dst({10, 20, 30});
+  buffer<char, 3> src({10, 20, 30});
+  dst.allocate();
+  src.allocate();
+  char x = 42;
+  fill(src, &x);
   int slices = 0;
   for_each_contiguous_slice(
-      buf,
-      [&](void* slice, index_t slice_extent, void* slice2) {
-        memset(slice, 7, slice_extent);
-        memset(slice2, 7, slice_extent);
+      dst,
+      [&](void* dst, index_t slice_extent, void* src) {
+        const char* s = reinterpret_cast<const char*>(src);
+        char* d = reinterpret_cast<char*>(dst);
+        memcpy(d, s, slice_extent);
         slices++;
       },
-      buf2);
+      src);
   ASSERT_EQ(slices, 1);
-  for_each_index(buf, [&](auto i) { ASSERT_EQ(buf(i), 7); });
-  for_each_index(buf2, [&](auto i) { ASSERT_EQ(buf2(i), 7); });
+  for_each_index(dst, [&](auto i) { ASSERT_EQ(dst(i), 42); });
+  for_each_index(src, [&](auto i) { ASSERT_EQ(src(i), 42); });
 }
 
 TEST(buffer, for_each_contiguous_slice_multi_padded) {


### PR DESCRIPTION
~~I added this as a separate API because during dev work I didn't want to involve conflicts, but~~ the API is backwards-compatible and the performance is basically identical when you pass just a single buffer (according to the benchmarks I added).

I think that the fusing and folding handling is basically correct; there might be additional opportunities for optimization (especially for folding) but I think this is ready for review.