### PR TITLE
Fix more bugs

### DIFF
--- a/builder/simplify.cc
+++ b/builder/simplify.cc
@@ -355,6 +355,7 @@ public:
     auto body = mutate(op->body, &body_bounds);
 
     for (auto it = lets.rbegin(); it != lets.rend();) {
+      scoped_values.pop_back();
       auto deps = depends_on(body, it->first);
       // Find any deps on this variable in the inner let values.
       for (auto inner = lets.rbegin(); inner != it; ++inner) {
@@ -373,7 +374,6 @@ public:
       } else {
         ++it;
       }
-      scoped_values.pop_back();
     }
 
     if (lets.empty()) {

--- a/builder/simplify_test.cc
+++ b/builder/simplify_test.cc
@@ -154,6 +154,12 @@ TEST(simplify, let) {
   test_simplify(
     let_stmt::make(x.sym(), y * w, block::make({check::make(x > 0), check::make(x < 10)})),
     let_stmt::make(x.sym(), y * w, block::make({check::make(x > 0), check::make(x < 10)})));  // Non-trivial, used twice
+
+  // Compound lets with dependencies between let values.
+  test_simplify(let::make({{x.sym(), y}, {z.sym(), x}}, z), y);
+  test_simplify(let::make({{x.sym(), y}, {z.sym(), x * 2}}, z), y * 2);
+  test_simplify(let::make({{x.sym(), y * 2}, {z.sym(), x}}, z), y * 2);
+  test_simplify(let::make({{x.sym(), y * 2}, {z.sym(), y}}, z), y);
 }
 
 TEST(simplify, buffer_intrinsics) {

--- a/builder/substitute.h
+++ b/builder/substitute.h
@@ -30,6 +30,9 @@ int compare(const expr& a, const expr& b);
 int compare(const base_expr_node* a, const base_expr_node* b);
 int compare(const stmt& a, const stmt& b);
 
+// Update buffer metadata expressions to account for a slice that has occurred.
+expr update_sliced_buffer_metadata(const expr& e, symbol_id buf, span<const int> slices);
+
 // A comparator suitable for using expr/stmt as keys in an std::map/std::set.
 struct node_less {
   bool operator()(const expr& a, const expr& b) const { return compare(a, b) < 0; }

--- a/runtime/depends_on.h
+++ b/runtime/depends_on.h
@@ -12,8 +12,6 @@ struct depends_on_result {
 
   // The remaining fields all indicate the symbol is used as a buffer.
   bool buffer = false;
-  // True if the buffer's base pointer is used.
-  bool buffer_base = false;
   // True if the buffer is used as a call input or output, respectively.
   bool buffer_input = false;
   bool buffer_output = false;
@@ -21,10 +19,21 @@ struct depends_on_result {
   bool buffer_src = false;
   bool buffer_dst = false;
 
+  // How many references there are.
+  int ref_count = 0;
+
+  // True if any reference is in a loop.
+  bool used_in_loop = false;
+
   bool any() const { return var || buffer; }
 };
 
 // Check if the node depends on a symbol or set of symbols.
+
+void depends_on(const expr& e, span<const std::pair<symbol_id, depends_on_result&>> var_deps);
+void depends_on(const stmt& s, span<const std::pair<symbol_id, depends_on_result&>> var_deps);
+void depends_on(const expr& e, symbol_id var, depends_on_result& deps);
+void depends_on(const stmt& s, symbol_id var, depends_on_result& deps);
 depends_on_result depends_on(const expr& e, symbol_id var);
 depends_on_result depends_on(const interval_expr& e, symbol_id var);
 depends_on_result depends_on(const stmt& s, symbol_id var);


### PR DESCRIPTION
I realized that the way the simplifier handles symbol references isn't safe, because we see symbol references from nodes that later get simplified or removed entirely. Fixing this uncovered more bugs. Fixes in this PR:

- Use `depends_on` instead of trying to avoid recursive visitors in simplify. This has bad algorithmic complexity, but it's correct. We can fix the algorithmic complexity later if/when it's a problem.
- Slices need to update *all* references to the buffer metadata, not just the bounds of the buffer itself.
- Lets need to be simplified in reverse order to get interdependent lets correct.
- `depends_on` didn't handle shadowing correctly.