### PR TITLE
Support constants directly in pipeline object

### DIFF
--- a/builder/pipeline.cc
+++ b/builder/pipeline.cc
@@ -611,13 +611,22 @@ std::vector<var> vars(const std::vector<buffer_expr_ptr>& bufs) {
   return result;
 }
 
+std::vector<std::pair<symbol_id, const raw_buffer*>> constant_map(const std::set<buffer_expr_ptr>& constants) {
+  std::vector<std::pair<symbol_id, const raw_buffer*>> result;
+  result.reserve(constants.size());
+  for (const buffer_expr_ptr& i : constants) {
+    result.push_back({i->sym(), i->constant()});
+  }
+  return result;
+}
+
 }  // namespace
 
 pipeline build_pipeline(node_context& ctx, std::vector<var> args, const std::vector<buffer_expr_ptr>& inputs,
     const std::vector<buffer_expr_ptr>& outputs, const build_options& options) {
   std::set<buffer_expr_ptr> constants;
   stmt body = build_pipeline(ctx, inputs, outputs, constants, options);
-  return pipeline(std::move(args), vars(inputs), vars(outputs), std::move(body));
+  return pipeline(std::move(args), vars(inputs), vars(outputs), constant_map(constants), std::move(body));
 }
 
 pipeline build_pipeline(node_context& ctx, const std::vector<buffer_expr_ptr>& inputs,

--- a/builder/pipeline_test.cc
+++ b/builder/pipeline_test.cc
@@ -1280,8 +1280,6 @@ TEST(pipeline, constant) {
   // Not having span(std::initializer_list<T>) is unfortunate.
   const raw_buffer* outputs[] = {&out_buf};
   test_context eval_ctx;
-  // TODO: Should pipeline understand constants and do this itself?
-  eval_ctx[constant->sym()] = reinterpret_cast<index_t>(constant->constant());
   p.evaluate({}, outputs, eval_ctx);
 
   for (int y = 0; y < H; ++y) {

--- a/runtime/pipeline.cc
+++ b/runtime/pipeline.cc
@@ -7,11 +7,9 @@
 
 namespace slinky {
 
-pipeline::pipeline(std::vector<var> args, std::vector<var> inputs, std::vector<var> outputs, stmt body)
-    : args_(std::move(args)), inputs_(std::move(inputs)), outputs_(std::move(outputs)), body_(std::move(body)) {}
-
-pipeline::pipeline(std::vector<var> inputs, std::vector<var> outputs, stmt body)
-    : pipeline({}, std::move(inputs), std::move(outputs), std::move(body)) {}
+pipeline::pipeline(std::vector<var> args, std::vector<var> inputs, std::vector<var> outputs,
+    std::vector<std::pair<symbol_id, const raw_buffer*>> constants, stmt body)
+    : args_(std::move(args)), inputs_(std::move(inputs)), outputs_(std::move(outputs)), constants_(std::move(constants)), body_(std::move(body)) {}
 
 index_t pipeline::evaluate(scalars args, buffers inputs, buffers outputs, eval_context& ctx) const {
   assert(args.size() == args_.size());
@@ -26,6 +24,9 @@ index_t pipeline::evaluate(scalars args, buffers inputs, buffers outputs, eval_c
   }
   for (std::size_t i = 0; i < outputs.size(); ++i) {
     ctx[outputs_[i]] = reinterpret_cast<index_t>(outputs[i]);
+  }
+  for (const auto& i : constants_) {
+    ctx[i.first] = reinterpret_cast<index_t>(i.second);
   }
 
   return slinky::evaluate(body_, ctx);

--- a/runtime/pipeline.h
+++ b/runtime/pipeline.h
@@ -14,12 +14,13 @@ class pipeline {
   std::vector<var> args_;
   std::vector<var> inputs_;
   std::vector<var> outputs_;
+  std::vector<std::pair<symbol_id, const raw_buffer*>> constants_;
 
   stmt body_;
 
 public:
-  pipeline(std::vector<var> args, std::vector<var> inputs, std::vector<var> outputs, stmt body);
-  pipeline(std::vector<var> inputs, std::vector<var> outputs, stmt body);
+  pipeline(std::vector<var> args, std::vector<var> inputs, std::vector<var> outputs,
+      std::vector<std::pair<symbol_id, const raw_buffer*>> constants, stmt body);
 
   using scalars = span<const index_t>;
   using buffers = span<const raw_buffer*>;


### PR DESCRIPTION
This is something that I delayed doing for a while because it feels like a lot of boilerplate for what it is. But, I think we should have this capability, manually needing to set constants explicitly is a real pain in real use cases.