### PR TITLE
Add `callable_attrs::allow_in_place` and use that for aliasing

### DIFF
--- a/builder/elementwise_test.cc
+++ b/builder/elementwise_test.cc
@@ -84,7 +84,8 @@ public:
       for_each_index(c, [&](auto i) { c(i) = impl(a(i), b(i)); });
       return 0;
     };
-    func r = func::make<const T, const T, T>(std::move(fn), {{a, bounds}, {b, bounds}}, {{result, dims}});
+    func r = func::make<const T, const T, T>(
+        std::move(fn), {{a, bounds}, {b, bounds}}, {{result, dims}}, call_stmt::callable_attrs{.allow_in_place = true});
     result_funcs.push_back(std::move(r));
   }
 
@@ -120,8 +121,8 @@ public:
       for_each_index(c, [&](auto i) { r(i) = c(i) != 0 ? t(i) : f(i); });
       return 0;
     };
-    func r = func::make<const T, const T, const T, T>(
-        std::move(fn), {{c, bounds}, {t, bounds}, {f, bounds}}, {{result, dims}});
+    func r = func::make<const T, const T, const T, T>(std::move(fn), {{c, bounds}, {t, bounds}, {f, bounds}},
+        {{result, dims}}, call_stmt::callable_attrs{.allow_in_place = true});
     result_funcs.push_back(std::move(r));
   }
 

--- a/builder/pipeline.cc
+++ b/builder/pipeline.cc
@@ -77,8 +77,9 @@ box_expr buffer_expr::bounds() const {
   return result;
 }
 
-func::func(call_stmt::callable impl, std::vector<input> inputs, std::vector<output> outputs)
-    : impl_(std::move(impl)), inputs_(std::move(inputs)), outputs_(std::move(outputs)) {
+func::func(
+    call_stmt::callable impl, std::vector<input> inputs, std::vector<output> outputs, call_stmt::callable_attrs attrs)
+    : impl_(std::move(impl)), attrs_(attrs), inputs_(std::move(inputs)), outputs_(std::move(outputs)) {
   add_this_to_buffers();
 }
 
@@ -126,7 +127,7 @@ stmt func::make_call() const {
     for (const func::output& i : outputs_) {
       outputs.push_back(i.sym());
     }
-    return call_stmt::make(impl_, std::move(inputs), std::move(outputs));
+    return call_stmt::make(impl_, std::move(inputs), std::move(outputs), attrs_);
   } else {
     std::vector<stmt> copies;
     for (const func::input& input : inputs_) {

--- a/builder/pipeline_test.cc
+++ b/builder/pipeline_test.cc
@@ -200,7 +200,8 @@ TEST(pipeline, trivial) {
 
       var x(ctx, "x");
 
-      func mul = func::make(multiply_2<int>, {{in, {point(x)}}}, {{out, {x}}});
+      func mul = func::make(
+          multiply_2<int>, {{in, {point(x)}}}, {{out, {x}}}, call_stmt::callable_attrs{.allow_in_place = true});
       if (split > 0) {
         mul.loops({{x, split, lm}});
       }
@@ -253,8 +254,10 @@ TEST(pipeline, elementwise_1d) {
         func::callable<const int, int> m2 = multiply_2<int>;
         func::callable<const int, int> a1 = add_1<int>;
 
-        func mul = func::make(std::move(m2), {{in, {point(x)}}}, {{intm, {x}}});
-        func add = func::make(std::move(a1), {{intm, {point(x)}}}, {{out, {x}}});
+        func mul = func::make(
+            std::move(m2), {{in, {point(x)}}}, {{intm, {x}}}, call_stmt::callable_attrs{.allow_in_place = true});
+        func add = func::make(
+            std::move(a1), {{intm, {point(x)}}}, {{out, {x}}}, call_stmt::callable_attrs{.allow_in_place = true});
 
         if (split > 0) {
           add.loops({{x, split, lm}});
@@ -315,8 +318,10 @@ TEST(pipeline, elementwise_2d) {
         auto m2 = [](const buffer<const int>& a, const buffer<int>& b) -> index_t { return multiply_2<int>(a, b); };
         auto a1 = [](const buffer<const int>& a, const buffer<int>& b) -> index_t { return add_1<int>(a, b); };
 
-        func mul = func::make(std::move(m2), {{in, {point(x), point(y)}}}, {{intm, {x, y}}});
-        func add = func::make(std::move(a1), {{intm, {point(x), point(y)}}}, {{out, {x, y}}});
+        func mul = func::make(std::move(m2), {{in, {point(x), point(y)}}}, {{intm, {x, y}}},
+            call_stmt::callable_attrs{.allow_in_place = true});
+        func add = func::make(std::move(a1), {{intm, {point(x), point(y)}}}, {{out, {x, y}}},
+            call_stmt::callable_attrs{.allow_in_place = true});
 
         if (split > 0) {
           add.loops({{x, split, lm}, {y, split, lm}});
@@ -897,11 +902,14 @@ TEST(pipeline, unrelated) {
   var x(ctx, "x");
   var y(ctx, "y");
 
-  func add1 = func::make(add_1<short>, {{in1, {point(x), point(y)}}}, {{intm1, {x, y}}});
+  func add1 = func::make(add_1<short>, {{in1, {point(x), point(y)}}}, {{intm1, {x, y}}},
+      call_stmt::callable_attrs{.allow_in_place = true});
   func stencil1 = func::make(sum3x3<short>, {{intm1, {bounds(-1, 1) + x, bounds(-1, 1) + y}}}, {{out1, {x, y}}});
 
-  func mul2 = func::make(multiply_2<int>, {{in2, {point(x)}}}, {{intm2, {x}}});
-  func add2 = func::make(add_1<int>, {{intm2, {point(x)}}}, {{out2, {x}}});
+  func mul2 = func::make(
+      multiply_2<int>, {{in2, {point(x)}}}, {{intm2, {x}}}, call_stmt::callable_attrs{.allow_in_place = true});
+  func add2 =
+      func::make(add_1<int>, {{intm2, {point(x)}}}, {{out2, {x}}}, call_stmt::callable_attrs{.allow_in_place = true});
 
   stencil1.loops({{y, 2}});
 

--- a/runtime/evaluate_benchmark.cc
+++ b/runtime/evaluate_benchmark.cc
@@ -27,7 +27,7 @@ stmt make_call_counter(std::atomic<int>& calls) {
         ++calls;
         return 0;
       },
-      {}, {});
+      {}, {}, {});
 }
 
 stmt make_loop(stmt body) { return loop::make(x.sym(), loop_mode::serial, range(0, iterations), 1, body); }

--- a/runtime/evaluate_test.cc
+++ b/runtime/evaluate_test.cc
@@ -45,7 +45,7 @@ TEST(evaluate, call) {
         calls.push_back(*ctx[x]);
         return 0;
       },
-      {}, {});
+      {}, {}, {});
 
   eval_context context;
   context[x] = 2;
@@ -74,7 +74,7 @@ TEST(evaluate, loop) {
           sum_x += *ctx[x];
           return 0;
         },
-        {}, {});
+        {}, {}, {});
 
     stmt l = loop::make(x.sym(), type, range(2, 12), 3, c);
 

--- a/runtime/expr.cc
+++ b/runtime/expr.cc
@@ -302,11 +302,12 @@ expr call::make(slinky::intrinsic i, std::vector<expr> args) {
   return n;
 }
 
-stmt call_stmt::make(call_stmt::callable target, symbol_list inputs, symbol_list outputs) {
+stmt call_stmt::make(call_stmt::callable target, symbol_list inputs, symbol_list outputs, callable_attrs attrs) {
   auto n = new call_stmt();
   n->target = std::move(target);
   n->inputs = std::move(inputs);
   n->outputs = std::move(outputs);
+  n->attrs = attrs;
   return n;
 }
 

--- a/runtime/expr.h
+++ b/runtime/expr.h
@@ -449,15 +449,21 @@ public:
   using callable = std::function<index_t(eval_context&)>;
   using symbol_list = std::vector<symbol_id>;
 
+  struct callable_attrs {
+    // Allow inputs and outputs to this call to be aliased to the same buffer.
+    bool allow_in_place = false;
+  };
+
   callable target;
   // These are not actually used during evaluation. They are only here for analyzing the IR, so we can know what will be
   // accessed (and how) by the callable.
   symbol_list inputs;
   symbol_list outputs;
+  callable_attrs attrs; 
 
   void accept(node_visitor* v) const override;
 
-  static stmt make(callable target, symbol_list inputs, symbol_list outputs);
+  static stmt make(callable target, symbol_list inputs, symbol_list outputs, callable_attrs attrs);
 
   static constexpr node_type static_type = node_type::call_stmt;
 };


### PR DESCRIPTION
Basically this is #11. I'm not that happy with how this appears in the `func` API, I wish the attributes were attached to the callbacks themselves, so the callable would only need to be annotated with its attributes once, instead of N times at each use.

But, this is mostly a step in that direction, and it allows cleaning up the alias_buffers optimization quite a bit.