### PR TITLE
Take < rules from Halide

### DIFF
--- a/builder/simplify.cc
+++ b/builder/simplify.cc
@@ -730,7 +730,7 @@ public:
     stmt body = mutate_with_bounds(op->body, op->sym, std::move(bounds));
     auto deps = depends_on(body, op->sym);
     if (!deps.any()) {
-      set_result(body);
+      set_result(std::move(body));
       return;
     } else if (!crop_needed(deps)) {
       // Add clamps for the implicit bounds like crop would have done.
@@ -797,7 +797,7 @@ public:
     stmt body = mutate_with_bounds(op->body, op->sym, std::move(buf_bounds));
     auto deps = depends_on(body, op->sym);
     if (!deps.any()) {
-      set_result(body);
+      set_result(std::move(body));
       return;
     } else if (!crop_needed(deps)) {
       body = substitute_bounds(body, op->sym, op->dim, bounds & slinky::buffer_bounds(sym_var, op->dim));
@@ -878,7 +878,7 @@ public:
 
     auto deps = depends_on(body, op->sym);
     if (!deps.any()) {
-      set_result(stmt());
+      set_result(std::move(body));
       return;
     }
 
@@ -923,7 +923,7 @@ public:
 
     auto deps = depends_on(body, op->sym);
     if (!deps.any()) {
-      set_result(stmt());
+      set_result(std::move(body));
     } else if (const block* b = body.as<block>()) {
       std::vector<stmt> stmts;
       stmts.reserve(b->stmts.size());

--- a/builder/simplify.cc
+++ b/builder/simplify.cc
@@ -369,6 +369,9 @@ public:
       } else if ((deps.ref_count == 1 && !deps.used_in_loop) || is_trivial_let_value(it->second)) {
         // Inline single-ref lets outside of a loop, along with lets that are trivial
         body = mutate(substitute(body, it->first, it->second), &body_bounds);
+        for (auto inner = lets.rbegin(); inner != it; ++inner) {
+          inner->second = substitute(inner->second, it->first, it->second);
+        }
         it = std::make_reverse_iterator(lets.erase(std::next(it).base()));
         values_changed = true;
       } else {

--- a/builder/simplify_exprs.cc
+++ b/builder/simplify_exprs.cc
@@ -431,8 +431,8 @@ expr simplify(const less* op, expr a, expr b) {
       r.rewrite(c0 < c1 - x, x < eval(c1 - c0)) ||
       r.rewrite(c0 < x + c1, eval(c0 - c1) < x) ||
 
-      r.rewrite((x + c0) / c1 < x / c1, eval(c0 < 0)) ||
-      r.rewrite(x / c1 < (x + c0) / c1, eval(c1 <= c0)) ||
+      r.rewrite((x + c0) / c1 < x / c1, eval(c0 < 0), eval(c1 > 0)) ||
+      r.rewrite(x / c1 < (x + c0) / c1, eval(c1 <= c0), eval(c1 > 0)) ||
     
       r.rewrite(x < x + y, 0 < y) ||
       r.rewrite(x + y < x, y < 0) ||

--- a/builder/simplify_exprs.cc
+++ b/builder/simplify_exprs.cc
@@ -432,7 +432,7 @@ expr simplify(const less* op, expr a, expr b) {
       r.rewrite(c0 < x + c1, eval(c0 - c1) < x) ||
 
       r.rewrite((x + c0) / c1 < x / c1, eval(c0 < 0)) ||
-      r.rewrite(x / c1 < (x + c0) / c1, eval(0 < c0)) ||
+      r.rewrite(x / c1 < (x + c0) / c1, eval(c1 <= c0)) ||
     
       r.rewrite(x < x + y, 0 < y) ||
       r.rewrite(x + y < x, y < 0) ||

--- a/builder/simplify_test.cc
+++ b/builder/simplify_test.cc
@@ -119,6 +119,7 @@ TEST(simplify, basic) {
 
   test_simplify(x < x + 1, true);
   test_simplify(x - 1 < x + 1, true);
+  test_simplify(min(x + 1, z) < x + 2, true);
 
   test_simplify(abs(abs(x)), abs(x));
 
@@ -127,9 +128,6 @@ TEST(simplify, basic) {
 
   test_simplify(select(x, y + 1, y + 2), y + select(x, 1, 2));
   test_simplify(select(x, 1, 2) + 1, select(x, 2, 3));
-
-  test_simplify(x + 1 < x + 2, true);
-  test_simplify(min(x + 1, z) < x + 2, true);
 }
 
 TEST(simplify, let) {

--- a/builder/simplify_test.cc
+++ b/builder/simplify_test.cc
@@ -161,6 +161,7 @@ TEST(simplify, let) {
   test_simplify(let::make({{x.sym(), y}, {z.sym(), x * 2}}, z), y * 2);
   test_simplify(let::make({{x.sym(), y * 2}, {z.sym(), x}}, z), y * 2);
   test_simplify(let::make({{x.sym(), y * 2}, {z.sym(), y}}, z), y);
+  test_simplify(let::make({{x.sym(), y}, {z.sym(), (x + 1) / x}}, (z + 1) / z), let::make({{z.sym(), (y + 1) / y}}, (z + 1) / z));
 }
 
 TEST(simplify, buffer_intrinsics) {

--- a/builder/simplify_test.cc
+++ b/builder/simplify_test.cc
@@ -127,6 +127,9 @@ TEST(simplify, basic) {
 
   test_simplify(select(x, y + 1, y + 2), y + select(x, 1, 2));
   test_simplify(select(x, 1, 2) + 1, select(x, 2, 3));
+
+  test_simplify(x + 1 < x + 2, true);
+  test_simplify(min(x + 1, z) < x + 2, true);
 }
 
 TEST(simplify, let) {


### PR DESCRIPTION
This PR also handles `a <= b` by rewriting it to `!(b < a)` to avoid duplicating a lot of very similar rules (like Halide does).

This PR also includes some other simplifier fixes:
- We didn't substitute into the inner let values where the the let variable could have been used.
- Use a helper function to handle the right scope for setting bounds in recursive simplification.
- Fix some bugs in rewrite rules for <
- Fix unused slices being dropped entirely