### PR TITLE
`for_each_contiguous_slice` minor improvements

### DIFF
--- a/runtime/buffer.h
+++ b/runtime/buffer.h
@@ -506,9 +506,8 @@ SLINKY_NO_STACK_PROTECTOR void for_each_contiguous_slice(const raw_buffer& buf, 
   }
 
   // We might need a slice dim for each dimension in the buffer, plus one for the call to f.
-  internal::for_each_contiguous_slice_dim* slice_dims =
-      SLINKY_ALLOCA(internal::for_each_contiguous_slice_dim, bufs[0]->rank + 1);
-  internal::dim_or_stride* dims = SLINKY_ALLOCA(internal::dim_or_stride, bufs[0]->rank * NumBufs);
+  auto* slice_dims = SLINKY_ALLOCA(internal::for_each_contiguous_slice_dim, bufs[0]->rank + 1);
+  auto* dims = SLINKY_ALLOCA(internal::dim_or_stride, bufs[0]->rank * NumBufs);
   std::array<void*, NumBufs> bases;
   internal::make_for_each_contiguous_slice_dims(bufs, bases.data(), slice_dims, dims);
 


### PR DESCRIPTION
- A few small tweaks to `make_for_each_contiguous_slice_dims` that might be optimizations and simplify a little.
- Benchmarks are more easily compared to a speed of light for 2 buffers case.
- The 3 buffer case is not useful, it's dominated by the slow callback.