### PR TITLE
Add tests of saturating arithmetic

### DIFF
--- a/runtime/arithmetic_test.cc
+++ b/runtime/arithmetic_test.cc
@@ -33,4 +33,24 @@ TEST(arithmetic, euclidean_div_mod) {
   }
 }
 
+template <typename Dst, typename Src>
+Dst saturate(Src x) {
+  return std::max<Src>(std::min<Src>(x, std::numeric_limits<Dst>::max()), std::numeric_limits<Dst>::min());
+}
+
+TEST(arithmetic, saturate) {
+  constexpr int32_t min = std::numeric_limits<int32_t>::min();
+  constexpr int32_t max = std::numeric_limits<int32_t>::max();
+  const int32_t values[] = {min, min + 1, min + 2, -2, -1, 0, 1, 2, max - 2, max - 1, max};
+  for (int32_t a : values) {
+    for (int32_t b : values) {
+      ASSERT_EQ(saturate_add(a, b), saturate<int32_t>(static_cast<int64_t>(a) + static_cast<int64_t>(b)));
+      ASSERT_EQ(saturate_sub(a, b), saturate<int32_t>(static_cast<int64_t>(a) - static_cast<int64_t>(b)));
+      ASSERT_EQ(saturate_mul(a, b), saturate<int32_t>(static_cast<int64_t>(a) * static_cast<int64_t>(b)));
+      ASSERT_EQ(saturate_div(a, b), saturate<int32_t>(euclidean_div(static_cast<int64_t>(a), static_cast<int64_t>(b))));
+      ASSERT_EQ(saturate_mod(a, b), saturate<int32_t>(euclidean_mod(static_cast<int64_t>(a), static_cast<int64_t>(b))));
+    }
+  }
+}
+
 }  // namespace slinky

--- a/runtime/util.h
+++ b/runtime/util.h
@@ -124,8 +124,8 @@ inline T saturate_mul(T a, T b) {
 template <typename T>
 inline T saturate_div(T a, T b) {
   // This is safe from overflow unless a is max and b is -1.
-  if (a == std::numeric_limits<T>::max() && b == -1) {
-    return std::numeric_limits<T>::min();
+  if (b == -1 && a == std::numeric_limits<T>::min()) {
+    return std::numeric_limits<T>::max();
   } else {
     return euclidean_div(a, b);
   }
@@ -134,7 +134,11 @@ inline T saturate_div(T a, T b) {
 template <typename T>
 inline T saturate_mod(T a, T b) {
   // Can this overflow...?
-  return euclidean_mod(a, b);
+  if (b == -1) {
+    return 0;
+  } else {
+    return euclidean_mod(a, b);
+  }
 }
 
 // Don't want to depend on C++20, so just provide our own span-like helper. Differences:


### PR DESCRIPTION
This isn't actually used currently. I had thought I was going to want to use this for evaluating expressions, but I've since abandoned that. As long as this code exists though, we should have tests for it.