### PR TITLE
Fix a bunch of bugs related to pipeline construction

### DIFF
--- a/builder/infer_bounds.cc
+++ b/builder/infer_bounds.cc
@@ -255,7 +255,6 @@ public:
               substitute(j.max, op->sym, op->bounds.max));
         }
       }
-      result = crop_buffer::make(buf, *inferring, result);
     }
     set_result(result);
   }

--- a/builder/infer_bounds.cc
+++ b/builder/infer_bounds.cc
@@ -411,10 +411,10 @@ public:
 
               (*bounds)[d].min = new_min;
             } else {
-              // We couldn't find the new loop min. We need to warm up the loop on the first iteration.
-              // TODO: If another loop or func adjusts the loop min, we're going to run before the original min... that
-              // seems like it might be fine anyways here, but pretty janky.
-              (*bounds)[d].min = select(loop_var == loops[loop_index].orig_min, old_min, new_min);
+              // We couldn't find the new loop min. We need to warm up the loop on (or before) the first iteration.
+              // TODO(https://github.com/dsharlet/slinky/issues/118): If there is a mix of warmup strategies, this will
+              // effectively not slide while running before the original loop min.
+              (*bounds)[d].min = select(loop_var <= loops[loop_index].orig_min, old_min, new_min);
             }
             did_overlapped_fold = true;
           } else if (prove_true(ignore_loop_max(is_monotonic_decreasing))) {

--- a/builder/pipeline_test.cc
+++ b/builder/pipeline_test.cc
@@ -350,8 +350,8 @@ TEST(pipeline, elementwise_2d) {
         p.evaluate(inputs, outputs, eval_ctx);
         if (schedule_storage) {
           ASSERT_EQ(eval_ctx.heap.total_count, 0);  // The intermediate only needs stack.
-        } else if (split > 0 && lm == loop_mode::serial) {
-          ASSERT_EQ(eval_ctx.heap.total_size, split * split * sizeof(int));
+        } else {
+          ASSERT_EQ(eval_ctx.heap.total_count, 0);  // The buffers should alias.
         }
 
         for (int y = 0; y < H; ++y) {

--- a/builder/simplify.cc
+++ b/builder/simplify.cc
@@ -489,7 +489,7 @@ public:
     for (std::size_t d = 0; d < op->dims.size(); ++d) {
       interval_expr bounds_d = mutate(op->dims[d].bounds);
       dim_expr new_dim = {bounds_d, mutate(op->dims[d].stride), mutate(op->dims[d].fold_factor)};
-      if (prove_true(new_dim.fold_factor == 1 || new_dim.bounds.extent() == 1)) {
+      if (!is_zero(new_dim.stride) && prove_true(new_dim.fold_factor == 1 || new_dim.bounds.extent() == 1)) {
         new_dim.stride = 0;
       }
       changed = changed || !new_dim.same_as(op->dims[d]);
@@ -520,7 +520,7 @@ public:
     for (std::size_t d = 0; d < op->dims.size(); ++d) {
       interval_expr new_bounds = mutate(op->dims[d].bounds);
       dim_expr new_dim = {new_bounds, mutate(op->dims[d].stride), mutate(op->dims[d].fold_factor)};
-      if (prove_true(new_dim.fold_factor == 1 || new_dim.bounds.extent() == 1)) {
+      if (!is_zero(new_dim.stride) && prove_true(new_dim.fold_factor == 1 || new_dim.bounds.extent() == 1)) {
         new_dim.stride = 0;
       }
       changed = changed || !new_dim.same_as(op->dims[d]);
@@ -583,7 +583,7 @@ public:
         }
         if (is_slice && slice_rank == dims.size()) {
           std::vector<expr> at(bc->args.begin() + 1, bc->args.end());
-          set_result(slice_buffer::make(op->sym, std::move(at), std::move(body)));
+          set_result(mutate(slice_buffer::make(op->sym, std::move(at), std::move(body))));
           return;
         }
 

--- a/builder/simplify.cc
+++ b/builder/simplify.cc
@@ -745,7 +745,7 @@ public:
     if (!depends_on(body, op->sym).buffer_base) {
       // This crop only affects bounds. Just substitute the bounds.
       body = substitute_bounds(body, op->sym, op->dim, bounds);
-      set_result(body);
+      set_result(mutate(body));
       return;
     }
     {

--- a/builder/simplify.cc
+++ b/builder/simplify.cc
@@ -432,7 +432,7 @@ public:
         for (auto i = new_crops.rbegin(); i != new_crops.rend(); ++i) {
           result = crop_dim::make(std::get<0>(*i), std::get<1>(*i), std::get<2>(*i), result);
         }
-        set_result(std::move(result));
+        set_result(mutate(result));
         return;
       }
     }

--- a/builder/simplify.cc
+++ b/builder/simplify.cc
@@ -407,11 +407,16 @@ public:
           };
           if (prove_true(crop->bounds.max + 1 >= next_iter.min || next_iter.max + 1 >= crop->bounds.min)) {
             result = crop->body;
-            interval_expr new_crop = {
+            // If the crop negates the loop variable, the min could become the max. Just do both and take the union.
+            interval_expr new_crop_a = {
                 substitute(crop->bounds.min, op->sym, op->bounds.min),
                 substitute(crop->bounds.max, op->sym, op->bounds.max),
             };
-            new_crops.emplace_back(crop->sym, crop->dim, new_crop);
+            interval_expr new_crop_b = {
+                substitute(crop->bounds.min, op->sym, op->bounds.max),
+                substitute(crop->bounds.max, op->sym, op->bounds.min),
+            };
+            new_crops.emplace_back(crop->sym, crop->dim, new_crop_a | new_crop_b);
           } else {
             // This crop was not contiguous, we can't drop the loop.
             drop_loop = false;

--- a/builder/simplify_exprs.cc
+++ b/builder/simplify_exprs.cc
@@ -510,6 +510,13 @@ expr simplify(const less_equal* op, expr a, expr b) {
       r.rewrite(x <= min(x, y), x <= y) ||
       r.rewrite(min(x, y) <= max(x, y), true) ||
       r.rewrite(max(x, y) <= min(x, y), x == y) ||
+    
+      r.rewrite(min(x, y) <= min(x, y + c0), eval(0 <= c0)) ||
+      r.rewrite(max(x, y) <= max(x, y + c0), eval(0 <= c0)) ||
+      r.rewrite(min(x, y + c0) <= min(x, y), eval(c0 <= 0)) ||
+      r.rewrite(max(x, y + c0) <= max(x, y), eval(c0 <= 0)) ||
+      r.rewrite(min(x, y + c0) <= min(x, y + c1), eval(c0 <= c1)) ||
+      r.rewrite(max(x, y + c0) <= max(x, y + c1), eval(c0 <= c1)) ||
 
       r.rewrite(c0 <= max(x, c1), c0 <= x || eval(c0 <= c1)) ||
       r.rewrite(c0 <= min(x, c1), c0 <= x && eval(c0 <= c1)) ||

--- a/builder/simplify_test.cc
+++ b/builder/simplify_test.cc
@@ -141,9 +141,10 @@ TEST(simplify, let) {
 }
 
 TEST(simplify, buffer_intrinsics) {
-  test_simplify(buffer_extent(x, y) >= 0, true);
-  test_simplify((buffer_max(x, y) - buffer_min(x, y) + 1) * 4, buffer_extent(x, y) * 4);
-  test_simplify(max(buffer_max(x, y) + 1, buffer_min(x, y) - 1), buffer_max(x, y) + 1);
+  test_simplify(buffer_extent(x, 0) >= 0, true);
+  test_simplify((buffer_max(x, 0) - buffer_min(x, 0) + 1) * 4, buffer_extent(x, 0) * 4);
+  test_simplify(buffer_max(x, 0) - buffer_min(x, 1) + 1, buffer_max(x, 0) - buffer_min(x, 1) + 1);
+  test_simplify(max(buffer_max(x, 0) + 1, buffer_min(x, 0) - 1), buffer_max(x, 0) + 1);
 }
 
 TEST(simplify, bounds) {

--- a/builder/substitute.cc
+++ b/builder/substitute.cc
@@ -354,10 +354,8 @@ int compare(const stmt& a, const stmt& b) {
 
 namespace {
 
-symbol_map<expr> empty_replacements;
-
 class substitutor : public node_mutator {
-  const symbol_map<expr>& replacements = empty_replacements;
+  const symbol_map<expr>* replacements = nullptr;
   symbol_id target_var = -1;
   expr replacement;
   span<const std::pair<expr, expr>> expr_replacements;
@@ -366,7 +364,7 @@ class substitutor : public node_mutator {
   std::vector<symbol_id> shadowed;
 
 public:
-  substitutor(const symbol_map<expr>& replacements) : replacements(replacements) {}
+  substitutor(const symbol_map<expr>& replacements) : replacements(&replacements) {}
   substitutor(symbol_id target, const expr& replacement) : target_var(target), replacement(replacement) {}
   substitutor(span<const std::pair<expr, expr>> expr_replacements) : expr_replacements(expr_replacements) {}
 
@@ -383,17 +381,17 @@ public:
   void visit(const variable* v) override {
     if (std::find(shadowed.begin(), shadowed.end(), v->sym) != shadowed.end()) {
       // This variable has been shadowed, don't substitute it.
-      set_result(v);
     } else if (v->sym == target_var && !depends_on(replacement, shadowed).any()) {
       set_result(replacement);
-    } else {
-      std::optional<expr> r = replacements.lookup(v->sym);
+      return;
+    } else if (replacements) {
+      std::optional<expr> r = replacements->lookup(v->sym);
       if (r && !depends_on(*r, shadowed).any()) {
         set_result(*r);
-      } else {
-        set_result(v);
+        return;
       }
     }
+    set_result(v);
   }
 
   template <typename T>
@@ -473,15 +471,115 @@ public:
       set_result(make_buffer::make(op->sym, std::move(base), std::move(elem_size), std::move(dims), std::move(body)));
     }
   }
+
+  stmt mutate_slice_body(symbol_id sym, span<const int> slices, stmt body) {
+    // Rewrite buffer metadata accessing dimensions of sliced buffers to refer to the correct dimension.
+    class rewriter : public node_mutator {
+      symbol_id sym;
+      span<const int> slices;
+
+    public:
+      rewriter(symbol_id sym, span<const int> slices) : sym(sym), slices(slices) {}
+
+      void visit(const call* op) override {
+        switch (op->intrinsic) {
+        case intrinsic::buffer_min:
+        case intrinsic::buffer_max:
+        case intrinsic::buffer_stride:
+        case intrinsic::buffer_fold_factor:
+        case intrinsic::buffer_extent:
+          if (is_variable(op->args[0], sym)) {
+            const index_t* dim = as_constant(op->args[1]);
+            assert(dim);
+            index_t new_dim = *dim;
+            for (int i = static_cast<int>(slices.size()) - 1; i >= 0; --i) {
+              if (slices[i] == new_dim) {
+                // This dimension is gone.
+                set_result(expr());
+                return;
+              } else if (slices[i] < new_dim) {
+                --new_dim;
+              }
+            }
+            if (new_dim != *dim) {
+              set_result(call::make(op->intrinsic, {op->args[0], new_dim}));
+            } else {
+              set_result(op);
+            }
+            return;
+          }
+          break;
+        case intrinsic::buffer_at:
+          if (is_variable(op->args[0], sym)) {
+            std::vector<expr> args = op->args;
+            for (int i = static_cast<int>(slices.size()) - 1; i >= 0; --i) {
+              if (slices[i] + 1 < static_cast<int>(args.size())) {
+                args.erase(args.begin() + slices[i] + 1);
+              }
+            }
+            bool changed = args.size() < op->args.size();
+            for (expr& i : args) {
+              expr new_i = mutate(i);
+              changed = changed || !new_i.same_as(i);
+              i = new_i;
+            }
+            if (changed) {
+              set_result(call::make(intrinsic::buffer_at, std::move(args)));
+            } else {
+              set_result(op);
+            }
+            return;
+          }
+          break;
+        default: break;
+        }
+        node_mutator::visit(op);
+      }
+    } r(sym, slices);
+
+    const symbol_map<expr>* old_replacements = replacements;
+    expr old_replacement = replacement;
+    span<const std::pair<expr, expr>> old_expr_replacements = expr_replacements;
+
+    symbol_map<expr> new_replacements;
+    if (replacements) {
+      new_replacements = *replacements;
+      for (std::optional<expr>& i : new_replacements) {
+        if (i) i = r.mutate(*i);
+      }
+      replacements = &new_replacements;
+    }
+
+    replacement = r.mutate(replacement);
+
+    std::vector<std::pair<expr, expr>> new_expr_replacements;
+    new_expr_replacements.reserve(expr_replacements.size());
+    for (const std::pair<expr, expr>& i : expr_replacements) {
+      new_expr_replacements.emplace_back(r.mutate(i.first), r.mutate(i.second));
+    }
+    expr_replacements = span<const std::pair<expr, expr>>(new_expr_replacements);
+
+    body = mutate(body);
+
+    replacements = old_replacements;
+    replacement = old_replacement;
+    expr_replacements = old_expr_replacements;
+
+    return body;
+  }
   void visit(const slice_buffer* op) override {
-    std::vector<expr> at;
+    std::vector<expr> at(op->at.size());
     at.reserve(op->at.size());
     bool changed = false;
-    for (const expr& i : op->at) {
-      at.push_back(mutate(i));
-      changed = changed || !at.back().same_as(i);
+    std::vector<int> dims;
+    for (int d = 0; d < static_cast<int>(op->at.size()); ++d) {
+      at[d] = mutate(op->at[d]);
+      changed = changed || !at[d].same_as(op->at[d]);
+      if (at[d].defined()) {
+        dims.push_back(d);
+      }
     }
-    stmt body = mutate_decl_body(op->sym, op->body);
+    stmt body = mutate_slice_body(op->sym, dims, op->body);
     if (!changed && body.same_as(op->body)) {
       set_result(op);
     } else {
@@ -490,19 +588,61 @@ public:
   }
   void visit(const slice_dim* op) override {
     expr at = mutate(op->at);
-    stmt body = mutate_decl_body(op->sym, op->body);
+    int slices[] = {op->dim};
+    stmt body = mutate_slice_body(op->sym, slices, op->body);
     if (at.same_as(op->at) && body.same_as(op->body)) {
       set_result(op);
     } else {
       set_result(slice_dim::make(op->sym, op->dim, std::move(at), std::move(body)));
     }
   }
-  // truncate_rank, clone_buffer, crop_buffer, crop_dim not treated here because references to dimensions of these
+
+  interval_expr substitute_crop_bounds(symbol_id sym, int dim, const interval_expr& bounds) {
+    // When substituting crop bounds, we need to apply the implicit clamp, which uses buffer_min(sym, dim) and
+    // buffer_max(sym, dim).
+    expr buf_var = variable::make(sym);
+    interval_expr old_bounds = {buffer_min(buf_var, dim), buffer_max(buf_var, dim)};
+    interval_expr new_bounds = {mutate(old_bounds.min), mutate(old_bounds.max)};
+    interval_expr result = {mutate(bounds.min), mutate(bounds.max)};
+    if (!old_bounds.min.same_as(new_bounds.min)) {
+      // The substitution changed the implicit clamp, include it.
+      result.min = max(result.min, new_bounds.min);
+    }
+    if (!old_bounds.max.same_as(new_bounds.max)) {
+      // The substitution changed the implicit clamp, include it.
+      result.max = min(result.max, new_bounds.max);
+    }
+    return result;
+  }
+
+  void visit(const crop_buffer* op) override {
+    box_expr bounds(op->bounds.size());
+    bool changed = false;
+    for (std::size_t i = 0; i < op->bounds.size(); ++i) {
+      bounds[i] = substitute_crop_bounds(op->sym, i, op->bounds[i]);
+      changed = changed || !bounds[i].same_as(op->bounds[i]);
+    }
+    stmt body = mutate_decl_body(op->sym, op->body);
+    if (changed || !body.same_as(op->body)) {
+      set_result(crop_buffer::make(op->sym, std::move(bounds), std::move(body)));
+    } else {
+      set_result(op);
+    }
+  }
+
+  void visit(const crop_dim* op) override {
+    interval_expr bounds = substitute_crop_bounds(op->sym, op->dim, op->bounds);
+    stmt body = mutate_decl_body(op->sym, op->body);
+    if (bounds.same_as(op->bounds) && body.same_as(op->body)) {
+      set_result(op);
+    } else {
+      set_result(crop_dim::make(op->sym, op->dim, std::move(bounds), std::move(body)));
+    }
+  }
+  // truncate_rank, clone_buffer, not treated here because references to dimensions of these
   // operations are still valid.
-  // TODO: This seems sketchy. Shadowed symbols are shadowed symbols. But the simplifier relies on this behavior
-  // currently... Another reason this is sketchy: we treat make_buffers as shadowing, but not crop_buffer. But the
-  // simplifier will rewrite some make_buffer to crop_buffer, so that means substitute will behave differently before
-  // vs. after simplification.
+  // TODO: truncate_rank is a bit tricky, the replacements for expressions might be invalid if they access truncated
+  // dims.
 };
 
 template <typename T>
@@ -539,7 +679,7 @@ stmt substitute(const stmt& s, symbol_id target, const expr& replacement) {
   return substitutor(target, replacement).mutate(s);
 }
 
-expr substitute(const expr& e, const expr& target, const expr& replacement){
+expr substitute(const expr& e, const expr& target, const expr& replacement) {
   std::pair<expr, expr> subs[] = {{target, replacement}};
   return substitutor(subs).mutate(e);
 }

--- a/builder/substitute_test.cc
+++ b/builder/substitute_test.cc
@@ -57,6 +57,8 @@ TEST(substitute, shadowed) {
   test_substitute(let::make(x.sym(), y, x + z), x.sym(), w, let::make(x.sym(), y, x + z));
   test_substitute(slice_dim::make(x.sym(), 2, 0, check::make(buffer_min(x, 3) == 0)), buffer_min(x, 3), 1,
       slice_dim::make(x.sym(), 2, 0, check::make(buffer_min(x, 3) == 0)));
+  test_substitute(let::make({{x.sym(), 1}, {y.sym(), 2}}, z + 1), z.sym(), z + w,
+      let::make({{x.sym(), 1}, {y.sym(), 2}}, z + w + 1));
 }
 
 TEST(match, basic) {

--- a/builder/substitute_test.cc
+++ b/builder/substitute_test.cc
@@ -57,6 +57,8 @@ TEST(substitute, shadowed) {
   test_substitute(let::make(x.sym(), y, x + z), x.sym(), w, let::make(x.sym(), y, x + z));
   test_substitute(slice_dim::make(x.sym(), 2, 0, check::make(buffer_min(x, 3) == 0)), buffer_min(x, 3), 1,
       slice_dim::make(x.sym(), 2, 0, check::make(buffer_min(x, 3) == 0)));
+  test_substitute(slice_dim::make(x.sym(), 2, 0, check::make(y == buffer_min(x, 3))), y, buffer_max(x, 3),
+      slice_dim::make(x.sym(), 2, 0, check::make(y == buffer_min(x, 3))));
   test_substitute(let::make({{x.sym(), 1}, {y.sym(), 2}}, z + 1), z.sym(), z + w,
       let::make({{x.sym(), 1}, {y.sym(), 2}}, z + w + 1));
 }

--- a/builder/substitute_test.cc
+++ b/builder/substitute_test.cc
@@ -55,12 +55,20 @@ TEST(substitute, basic) {
 
 TEST(substitute, shadowed) {
   test_substitute(let::make(x.sym(), y, x + z), x.sym(), w, let::make(x.sym(), y, x + z));
+  test_substitute(let::make({{x.sym(), 1}, {y.sym(), 2}}, z + 1), z.sym(), z + w,
+      let::make({{x.sym(), 1}, {y.sym(), 2}}, z + w + 1));
+
+  test_substitute(crop_dim::make(x.sym(), 1, {y, z}, check::make(0 < buffer_min(x, 1))), buffer_min(x, 1), w,
+      crop_dim::make(x.sym(), 1, {max(y, w), z}, check::make(0 < buffer_min(x, 1))));
+
   test_substitute(slice_dim::make(x.sym(), 2, 0, check::make(buffer_min(x, 3) == 0)), buffer_min(x, 3), 1,
       slice_dim::make(x.sym(), 2, 0, check::make(buffer_min(x, 3) == 0)));
   test_substitute(slice_dim::make(x.sym(), 2, 0, check::make(y == buffer_min(x, 3))), y, buffer_max(x, 3),
-      slice_dim::make(x.sym(), 2, 0, check::make(y == buffer_min(x, 3))));
-  test_substitute(let::make({{x.sym(), 1}, {y.sym(), 2}}, z + 1), z.sym(), z + w,
-      let::make({{x.sym(), 1}, {y.sym(), 2}}, z + w + 1));
+      slice_dim::make(x.sym(), 2, 0, check::make(buffer_max(x, 2) == buffer_min(x, 3))));
+  test_substitute(slice_dim::make(x.sym(), 2, 0, check::make(y == buffer_min(x, 3))), y, buffer_max(x, 2),
+      slice_dim::make(x.sym(), 2, 0, check::make(expr() == buffer_min(x, 3))));
+  test_substitute(slice_dim::make(x.sym(), 2, 0, check::make(y == buffer_min(x, 3))), y, buffer_max(x, 1),
+      slice_dim::make(x.sym(), 2, 0, check::make(buffer_max(x, 1) == buffer_min(x, 3))));
 }
 
 TEST(match, basic) {

--- a/runtime/depends_on.cc
+++ b/runtime/depends_on.cc
@@ -92,6 +92,12 @@ depends_on_result depends_on(const stmt& s, symbol_id var) {
   return v.result;
 }
 
+depends_on_result depends_on(const expr& e, span<const symbol_id> vars) {
+  dependencies v(vars);
+  if (e.defined()) e.accept(&v);
+  return v.result;
+}
+
 depends_on_result depends_on(const stmt& s, span<const symbol_id> vars) {
   dependencies v(vars);
   if (s.defined()) s.accept(&v);

--- a/runtime/depends_on.h
+++ b/runtime/depends_on.h
@@ -14,6 +14,12 @@ struct depends_on_result {
   bool buffer = false;
   // True if the buffer's base pointer is used.
   bool buffer_base = false;
+  // True if the buffer is used as a call input or output, respectively.
+  bool buffer_input = false;
+  bool buffer_output = false;
+  // True if the buffer is used as a copy source or destination, respectively.
+  bool buffer_src = false;
+  bool buffer_dst = false;
 
   bool any() const { return var || buffer; }
 };

--- a/runtime/depends_on.h
+++ b/runtime/depends_on.h
@@ -28,6 +28,7 @@ struct depends_on_result {
 depends_on_result depends_on(const expr& e, symbol_id var);
 depends_on_result depends_on(const interval_expr& e, symbol_id var);
 depends_on_result depends_on(const stmt& s, symbol_id var);
+depends_on_result depends_on(const expr& e, span<const symbol_id> vars);
 depends_on_result depends_on(const stmt& s, span<const symbol_id> vars);
 
 }  // namespace slinky

--- a/runtime/util.h
+++ b/runtime/util.h
@@ -148,8 +148,6 @@ class span {
 
 public:
   span() : data_(nullptr), size_(0) {}
-  span(const span&) = default;
-  span(span&&) = default;
   span(const value_type* data, std::size_t size) : data_(data), size_(size) {}
   span(const value_type* begin, const value_type* end) : data_(begin), size_(end - begin) {}
   template <std::size_t N>
@@ -157,6 +155,12 @@ public:
   template <std::size_t N>
   span(const std::array<value_type, N>& x) : data_(std::data(x)), size_(N) {}
   span(const std::vector<value_type>& c) : data_(std::data(c)), size_(std::size(c)) {}
+
+  // Allow shallow copying/assignment.
+  span(const span&) = default;
+  span(span&&) = default;
+  span& operator=(const span&) = default;
+  span& operator=(span&&) = default;
 
   const value_type* data() const { return data_; }
   std::size_t size() const { return size_; }


### PR DESCRIPTION
It turns out that we had a lot of bugs that were essentially accidentally working around other bugs. Untangling that mess is this PR.

- Don't try to fold storage in two overlapped dimensions at once.
- Fix a few missed/bad simplifications related to crops and loops.
- Only substitute the body of lets once instead of N times, once for each let value.
- Remove a crop added in `infer_bounds` after working through a loop (maybe related to #102)
- Reduced (but not eliminated) the hacky input crop removal.
- Substitution of shadowed expressions is more correct now.
- We can substitute buffer bounds expressions across crops and slices correctly, now it should always be "safe" to substitute buffer bounds (related to #20 and #55)
- Fix loops that use both sliding window warmup strategies (with a TODO #118).