### PR TITLE
Fix bounds inference for multiple consumers of the same buffer

### DIFF
--- a/builder/infer_bounds.cc
+++ b/builder/infer_bounds.cc
@@ -176,8 +176,13 @@ public:
   void visit(const call_stmt* op) override {
     // Record the bounds we currently have from the crops.
     for (symbol_id input : op->inputs) {
-      if (infer.contains(input)) {
-        infer[input] = crops[input];
+      std::optional<box_expr>& infer_i = infer[input];
+      std::optional<box_expr>& crop_i = crops[input];
+      if (!infer_i || !crop_i) continue;
+      if (infer_i->empty()) {
+        infer_i = crop_i;
+      } else {
+        *infer_i = *infer_i | *crop_i;
       }
     }
     set_result(op);

--- a/builder/infer_bounds.cc
+++ b/builder/infer_bounds.cc
@@ -177,7 +177,7 @@ public:
     // Record the bounds we currently have from the crops.
     for (symbol_id input : op->inputs) {
       std::optional<box_expr>& infer_i = infer[input];
-      std::optional<box_expr>& crop_i = crops[input];
+      const std::optional<box_expr>& crop_i = crops[input];
       if (!infer_i || !crop_i) continue;
       if (infer_i->empty()) {
         infer_i = crop_i;

--- a/builder/pipeline_test.cc
+++ b/builder/pipeline_test.cc
@@ -1304,7 +1304,6 @@ TEST(pipeline, diamond_stencils) {
   node_context ctx;
 
   auto in = buffer_expr::make(ctx, "in1", sizeof(short), 2);
-  auto intm1 = buffer_expr::make(ctx, "intm1", sizeof(short), 2);
   auto intm2 = buffer_expr::make(ctx, "intm2", sizeof(short), 2);
   auto intm3 = buffer_expr::make(ctx, "intm3", sizeof(short), 2);
   auto intm4 = buffer_expr::make(ctx, "intm4", sizeof(short), 2);
@@ -1313,9 +1312,8 @@ TEST(pipeline, diamond_stencils) {
   var x(ctx, "x");
   var y(ctx, "y");
 
-  func add1 = func::make(add_1<short>, {{in, {point(x), point(y)}}}, {{intm1, {x, y}}});
   func add2 = func::make(multiply_2<short>, {{in, {point(x), point(y)}}}, {{intm2, {x, y}}});
-  func stencil1 = func::make(sum3x3<short>, {{intm1, {bounds(-1, 1) + x, bounds(-1, 1) + y}}}, {{intm3, {x, y}}});
+  func stencil1 = func::make(sum3x3<short>, {{intm2, {bounds(-1, 1) + x, bounds(-1, 1) + y}}}, {{intm3, {x, y}}});
   func stencil2 = func::make(sum5x5<short>, {{intm2, {bounds(-2, 2) + x, bounds(-2, 2) + y}}}, {{intm4, {x, y}}});
   func diff = func::make(subtract<short>, {{intm3, {point(x), point(y)}}, {intm4, {point(x), point(y)}}}, {{out, {x, y}}});
 
@@ -1340,22 +1338,18 @@ TEST(pipeline, diamond_stencils) {
   p.evaluate(inputs, outputs, eval_ctx);
 
   // Run the pipeline stages manually to get the reference result.
-  buffer<short, 2> ref_intm1({W + 2, H + 2});
   buffer<short, 2> ref_intm2({W + 4, H + 4});
   buffer<short, 2> ref_intm3({W, H});
   buffer<short, 2> ref_intm4({W, H});
   buffer<short, 2> ref_out({W, H});
-  ref_intm1.translate(-1, -1);
   ref_intm2.translate(-2, -2);
-  ref_intm1.allocate();
   ref_intm2.allocate();
   ref_intm3.allocate();
   ref_intm4.allocate();
   ref_out.allocate();
 
-  add_1<short>(in_buf.cast<const short>(), ref_intm1.cast<short>());
   multiply_2<short>(in_buf.cast<const short>(), ref_intm2.cast<short>());
-  sum3x3<short>(ref_intm1.cast<const short>(), ref_intm3.cast<short>());
+  sum3x3<short>(ref_intm2.cast<const short>(), ref_intm3.cast<short>());
   sum5x5<short>(ref_intm2.cast<const short>(), ref_intm4.cast<short>());
   subtract<short>(ref_intm3.cast<const short>(), ref_intm4.cast<const short>(), ref_out.cast<short>());
 

--- a/builder/pipeline_test.cc
+++ b/builder/pipeline_test.cc
@@ -1240,7 +1240,7 @@ TEST(pipeline, parallel_stencils) {
   var y(ctx, "y");
 
   func add1 = func::make(add_1<short>, {{in1, {point(x), point(y)}}}, {{intm1, {x, y}}});
-  func add2 = func::make(multiply_2<short>, {{in2, {point(x), point(y)}}}, {{intm2, {x, y}}});
+  func mul2 = func::make(multiply_2<short>, {{in2, {point(x), point(y)}}}, {{intm2, {x, y}}});
   func stencil1 = func::make(sum3x3<short>, {{intm1, {bounds(-1, 1) + x, bounds(-1, 1) + y}}}, {{intm3, {x, y}}});
   func stencil2 = func::make(sum5x5<short>, {{intm2, {bounds(-2, 2) + x, bounds(-2, 2) + y}}}, {{intm4, {x, y}}});
   func diff =
@@ -1312,7 +1312,7 @@ TEST(pipeline, diamond_stencils) {
   var x(ctx, "x");
   var y(ctx, "y");
 
-  func add2 = func::make(multiply_2<short>, {{in, {point(x), point(y)}}}, {{intm2, {x, y}}});
+  func mul2 = func::make(multiply_2<short>, {{in, {point(x), point(y)}}}, {{intm2, {x, y}}});
   func stencil1 = func::make(sum3x3<short>, {{intm2, {bounds(-1, 1) + x, bounds(-1, 1) + y}}}, {{intm3, {x, y}}});
   func stencil2 = func::make(sum5x5<short>, {{intm2, {bounds(-2, 2) + x, bounds(-2, 2) + y}}}, {{intm4, {x, y}}});
   func diff = func::make(subtract<short>, {{intm3, {point(x), point(y)}}, {intm4, {point(x), point(y)}}}, {{out, {x, y}}});


### PR DESCRIPTION
This fixes #104, by adjusting `add_input_crops` to take the union of any existing crops rather than simply adding a crop, which effectively takes the intersection.