### PR TITLE
Clean up simplifier

### DIFF
--- a/builder/pipeline.cc
+++ b/builder/pipeline.cc
@@ -494,7 +494,7 @@ void add_buffer_checks(const buffer_expr_ptr& b, bool output, std::vector<stmt>&
   checks.push_back(check::make(buf_var != 0));
   // TODO: Maybe this check is overzealous (https://github.com/dsharlet/slinky/issues/17).
   checks.push_back(check::make(buffer_rank(buf_var) == rank));
-  checks.push_back(check::make(buffer_base(buf_var) != 0));
+  checks.push_back(check::make(buffer_at(buf_var) != 0));
   checks.push_back(check::make(buffer_elem_size(buf_var) == b->elem_size()));
   for (int d = 0; d < rank; ++d) {
     expr fold_factor = buffer_fold_factor(buf_var, d);

--- a/builder/rewrite.h
+++ b/builder/rewrite.h
@@ -126,8 +126,9 @@ bool match(const pattern_binary<T, A, B>& p, const expr& x, match_context& ctx) 
     if (this_bit >= 0 && (ctx.variant & (1 << this_bit)) != 0) {
       // We should commute in this variant.
       return match(p.a, t->b, ctx) && match(p.b, t->a, ctx);
+    } else {
+      return match(p.a, t->a, ctx) && match(p.b, t->b, ctx);
     }
-    return match(p.a, t->a, ctx) && match(p.b, t->b, ctx);
   } else {
     return false;
   }

--- a/builder/rewrite.h
+++ b/builder/rewrite.h
@@ -21,8 +21,8 @@ struct match_context {
   int variant_bits;
 };
 
-SLINKY_ALWAYS_INLINE inline bool match(index_t p, const expr& x, match_context& ctx) { return is_constant(x, p); }
-SLINKY_ALWAYS_INLINE inline expr substitute(index_t p, const match_context& ctx) { return p; }
+SLINKY_ALWAYS_INLINE inline bool match(index_t p, const expr& x, match_context&) { return is_constant(x, p); }
+SLINKY_ALWAYS_INLINE inline expr substitute(index_t p, const match_context&) { return p; }
 SLINKY_ALWAYS_INLINE inline node_type pattern_type(index_t) { return node_type::constant; }
 
 class pattern_expr {

--- a/builder/rewrite.h
+++ b/builder/rewrite.h
@@ -239,11 +239,6 @@ public:
 };
 
 template <typename T, typename Fn>
-SLINKY_ALWAYS_INLINE inline node_type pattern_type(const replacement_predicate<T, Fn>&) {
-  return node_type::none;
-}
-
-template <typename T, typename Fn>
 bool substitute(const replacement_predicate<T, Fn>& r, const match_context& ctx) {
   return r.fn(substitute(r.a, ctx));
 }

--- a/builder/simplify.cc
+++ b/builder/simplify.cc
@@ -533,7 +533,7 @@ public:
     }
 
     if (const call* bc = base.as<call>()) {
-      if (bc->intrinsic == intrinsic::buffer_base) {
+      if (bc->intrinsic == intrinsic::buffer_at && bc->args.size() == 1) {
         // Check if this make_buffer is truncate_rank, or a clone.
         const symbol_id* src_buf = as_variable(bc->args[0]);
         if (src_buf) {

--- a/builder/simplify.cc
+++ b/builder/simplify.cc
@@ -517,9 +517,8 @@ public:
       interval_expr new_bounds = mutate(op->dims[d].bounds);
       body = substitute_bounds(body, op->sym, d, new_bounds);
       dim_expr new_dim = {new_bounds, mutate(op->dims[d].stride), mutate(op->dims[d].fold_factor)};
-      if (is_one(new_dim.fold_factor) || prove_true(new_dim.bounds.extent() == 1)) {
+      if (prove_true(new_dim.fold_factor == 1 || new_dim.bounds.extent() == 1)) {
         new_dim.stride = 0;
-        new_dim.fold_factor = expr();
       }
       changed = changed || !new_dim.same_as(op->dims[d]);
       dims.push_back(std::move(new_dim));

--- a/builder/simplify_exprs.cc
+++ b/builder/simplify_exprs.cc
@@ -29,11 +29,16 @@ expr simplify(const class min* op, expr a, expr b) {
   if (should_commute(a, b)) {
     std::swap(a, b);
   }
+
   const index_t* ca = as_constant(a);
   const index_t* cb = as_constant(b);
   if (ca && cb) {
     return std::min(*ca, *cb);
   }
+
+  if (is_indeterminate(a)) return a;
+  if (is_indeterminate(b)) return b;
+
   expr e;
   if (op && a.same_as(op->a) && b.same_as(op->b)) {
     e = op;
@@ -43,7 +48,6 @@ expr simplify(const class min* op, expr a, expr b) {
 
   rewriter r(e);
   if (// Constant simplifications
-      r.rewrite(min(x, rewrite::indeterminate()), rewrite::indeterminate()) ||
       r.rewrite(min(x, std::numeric_limits<index_t>::max()), x) ||
       r.rewrite(min(x, rewrite::positive_infinity()), x) ||
       r.rewrite(min(x, std::numeric_limits<index_t>::min()), std::numeric_limits<index_t>::min()) ||
@@ -94,11 +98,16 @@ expr simplify(const class max* op, expr a, expr b) {
   if (should_commute(a, b)) {
     std::swap(a, b);
   }
+
   const index_t* ca = as_constant(a);
   const index_t* cb = as_constant(b);
   if (ca && cb) {
     return std::max(*ca, *cb);
   }
+
+  if (is_indeterminate(a)) return a;
+  if (is_indeterminate(b)) return b;
+
   expr e;
   if (op && a.same_as(op->a) && b.same_as(op->b)) {
     e = op;
@@ -108,7 +117,6 @@ expr simplify(const class max* op, expr a, expr b) {
 
   rewriter r(e);
   if (// Constant simplifications
-      r.rewrite(max(x, rewrite::indeterminate()), rewrite::indeterminate()) ||
       r.rewrite(max(x, std::numeric_limits<index_t>::min()), x) ||
       r.rewrite(max(x, rewrite::negative_infinity()), x) ||
       r.rewrite(max(x, std::numeric_limits<index_t>::max()), std::numeric_limits<index_t>::max()) ||
@@ -155,11 +163,16 @@ expr simplify(const add* op, expr a, expr b) {
   if (should_commute(a, b)) {
     std::swap(a, b);
   }
+
   const index_t* ca = as_constant(a);
   const index_t* cb = as_constant(b);
   if (ca && cb) {
     return *ca + *cb;
   }
+
+  if (is_indeterminate(a)) return a;
+  if (is_indeterminate(b)) return b;
+
   expr e;
   if (op && a.same_as(op->a) && b.same_as(op->b)) {
     e = op;
@@ -168,8 +181,7 @@ expr simplify(const add* op, expr a, expr b) {
   }
 
   rewriter r(e);
-  if (r.rewrite(x + rewrite::indeterminate(), rewrite::indeterminate()) ||
-      r.rewrite(rewrite::positive_infinity() + rewrite::positive_infinity(), rewrite::positive_infinity()) ||
+  if (r.rewrite(rewrite::positive_infinity() + rewrite::positive_infinity(), rewrite::positive_infinity()) ||
       r.rewrite(rewrite::negative_infinity() + rewrite::negative_infinity(), rewrite::negative_infinity()) ||
       r.rewrite(rewrite::negative_infinity() + rewrite::positive_infinity(), rewrite::indeterminate()) ||
       r.rewrite(x + rewrite::positive_infinity(), rewrite::positive_infinity(), is_finite(x)) ||
@@ -229,8 +241,6 @@ expr simplify(const add* op, expr a, expr b) {
 }
 
 expr simplify(const sub* op, expr a, expr b) {
-  assert(a.defined());
-  assert(b.defined());
   const index_t* ca = as_constant(a);
   const index_t* cb = as_constant(b);
   if (ca && cb) {
@@ -240,6 +250,9 @@ expr simplify(const sub* op, expr a, expr b) {
     return simplify(static_cast<add*>(nullptr), a, -*cb);
   }
 
+  if (is_indeterminate(a)) return a;
+  if (is_indeterminate(b)) return b;
+
   expr e;
   if (op && a.same_as(op->a) && b.same_as(op->b)) {
     e = op;
@@ -248,9 +261,7 @@ expr simplify(const sub* op, expr a, expr b) {
   }
 
   rewriter r(e);
-  if (r.rewrite(x - rewrite::indeterminate(), rewrite::indeterminate()) ||
-      r.rewrite(rewrite::indeterminate() - x, rewrite::indeterminate()) ||
-      r.rewrite(rewrite::positive_infinity() - rewrite::positive_infinity(), rewrite::indeterminate()) ||
+  if (r.rewrite(rewrite::positive_infinity() - rewrite::positive_infinity(), rewrite::indeterminate()) ||
       r.rewrite(rewrite::positive_infinity() - rewrite::negative_infinity(), rewrite::positive_infinity()) ||
       r.rewrite(rewrite::negative_infinity() - rewrite::negative_infinity(), rewrite::indeterminate()) ||
       r.rewrite(rewrite::negative_infinity() - rewrite::positive_infinity(), rewrite::negative_infinity()) ||
@@ -302,11 +313,16 @@ expr simplify(const mul* op, expr a, expr b) {
   if (should_commute(a, b)) {
     std::swap(a, b);
   }
+
   const index_t* ca = as_constant(a);
   const index_t* cb = as_constant(b);
   if (ca && cb) {
     return *ca * *cb;
   }
+
+  if (is_indeterminate(a)) return a;
+  if (is_indeterminate(b)) return b;
+
   expr e;
   if (op && a.same_as(op->a) && b.same_as(op->b)) {
     e = op;
@@ -315,8 +331,7 @@ expr simplify(const mul* op, expr a, expr b) {
   }
 
   rewriter r(e);
-  if (r.rewrite(x * rewrite::indeterminate(), rewrite::indeterminate()) ||
-      r.rewrite(rewrite::positive_infinity() * rewrite::positive_infinity(), rewrite::positive_infinity()) ||
+  if (r.rewrite(rewrite::positive_infinity() * rewrite::positive_infinity(), rewrite::positive_infinity()) ||
       r.rewrite(rewrite::negative_infinity() * rewrite::positive_infinity(), rewrite::negative_infinity()) ||
       r.rewrite(rewrite::negative_infinity() * rewrite::negative_infinity(), rewrite::positive_infinity()) ||
       r.rewrite(rewrite::positive_infinity() * c0, rewrite::positive_infinity(), eval(c0 > 0)) ||
@@ -341,6 +356,10 @@ expr simplify(const div* op, expr a, expr b) {
   if (ca && cb) {
     return euclidean_div(*ca, *cb);
   }
+
+  if (is_indeterminate(a)) return a;
+  if (is_indeterminate(b)) return b;
+
   expr e;
   if (op && a.same_as(op->a) && b.same_as(op->b)) {
     e = op;
@@ -349,9 +368,7 @@ expr simplify(const div* op, expr a, expr b) {
   }
 
   rewriter r(e);
-  if (r.rewrite(x / rewrite::indeterminate(), rewrite::indeterminate()) ||
-      r.rewrite(rewrite::indeterminate() / x, rewrite::indeterminate()) ||
-      r.rewrite(rewrite::positive_infinity() / rewrite::positive_infinity(), rewrite::indeterminate()) ||
+  if (r.rewrite(rewrite::positive_infinity() / rewrite::positive_infinity(), rewrite::indeterminate()) ||
       r.rewrite(rewrite::positive_infinity() / rewrite::negative_infinity(), rewrite::indeterminate()) ||
       r.rewrite(rewrite::negative_infinity() / rewrite::positive_infinity(), rewrite::indeterminate()) ||
       r.rewrite(rewrite::negative_infinity() / rewrite::negative_infinity(), rewrite::indeterminate()) ||
@@ -529,6 +546,7 @@ expr simplify(const equal* op, expr a, expr b) {
   if (should_commute(a, b)) {
     std::swap(a, b);
   }
+
   const index_t* ca = as_constant(a);
   const index_t* cb = as_constant(b);
   if (ca && cb) {

--- a/builder/simplify_exprs.cc
+++ b/builder/simplify_exprs.cc
@@ -422,18 +422,19 @@ expr simplify(const less* op, expr a, expr b) {
       r.rewrite(x < rewrite::positive_infinity(), true, is_finite(x)) ||
       r.rewrite(x < rewrite::negative_infinity(), false, is_finite(x)) ||
       r.rewrite(x < x, false) ||
+    
       r.rewrite(x + c0 < c1, x < eval(c1 - c0)) ||
-      r.rewrite(x < x + y, 0 < y) ||
-      r.rewrite(x + y < x, y < 0) ||
-      r.rewrite(x - y < x, 0 < y) ||
-      r.rewrite(0 - x < c0, -c0 < x) ||
       r.rewrite(c0 - x < c1, eval(c0 - c1) < x) ||
       r.rewrite(c0 < c1 - x, x < eval(c1 - c0)) ||
+      r.rewrite(c0 < x + c1, eval(c0 - c1) < x) ||
 
       r.rewrite(x < x + y, 0 < y) ||
       r.rewrite(x + y < x, y < 0) ||
-      r.rewrite(x < x - y, y < 0) ||
       r.rewrite(x - y < x, 0 < y) ||
+      r.rewrite(x < x - y, y < 0) ||
+      r.rewrite(x - y < y, x < y * 2) ||
+      r.rewrite(y < x - y, y * 2 < x) ||
+
       r.rewrite(x + y < x + z, y < z) ||
       r.rewrite(x - y < x - z, z < y) ||
       r.rewrite(x - y < z - y, x < z) ||
@@ -483,18 +484,22 @@ expr simplify(const less_equal* op, expr a, expr b) {
       r.rewrite(x <= x + y, 0 <= y) ||
       r.rewrite(x + y <= x, y <= 0) ||
       r.rewrite(x - y <= x, 0 <= y) ||
-      r.rewrite(0 - x <= c0, -c0 <= x) ||
-      r.rewrite(c0 - x <= y, c0 <= y + x) ||
-      r.rewrite(x <= c1 - y, x + y <= c1) ||
-      r.rewrite(x + c0 <= y + c1, x - y <= eval(c1 - c0)) ||
+
+      r.rewrite(x + c0 <= c1, x <= eval(c1 - c0)) ||
+      r.rewrite(c0 - x <= c1, eval(c0 - c1) <= x) ||
+      r.rewrite(c0 <= c1 - x, x <= eval(c1 - c0)) ||
+      r.rewrite(c0 <= x + c1, eval(c0 - c1) <= x) ||
 
       r.rewrite((x + c0) / c1 <= x / c1, eval(c0 <= 0)) ||
       r.rewrite(x / c1 <= (x + c0) / c1, eval(0 <= c0)) ||
-
+    
       r.rewrite(x <= x + y, 0 <= y) ||
       r.rewrite(x + y <= x, y <= 0) ||
-      r.rewrite(x <= x - y, y <= 0) ||
       r.rewrite(x - y <= x, 0 <= y) ||
+      r.rewrite(x <= x - y, y <= 0) ||
+      r.rewrite(x - y <= y, x <= y * 2) ||
+      r.rewrite(y <= x - y, y * 2 <= x) ||
+    
       r.rewrite(x + y <= x + z, y <= z) ||
       r.rewrite(x - y <= x - z, z <= y) ||
       r.rewrite(x - y <= z - y, x <= z) ||

--- a/builder/simplify_exprs.cc
+++ b/builder/simplify_exprs.cc
@@ -732,7 +732,7 @@ expr simplify(const call* op, intrinsic fn, std::vector<expr> args) {
   if (fn == intrinsic::buffer_at) {
     // Trailing undefined indices can be removed.
     for (index_t d = 1; d < static_cast<index_t>(args.size()); ++d) {
-      // buffer_at(b, buffer_min(b, 0)) is equivalent to buffer_base(b)
+      // buffer_at(b, buffer_min(b, 0)) is equivalent to buffer_at(b)
       if (args[d].defined() && match(args[d], buffer_min(args[0], d - 1))) {
         args[d] = expr();
         changed = true;
@@ -742,10 +742,6 @@ expr simplify(const call* op, intrinsic fn, std::vector<expr> args) {
     while (args.size() > 1 && !args.back().defined()) {
       args.pop_back();
       changed = true;
-    }
-
-    if (args.size() == 1) {
-      return call::make(intrinsic::buffer_base, std::move(args));
     }
   }
 

--- a/builder/simplify_exprs.cc
+++ b/builder/simplify_exprs.cc
@@ -331,8 +331,7 @@ expr simplify(const mul* op, expr a, expr b) {
       r.rewrite(x * 1, x) ||
       r.rewrite((x * c0) * c1, x * eval(c0 * c1)) ||
       r.rewrite((x + c0) * c1, x * c1 + eval(c0 * c1)) ||
-      r.rewrite((0 - x) * c1, x * eval(-c1)) ||
-      r.rewrite((c0 - x) * c1, eval(c0 * c1) - x * c1) ||
+      r.rewrite((c0 - x) * c1, eval(c0 * c1) + x * eval(-c1)) ||
       false) {
     return r.result;
   }

--- a/builder/simplify_exprs.cc
+++ b/builder/simplify_exprs.cc
@@ -172,6 +172,9 @@ expr simplify(const add* op, expr a, expr b) {
 
   if (is_indeterminate(a)) return a;
   if (is_indeterminate(b)) return b;
+  int inf_a = is_infinity(a);
+  int inf_b = is_infinity(b);
+  if (inf_a && inf_b) return inf_a == inf_b ? a : slinky::indeterminate();
 
   expr e;
   if (op && a.same_as(op->a) && b.same_as(op->b)) {
@@ -181,10 +184,7 @@ expr simplify(const add* op, expr a, expr b) {
   }
 
   rewriter r(e);
-  if (r.rewrite(rewrite::positive_infinity() + rewrite::positive_infinity(), rewrite::positive_infinity()) ||
-      r.rewrite(rewrite::negative_infinity() + rewrite::negative_infinity(), rewrite::negative_infinity()) ||
-      r.rewrite(rewrite::negative_infinity() + rewrite::positive_infinity(), rewrite::indeterminate()) ||
-      r.rewrite(x + rewrite::positive_infinity(), rewrite::positive_infinity(), is_finite(x)) ||
+  if (r.rewrite(x + rewrite::positive_infinity(), rewrite::positive_infinity(), is_finite(x)) ||
       r.rewrite(x + rewrite::negative_infinity(), rewrite::negative_infinity(), is_finite(x)) ||
       r.rewrite(x + 0, x) ||
       r.rewrite(x + x, x * 2) ||
@@ -252,6 +252,9 @@ expr simplify(const sub* op, expr a, expr b) {
 
   if (is_indeterminate(a)) return a;
   if (is_indeterminate(b)) return b;
+  int inf_a = is_infinity(a);
+  int inf_b = is_infinity(b);
+  if (inf_a && inf_b) return inf_a == inf_b ? slinky::indeterminate() : a;
 
   expr e;
   if (op && a.same_as(op->a) && b.same_as(op->b)) {
@@ -261,11 +264,7 @@ expr simplify(const sub* op, expr a, expr b) {
   }
 
   rewriter r(e);
-  if (r.rewrite(rewrite::positive_infinity() - rewrite::positive_infinity(), rewrite::indeterminate()) ||
-      r.rewrite(rewrite::positive_infinity() - rewrite::negative_infinity(), rewrite::positive_infinity()) ||
-      r.rewrite(rewrite::negative_infinity() - rewrite::negative_infinity(), rewrite::indeterminate()) ||
-      r.rewrite(rewrite::negative_infinity() - rewrite::positive_infinity(), rewrite::negative_infinity()) ||
-      r.rewrite(x - rewrite::positive_infinity(), rewrite::negative_infinity(), is_finite(x)) ||
+  if (r.rewrite(x - rewrite::positive_infinity(), rewrite::negative_infinity(), is_finite(x)) ||
       r.rewrite(x - rewrite::negative_infinity(), rewrite::positive_infinity(), is_finite(x)) ||
       r.rewrite(x - x, 0) ||
       r.rewrite(x - 0, x) ||
@@ -322,6 +321,9 @@ expr simplify(const mul* op, expr a, expr b) {
 
   if (is_indeterminate(a)) return a;
   if (is_indeterminate(b)) return b;
+  int inf_a = is_infinity(a);
+  int inf_b = is_infinity(b);
+  if (inf_a && inf_b) return infinity(inf_a * inf_b);
 
   expr e;
   if (op && a.same_as(op->a) && b.same_as(op->b)) {
@@ -331,10 +333,7 @@ expr simplify(const mul* op, expr a, expr b) {
   }
 
   rewriter r(e);
-  if (r.rewrite(rewrite::positive_infinity() * rewrite::positive_infinity(), rewrite::positive_infinity()) ||
-      r.rewrite(rewrite::negative_infinity() * rewrite::positive_infinity(), rewrite::negative_infinity()) ||
-      r.rewrite(rewrite::negative_infinity() * rewrite::negative_infinity(), rewrite::positive_infinity()) ||
-      r.rewrite(rewrite::positive_infinity() * c0, rewrite::positive_infinity(), eval(c0 > 0)) ||
+  if (r.rewrite(rewrite::positive_infinity() * c0, rewrite::positive_infinity(), eval(c0 > 0)) ||
       r.rewrite(rewrite::negative_infinity() * c0, rewrite::negative_infinity(), eval(c0 > 0)) ||
       r.rewrite(rewrite::positive_infinity() * c0, rewrite::negative_infinity(), eval(c0 < 0)) ||
       r.rewrite(rewrite::negative_infinity() * c0, rewrite::positive_infinity(), eval(c0 < 0)) ||
@@ -359,6 +358,7 @@ expr simplify(const div* op, expr a, expr b) {
 
   if (is_indeterminate(a)) return a;
   if (is_indeterminate(b)) return b;
+  if (is_infinity(a) && is_infinity(b)) return slinky::indeterminate();
 
   expr e;
   if (op && a.same_as(op->a) && b.same_as(op->b)) {
@@ -368,11 +368,7 @@ expr simplify(const div* op, expr a, expr b) {
   }
 
   rewriter r(e);
-  if (r.rewrite(rewrite::positive_infinity() / rewrite::positive_infinity(), rewrite::indeterminate()) ||
-      r.rewrite(rewrite::positive_infinity() / rewrite::negative_infinity(), rewrite::indeterminate()) ||
-      r.rewrite(rewrite::negative_infinity() / rewrite::positive_infinity(), rewrite::indeterminate()) ||
-      r.rewrite(rewrite::negative_infinity() / rewrite::negative_infinity(), rewrite::indeterminate()) ||
-      r.rewrite(x / rewrite::positive_infinity(), 0, is_finite(x)) ||
+  if (r.rewrite(x / rewrite::positive_infinity(), 0, is_finite(x)) ||
       r.rewrite(x / rewrite::negative_infinity(), 0, is_finite(x)) ||
       r.rewrite(rewrite::positive_infinity() / c0, rewrite::positive_infinity(), eval(c0 > 0)) ||
       r.rewrite(rewrite::negative_infinity() / c0, rewrite::negative_infinity(), eval(c0 > 0)) ||

--- a/builder/simplify_exprs.cc
+++ b/builder/simplify_exprs.cc
@@ -540,7 +540,7 @@ expr simplify(const equal* op, expr a, expr b) {
   rewriter r(e);
   if (r.rewrite(x == x, true) ||
       r.rewrite(x + c0 == c1, x == eval(c1 - c0)) ||
-      r.rewrite(c0 - x == c1, -x == eval(c1 - c0), eval(c0 != 0)) ||
+      r.rewrite(c0 - x == c1, x == eval(c0 - c1)) ||
       false) {
     return r.result;
   }
@@ -567,7 +567,7 @@ expr simplify(const not_equal* op, expr a, expr b) {
   rewriter r(e);
   if (r.rewrite(x != x, false) ||
       r.rewrite(x + c0 != c1, x != eval(c1 - c0)) ||
-      r.rewrite(c0 - x != c1, -x != eval(c1 - c0), eval(c0 != 0)) ||
+      r.rewrite(c0 - x != c1, x != eval(c0 - c1)) ||
       false) {
     return r.result;
   }

--- a/builder/simplify_exprs.cc
+++ b/builder/simplify_exprs.cc
@@ -23,7 +23,7 @@ pattern_constant c0{0};
 pattern_constant c1{1};
 pattern_constant c2{2};
 
-} // namespace
+}  // namespace
 
 expr simplify(const class min* op, expr a, expr b) {
   if (should_commute(a, b)) {
@@ -40,6 +40,7 @@ expr simplify(const class min* op, expr a, expr b) {
   if (is_indeterminate(b)) return b;
 
   auto r = make_rewriter(min(pattern_expr{a}, pattern_expr{b}));
+  // clang-format off
   if (// Constant simplifications
       r.rewrite(min(x, std::numeric_limits<index_t>::max()), x) ||
       r.rewrite(min(x, rewrite::positive_infinity()), x) ||
@@ -84,6 +85,7 @@ expr simplify(const class min* op, expr a, expr b) {
       false) {
     return r.result;
   }
+  // clang-format on
   if (op && a.same_as(op->a) && b.same_as(op->b)) {
     return op;
   } else {
@@ -106,6 +108,7 @@ expr simplify(const class max* op, expr a, expr b) {
   if (is_indeterminate(b)) return b;
 
   auto r = make_rewriter(max(pattern_expr{a}, pattern_expr{b}));
+  // clang-format off
   if (// Constant simplifications
       r.rewrite(max(x, std::numeric_limits<index_t>::min()), x) ||
       r.rewrite(max(x, rewrite::negative_infinity()), x) ||
@@ -146,6 +149,7 @@ expr simplify(const class max* op, expr a, expr b) {
       false) {
     return r.result;
   }
+  // clang-format on
   if (op && a.same_as(op->a) && b.same_as(op->b)) {
     return op;
   } else {
@@ -171,6 +175,7 @@ expr simplify(const add* op, expr a, expr b) {
   if (inf_a && inf_b) return inf_a == inf_b ? a : slinky::indeterminate();
 
   auto r = make_rewriter(pattern_expr{a} + pattern_expr{b});
+  // clang-format off
   if (r.rewrite(x + rewrite::positive_infinity(), rewrite::positive_infinity(), is_finite(x)) ||
       r.rewrite(x + rewrite::negative_infinity(), rewrite::negative_infinity(), is_finite(x)) ||
       r.rewrite(x + 0, x) ||
@@ -224,6 +229,7 @@ expr simplify(const add* op, expr a, expr b) {
       false) {
     return r.result;
   }
+  // clang-format on
   if (op && a.same_as(op->a) && b.same_as(op->b)) {
     return op;
   } else {
@@ -248,6 +254,7 @@ expr simplify(const sub* op, expr a, expr b) {
   if (inf_a && inf_b) return inf_a == inf_b ? slinky::indeterminate() : a;
 
   auto r = make_rewriter(pattern_expr{a} - pattern_expr{b});
+  // clang-format off
   if (r.rewrite(x - rewrite::positive_infinity(), rewrite::negative_infinity(), is_finite(x)) ||
       r.rewrite(x - rewrite::negative_infinity(), rewrite::positive_infinity(), is_finite(x)) ||
       r.rewrite(x - x, 0) ||
@@ -289,6 +296,7 @@ expr simplify(const sub* op, expr a, expr b) {
       false) {
     return r.result;
   }
+  // clang-format on
   if (op && a.same_as(op->a) && b.same_as(op->b)) {
     return op;
   } else {
@@ -314,6 +322,7 @@ expr simplify(const mul* op, expr a, expr b) {
   if (inf_a && inf_b) return infinity(inf_a * inf_b);
 
   auto r = make_rewriter(pattern_expr{a} * pattern_expr{b});
+  // clang-format off
   if (r.rewrite(rewrite::positive_infinity() * c0, rewrite::positive_infinity(), eval(c0 > 0)) ||
       r.rewrite(rewrite::negative_infinity() * c0, rewrite::negative_infinity(), eval(c0 > 0)) ||
       r.rewrite(rewrite::positive_infinity() * c0, rewrite::negative_infinity(), eval(c0 < 0)) ||
@@ -327,6 +336,7 @@ expr simplify(const mul* op, expr a, expr b) {
       false) {
     return r.result;
   }
+  // clang-format on
   if (op && a.same_as(op->a) && b.same_as(op->b)) {
     return op;
   } else {
@@ -346,6 +356,7 @@ expr simplify(const div* op, expr a, expr b) {
   if (is_infinity(a) && is_infinity(b)) return slinky::indeterminate();
 
   auto r = make_rewriter(pattern_expr{a} / pattern_expr{b});
+  // clang-format off
   if (r.rewrite(x / rewrite::positive_infinity(), 0, is_finite(x)) ||
       r.rewrite(x / rewrite::negative_infinity(), 0, is_finite(x)) ||
       r.rewrite(rewrite::positive_infinity() / c0, rewrite::positive_infinity(), eval(c0 > 0)) ||
@@ -367,6 +378,7 @@ expr simplify(const div* op, expr a, expr b) {
       false) {
     return r.result;
   }
+  // clang-format on
   if (op && a.same_as(op->a) && b.same_as(op->b)) {
     return op;
   } else {
@@ -382,12 +394,14 @@ expr simplify(const mod* op, expr a, expr b) {
   }
 
   auto r = make_rewriter(pattern_expr{a} % pattern_expr{b});
+  // clang-format off
   if (r.rewrite(x % 1, 0) || 
       r.rewrite(x % 0, 0) || 
       r.rewrite(x % x, 0) ||
       false) {
     return r.result;
   }
+  // clang-format on
   if (op && a.same_as(op->a) && b.same_as(op->b)) {
     return op;
   } else {
@@ -403,6 +417,7 @@ expr simplify(const less* op, expr a, expr b) {
   }
 
   auto r = make_rewriter(pattern_expr{a} < pattern_expr{b});
+  // clang-format off
   if (r.rewrite(rewrite::positive_infinity() < x, false, is_finite(x)) ||
       r.rewrite(rewrite::negative_infinity() < x, true, is_finite(x)) ||
       r.rewrite(x < rewrite::positive_infinity(), true, is_finite(x)) ||
@@ -444,6 +459,7 @@ expr simplify(const less* op, expr a, expr b) {
       false) {
     return r.result;
   }
+  // clang-format on
   if (op && a.same_as(op->a) && b.same_as(op->b)) {
     return op;
   } else {
@@ -459,6 +475,7 @@ expr simplify(const less_equal* op, expr a, expr b) {
   }
 
   auto r = make_rewriter(pattern_expr{a} <= pattern_expr{b});
+  // clang-format off
   if (r.rewrite(rewrite::positive_infinity() <= x, false, is_finite(x)) ||
       r.rewrite(rewrite::negative_infinity() <= x, true, is_finite(x)) ||
       r.rewrite(x <= rewrite::positive_infinity(), true, is_finite(x)) ||
@@ -505,6 +522,7 @@ expr simplify(const less_equal* op, expr a, expr b) {
       false) {
     return r.result;
   }
+  // clang-format on
   if (op && a.same_as(op->a) && b.same_as(op->b)) {
     return op;
   } else {
@@ -524,12 +542,14 @@ expr simplify(const equal* op, expr a, expr b) {
   }
 
   auto r = make_rewriter(pattern_expr{a} == pattern_expr{b});
+  // clang-format off
   if (r.rewrite(x == x, true) ||
       r.rewrite(x + c0 == c1, x == eval(c1 - c0)) ||
       r.rewrite(c0 - x == c1, x == eval(c0 - c1)) ||
       false) {
     return r.result;
   }
+  // clang-format on
   if (op && a.same_as(op->a) && b.same_as(op->b)) {
     return op;
   } else {
@@ -548,12 +568,14 @@ expr simplify(const not_equal* op, expr a, expr b) {
   }
 
   auto r = make_rewriter(pattern_expr{a} != pattern_expr{b});
+  // clang-format off
   if (r.rewrite(x != x, false) ||
       r.rewrite(x + c0 != c1, x != eval(c1 - c0)) ||
       r.rewrite(c0 - x != c1, x != eval(c0 - c1)) ||
       false) {
     return r.result;
   }
+  // clang-format on
   if (op && a.same_as(op->a) && b.same_as(op->b)) {
     return op;
   } else {
@@ -575,6 +597,7 @@ expr simplify(const logical_and* op, expr a, expr b) {
   }
 
   auto r = make_rewriter(pattern_expr{a} && pattern_expr{b});
+  // clang-format off
   if (r.rewrite(x && x, x) ||
       r.rewrite(x && !x, false) ||
       r.rewrite(!x && x, false) ||
@@ -586,6 +609,7 @@ expr simplify(const logical_and* op, expr a, expr b) {
       false) {
     return r.result;
   }
+  // clang-format on
   if (op && a.same_as(op->a) && b.same_as(op->b)) {
     return op;
   } else {
@@ -607,6 +631,7 @@ expr simplify(const logical_or* op, expr a, expr b) {
   }
 
   auto r = make_rewriter(pattern_expr{a} || pattern_expr{b});
+  // clang-format off
   if (r.rewrite(x || x, x) ||
       r.rewrite(x || !x, true) ||
       r.rewrite(!x || x, true) ||
@@ -617,7 +642,8 @@ expr simplify(const logical_or* op, expr a, expr b) {
       r.rewrite((x || y) || x, x || y) ||
       false) {
     return r.result;
-  };
+  }
+  // clang-format on
   if (op && a.same_as(op->a) && b.same_as(op->b)) {
     return op;
   } else {
@@ -632,6 +658,7 @@ expr simplify(const class logical_not* op, expr a) {
   }
 
   auto r = make_rewriter(!pattern_expr{a});
+  // clang-format off
   if (r.rewrite(!!x, x) ||
       r.rewrite(!(x == y), x != y) ||
       r.rewrite(!(x != y), x == y) ||
@@ -640,6 +667,7 @@ expr simplify(const class logical_not* op, expr a) {
       false) {
     return r.result;
   }
+  // clang-format on
   if (op && a.same_as(op->a)) {
     return op;
   } else {
@@ -658,6 +686,7 @@ expr simplify(const class select* op, expr c, expr t, expr f) {
   }
 
   auto r = make_rewriter(select(pattern_expr{c}, pattern_expr{t}, pattern_expr{f}));
+  // clang-format off
   if (r.rewrite(select(x, y, y), y) ||
       r.rewrite(select(!x, y, z), select(x, z, y)) ||
 
@@ -669,6 +698,7 @@ expr simplify(const class select* op, expr c, expr t, expr f) {
       false) {
     return r.result;
   }
+  // clang-format on
   if (op && c.same_as(op->condition) && t.same_as(op->true_value) && f.same_as(op->false_value)) {
     return op;
   } else {
@@ -713,12 +743,14 @@ expr simplify(const call* op, intrinsic fn, std::vector<expr> args) {
   }
 
   rewriter r(e);
+  // clang-format off
   if (r.rewrite(abs(rewrite::negative_infinity()), rewrite::positive_infinity()) || 
       r.rewrite(abs(-x), abs(x)) ||
       r.rewrite(abs(abs(x)), abs(x)) ||
       false) {
     return r.result;
   }
+  // clang-format on
   return e;
 }
 

--- a/builder/simplify_test.cc
+++ b/builder/simplify_test.cc
@@ -282,7 +282,7 @@ expr random_buffer_intrinsic() {
   case 0: return buffer_min(random_pick(bufs), rand() % max_rank);
   case 1: return buffer_extent(random_pick(bufs), rand() % max_rank);
   case 2: return buffer_max(random_pick(bufs), rand() % max_rank);
-  default: return buffer_base(random_pick(bufs));
+  default: return buffer_at(random_pick(bufs));
   }
 }
 

--- a/builder/substitute_test.cc
+++ b/builder/substitute_test.cc
@@ -59,4 +59,38 @@ TEST(substitute, shadowed) {
       slice_dim::make(x.sym(), 2, 0, check::make(buffer_min(x, 3) == 0)));
 }
 
+TEST(match, basic) {
+  ASSERT_TRUE(match(x, x));
+  ASSERT_FALSE(match(x, y));
+  ASSERT_FALSE(match(x, 2));
+  ASSERT_TRUE(match(x * 2, x * 2));
+  ASSERT_FALSE(match(x, x * 2));
+  ASSERT_FALSE(match(x + y, x - y));
+  ASSERT_TRUE(match(x + y, x + y));
+}
+
+void test_wildcards(const expr& pattern, const expr& target, const expr& replacement, const expr& expected) {
+  symbol_map<expr> matches;
+  if (!match(pattern, target, matches)) {
+    std::cout << "match failed" << std::endl;
+    std::cout << "pattern: " << pattern << std::endl;
+    std::cout << "target: " << target << std::endl;
+    ASSERT_TRUE(false);
+  }
+  expr result = substitute(replacement, matches);
+  if (!match(result, expected)) {
+    std::cout << "match failed" << std::endl;
+    std::cout << "pattern: " << pattern << std::endl;
+    std::cout << "target: " << target << std::endl;
+    std::cout << "result: " << result << std::endl;
+    std::cout << "expected: " << expected << std::endl;
+  }
+}
+
+TEST(match, wildcards) {
+  test_wildcards(x, y, x * 2, y * 2);
+  test_wildcards(x - y, z - 2, x + y, z + 2);
+  test_wildcards(x - y, x * 2 - y * 3, x + y, x * 2 + y * 3);
+}
+
 }  // namespace slinky

--- a/runtime/depends_on.cc
+++ b/runtime/depends_on.cc
@@ -48,7 +48,7 @@ public:
   void visit(const call* op) override {
     if (is_buffer_intrinsic(op->intrinsic)) {
       assert(op->args.size() >= 1);
-      accept_buffer(op->args[0], op->intrinsic == intrinsic::buffer_at || op->intrinsic == intrinsic::buffer_base);
+      accept_buffer(op->args[0], op->intrinsic == intrinsic::buffer_at);
 
       for (std::size_t i = 1; i < op->args.size(); ++i) {
         if (op->args[i].defined()) op->args[i].accept(this);

--- a/runtime/evaluate.cc
+++ b/runtime/evaluate.cc
@@ -168,7 +168,6 @@ public:
     switch (op->intrinsic) {
     case intrinsic::buffer_rank: return buf->rank;
     case intrinsic::buffer_elem_size: return buf->elem_size;
-    case intrinsic::buffer_base: return reinterpret_cast<index_t>(buf->base);
     case intrinsic::buffer_size_bytes: return buf->size_bytes();
     default: std::abort();
     }
@@ -217,7 +216,6 @@ public:
 
     case intrinsic::buffer_rank:
     case intrinsic::buffer_elem_size:
-    case intrinsic::buffer_base:
     case intrinsic::buffer_size_bytes: result = eval_buffer_metadata(op); return;
 
     case intrinsic::buffer_min:

--- a/runtime/evaluate_benchmark.cc
+++ b/runtime/evaluate_benchmark.cc
@@ -173,7 +173,7 @@ BENCHMARK(BM_make_buffer);
 void BM_buffer_metadata(benchmark::State& state) {
   std::atomic<int> calls = 0;
   std::vector<dim_expr> dims = {buffer_dim(buf, 0), buffer_dim(buf, 1), buffer_dim(buf, 2)};
-  stmt clone = make_buffer::make(buf2.sym(), buffer_base(buf), buffer_elem_size(buf), dims, make_call_counter(calls));
+  stmt clone = make_buffer::make(buf2.sym(), buffer_at(buf), buffer_elem_size(buf), dims, make_call_counter(calls));
   stmt body = make_buf(3, make_loop(clone));
 
   for (auto _ : state) {

--- a/runtime/expr.cc
+++ b/runtime/expr.cc
@@ -472,6 +472,10 @@ const expr& negative_infinity() {
   static expr e = call::make(intrinsic::negative_infinity, {});
   return e;
 }
+const expr& infinity(int sign) {
+  assert(sign != 0);
+  return sign < 0 ? negative_infinity() : positive_infinity();
+}
 const expr& indeterminate() {
   static expr e = call::make(intrinsic::indeterminate, {});
   return e;

--- a/runtime/expr.cc
+++ b/runtime/expr.cc
@@ -461,15 +461,21 @@ stmt check::make(expr condition) {
 
 namespace {
 
-expr global_positive_infinity = call::make(intrinsic::positive_infinity, {});
-expr global_negative_infinity = call::make(intrinsic::negative_infinity, {});
-expr global_indeterminate = call::make(intrinsic::indeterminate, {});
 
 }  // namespace
 
-const expr& positive_infinity() { return global_positive_infinity; }
-const expr& negative_infinity() { return global_negative_infinity; }
-const expr& indeterminate() { return global_indeterminate; }
+const expr& positive_infinity() {
+  static expr e = call::make(intrinsic::positive_infinity, {});
+  return e;
+}
+const expr& negative_infinity() {
+  static expr e = call::make(intrinsic::negative_infinity, {});
+  return e;
+}
+const expr& indeterminate() {
+  static expr e = call::make(intrinsic::indeterminate, {});
+  return e;
+}
 
 expr abs(expr x) { return call::make(intrinsic::abs, {std::move(x)}); }
 

--- a/runtime/expr.cc
+++ b/runtime/expr.cc
@@ -484,7 +484,6 @@ const expr& indeterminate() {
 expr abs(expr x) { return call::make(intrinsic::abs, {std::move(x)}); }
 
 expr buffer_rank(expr buf) { return call::make(intrinsic::buffer_rank, {std::move(buf)}); }
-expr buffer_base(expr buf) { return call::make(intrinsic::buffer_base, {std::move(buf)}); }
 expr buffer_elem_size(expr buf) { return call::make(intrinsic::buffer_elem_size, {std::move(buf)}); }
 expr buffer_min(expr buf, expr dim) { return call::make(intrinsic::buffer_min, {std::move(buf), std::move(dim)}); }
 expr buffer_max(expr buf, expr dim) { return call::make(intrinsic::buffer_max, {std::move(buf), std::move(dim)}); }
@@ -510,6 +509,8 @@ expr buffer_at(expr buf, span<const var> at) {
   return call::make(intrinsic::buffer_at, std::move(args));
 }
 
+expr buffer_at(expr buf) { return call::make(intrinsic::buffer_at, {std::move(buf)}); }
+
 interval_expr buffer_bounds(const expr& buf, const expr& dim) { return {buffer_min(buf, dim), buffer_max(buf, dim)}; }
 dim_expr buffer_dim(const expr& buf, const expr& dim) {
   return {buffer_bounds(buf, dim), buffer_stride(buf, dim), buffer_fold_factor(buf, dim)};
@@ -534,7 +535,6 @@ box_expr dims_bounds(span<const dim_expr> dims) {
 bool is_buffer_intrinsic(intrinsic fn) {
   switch (fn) {
   case intrinsic::buffer_rank:
-  case intrinsic::buffer_base:
   case intrinsic::buffer_elem_size:
   case intrinsic::buffer_size_bytes:
   case intrinsic::buffer_min:

--- a/runtime/expr.h
+++ b/runtime/expr.h
@@ -87,7 +87,6 @@ enum class intrinsic {
   abs,
 
   buffer_rank,
-  buffer_base,
   buffer_elem_size,
   buffer_size_bytes,
 
@@ -903,7 +902,6 @@ public:
 expr abs(expr x);
 
 expr buffer_rank(expr buf);
-expr buffer_base(expr buf);
 expr buffer_elem_size(expr buf);
 expr buffer_min(expr buf, expr dim);
 expr buffer_max(expr buf, expr dim);
@@ -912,6 +910,7 @@ expr buffer_stride(expr buf, expr dim);
 expr buffer_fold_factor(expr buf, expr dim);
 expr buffer_at(expr buf, span<const expr> at);
 expr buffer_at(expr buf, span<const var> at);
+expr buffer_at(expr buf);
 
 interval_expr buffer_bounds(const expr& buf, const expr& dim);
 dim_expr buffer_dim(const expr& buf, const expr& dim);

--- a/runtime/expr.h
+++ b/runtime/expr.h
@@ -847,12 +847,17 @@ bool is_buffer_intrinsic(intrinsic fn);
 inline bool is_positive_infinity(const expr& x) { return is_intrinsic(x, intrinsic::positive_infinity); }
 inline bool is_negative_infinity(const expr& x) { return is_intrinsic(x, intrinsic::negative_infinity); }
 inline bool is_indeterminate(const expr& x) { return is_intrinsic(x, intrinsic::indeterminate); }
-inline bool is_infinity(const expr& x) { return is_positive_infinity(x) || is_negative_infinity(x); }
+inline int is_infinity(const expr& x) {
+  if (is_positive_infinity(x)) return 1;
+  if (is_negative_infinity(x)) return -1;
+  return 0;
+}
 bool is_finite(const expr& x);
 
 // Get an expression representing non-numerical constants.
 const expr& positive_infinity();
 const expr& negative_infinity();
+const expr& infinity(int sign = 1);
 const expr& indeterminate();
 
 inline bool is_positive(const expr& x) {

--- a/runtime/print.cc
+++ b/runtime/print.cc
@@ -31,7 +31,6 @@ std::ostream& operator<<(std::ostream& os, intrinsic fn) {
   case intrinsic::indeterminate: return os << "indeterminate";
   case intrinsic::abs: return os << "abs";
   case intrinsic::buffer_rank: return os << "buffer_rank";
-  case intrinsic::buffer_base: return os << "buffer_base";
   case intrinsic::buffer_elem_size: return os << "buffer_elem_size";
   case intrinsic::buffer_size_bytes: return os << "buffer_size_bytes";
   case intrinsic::buffer_min: return os << "buffer_min";

--- a/runtime/visualize.cc
+++ b/runtime/visualize.cc
@@ -463,7 +463,6 @@ function buffer_extent(b, d) { return b.dims[d].bounds.max - b.dims[d].bounds.mi
 function buffer_stride(b, d) { return b.dims[d].stride; }
 function buffer_fold_factor(b, d) { return b.dims[d].fold_factor; }
 function buffer_rank(b) { return b.dims.length; }
-function buffer_base(b) { return b.base; }
 function buffer_elem_size(b) { return b.elem_size; }
 function flat_offset_dim(d, x) { return ((x - d.bounds.min) % d.fold_factor) * d.stride; }
 function buffer_at(b, ...at) {


### PR DESCRIPTION
- `matcher` visitor is cleaner and faster
- Some rules are easier expressed as hardcoded logic
- `==` and `!=` had some rewrites that weren't fully simplified
- `<` and `<=` had a messy set of rules
- Minor cleanups