### PR TITLE
Benchmark cleanups

### DIFF
--- a/runtime/BUILD
+++ b/runtime/BUILD
@@ -72,17 +72,17 @@ cc_test(
     ],
 )
 
-cc_binary(
+cc_test(
     name = "buffer_benchmark",
     srcs = ["buffer_benchmark.cc"],
     deps = [
         ":runtime",
         "@google_benchmark//:benchmark_main",
     ],
-    testonly = 1,
+    args=["--benchmark_min_time=0.1s"],
 )
 
-cc_binary(
+cc_test(
     name = "evaluate_benchmark",
     srcs = ["evaluate_benchmark.cc"],
     deps = [
@@ -90,5 +90,5 @@ cc_binary(
         ":thread_pool",
         "@google_benchmark//:benchmark_main",
     ],
-    testonly = 1,
+    args=["--benchmark_min_time=0.1s"],
 )

--- a/runtime/buffer_benchmark.cc
+++ b/runtime/buffer_benchmark.cc
@@ -23,58 +23,6 @@ __attribute__((noinline)) void no_inline(Fn&& fn) {
   fn();
 }
 
-void BM_memcpy(benchmark::State& state) {
-  std::size_t size = state.range(0);
-  char* src = new char[size];
-  char* dst = new char[size];
-
-  memset(src, 0, size);
-  memset(dst, 0, size);
-
-  for (auto _ : state) {
-    no_inline([=]() { memcpy(dst, src, size); });
-  }
-
-  benchmark::DoNotOptimize(src);
-  benchmark::DoNotOptimize(dst);
-
-  delete[] src;
-  delete[] dst;
-}
-
-BENCHMARK(BM_memcpy)->Arg(1024 * 1024);
-
-void BM_copy(benchmark::State& state) {
-  std::vector<index_t> extents = state_to_vector(4, state);
-  buffer<char, 4> src(extents);
-  buffer<char, 4> dst(extents);
-  src.allocate();
-  dst.allocate();
-
-  for (auto _ : state) {
-    copy(src, dst);
-  }
-}
-
-BENCHMARK(BM_copy)->Args({1024, 256, 4, -1});
-BENCHMARK(BM_copy)->Args({32, 32, 256, 4});
-
-void BM_copy_padded(benchmark::State& state) {
-  std::vector<index_t> extents = state_to_vector(4, state);
-  buffer<char, 4> src(extents);
-  buffer<char, 4> dst(extents);
-  dst.dim(0).set_min_extent(0, extents[0] + 16);
-  src.allocate();
-  dst.allocate();
-
-  for (auto _ : state) {
-    copy(src, dst);
-  }
-}
-
-BENCHMARK(BM_copy_padded)->Args({1024, 256, 4, -1});
-BENCHMARK(BM_copy_padded)->Args({32, 32, 256, 4});
-
 void BM_memset(benchmark::State& state) {
   std::size_t size = state.range(0);
   char* dst = new char[size];
@@ -140,6 +88,58 @@ void BM_pad(benchmark::State& state) {
 
 BENCHMARK(BM_pad)->Args({1024, 256, 4, -1});
 BENCHMARK(BM_pad)->Args({32, 32, 256, 4});
+
+void BM_memcpy(benchmark::State& state) {
+  std::size_t size = state.range(0);
+  char* src = new char[size];
+  char* dst = new char[size];
+
+  memset(src, 0, size);
+  memset(dst, 0, size);
+
+  for (auto _ : state) {
+    no_inline([=]() { memcpy(dst, src, size); });
+  }
+
+  benchmark::DoNotOptimize(src);
+  benchmark::DoNotOptimize(dst);
+
+  delete[] src;
+  delete[] dst;
+}
+
+BENCHMARK(BM_memcpy)->Arg(1024 * 1024);
+
+void BM_copy(benchmark::State& state) {
+  std::vector<index_t> extents = state_to_vector(4, state);
+  buffer<char, 4> src(extents);
+  buffer<char, 4> dst(extents);
+  src.allocate();
+  dst.allocate();
+
+  for (auto _ : state) {
+    copy(src, dst);
+  }
+}
+
+BENCHMARK(BM_copy)->Args({1024, 256, 4, -1});
+BENCHMARK(BM_copy)->Args({32, 32, 256, 4});
+
+void BM_copy_padded(benchmark::State& state) {
+  std::vector<index_t> extents = state_to_vector(4, state);
+  buffer<char, 4> src(extents);
+  buffer<char, 4> dst(extents);
+  dst.dim(0).set_min_extent(0, extents[0] + 16);
+  src.allocate();
+  dst.allocate();
+
+  for (auto _ : state) {
+    copy(src, dst);
+  }
+}
+
+BENCHMARK(BM_copy_padded)->Args({1024, 256, 4, -1});
+BENCHMARK(BM_copy_padded)->Args({32, 32, 256, 4});
 
 constexpr index_t slice_extent = 64;
 

--- a/runtime/buffer_benchmark.cc
+++ b/runtime/buffer_benchmark.cc
@@ -132,6 +132,7 @@ void BM_copy_padded(benchmark::State& state) {
   dst.dim(0).set_min_extent(0, extents[0] + 16);
   src.allocate();
   dst.allocate();
+  dst.dim(0).set_min_extent(0, extents[0]);
 
   for (auto _ : state) {
     copy(src, dst);

--- a/runtime/buffer_benchmark.cc
+++ b/runtime/buffer_benchmark.cc
@@ -35,6 +35,9 @@ void BM_memcpy(benchmark::State& state) {
     no_inline([=]() { memcpy(dst, src, size); });
   }
 
+  benchmark::DoNotOptimize(src);
+  benchmark::DoNotOptimize(dst);
+
   delete[] src;
   delete[] dst;
 }
@@ -79,6 +82,8 @@ void BM_memset(benchmark::State& state) {
   for (auto _ : state) {
     no_inline([=]() { memset(dst, 0, size); });
   }
+
+  benchmark::DoNotOptimize(dst);
 
   delete[] dst;
 }


### PR DESCRIPTION
- Stop compilers from stripping `memset`/`memcpy` baselines
- Make the benchmark a test to get test coverage
- Fix copy_padded to actually pad