### PR TITLE
Avoid creating expressions until after rewriting

### DIFF
--- a/builder/rewrite.h
+++ b/builder/rewrite.h
@@ -110,7 +110,7 @@ SLINKY_ALWAYS_INLINE inline node_type pattern_type(const pattern_binary<T, A, B>
 }
 
 template <typename T, typename A, typename B>
-bool match(const pattern_binary<T, A, B>& p, const expr& x, match_context& ctx) {
+int commute_bit(const pattern_binary<T, A, B>& p, match_context& ctx) {
   int this_bit = -1;
   if (T::commutative) {
     node_type ta = pattern_type(p.a);
@@ -121,16 +121,33 @@ bool match(const pattern_binary<T, A, B>& p, const expr& x, match_context& ctx) 
       this_bit = ctx.variant_bits++;
     }
   }
+  return this_bit;
+}
+
+template <typename T, typename A, typename B>
+bool match(const pattern_binary<T, A, B>& p, int this_bit, const expr& a, const expr& b, match_context& ctx) {
+  if (this_bit >= 0 && (ctx.variant & (1 << this_bit)) != 0) {
+    // We should commute in this variant.
+    return match(p.a, b, ctx) && match(p.b, a, ctx);
+  } else {
+    return match(p.a, a, ctx) && match(p.b, b, ctx);
+  }
+}
+
+template <typename T, typename A, typename B>
+bool match(const pattern_binary<T, A, B>& p, const expr& x, match_context& ctx) {
+  int this_bit = commute_bit(p, ctx);
 
   if (const T* t = x.as<T>()) {
-    if (this_bit >= 0 && (ctx.variant & (1 << this_bit)) != 0) {
-      // We should commute in this variant.
-      return match(p.a, t->b, ctx) && match(p.b, t->a, ctx);
-    }
-    return match(p.a, t->a, ctx) && match(p.b, t->b, ctx);
+    return match(p, this_bit, t->a, t->b, ctx);
   } else {
     return false;
   }
+}
+
+template <typename T, typename A, typename B>
+bool match(const pattern_binary<T, A, B>& p, const pattern_binary<T, pattern_expr, pattern_expr>& x, match_context& ctx) {
+  return match(p, commute_bit(p, ctx), x.a.e, x.b.e, ctx);
 }
 
 template <typename T, typename A, typename B>
@@ -157,6 +174,11 @@ bool match(const pattern_unary<T, A>& p, const expr& x, match_context& ctx) {
   } else {
     return false;
   }
+}
+
+template <typename T, typename A>
+bool match(const pattern_unary<T, A>& p, const pattern_unary<T, expr>& x, match_context& ctx) {
+  return match(p.a, x.a, ctx);
 }
 
 template <typename T, typename A>
@@ -371,8 +393,9 @@ auto eval(const T& x) {
   return replacement_eval<T>{x};
 }
 
-class rewriter {
-  const expr& x;
+template <typename T>
+class base_rewriter {
+  T x;
 
   template <typename Pattern>
   bool variant_match(const Pattern& p, match_context& ctx) {
@@ -394,7 +417,7 @@ class rewriter {
 public:
   expr result;
 
-  rewriter(const expr& x) : x(x) {}
+  base_rewriter(T x) : x(std::move(x)) {}
 
   template <typename Pattern, typename Replacement>
   bool rewrite(const Pattern& p, const Replacement& r) {
@@ -416,6 +439,18 @@ public:
     return true;
   }
 };
+
+class rewriter : public base_rewriter<const expr&> {
+public:
+  rewriter(const expr& x) : base_rewriter(x) {}
+  using base_rewriter::result;
+  using base_rewriter::rewrite;
+};
+
+template <typename T>
+base_rewriter<T> make_rewriter(T x) {
+  return base_rewriter<T>(std::move(x));
+}
 
 }  // namespace rewrite
 }  // namespace slinky

--- a/builder/rewrite.h
+++ b/builder/rewrite.h
@@ -210,6 +210,12 @@ bool match(const pattern_select<C, T, F>& p, const expr& x, match_context& ctx) 
 }
 
 template <typename C, typename T, typename F>
+bool match(const pattern_select<C, T, F>& p, const pattern_select<pattern_expr, pattern_expr, pattern_expr>& x,
+    match_context& ctx) {
+  return match(p.c, x.c.e, ctx) && match(p.t, x.t.e, ctx) && match(p.f, x.f.e, ctx);
+}
+
+template <typename C, typename T, typename F>
 expr substitute(const pattern_select<C, T, F>& p, const match_context& ctx) {
   return select::make(substitute(p.c, ctx), substitute(p.t, ctx), substitute(p.f, ctx));
 }

--- a/builder/rewrite.h
+++ b/builder/rewrite.h
@@ -177,8 +177,8 @@ bool match(const pattern_unary<T, A>& p, const expr& x, match_context& ctx) {
 }
 
 template <typename T, typename A>
-bool match(const pattern_unary<T, A>& p, const pattern_unary<T, expr>& x, match_context& ctx) {
-  return match(p.a, x.a, ctx);
+bool match(const pattern_unary<T, A>& p, const pattern_unary<T, pattern_expr>& x, match_context& ctx) {
+  return match(p.a, x.a.e, ctx);
 }
 
 template <typename T, typename A>

--- a/builder/simplify_exprs.cc
+++ b/builder/simplify_exprs.cc
@@ -34,14 +34,8 @@ expr simplify(const class min* op, expr a, expr b) {
   if (ca && cb) {
     return std::min(*ca, *cb);
   }
-  expr e;
-  if (op && a.same_as(op->a) && b.same_as(op->b)) {
-    e = op;
-  } else {
-    e = min::make(std::move(a), std::move(b));
-  }
-
-  rewriter r(e);
+  
+  auto r = make_rewriter(min(pattern_expr{a}, pattern_expr{b}));
   if (// Constant simplifications
       r.rewrite(min(x, rewrite::indeterminate()), rewrite::indeterminate()) ||
       r.rewrite(min(x, std::numeric_limits<index_t>::max()), x) ||
@@ -87,7 +81,11 @@ expr simplify(const class min* op, expr a, expr b) {
       false) {
     return r.result;
   }
-  return e;
+  if (op && a.same_as(op->a) && b.same_as(op->b)) {
+    return op;
+  } else {
+    return min::make(std::move(a), std::move(b));
+  }
 }
 
 expr simplify(const class max* op, expr a, expr b) {
@@ -99,14 +97,8 @@ expr simplify(const class max* op, expr a, expr b) {
   if (ca && cb) {
     return std::max(*ca, *cb);
   }
-  expr e;
-  if (op && a.same_as(op->a) && b.same_as(op->b)) {
-    e = op;
-  } else {
-    e = max::make(std::move(a), std::move(b));
-  }
 
-  rewriter r(e);
+  auto r = make_rewriter(max(pattern_expr{a}, pattern_expr{b}));
   if (// Constant simplifications
       r.rewrite(max(x, rewrite::indeterminate()), rewrite::indeterminate()) ||
       r.rewrite(max(x, std::numeric_limits<index_t>::min()), x) ||
@@ -148,7 +140,11 @@ expr simplify(const class max* op, expr a, expr b) {
       false) {
     return r.result;
   }
-  return e;
+  if (op && a.same_as(op->a) && b.same_as(op->b)) {
+    return op;
+  } else {
+    return max::make(std::move(a), std::move(b));
+  }
 }
 
 expr simplify(const add* op, expr a, expr b) {
@@ -160,14 +156,8 @@ expr simplify(const add* op, expr a, expr b) {
   if (ca && cb) {
     return *ca + *cb;
   }
-  expr e;
-  if (op && a.same_as(op->a) && b.same_as(op->b)) {
-    e = op;
-  } else {
-    e = add::make(std::move(a), std::move(b));
-  }
 
-  rewriter r(e);
+  auto r = make_rewriter(pattern_expr{a} + pattern_expr{b});
   if (r.rewrite(x + rewrite::indeterminate(), rewrite::indeterminate()) ||
       r.rewrite(rewrite::positive_infinity() + rewrite::positive_infinity(), rewrite::positive_infinity()) ||
       r.rewrite(rewrite::negative_infinity() + rewrite::negative_infinity(), rewrite::negative_infinity()) ||
@@ -225,7 +215,11 @@ expr simplify(const add* op, expr a, expr b) {
       false) {
     return r.result;
   }
-  return e;
+  if (op && a.same_as(op->a) && b.same_as(op->b)) {
+    return op;
+  } else {
+    return add::make(std::move(a), std::move(b));
+  }
 }
 
 expr simplify(const sub* op, expr a, expr b) {
@@ -240,14 +234,7 @@ expr simplify(const sub* op, expr a, expr b) {
     return simplify(static_cast<add*>(nullptr), a, -*cb);
   }
 
-  expr e;
-  if (op && a.same_as(op->a) && b.same_as(op->b)) {
-    e = op;
-  } else {
-    e = sub::make(std::move(a), std::move(b));
-  }
-
-  rewriter r(e);
+  auto r = make_rewriter(pattern_expr{a} - pattern_expr{b});
   if (r.rewrite(x - rewrite::indeterminate(), rewrite::indeterminate()) ||
       r.rewrite(rewrite::indeterminate() - x, rewrite::indeterminate()) ||
       r.rewrite(rewrite::positive_infinity() - rewrite::positive_infinity(), rewrite::indeterminate()) ||
@@ -295,7 +282,11 @@ expr simplify(const sub* op, expr a, expr b) {
       false) {
     return r.result;
   }
-  return e;
+  if (op && a.same_as(op->a) && b.same_as(op->b)) {
+    return op;
+  } else {
+    return sub::make(std::move(a), std::move(b));
+  }
 }
 
 expr simplify(const mul* op, expr a, expr b) {
@@ -307,14 +298,8 @@ expr simplify(const mul* op, expr a, expr b) {
   if (ca && cb) {
     return *ca * *cb;
   }
-  expr e;
-  if (op && a.same_as(op->a) && b.same_as(op->b)) {
-    e = op;
-  } else {
-    e = mul::make(std::move(a), std::move(b));
-  }
 
-  rewriter r(e);
+  auto r = make_rewriter(pattern_expr{a} * pattern_expr{b});
   if (r.rewrite(x * rewrite::indeterminate(), rewrite::indeterminate()) ||
       r.rewrite(rewrite::positive_infinity() * rewrite::positive_infinity(), rewrite::positive_infinity()) ||
       r.rewrite(rewrite::negative_infinity() * rewrite::positive_infinity(), rewrite::negative_infinity()) ||
@@ -332,7 +317,11 @@ expr simplify(const mul* op, expr a, expr b) {
       false) {
     return r.result;
   }
-  return e;
+  if (op && a.same_as(op->a) && b.same_as(op->b)) {
+    return op;
+  } else {
+    return mul::make(std::move(a), std::move(b));
+  }
 }
 
 expr simplify(const div* op, expr a, expr b) {
@@ -341,14 +330,8 @@ expr simplify(const div* op, expr a, expr b) {
   if (ca && cb) {
     return euclidean_div(*ca, *cb);
   }
-  expr e;
-  if (op && a.same_as(op->a) && b.same_as(op->b)) {
-    e = op;
-  } else {
-    e = div::make(std::move(a), std::move(b));
-  }
 
-  rewriter r(e);
+  auto r = make_rewriter(pattern_expr{a} / pattern_expr{b});
   if (r.rewrite(x / rewrite::indeterminate(), rewrite::indeterminate()) ||
       r.rewrite(rewrite::indeterminate() / x, rewrite::indeterminate()) ||
       r.rewrite(rewrite::positive_infinity() / rewrite::positive_infinity(), rewrite::indeterminate()) ||
@@ -376,7 +359,11 @@ expr simplify(const div* op, expr a, expr b) {
       false) {
     return r.result;
   }
-  return e;
+  if (op && a.same_as(op->a) && b.same_as(op->b)) {
+    return op;
+  } else {
+    return div::make(std::move(a), std::move(b));
+  }
 }
 
 expr simplify(const mod* op, expr a, expr b) {
@@ -385,21 +372,19 @@ expr simplify(const mod* op, expr a, expr b) {
   if (ca && cb) {
     return euclidean_mod(*ca, *cb);
   }
-  expr e;
-  if (op && a.same_as(op->a) && b.same_as(op->b)) {
-    e = op;
-  } else {
-    e = mod::make(std::move(a), std::move(b));
-  }
 
-  rewriter r(e);
+  auto r = make_rewriter(pattern_expr{a} % pattern_expr{b});
   if (r.rewrite(x % 1, 0) || 
       r.rewrite(x % 0, 0) || 
       r.rewrite(x % x, 0) ||
       false) {
     return r.result;
   }
-  return e;
+  if (op && a.same_as(op->a) && b.same_as(op->b)) {
+    return op;
+  } else {
+    return mod::make(std::move(a), std::move(b));
+  }
 }
 
 expr simplify(const less* op, expr a, expr b) {
@@ -409,14 +394,7 @@ expr simplify(const less* op, expr a, expr b) {
     return *ca < *cb;
   }
 
-  expr e;
-  if (op && a.same_as(op->a) && b.same_as(op->b)) {
-    e = op;
-  } else {
-    e = less::make(std::move(a), std::move(b));
-  }
-
-  rewriter r(e);
+  auto r = make_rewriter(pattern_expr{a} < pattern_expr{b});
   if (r.rewrite(rewrite::positive_infinity() < x, false, is_finite(x)) ||
       r.rewrite(rewrite::negative_infinity() < x, true, is_finite(x)) ||
       r.rewrite(x < rewrite::positive_infinity(), true, is_finite(x)) ||
@@ -457,7 +435,11 @@ expr simplify(const less* op, expr a, expr b) {
       false) {
     return r.result;
   }
-  return e;
+  if (op && a.same_as(op->a) && b.same_as(op->b)) {
+    return op;
+  } else {
+    return less::make(std::move(a), std::move(b));
+  }
 }
 
 expr simplify(const less_equal* op, expr a, expr b) {
@@ -467,14 +449,7 @@ expr simplify(const less_equal* op, expr a, expr b) {
     return *ca <= *cb;
   }
 
-  expr e;
-  if (op && a.same_as(op->a) && b.same_as(op->b)) {
-    e = op;
-  } else {
-    e = less_equal::make(std::move(a), std::move(b));
-  }
-
-  rewriter r(e);
+  auto r = make_rewriter(pattern_expr{a} <= pattern_expr{b});
   if (r.rewrite(rewrite::positive_infinity() <= x, false, is_finite(x)) ||
       r.rewrite(rewrite::negative_infinity() <= x, true, is_finite(x)) ||
       r.rewrite(x <= rewrite::positive_infinity(), true, is_finite(x)) ||
@@ -517,7 +492,11 @@ expr simplify(const less_equal* op, expr a, expr b) {
       false) {
     return r.result;
   }
-  return e;
+  if (op && a.same_as(op->a) && b.same_as(op->b)) {
+    return op;
+  } else {
+    return less_equal::make(std::move(a), std::move(b));
+  }
 }
 
 expr simplify(const equal* op, expr a, expr b) {
@@ -530,21 +509,18 @@ expr simplify(const equal* op, expr a, expr b) {
     return *ca == *cb;
   }
 
-  expr e;
-  if (op && a.same_as(op->a) && b.same_as(op->b)) {
-    e = op;
-  } else {
-    e = equal::make(std::move(a), std::move(b));
-  }
-  
-  rewriter r(e);
+  auto r = make_rewriter(pattern_expr{a} == pattern_expr{b});
   if (r.rewrite(x == x, true) ||
       r.rewrite(x + c0 == c1, x == eval(c1 - c0)) ||
       r.rewrite(c0 - x == c1, -x == eval(c1 - c0), eval(c0 != 0)) ||
       false) {
     return r.result;
   }
-  return e;
+  if (op && a.same_as(op->a) && b.same_as(op->b)) {
+    return op;
+  } else {
+    return equal::make(std::move(a), std::move(b));
+  }
 }
 
 expr simplify(const not_equal* op, expr a, expr b) {
@@ -557,21 +533,18 @@ expr simplify(const not_equal* op, expr a, expr b) {
     return *ca != *cb;
   }
 
-  expr e;
-  if (op && a.same_as(op->a) && b.same_as(op->b)) {
-    e = op;
-  } else {
-    e = not_equal::make(std::move(a), std::move(b));
-  }
-
-  rewriter r(e);
+  auto r = make_rewriter(pattern_expr{a} != pattern_expr{b});
   if (r.rewrite(x != x, false) ||
       r.rewrite(x + c0 != c1, x != eval(c1 - c0)) ||
       r.rewrite(c0 - x != c1, -x != eval(c1 - c0), eval(c0 != 0)) ||
       false) {
     return r.result;
   }
-  return e;
+  if (op && a.same_as(op->a) && b.same_as(op->b)) {
+    return op;
+  } else {
+    return not_equal::make(std::move(a), std::move(b));
+  }
 }
 
 expr simplify(const logical_and* op, expr a, expr b) {
@@ -587,14 +560,7 @@ expr simplify(const logical_and* op, expr a, expr b) {
     return *cb ? a : b;
   }
 
-  expr e;
-  if (op && a.same_as(op->a) && b.same_as(op->b)) {
-    e = op;
-  } else {
-    e = logical_and::make(std::move(a), std::move(b));
-  }
-
-  rewriter r(e);
+  auto r = make_rewriter(pattern_expr{a} && pattern_expr{b});
   if (r.rewrite(x && x, x) ||
       r.rewrite(x && !x, false) ||
       r.rewrite(!x && x, false) ||
@@ -606,7 +572,11 @@ expr simplify(const logical_and* op, expr a, expr b) {
       false) {
     return r.result;
   }
-  return e;
+  if (op && a.same_as(op->a) && b.same_as(op->b)) {
+    return op;
+  } else {
+    return logical_and::make(std::move(a), std::move(b));
+  }
 }
 
 expr simplify(const logical_or* op, expr a, expr b) {
@@ -622,14 +592,7 @@ expr simplify(const logical_or* op, expr a, expr b) {
     return *cb ? b : a;
   }
 
-  expr e;
-  if (op && a.same_as(op->a) && b.same_as(op->b)) {
-    e = op;
-  } else {
-    e = logical_or::make(std::move(a), std::move(b));
-  }
-
-  rewriter r(e);
+  auto r = make_rewriter(pattern_expr{a} || pattern_expr{b});
   if (r.rewrite(x || x, x) ||
       r.rewrite(x || !x, true) ||
       r.rewrite(!x || x, true) ||
@@ -641,23 +604,20 @@ expr simplify(const logical_or* op, expr a, expr b) {
       false) {
     return r.result;
   };
-  return e;
+  if (op && a.same_as(op->a) && b.same_as(op->b)) {
+    return op;
+  } else {
+    return logical_or::make(std::move(a), std::move(b));
+  }
 }
 
-expr simplify(const logical_not* op, expr a) {
+expr simplify(const class logical_not* op, expr a) {
   const index_t* cv = as_constant(a);
   if (cv) {
     return *cv == 0;
   }
 
-  expr e;
-  if (op && a.same_as(op->a)) {
-    e = op;
-  } else {
-    e = logical_not::make(std::move(a));
-  }
-
-  rewriter r(e);
+  auto r = make_rewriter(rewrite::operator!(a));
   if (r.rewrite(!!x, x) ||
       r.rewrite(!(x == y), x != y) ||
       r.rewrite(!(x != y), x == y) ||
@@ -666,7 +626,11 @@ expr simplify(const logical_not* op, expr a) {
       false) {
     return r.result;
   }
-  return e;
+  if (op && a.same_as(op->a)) {
+    return op;
+  } else {
+    return logical_not::make(std::move(a));
+  }
 }
 
 expr simplify(const class select* op, expr c, expr t, expr f) {

--- a/builder/simplify_exprs.cc
+++ b/builder/simplify_exprs.cc
@@ -617,7 +617,7 @@ expr simplify(const class logical_not* op, expr a) {
     return *cv == 0;
   }
 
-  auto r = make_rewriter(rewrite::operator!(a));
+  auto r = make_rewriter(!pattern_expr{a});
   if (r.rewrite(!!x, x) ||
       r.rewrite(!(x == y), x != y) ||
       r.rewrite(!(x != y), x == y) ||
@@ -703,7 +703,7 @@ expr simplify(const call* op, intrinsic fn, std::vector<expr> args) {
   }
 
   rewriter r(e);
-  if (r.rewrite(rewrite::abs(rewrite::negative_infinity()), rewrite::positive_infinity()) || 
+  if (r.rewrite(abs(rewrite::negative_infinity()), rewrite::positive_infinity()) || 
       r.rewrite(abs(-x), abs(x)) ||
       r.rewrite(abs(abs(x)), abs(x)) ||
       false) {


### PR DESCRIPTION
This avoids creating expressions that may not need to be returned.