### PR TITLE
Stronger simplification of bounds

### DIFF
--- a/builder/rewrite.h
+++ b/builder/rewrite.h
@@ -147,28 +147,6 @@ bool match(
   return match_binary(p, commute_bit(p, ctx), x.a.e, x.b.e, ctx);
 }
 
-template <typename T>
-expr make_binary(expr a, expr b) {
-  return T::make(std::move(a), std::move(b));
-}
-
-// clang-format off
-template <typename T> index_t make_binary(index_t a, index_t b);
-template <> inline index_t make_binary<add>(index_t a, index_t b) { return a + b; }
-template <> inline index_t make_binary<sub>(index_t a, index_t b) { return a - b; }
-template <> inline index_t make_binary<mul>(index_t a, index_t b) { return a * b; }
-template <> inline index_t make_binary<div>(index_t a, index_t b) { return euclidean_div(a, b); }
-template <> inline index_t make_binary<mod>(index_t a, index_t b) { return euclidean_mod(a, b); }
-template <> inline index_t make_binary<class min>(index_t a, index_t b) { return std::min(a, b); }
-template <> inline index_t make_binary<class max>(index_t a, index_t b) { return std::max(a, b); }
-template <> inline index_t make_binary<equal>(index_t a, index_t b) { return a == b; }
-template <> inline index_t make_binary<not_equal>(index_t a, index_t b) { return a != b; }
-template <> inline index_t make_binary<less>(index_t a, index_t b) { return a < b; }
-template <> inline index_t make_binary<less_equal>(index_t a, index_t b) { return a <= b; }
-template <> inline index_t make_binary<logical_and>(index_t a, index_t b) { return ((a != 0) && (b != 0)) ? 1 : 0; }
-template <> inline index_t make_binary<logical_or>(index_t a, index_t b) { return ((a != 0) || (b != 0)) ? 1 : 0; }
-// clang-format on
-
 template <typename T, typename A, typename B>
 auto substitute(const pattern_binary<T, A, B>& p, const match_context& ctx) {
   return make_binary<T>(substitute(p.a, ctx), substitute(p.b, ctx));

--- a/builder/rewrite.h
+++ b/builder/rewrite.h
@@ -121,7 +121,7 @@ int commute_bit(const pattern_binary<T, A, B>& p, match_context& ctx) {
 }
 
 template <typename T, typename A, typename B>
-bool match(const pattern_binary<T, A, B>& p, int this_bit, const expr& a, const expr& b, match_context& ctx) {
+bool match_binary(const pattern_binary<T, A, B>& p, int this_bit, const expr& a, const expr& b, match_context& ctx) {
   if (this_bit >= 0 && (ctx.variant & (1 << this_bit)) != 0) {
     // We should commute in this variant.
     return match(p.a, b, ctx) && match(p.b, a, ctx);
@@ -135,7 +135,7 @@ bool match(const pattern_binary<T, A, B>& p, const expr& x, match_context& ctx) 
   int this_bit = commute_bit(p, ctx);
 
   if (const T* t = x.as<T>()) {
-    return match(p, this_bit, t->a, t->b, ctx);
+    return match_binary(p, this_bit, t->a, t->b, ctx);
   } else {
     return false;
   }
@@ -144,7 +144,7 @@ bool match(const pattern_binary<T, A, B>& p, const expr& x, match_context& ctx) 
 template <typename T, typename A, typename B>
 bool match(
     const pattern_binary<T, A, B>& p, const pattern_binary<T, pattern_expr, pattern_expr>& x, match_context& ctx) {
-  return match(p, commute_bit(p, ctx), x.a.e, x.b.e, ctx);
+  return match_binary(p, commute_bit(p, ctx), x.a.e, x.b.e, ctx);
 }
 
 template <typename T>

--- a/builder/simplify.cc
+++ b/builder/simplify.cc
@@ -312,6 +312,15 @@ public:
           return;
         }
       }
+    } else if (op->intrinsic == intrinsic::abs) {
+      assert(args.size() == 1);
+      if (is_non_negative(args_bounds[0].min)) {
+        set_result(args[0], std::move(args_bounds[0]));
+        return;
+      } else if (is_non_positive(args_bounds[0].max)) {
+        mutate_and_set_result(-args[0]);
+        return;
+      }
     }
 
     expr e = simplify(op, op->intrinsic, std::move(args));

--- a/builder/simplify.cc
+++ b/builder/simplify.cc
@@ -152,7 +152,7 @@ public:
   }
 
   template <typename T>
-  void visit_compare(const T* op) {
+  void visit_logical(const T* op) {
     interval_expr a_bounds;
     expr a = mutate(op->a, &a_bounds);
     interval_expr b_bounds;
@@ -232,12 +232,12 @@ public:
   void visit(const mul* op) override { visit_binary(op); }
   void visit(const div* op) override { visit_binary(op); }
   void visit(const mod* op) override { visit_binary(op); }
-  void visit(const less* op) override { visit_compare(op); }
-  void visit(const less_equal* op) override { visit_compare(op); }
-  void visit(const equal* op) override { visit_compare(op); }
-  void visit(const not_equal* op) override { visit_compare(op); }
-  void visit(const logical_and* op) override { visit_binary(op); }
-  void visit(const logical_or* op) override { visit_binary(op); }
+  void visit(const less* op) override { visit_logical(op); }
+  void visit(const less_equal* op) override { visit_logical(op); }
+  void visit(const equal* op) override { visit_logical(op); }
+  void visit(const not_equal* op) override { visit_logical(op); }
+  void visit(const logical_and* op) override { visit_logical(op); }
+  void visit(const logical_or* op) override { visit_logical(op); }
   void visit(const logical_not* op) override {
     interval_expr bounds;
     expr a = mutate(op->a, &bounds);

--- a/builder/simplify.cc
+++ b/builder/simplify.cc
@@ -775,12 +775,7 @@ public:
     if (!crop_needed(depends_on(body, op->sym))) {
       // Add clamps for the implicit bounds like crop would have done.
       for (index_t d = 0; d < static_cast<index_t>(new_bounds.size()); ++d) {
-        if (new_bounds[d].min.defined()) {
-          new_bounds[d].min = max(new_bounds[d].min, buffer_min(sym_var, d));
-        }
-        if (new_bounds[d].max.defined()) {
-          new_bounds[d].max = min(new_bounds[d].max, buffer_max(sym_var, d));
-        }
+        new_bounds[d] &= slinky::buffer_bounds(sym_var, d);
       }
       body = substitute_bounds(body, op->sym, new_bounds);
       set_result(mutate(body));

--- a/builder/simplify_exprs.cc
+++ b/builder/simplify_exprs.cc
@@ -750,9 +750,9 @@ expr simplify(const call* op, intrinsic fn, std::vector<expr> args) {
 
   rewriter r(e);
   // clang-format off
-  if (r.rewrite(abs(rewrite::negative_infinity()), rewrite::positive_infinity()) || 
-      r.rewrite(abs(-x), abs(x)) ||
-      r.rewrite(abs(abs(x)), abs(x)) ||
+  if (r.rewrite(abs(x * c0), abs(x) * c0, c0 > 0) ||
+      r.rewrite(abs(x * c0), abs(x) * eval(-c0), c0 < 0) ||
+      r.rewrite(abs(c0 - x), abs(x + eval(-c0))) ||
       false) {
     return r.result;
   }

--- a/builder/simplify_exprs.cc
+++ b/builder/simplify_exprs.cc
@@ -50,9 +50,10 @@ expr simplify(const class min* op, expr a, expr b) {
       r.rewrite(min(x, x + c0), x, eval(c0 > 0)) ||
       r.rewrite(min(x, x + c0), x + c0, eval(c0 < 0)) ||
       r.rewrite(min(x + c0, c1), min(x, eval(c1 - c0)) + c0) ||
-      r.rewrite(min(c0 - x, c0 - y), c0 - max(x, y)) ||
       r.rewrite(min(x, -x), -abs(x)) ||
       r.rewrite(min(x + c0, c0 - x), c0 - abs(x)) ||
+      r.rewrite(min(x + c0, y + c1), min(x, y + eval(c1 - c0)) + c0) ||
+      r.rewrite(min(c0 - x, c1 - y), c0 - max(x, y + eval(c0 - c1))) ||
 
       // Algebraic simplifications
       r.rewrite(min(x, x), x) ||
@@ -118,9 +119,10 @@ expr simplify(const class max* op, expr a, expr b) {
       r.rewrite(max(x, x + c0), x + c0, eval(c0 > 0)) ||
       r.rewrite(max(x, x + c0), x, eval(c0 < 0)) ||
       r.rewrite(max(x + c0, c1), max(x, eval(c1 - c0)) + c0) ||
-      r.rewrite(max(c0 - x, c0 - y), c0 - min(x, y)) ||
       r.rewrite(max(x, -x), abs(x)) ||
       r.rewrite(max(x + c0, c0 - x), abs(x) + c0) ||
+      r.rewrite(max(x + c0, y + c1), max(x, y + eval(c1 - c0)) + c0) ||
+      r.rewrite(max(c0 - x, c1 - y), c0 - min(x, y + eval(c0 - c1))) ||
 
       // Algebraic simplifications
       r.rewrite(max(x, x), x) ||
@@ -204,15 +206,6 @@ expr simplify(const add* op, expr a, expr b) {
       r.rewrite(z + min(x, y - z), min(y, x + z)) ||
       r.rewrite(z + max(x, y - z), max(y, x + z)) ||
 
-      r.rewrite(min(x + c0, y + c1) + c2, min(x + eval(c0 + c2), y + eval(c1 + c2))) ||
-      r.rewrite(max(x + c0, y + c1) + c2, max(x + eval(c0 + c2), y + eval(c1 + c2))) ||
-      r.rewrite(min(y + c1, c0 - x) + c2, min(y + eval(c1 + c2), eval(c0 + c2) - x)) ||
-      r.rewrite(max(y + c1, c0 - x) + c2, max(y + eval(c1 + c2), eval(c0 + c2) - x)) ||
-      r.rewrite(min(c0 - x, c1 - y) + c2, min(eval(c0 + c2) - x, eval(c1 + c2) - y)) ||
-      r.rewrite(max(c0 - x, c1 - y) + c2, max(eval(c0 + c2) - x, eval(c1 + c2) - y)) ||
-      r.rewrite(min(x, y + c0) + c1, min(x + c1, y + eval(c0 + c1))) ||
-      r.rewrite(max(x, y + c0) + c1, max(x + c1, y + eval(c0 + c1))) ||
-
       r.rewrite(select(x, c0, c1) + c2, select(x, eval(c0 + c2), eval(c1 + c2))) ||
       r.rewrite(select(x, y + c0, c1) + c2, select(x, y + eval(c0 + c2), eval(c1 + c2))) ||
       r.rewrite(select(x, c0 - y, c1) + c2, select(x, eval(c0 + c2) - y, eval(c1 + c2))) ||
@@ -289,6 +282,9 @@ expr simplify(const sub* op, expr a, expr b) {
       r.rewrite(c2 - select(x, c0 - y, z + c1), select(x, y + eval(c2 - c0), eval(c2 - c1) - z)) ||
       r.rewrite(c2 - select(x, y + c0, c1 - z), select(x, eval(c2 - c0) - y, z + eval(c2 - c1))) ||
       r.rewrite(c2 - select(x, c0 - y, c1 - z), select(x, y + eval(c2 - c0), z + eval(c2 - c1))) ||
+    
+      r.rewrite(max(x, y) - min(x, y), abs(x - y)) ||
+      r.rewrite(min(x, y) - max(x, y), -abs(x - y)) ||
 
       r.rewrite(buffer_max(x, y) - buffer_min(x, y), buffer_extent(x, y) + -1) ||
       r.rewrite(buffer_max(x, y) - (z + buffer_min(x, y)), (buffer_extent(x, y) - z) + -1) ||

--- a/builder/simplify_exprs.cc
+++ b/builder/simplify_exprs.cc
@@ -54,6 +54,8 @@ expr simplify(const class min* op, expr a, expr b) {
       r.rewrite(min(x + c0, c0 - x), c0 - abs(x)) ||
       r.rewrite(min(x + c0, y + c1), min(x, y + eval(c1 - c0)) + c0) ||
       r.rewrite(min(c0 - x, c1 - y), c0 - max(x, y + eval(c0 - c1))) ||
+      r.rewrite(min(abs(x), c0), c0, c0 <= 0) ||
+      r.rewrite(min(c1 - abs(x), c0), c1 - abs(x), c1 <= c0) ||
 
       // Algebraic simplifications
       r.rewrite(min(x, x), x) ||
@@ -123,6 +125,8 @@ expr simplify(const class max* op, expr a, expr b) {
       r.rewrite(max(x + c0, c0 - x), abs(x) + c0) ||
       r.rewrite(max(x + c0, y + c1), max(x, y + eval(c1 - c0)) + c0) ||
       r.rewrite(max(c0 - x, c1 - y), c0 - min(x, y + eval(c0 - c1))) ||
+      r.rewrite(max(abs(x), c0), abs(x), c0 <= 0) ||
+      r.rewrite(max(c1 - abs(x), c0), c0, c1 <= c0) ||
 
       // Algebraic simplifications
       r.rewrite(max(x, x), x) ||

--- a/builder/simplify_test.cc
+++ b/builder/simplify_test.cc
@@ -177,7 +177,7 @@ TEST(simplify, allocate) {
                     block::make({check::make(y), clone_buffer::make(w.sym(), x.sym(), check::make(w)), check::make(z)})),
       block::make({check::make(y),
           allocate::make(x.sym(), memory_type::heap, 1, {{bounds(2, 3), 4, 5}},
-              clone_buffer::make(w.sym(), x.sym(), check::make(w))),
+              check::make(x)),
           check::make(z)}));
 }
 

--- a/builder/simplify_test.cc
+++ b/builder/simplify_test.cc
@@ -75,6 +75,7 @@ TEST(simplify, basic) {
   test_simplify(positive_infinity() + negative_infinity(), indeterminate());
   test_simplify(positive_infinity() * positive_infinity(), positive_infinity());
   test_simplify(positive_infinity() * negative_infinity(), negative_infinity());
+  test_simplify(abs(negative_infinity()), positive_infinity());
 
   test_simplify(min(1, 2), 1);
   test_simplify(max(1, 2), 2);

--- a/builder/substitute.cc
+++ b/builder/substitute.cc
@@ -394,6 +394,34 @@ public:
     set_result(v);
   }
 
+  static symbol_id replacement_symbol(const expr& r) {
+    const symbol_id* s = as_variable(r);
+    assert(s);
+    return *s;
+  }
+
+  symbol_id visit_symbol(symbol_id x) {
+    if (std::find(shadowed.begin(), shadowed.end(), x) != shadowed.end()) {
+      // This variable has been shadowed, don't substitute it.
+      return x;
+    } else if (x == target_var && !depends_on(replacement, shadowed).any()) {
+      return replacement_symbol(replacement);
+    } else if (replacements) {
+      std::optional<expr> r = replacements->lookup(x);
+      if (r && !depends_on(*r, shadowed).any()) {
+        return replacement_symbol(*r);
+      }
+    }
+    for (const auto& i : expr_replacements) {
+      const symbol_id* target = as_variable(i.first);
+      if (!target) continue;
+      if (*target == x) {
+        return replacement_symbol(i.second);
+      }
+    }
+    return x;
+  }
+
   template <typename T>
   T mutate_decl_body(symbol_id sym, const T& x) {
     shadowed.push_back(sym);
@@ -677,6 +705,45 @@ public:
   // operations are still valid.
   // TODO: truncate_rank is a bit tricky, the replacements for expressions might be invalid if they access truncated
   // dims.
+
+  void visit(const call_stmt* op) override {
+    call_stmt::symbol_list inputs(op->inputs.size());
+    call_stmt::symbol_list outputs(op->outputs.size());
+    bool changed = false;
+    for (std::size_t i = 0; i < op->inputs.size(); ++i) {
+      inputs[i] = visit_symbol(op->inputs[i]);
+      changed = changed || inputs[i] != op->inputs[i];
+    }
+    for (std::size_t i = 0; i < op->outputs.size(); ++i) {
+      outputs[i] = visit_symbol(op->outputs[i]);
+      changed = changed || outputs[i] != op->outputs[i];
+    }
+    if (changed) {
+      set_result(call_stmt::make(op->target, std::move(inputs), std::move(outputs), op->attrs));
+    } else {
+      set_result(op);
+    }
+  }
+
+  void visit(const copy_stmt* op) override {
+    symbol_id src = visit_symbol(op->src);
+    symbol_id dst = visit_symbol(op->dst);
+    if (src != op->src || dst != op->dst) {
+      set_result(copy_stmt::make(src, op->src_x, dst, op->dst_x, op->padding));
+    } else {
+      set_result(op);
+    }
+  }
+
+  void visit(const clone_buffer* op) override {
+    symbol_id src = visit_symbol(op->src);
+    stmt body = mutate(op->body);
+    if (src != op->src || !body.same_as(op->body)) {
+      set_result(clone_buffer::make(op->sym, src, std::move(body)));
+    } else {
+      set_result(op);
+    }
+  }
 };
 
 template <typename T>

--- a/builder/substitute.cc
+++ b/builder/substitute.cc
@@ -737,7 +737,7 @@ public:
 
   void visit(const clone_buffer* op) override {
     symbol_id src = visit_symbol(op->src);
-    stmt body = mutate(op->body);
+    stmt body = mutate_decl_body(op->sym, op->body);
     if (src != op->src || !body.same_as(op->body)) {
       set_result(clone_buffer::make(op->sym, src, std::move(body)));
     } else {

--- a/runtime/evaluate.h
+++ b/runtime/evaluate.h
@@ -48,6 +48,9 @@ index_t evaluate(const stmt& s, eval_context& context);
 index_t evaluate(const expr& e);
 index_t evaluate(const stmt& s);
 
+// Attempt to evaluate `e` as a constant. Returns `std::nullopt` if the expression is not constant.
+std::optional<index_t> evaluate_constant(const expr& e);
+
 // Returns true if `fn` can be evaluated.
 bool can_evaluate(intrinsic fn);
 

--- a/runtime/evaluate_test.cc
+++ b/runtime/evaluate_test.cc
@@ -84,4 +84,27 @@ TEST(evaluate, loop) {
   }
 }
 
+TEST(evaluate_constant, arithmetic) {
+  node_context ctx;
+  var x(ctx, "x");
+
+  ASSERT_EQ(evaluate_constant(x + 5), std::nullopt);
+  ASSERT_EQ(evaluate_constant(x - 3), std::nullopt);
+  ASSERT_EQ(evaluate_constant(2 * x), std::nullopt);
+  ASSERT_EQ(evaluate_constant(x / 2), std::nullopt);
+  ASSERT_EQ(evaluate_constant(4 % x), std::nullopt);
+  ASSERT_EQ(evaluate_constant(x < 4), std::nullopt);
+  ASSERT_EQ(evaluate_constant(x < 5), std::nullopt);
+  ASSERT_EQ(evaluate_constant(3 <= x), std::nullopt);
+  ASSERT_EQ(evaluate_constant(x <= 4), std::nullopt);
+  ASSERT_EQ(evaluate_constant(x > 3), std::nullopt);
+  ASSERT_EQ(evaluate_constant(x > 4), std::nullopt);
+  ASSERT_EQ(evaluate_constant(x >= 4), std::nullopt);
+  ASSERT_EQ(evaluate_constant(x >= 5), std::nullopt);
+  ASSERT_EQ(evaluate_constant(x == 4), std::nullopt);
+  ASSERT_EQ(evaluate_constant(x == 5), std::nullopt);
+  ASSERT_EQ(evaluate_constant(x != 4), std::nullopt);
+  ASSERT_EQ(evaluate_constant(x != 5), std::nullopt);
+}
+
 }  // namespace slinky

--- a/runtime/expr.h
+++ b/runtime/expr.h
@@ -403,6 +403,29 @@ DECLARE_BINARY_OP(logical_or, false)
 
 #undef DECLARE_BINARY_OP
 
+// Helpers that do compile-time constant folding based on type.
+template <typename T>
+expr make_binary(expr a, expr b) {
+  return T::make(std::move(a), std::move(b));
+}
+
+// clang-format off
+template <typename T> index_t make_binary(index_t a, index_t b);
+template <> inline index_t make_binary<add>(index_t a, index_t b) { return a + b; }
+template <> inline index_t make_binary<sub>(index_t a, index_t b) { return a - b; }
+template <> inline index_t make_binary<mul>(index_t a, index_t b) { return a * b; }
+template <> inline index_t make_binary<div>(index_t a, index_t b) { return euclidean_div(a, b); }
+template <> inline index_t make_binary<mod>(index_t a, index_t b) { return euclidean_mod(a, b); }
+template <> inline index_t make_binary<class min>(index_t a, index_t b) { return std::min(a, b); }
+template <> inline index_t make_binary<class max>(index_t a, index_t b) { return std::max(a, b); }
+template <> inline index_t make_binary<equal>(index_t a, index_t b) { return a == b; }
+template <> inline index_t make_binary<not_equal>(index_t a, index_t b) { return a != b; }
+template <> inline index_t make_binary<less>(index_t a, index_t b) { return a < b; }
+template <> inline index_t make_binary<less_equal>(index_t a, index_t b) { return a <= b; }
+template <> inline index_t make_binary<logical_and>(index_t a, index_t b) { return ((a != 0) && (b != 0)) ? 1 : 0; }
+template <> inline index_t make_binary<logical_or>(index_t a, index_t b) { return ((a != 0) || (b != 0)) ? 1 : 0; }
+// clang-format on
+
 class logical_not : public expr_node<logical_not> {
 public:
   expr a;


### PR DESCRIPTION
This PR makes the simplifier better at using the bounds of expressions and buffers. Aside from making the simplification of bounds much stronger, it also makes the simplifier much faster because it replaces nested simplification checks.