### PR TITLE
`for_each_contiguous_slice` tweaks and optimization

### DIFF
--- a/builder/copy_test.cc
+++ b/builder/copy_test.cc
@@ -29,7 +29,7 @@ public:
 template <typename T, std::size_t N>
 void init_random(buffer<T, N>& x) {
   x.allocate();
-  for_each_contiguous_slice(x, [&](void* base, index_t extent) {
+  for_each_contiguous_slice(x, [&](index_t extent, void* base) {
     for (index_t i = 0; i < extent; ++i) {
       reinterpret_cast<T*>(base)[i] = (rand() % 20) - 10;
     }

--- a/builder/elementwise_test.cc
+++ b/builder/elementwise_test.cc
@@ -16,7 +16,7 @@ namespace slinky {
 template <typename T, std::size_t N>
 void init_random(buffer<T, N>& x) {
   x.allocate();
-  for_each_contiguous_slice(x, [&](void* base, index_t extent) {
+  for_each_contiguous_slice(x, [&](index_t extent, void* base) {
     for (index_t i = 0; i < extent; ++i) {
       reinterpret_cast<T*>(base)[i] = (rand() % 20) - 10;
     }

--- a/runtime/buffer.cc
+++ b/runtime/buffer.cc
@@ -366,7 +366,7 @@ void make_for_each_contiguous_slice_dims_impl(const raw_buffer* const* bufs, std
   auto* next_dims = dims;
   index_t slice_extent = 1;
   index_t extent = 1;
-  for (int d = buf->rank - 1; d >= 0; --d) {
+  for (int d = static_cast<int>(buf->rank) - 1; d >= 0; --d) {
     if (buf->dim(d).extent() == 1) {
       // base already points to the min, we don't need to do anything.
       continue;

--- a/runtime/buffer.cc
+++ b/runtime/buffer.cc
@@ -323,11 +323,11 @@ void fill(const raw_buffer& dst, const void* value) {
 
 namespace internal {
 
-bool other_bufs_ok(const raw_buffer* buf, const raw_buffer* other_buf) {
-  if (other_buf->rank != buf->rank) return false;
-  for (std::size_t d = 0; d < buf->rank; d++) {
-    if (other_buf->dims[d].min() > buf->dims[d].min()) return false;
-    if (other_buf->dims[d].max() < buf->dims[d].max()) return false;
+bool other_bufs_ok(const raw_buffer& buf, const raw_buffer& other_buf) {
+  if (other_buf.rank != buf.rank) return false;
+  for (std::size_t d = 0; d < buf.rank; d++) {
+    if (other_buf.dims[d].min() > buf.dims[d].min()) return false;
+    if (other_buf.dims[d].max() < buf.dims[d].max()) return false;
   }
   return true;
 }

--- a/runtime/buffer.h
+++ b/runtime/buffer.h
@@ -406,14 +406,6 @@ inline bool can_fuse(const std::array<const raw_buffer*, NumBufs>& bufs, int d) 
 }
 
 template <std::size_t NumBufs>
-bool any_folded(const std::array<const raw_buffer*, NumBufs>& bufs, int d) {
-  for (const auto& buf : bufs) {
-    if (buf->dim(d).fold_factor() != dim::unfolded) return true;
-  }
-  return false;
-}
-
-template <std::size_t NumBufs>
 void make_for_each_contiguous_slice_dims(
     const std::array<const raw_buffer*, NumBufs>& bufs, for_each_contiguous_slice_dim* slice_dims, dim_or_stride* dims) {
   const auto* buf = bufs[0];

--- a/runtime/buffer.h
+++ b/runtime/buffer.h
@@ -471,29 +471,27 @@ inline void call_fn(const F& f, index_t slice_extent, const std::array<void*, Nu
 }
 
 template <typename F, std::size_t NumBufs>
-void for_each_contiguous_slice_impl(const std::array<void*, NumBufs>& bases,
+void for_each_contiguous_slice_impl(std::array<void*, NumBufs> bases,
     const for_each_contiguous_slice_dim* slice_dim, dim_or_stride* dims, const F& f) {
   if (slice_dim->impl == for_each_contiguous_slice_dim::call_f) {
 
     call_fn<F, NumBufs>(f, slice_dim->extent_here, bases);
 
   } else if (slice_dim->impl == for_each_contiguous_slice_dim::loop_linear) {
-    std::array<void*, NumBufs> offset_bases = bases;
-
     const auto* next = slice_dim + 1;
     if (next->impl == for_each_contiguous_slice_dim::call_f) {
       // If the next step is to call f, do that eagerly here to avoid an extra call.
       for (index_t i = 0; i < slice_dim->extent_here; ++i) {
-        call_fn<F, NumBufs>(f, next->extent_here, offset_bases);
+        call_fn<F, NumBufs>(f, next->extent_here, bases);
         for (std::size_t n = 0; n < NumBufs; n++) {
-          offset_bases[n] = offset_bytes(offset_bases[n], dims[n].stride);
+          bases[n] = offset_bytes(bases[n], dims[n].stride);
         }
       }
     } else {
       for (index_t i = 0; i < slice_dim->extent_here; ++i) {
-        for_each_contiguous_slice_impl<F, NumBufs>(offset_bases, slice_dim + 1, dims + NumBufs, f);
+        for_each_contiguous_slice_impl<F, NumBufs>(bases, slice_dim + 1, dims + NumBufs, f);
         for (std::size_t n = 0; n < NumBufs; n++) {
-          offset_bases[n] = offset_bytes(offset_bases[n], dims[n].stride);
+          bases[n] = offset_bytes(bases[n], dims[n].stride);
         }
       }
     }

--- a/runtime/buffer.h
+++ b/runtime/buffer.h
@@ -440,7 +440,7 @@ void make_for_each_contiguous_slice_dims(
       // This is the slice dimension.
       slice_extent = extent;
       extent = 1;
-    } else if (d > 0 && can_fuse<NumBufs>(bufs, d)) {
+    } else if (d > 0 && can_fuse(bufs, d)) {
       // Let this dimension fuse with the next dimension.
     } else {
       // For the "output" buf, we can't cross a fold boundary, which means we can treat it as linear.
@@ -476,7 +476,7 @@ void for_each_contiguous_slice_impl(std::array<void*, NumBufs> bases,
       }
     } else {
       for (index_t i = 0; i < slice_dim->extent_here; ++i) {
-        for_each_contiguous_slice_impl<F, NumBufs>(bases, slice_dim + 1, dims + NumBufs, f);
+        for_each_contiguous_slice_impl(bases, slice_dim + 1, dims + NumBufs, f);
         for (std::size_t n = 0; n < NumBufs; n++) {
           bases[n] = offset_bytes(bases[n], dims[n].stride);
         }
@@ -497,7 +497,7 @@ void for_each_contiguous_slice_impl(std::array<void*, NumBufs> bases,
       for (std::size_t n = 0; n < NumBufs; n++) {
         offset_bases[n] = offset_bytes(bases[n], dims[n].dim->flat_offset_bytes(i));
       }
-      for_each_contiguous_slice_impl<F, NumBufs>(offset_bases, slice_dim + 1, dims + NumBufs, f);
+      for_each_contiguous_slice_impl(offset_bases, slice_dim + 1, dims + NumBufs, f);
     }
   }
 }
@@ -596,7 +596,7 @@ void for_each_contiguous_slice(const raw_buffer& buf, const F& f, const Args&...
     bases[n] = offset_base_unfolded(*bufs[0], slice_dims, *bufs[n]);
   }
 
-  internal::for_each_contiguous_slice_impl<F, NumBufs>(bases, slice_dims, dims, f);
+  internal::for_each_contiguous_slice_impl(bases, slice_dims, dims, f);
 }
 
 // Call `f` for each slice of the first `slice_rank` dimensions of `buf`. The trailing dimensions of `bufs` will also be

--- a/runtime/buffer.h
+++ b/runtime/buffer.h
@@ -461,13 +461,13 @@ void make_for_each_contiguous_slice_dims(
 
 template <typename F, std::size_t NumBufs, std::size_t... Indices>
 inline void call_fn(const F& f, index_t slice_extent, const std::array<void*, NumBufs>& bases, std::index_sequence<Indices...>) {
-  static_assert(sizeof...(Indices) == NumBufs - 1);
-  f(bases[0], slice_extent, bases[Indices + 1]...);
+  static_assert(sizeof...(Indices) == NumBufs);
+  f(slice_extent, bases[Indices]...);
 }
 
 template <typename F, std::size_t NumBufs>
 inline void call_fn(const F& f, index_t slice_extent, const std::array<void*, NumBufs>& bases) {
-  call_fn<F, NumBufs>(f, slice_extent, bases, std::make_index_sequence<NumBufs - 1>());
+  call_fn<F, NumBufs>(f, slice_extent, bases, std::make_index_sequence<NumBufs>());
 }
 
 template <typename F, std::size_t NumBufs>

--- a/runtime/buffer.h
+++ b/runtime/buffer.h
@@ -461,7 +461,7 @@ void make_for_each_contiguous_slice_dims(
 
 template <typename F, std::size_t NumBufs>
 void for_each_contiguous_slice_impl(std::array<void*, NumBufs> bases,
-    const for_each_contiguous_slice_dim* slice_dim, dim_or_stride* dims, const F& f) {
+    const for_each_contiguous_slice_dim* slice_dim, const dim_or_stride* dims, const F& f) {
   if (slice_dim->impl == for_each_contiguous_slice_dim::call_f) {
     std::apply(f, std::tuple_cat(std::make_tuple(slice_dim->extent_here), bases));
   } else if (slice_dim->impl == for_each_contiguous_slice_dim::loop_linear) {

--- a/runtime/buffer.h
+++ b/runtime/buffer.h
@@ -578,17 +578,9 @@ void for_each_index(const raw_buffer& buf, const F& f) {
 // dimension.
 template <typename F, typename... Args>
 void for_each_contiguous_slice(const raw_buffer& buf, const F& f, const Args&... other_bufs) {
-  std::array<const raw_buffer*, sizeof...(Args) + 1> bufs = {&buf, &other_bufs...};
-  return for_each_contiguous_slice<F, sizeof...(Args)+1>(bufs, f);
-}
-
-// A non-variadic version of for_each_contiguous_slice() that takes the optional other_bufs
-// as a std::array<> rather than as variadic args.
-template <typename F, int NumBufs>
-void for_each_contiguous_slice(const std::array<const raw_buffer*, NumBufs>& bufs, const F& f) {
-  if (bufs.empty()) return;
-
-  for (int n = 1; n < NumBufs; n++) {
+  constexpr std::size_t NumBufs = sizeof...(Args) + 1;
+  std::array<const raw_buffer*, NumBufs> bufs = {&buf, &other_bufs...};
+  for (std::size_t n = 1; n < NumBufs; n++) {
     assert(internal::other_bufs_ok(*bufs[0], *bufs[n]));
   }
 
@@ -600,7 +592,7 @@ void for_each_contiguous_slice(const std::array<const raw_buffer*, NumBufs>& buf
 
   std::array<void*, NumBufs> bases;
   bases[0] = bufs[0]->base;
-  for (int n = 1; n < NumBufs; n++) {
+  for (std::size_t n = 1; n < NumBufs; n++) {
     bases[n] = offset_base_unfolded(*bufs[0], slice_dims, *bufs[n]);
   }
 

--- a/runtime/buffer.h
+++ b/runtime/buffer.h
@@ -389,15 +389,7 @@ struct for_each_contiguous_slice_dim {
 };
 
 template <std::size_t NumBufs>
-bool any_folded(const std::array<const raw_buffer*, NumBufs>& bufs, int d) {
-  for (const auto& buf : bufs) {
-    if (buf->dim(d).fold_factor() != dim::unfolded) return true;
-  }
-  return false;
-}
-
-template <std::size_t NumBufs>
-inline bool can_fuse(const std::array<const raw_buffer*, NumBufs>& bufs, int d) {
+bool can_fuse(const std::array<const raw_buffer*, NumBufs>& bufs, int d) {
   assert(d > 0);
   const auto* buf = bufs[0];
   const dim& outer = buf->dim(d);
@@ -411,6 +403,14 @@ inline bool can_fuse(const std::array<const raw_buffer*, NumBufs>& bufs, int d) 
     if (inner_other.stride() * inner_other.extent() != buf_dim_d_stride) return false;
   }
   return true;
+}
+
+template <std::size_t NumBufs>
+bool any_folded(const std::array<const raw_buffer*, NumBufs>& bufs, int d) {
+  for (const auto& buf : bufs) {
+    if (buf->dim(d).fold_factor() != dim::unfolded) return true;
+  }
+  return false;
 }
 
 template <std::size_t NumBufs>


### PR DESCRIPTION
- Split `for_each_contiguous_slice_dim` structure into two structures to save a little stack space and simplify the code
- Let the compiler do the copy of `bases` instead of copying it from a reference (big speedup here)
- Using `size_t` as the template parameter lets the compiler infer successfully
- Use `std::apply` instead of custom wrapper (using `std::tuple_cat`)
- Reordered the arguments to the callback to have the slice extent first.
- Move `make_for_each_contiguous_slice_dims` to cc file, with special cases.