### PR TITLE
Use SLINKY_NO_STACK_PROTECTOR in more places it makes sense

### DIFF
--- a/runtime/buffer.cc
+++ b/runtime/buffer.cc
@@ -215,7 +215,7 @@ int optimize_copy_dims(copy_dim* dims, int rank) {
 
 }  // namespace
 
-void copy(const raw_buffer& src, const raw_buffer& dst, const void* padding) {
+SLINKY_NO_STACK_PROTECTOR void copy(const raw_buffer& src, const raw_buffer& dst, const void* padding) {
   assert(src.rank == dst.rank);
   assert(src.elem_size == dst.elem_size);
 
@@ -262,7 +262,7 @@ void copy(const raw_buffer& src, const raw_buffer& dst, const void* padding) {
   copy(src_base, dst_base, dims, dst.elem_size, padding, rank - 1);
 }
 
-void pad(const dim* in_bounds, const raw_buffer& dst, const void* padding) {
+SLINKY_NO_STACK_PROTECTOR void pad(const dim* in_bounds, const raw_buffer& dst, const void* padding) {
   if (dst.rank == 0) {
     // The buffer is scalar.
     return;
@@ -290,7 +290,7 @@ void pad(const dim* in_bounds, const raw_buffer& dst, const void* padding) {
   copy(nullptr, dst_base, dims, dst.elem_size, padding, rank - 1);
 }
 
-void fill(const raw_buffer& dst, const void* value) {
+SLINKY_NO_STACK_PROTECTOR void fill(const raw_buffer& dst, const void* value) {
   if (dst.rank == 0) {
     // The buffer is scalar.
     memcpy(dst.base, value, dst.elem_size);

--- a/runtime/buffer.h
+++ b/runtime/buffer.h
@@ -11,15 +11,6 @@
 
 namespace slinky {
 
-#ifdef NDEBUG
-// alloca() will cause stack-smashing code to be inserted;
-// while laudable, we use alloca() in time-critical code
-// and don't want it inserted there.
-#define SLINKY_NO_STACK_PROTECTOR __attribute__ ((no_stack_protector))
-#else
-#define SLINKY_NO_STACK_PROTECTOR /* nothing */
-#endif
-
 using index_t = std::ptrdiff_t;
 
 // Helper to offset a pointer by a number of bytes.

--- a/runtime/evaluate.cc
+++ b/runtime/evaluate.cc
@@ -117,7 +117,7 @@ public:
   void visit(const constant* op) override { result = op->value; }
 
   template <typename T>
-  void visit_let(const T* op) {
+  SLINKY_NO_STACK_PROTECTOR void visit_let(const T* op) {
     // This is a bit ugly but we really want to avoid heap allocations here.
     const size_t size = op->lets.size();
     std::optional<index_t>* old_values = SLINKY_ALLOCA(std::optional<index_t>, size);
@@ -316,6 +316,7 @@ public:
     std::abort();
   }
 
+  // Not using SLINKY_NO_STACK_PROTECTOR here because this actually could allocate a lot of memory on the stack.
   void visit(const allocate* op) override {
     std::size_t rank = op->dims.size();
     raw_buffer* buffer = SLINKY_ALLOCA(raw_buffer, 1);
@@ -356,7 +357,7 @@ public:
     }
   }
 
-  void visit(const make_buffer* op) override {
+  SLINKY_NO_STACK_PROTECTOR void visit(const make_buffer* op) override {
     std::size_t rank = op->dims.size();
     raw_buffer* buffer = SLINKY_ALLOCA(raw_buffer, 1);
     buffer->elem_size = eval_expr(op->elem_size);
@@ -375,7 +376,7 @@ public:
     visit(op->body);
   }
 
-  void visit(const clone_buffer* op) override {
+  SLINKY_NO_STACK_PROTECTOR void visit(const clone_buffer* op) override {
     raw_buffer* src = reinterpret_cast<raw_buffer*>(*context.lookup(op->sym));
 
     raw_buffer* buffer = SLINKY_ALLOCA(raw_buffer, 1);
@@ -389,7 +390,7 @@ public:
     visit(op->body);
   }
 
-  void visit(const crop_buffer* op) override {
+  SLINKY_NO_STACK_PROTECTOR void visit(const crop_buffer* op) override {
     raw_buffer* buffer = reinterpret_cast<raw_buffer*>(*context.lookup(op->sym));
     assert(buffer);
 
@@ -457,7 +458,7 @@ public:
     dim.set_bounds(old_min, old_max);
   }
 
-  void visit(const slice_buffer* op) override {
+  SLINKY_NO_STACK_PROTECTOR void visit(const slice_buffer* op) override {
     raw_buffer* buffer = reinterpret_cast<raw_buffer*>(*context.lookup(op->sym));
     assert(buffer);
 
@@ -486,7 +487,7 @@ public:
     buffer->dims = dims;
   }
 
-  void visit(const slice_dim* op) override {
+  SLINKY_NO_STACK_PROTECTOR void visit(const slice_dim* op) override {
     raw_buffer* buffer = reinterpret_cast<raw_buffer*>(*context.lookup(op->sym));
     assert(buffer);
 

--- a/runtime/util.h
+++ b/runtime/util.h
@@ -14,6 +14,15 @@ namespace slinky {
 #define SLINKY_ALLOCA(T, N) reinterpret_cast<T*>(alloca((N) * sizeof(T)))
 #define SLINKY_ALWAYS_INLINE __attribute__((always_inline))
 
+#ifdef NDEBUG
+// alloca() will cause stack-smashing code to be inserted;
+// while laudable, we use alloca() in time-critical code
+// and don't want it inserted there.
+#define SLINKY_NO_STACK_PROTECTOR __attribute__((no_stack_protector))
+#else
+#define SLINKY_NO_STACK_PROTECTOR /* nothing */
+#endif
+
 // Signed integer division in C/C++ is terrible. These implementations
 // of Euclidean division and mod are taken from:
 // https://github.com/halide/Halide/blob/1a0552bb6101273a0e007782c07e8dafe9bc5366/src/CodeGen_Internal.cpp#L358-L408


### PR DESCRIPTION
This seems to help ~5% fairly consistently. It's marginal, but as long as we are doing it as of #109, we might as well do it everywhere it makes sense.