### PR TITLE
Revise constant-buffer handling

### DIFF
--- a/builder/elementwise_test.cc
+++ b/builder/elementwise_test.cc
@@ -64,7 +64,7 @@ public:
     auto* dims = SLINKY_ALLOCA(dim, Rank);
     for (std::size_t d = 0; d < Rank; ++d) {
       // TODO: Find a better way to not care about bounds of broadcasted dimensions.
-      dims[d].set_bounds(std::numeric_limits<index_t>::min() / 2, std::numeric_limits<index_t>::max() / 2);
+      dims[d].set_bounds(std::numeric_limits<index_t>::min() / 2 + 1, std::numeric_limits<index_t>::max() / 2);
       dims[d].set_stride(0);
       dims[d].set_fold_factor(dim::unfolded);
     }

--- a/builder/elementwise_test.cc
+++ b/builder/elementwise_test.cc
@@ -66,6 +66,7 @@ public:
       // TODO: Find a better way to not care about bounds of broadcasted dimensions.
       dims[d].set_bounds(std::numeric_limits<index_t>::min() / 2, std::numeric_limits<index_t>::max() / 2);
       dims[d].set_stride(0);
+      dims[d].set_fold_factor(dim::unfolded);
     }
 
     auto value = raw_buffer::make_allocated(sizeof(T), Rank, dims);

--- a/builder/elementwise_test.cc
+++ b/builder/elementwise_test.cc
@@ -61,7 +61,7 @@ public:
   }
 
   void visit(const constant* c) override {
-    auto* dims = SLINKY_ALLOCA(dim, Rank);
+    slinky::dim dims[Rank];
     for (std::size_t d = 0; d < Rank; ++d) {
       // TODO: Find a better way to not care about bounds of broadcasted dimensions.
       dims[d].set_bounds(std::numeric_limits<index_t>::min() / 2 + 1, std::numeric_limits<index_t>::max() / 2);
@@ -70,6 +70,7 @@ public:
     }
 
     auto value = raw_buffer::make_allocated(sizeof(T), Rank, dims);
+    assert(value->size_bytes() == sizeof(T));
     memcpy(value->base, &c->value, sizeof(T));
     result = buffer_expr::make_constant(ctx, "c" + std::to_string(c->value), std::move(value));
     constants.push_back(result);

--- a/builder/elementwise_test.cc
+++ b/builder/elementwise_test.cc
@@ -65,8 +65,6 @@ public:
     for (std::size_t d = 0; d < Rank; ++d) {
       // TODO: Find a better way to not care about bounds of broadcasted dimensions.
       dims[d].set_bounds(std::numeric_limits<index_t>::min() / 2 + 1, std::numeric_limits<index_t>::max() / 2);
-      dims[d].set_stride(0);
-      dims[d].set_fold_factor(dim::unfolded);
     }
 
     auto value = raw_buffer::make_allocated(sizeof(T), Rank, dims);

--- a/builder/elementwise_test.cc
+++ b/builder/elementwise_test.cc
@@ -70,7 +70,6 @@ public:
     }
 
     auto value = raw_buffer::make_allocated(sizeof(T), Rank, dims);
-    value->allocate();
     memcpy(value->base, &c->value, sizeof(T));
     result = buffer_expr::make_constant(ctx, "c" + std::to_string(c->value), std::move(value));
     constants.push_back(result);

--- a/builder/pipeline.cc
+++ b/builder/pipeline.cc
@@ -36,7 +36,7 @@ buffer_expr::buffer_expr(symbol_id sym, index_t elem_size, std::size_t rank)
   }
 }
 
-buffer_expr::buffer_expr(symbol_id sym, raw_buffer_ptr constant_buffer)
+buffer_expr::buffer_expr(symbol_id sym, const_raw_buffer_ptr constant_buffer)
     : sym_(sym), elem_size_(constant_buffer->elem_size), producer_(nullptr), constant_(std::move(constant_buffer)) {
   assert(constant_ != nullptr);
   dims_.reserve(constant_->rank);
@@ -58,10 +58,10 @@ buffer_expr_ptr buffer_expr::make(node_context& ctx, const std::string& sym, ind
   return buffer_expr_ptr(new buffer_expr(ctx.insert_unique(sym), elem_size, rank));
 }
 
-buffer_expr_ptr buffer_expr::make_constant(symbol_id sym, raw_buffer_ptr constant_buffer) {
+buffer_expr_ptr buffer_expr::make_constant(symbol_id sym, const_raw_buffer_ptr constant_buffer) {
   return buffer_expr_ptr(new buffer_expr(sym, std::move(constant_buffer)));
 }
-buffer_expr_ptr buffer_expr::make_constant(node_context& ctx, const std::string& sym, raw_buffer_ptr constant_buffer) {
+buffer_expr_ptr buffer_expr::make_constant(node_context& ctx, const std::string& sym, const_raw_buffer_ptr constant_buffer) {
   return buffer_expr_ptr(new buffer_expr(ctx.insert_unique(sym), std::move(constant_buffer)));
 }
 
@@ -619,8 +619,8 @@ std::vector<var> vars(const std::vector<buffer_expr_ptr>& bufs) {
   return result;
 }
 
-std::vector<std::pair<symbol_id, const raw_buffer*>> constant_map(const std::set<buffer_expr_ptr>& constants) {
-  std::vector<std::pair<symbol_id, const raw_buffer*>> result;
+std::vector<std::pair<symbol_id, const_raw_buffer_ptr>> constant_map(const std::set<buffer_expr_ptr>& constants) {
+  std::vector<std::pair<symbol_id, const_raw_buffer_ptr>> result;
   result.reserve(constants.size());
   for (const buffer_expr_ptr& i : constants) {
     result.push_back({i->sym(), i->constant()});

--- a/builder/pipeline.h
+++ b/builder/pipeline.h
@@ -28,13 +28,13 @@ class buffer_expr : public ref_counted<buffer_expr> {
   std::vector<dim_expr> dims_;
 
   func* producer_;
-  raw_buffer_ptr constant_;
+  const_raw_buffer_ptr constant_;
 
   memory_type storage_ = memory_type::heap;
   std::optional<loop_id> store_at_;
 
   buffer_expr(symbol_id sym, index_t elem_size, std::size_t rank);
-  buffer_expr(symbol_id sym, raw_buffer_ptr constant_buffer);
+  buffer_expr(symbol_id sym, const_raw_buffer_ptr constant_buffer);
   buffer_expr(const buffer_expr&) = delete;
   buffer_expr(buffer_expr&&) = delete;
   buffer_expr& operator=(const buffer_expr&) = delete;
@@ -48,8 +48,8 @@ public:
   static buffer_expr_ptr make(symbol_id sym, index_t elem_size, std::size_t rank);
   static buffer_expr_ptr make(node_context& ctx, const std::string& sym, index_t elem_size, std::size_t rank);
   // Make a constant buffer_expr. It takes ownership of the buffer from the caller.
-  static buffer_expr_ptr make_constant(symbol_id sym, raw_buffer_ptr constant_buffer);
-  static buffer_expr_ptr make_constant(node_context& ctx, const std::string& sym, raw_buffer_ptr constant_buffer);
+  static buffer_expr_ptr make_constant(symbol_id sym, const_raw_buffer_ptr constant_buffer);
+  static buffer_expr_ptr make_constant(node_context& ctx, const std::string& sym, const_raw_buffer_ptr constant_buffer);
 
   symbol_id sym() const { return sym_; }
   index_t elem_size() const { return elem_size_; }
@@ -81,7 +81,7 @@ public:
 
   const func* producer() const { return producer_; }
 
-  const raw_buffer* constant() const { return constant_.get(); }
+  const_raw_buffer_ptr constant() const { return constant_; }
 
   static void destroy(buffer_expr* p) { delete p; }
 };

--- a/builder/pipeline.h
+++ b/builder/pipeline.h
@@ -28,13 +28,13 @@ class buffer_expr : public ref_counted<buffer_expr> {
   std::vector<dim_expr> dims_;
 
   func* producer_;
-  const raw_buffer* constant_;
+  raw_buffer_ptr constant_;
 
   memory_type storage_ = memory_type::heap;
   std::optional<loop_id> store_at_;
 
   buffer_expr(symbol_id sym, index_t elem_size, std::size_t rank);
-  buffer_expr(symbol_id sym, const raw_buffer* buffer);
+  buffer_expr(symbol_id sym, raw_buffer_ptr constant_buffer);
   buffer_expr(const buffer_expr&) = delete;
   buffer_expr(buffer_expr&&) = delete;
   buffer_expr& operator=(const buffer_expr&) = delete;
@@ -47,12 +47,9 @@ class buffer_expr : public ref_counted<buffer_expr> {
 public:
   static buffer_expr_ptr make(symbol_id sym, index_t elem_size, std::size_t rank);
   static buffer_expr_ptr make(node_context& ctx, const std::string& sym, index_t elem_size, std::size_t rank);
-  // Make a constant buffer_expr. This does not take ownership of the object, and it must be kept alive as long as this
-  // buffer_expr is alive.
-  // TODO: This should probably either be some kind of smart pointer, or maybe at least copy the raw_buffer object (but
-  // not the underlying data).
-  static buffer_expr_ptr make(symbol_id sym, const raw_buffer* buffer);
-  static buffer_expr_ptr make(node_context& ctx, const std::string& sym, const raw_buffer* buffer);
+  // Make a constant buffer_expr. It takes ownership of the buffer from the caller.
+  static buffer_expr_ptr make_constant(symbol_id sym, raw_buffer_ptr constant_buffer);
+  static buffer_expr_ptr make_constant(node_context& ctx, const std::string& sym, raw_buffer_ptr constant_buffer);
 
   symbol_id sym() const { return sym_; }
   index_t elem_size() const { return elem_size_; }
@@ -84,7 +81,7 @@ public:
 
   const func* producer() const { return producer_; }
 
-  const raw_buffer* constant() const { return constant_; }
+  const raw_buffer* constant() const { return constant_.get(); }
 
   static void destroy(buffer_expr* p) { delete p; }
 };

--- a/builder/pipeline_test.cc
+++ b/builder/pipeline_test.cc
@@ -1268,10 +1268,8 @@ TEST(pipeline, constant) {
   slinky::dim dims[2];
   dims[0].set_bounds(0, W);
   dims[0].set_stride(1 * sizeof(short));
-  dims[0].set_fold_factor(dim::unfolded);
   dims[1].set_bounds(0, H);
   dims[1].set_stride(W * sizeof(short));
-  dims[1].set_fold_factor(dim::unfolded);
 
   auto constant_buf = raw_buffer::make_allocated(sizeof(short), 2, dims);
   fill_random<short>(*constant_buf);

--- a/builder/pipeline_test.cc
+++ b/builder/pipeline_test.cc
@@ -1278,11 +1278,6 @@ TEST(pipeline, constant) {
 
   auto out = buffer_expr::make(ctx, "out", sizeof(short), 2);
 
-  // Save a copy of the pointer for use in the test below,
-  // since std::move() may invalidate it in some build envs
-  // (we know it's real lifespan will be value for the life
-  // of this fn).
-  const raw_buffer* constant_buf_saved = constant_buf.get();
   auto constant = buffer_expr::make_constant(ctx, "constant", std::move(constant_buf));
 
   var x(ctx, "x");
@@ -1303,7 +1298,7 @@ TEST(pipeline, constant) {
 
   for (int y = 0; y < H; ++y) {
     for (int x = 0; x < W; ++x) {
-      ASSERT_EQ(out_buf(x, y), *reinterpret_cast<short*>(constant_buf_saved->address_at(x, y)) + 1);
+      ASSERT_EQ(out_buf(x, y), *reinterpret_cast<short*>(constant->constant()->address_at(x, y)) + 1);
     }
   }
 }

--- a/builder/pipeline_test.cc
+++ b/builder/pipeline_test.cc
@@ -1265,7 +1265,7 @@ TEST(pipeline, constant) {
   const int W = 20;
   const int H = 10;
 
-  auto* dims = SLINKY_ALLOCA(dim, 2);
+  slinky::dim dims[2];
   dims[0].set_bounds(0, W);
   dims[0].set_stride(1 * sizeof(short));
   dims[0].set_fold_factor(dim::unfolded);

--- a/builder/pipeline_test.cc
+++ b/builder/pipeline_test.cc
@@ -1268,8 +1268,10 @@ TEST(pipeline, constant) {
   auto* dims = SLINKY_ALLOCA(dim, 2);
   dims[0].set_bounds(0, W);
   dims[0].set_stride(1);
+  dims[0].set_fold_factor(dim::unfolded);
   dims[1].set_bounds(0, H);
   dims[1].set_stride(W);
+  dims[1].set_fold_factor(dim::unfolded);
 
   auto constant_buf = raw_buffer::make_allocated(sizeof(short), 2, dims);
   constant_buf->allocate();

--- a/builder/pipeline_test.cc
+++ b/builder/pipeline_test.cc
@@ -1274,7 +1274,6 @@ TEST(pipeline, constant) {
   dims[1].set_fold_factor(dim::unfolded);
 
   auto constant_buf = raw_buffer::make_allocated(sizeof(short), 2, dims);
-  constant_buf->allocate();
   fill_random<short>(*constant_buf);
 
   auto out = buffer_expr::make(ctx, "out", sizeof(short), 2);

--- a/builder/pipeline_test.cc
+++ b/builder/pipeline_test.cc
@@ -115,10 +115,17 @@ index_t subtract(const buffer<const T>& a, const buffer<const T>& b, const buffe
   return 0;
 }
 
+// init_random() for raw_buffer requires allocation be done by caller
+template <typename T>
+void fill_random(raw_buffer& x) {
+  assert(x.base != nullptr);
+  for_each_index(x, [&](auto i) { *reinterpret_cast<T*>(x.address_at(i)) = (rand() % 20) - 10; });
+}
+
 template <typename T, std::size_t N>
 void init_random(buffer<T, N>& x) {
   x.allocate();
-  for_each_index(x, [&](auto i) { x(i) = (rand() % 20) - 10; });
+  fill_random<T>(x);
 }
 
 // Matrix multiplication (not fast!)
@@ -589,7 +596,6 @@ TEST(pipeline, stencil) {
     }
   }
 }
-
 
 TEST(pipeline, slide_2d) {
   // Make the pipeline
@@ -1259,12 +1265,24 @@ TEST(pipeline, constant) {
   const int W = 20;
   const int H = 10;
 
-  buffer<short, 2> constant_buf({W, H});
-  init_random(constant_buf);
+  auto* dims = SLINKY_ALLOCA(dim, 2);
+  dims[0].set_bounds(0, W);
+  dims[0].set_stride(1);
+  dims[1].set_bounds(0, H);
+  dims[1].set_stride(W);
+
+  auto constant_buf = raw_buffer::make_allocated(sizeof(short), 2, dims);
+  constant_buf->allocate();
+  fill_random<short>(*constant_buf);
 
   auto out = buffer_expr::make(ctx, "out", sizeof(short), 2);
 
-  auto constant = buffer_expr::make(ctx, "constant", &constant_buf);
+  // Save a copy of the pointer for use in the test below,
+  // since std::move() may invalidate it in some build envs
+  // (we know it's real lifespan will be value for the life
+  // of this fn).
+  const raw_buffer* constant_buf_saved = constant_buf.get();
+  auto constant = buffer_expr::make_constant(ctx, "constant", std::move(constant_buf));
 
   var x(ctx, "x");
   var y(ctx, "y");
@@ -1284,7 +1302,7 @@ TEST(pipeline, constant) {
 
   for (int y = 0; y < H; ++y) {
     for (int x = 0; x < W; ++x) {
-      ASSERT_EQ(out_buf(x, y), constant_buf(x, y) + 1);
+      ASSERT_EQ(out_buf(x, y), *reinterpret_cast<short*>(constant_buf_saved->address_at(x, y)) + 1);
     }
   }
 }

--- a/builder/pipeline_test.cc
+++ b/builder/pipeline_test.cc
@@ -1267,10 +1267,10 @@ TEST(pipeline, constant) {
 
   auto* dims = SLINKY_ALLOCA(dim, 2);
   dims[0].set_bounds(0, W);
-  dims[0].set_stride(1);
+  dims[0].set_stride(1 * sizeof(short));
   dims[0].set_fold_factor(dim::unfolded);
   dims[1].set_bounds(0, H);
-  dims[1].set_stride(W);
+  dims[1].set_stride(W * sizeof(short));
   dims[1].set_fold_factor(dim::unfolded);
 
   auto constant_buf = raw_buffer::make_allocated(sizeof(short), 2, dims);

--- a/runtime/buffer.cc
+++ b/runtime/buffer.cc
@@ -41,6 +41,19 @@ raw_buffer_ptr raw_buffer::make_allocated(std::size_t elem_size, std::size_t ran
   return raw_buffer_ptr(buf);
 }
 
+raw_buffer_ptr raw_buffer::make_allocated_external(
+    std::size_t elem_size, std::size_t rank, const class dim* dims, void* base) {
+  char* mem = reinterpret_cast<char*>(malloc(sizeof(raw_buffer) + sizeof(slinky::dim) * rank));
+  raw_buffer* buf = new (mem) raw_buffer();
+  mem += sizeof(raw_buffer);
+  buf->rank = rank;
+  buf->elem_size = elem_size;
+  buf->dims = reinterpret_cast<slinky::dim*>(mem);
+  memcpy(buf->dims, dims, sizeof(slinky::dim) * rank);
+  buf->base = base;
+  return raw_buffer_ptr(buf);
+}
+
 raw_buffer_ptr raw_buffer::make_copy(const raw_buffer& src) {
   auto buf = make_allocated(src.elem_size, src.rank, src.dims);
   copy(src, *buf);

--- a/runtime/buffer.cc
+++ b/runtime/buffer.cc
@@ -38,7 +38,7 @@ raw_buffer_ptr raw_buffer::make_allocated(std::size_t elem_size, std::size_t ran
   memcpy(buf->dims, dims, sizeof(slinky::dim) * rank);
   mem += sizeof(slinky::dim) * rank;
   buf->base = mem;
-  return raw_buffer_ptr(buf);
+  return raw_buffer_ptr(buf, free);
 }
 
 raw_buffer_ptr raw_buffer::make(std::size_t elem_size, std::size_t rank) {
@@ -48,7 +48,7 @@ raw_buffer_ptr raw_buffer::make(std::size_t elem_size, std::size_t rank) {
   buf->rank = rank;
   buf->elem_size = elem_size;
   buf->dims = reinterpret_cast<slinky::dim*>(mem);
-  return raw_buffer_ptr(buf);
+  return raw_buffer_ptr(buf, free);
 }
 
 raw_buffer_ptr raw_buffer::make_copy(const raw_buffer& src) {

--- a/runtime/buffer.cc
+++ b/runtime/buffer.cc
@@ -41,16 +41,13 @@ raw_buffer_ptr raw_buffer::make_allocated(std::size_t elem_size, std::size_t ran
   return raw_buffer_ptr(buf);
 }
 
-raw_buffer_ptr raw_buffer::make_allocated_external(
-    std::size_t elem_size, std::size_t rank, const class dim* dims, void* base) {
+raw_buffer_ptr raw_buffer::make(std::size_t elem_size, std::size_t rank) {
   char* mem = reinterpret_cast<char*>(malloc(sizeof(raw_buffer) + sizeof(slinky::dim) * rank));
   raw_buffer* buf = new (mem) raw_buffer();
   mem += sizeof(raw_buffer);
   buf->rank = rank;
   buf->elem_size = elem_size;
   buf->dims = reinterpret_cast<slinky::dim*>(mem);
-  memcpy(buf->dims, dims, sizeof(slinky::dim) * rank);
-  buf->base = base;
   return raw_buffer_ptr(buf);
 }
 

--- a/runtime/buffer.h
+++ b/runtime/buffer.h
@@ -201,13 +201,11 @@ public:
   template <typename NewT>
   const buffer<NewT>& cast() const;
 
-  // Make a pointer to a buffer with an allocation for the buffer in the same allocation.
-  static raw_buffer_ptr make_allocated(std::size_t elem_size, std::size_t rank, const class dim* dims);
+  // Make a pointer to a buffer with an allocation for the dims (but not elements) in the same allocation.
+  static raw_buffer_ptr make(std::size_t elem_size, std::size_t rank);
 
-  // Like make_allocated(), but the base pointer (for the elements) is an arbitrary, unowned address
-  // that is expected to remain valid for the life of this buffer. (A typical use case for this might
-  // be if the buffer storage is in a memory-mapped file.)
-  static raw_buffer_ptr make_allocated_external(std::size_t elem_size, std::size_t rank, const class dim* dims, void* base);
+  // Make a pointer to a buffer with an allocation for the dims and the elements in the same allocation.
+  static raw_buffer_ptr make_allocated(std::size_t elem_size, std::size_t rank, const class dim* dims);
 
   // Make a deep copy of another buffer, including allocating and copying the data.
   static raw_buffer_ptr make_copy(const raw_buffer& src);

--- a/runtime/buffer.h
+++ b/runtime/buffer.h
@@ -84,11 +84,8 @@ class buffer;
 
 class raw_buffer;
 
-struct free_deleter {
-  void operator()(void* p) { free(p); }
-};
-
-using raw_buffer_ptr = std::unique_ptr<raw_buffer, free_deleter>;
+using raw_buffer_ptr = std::shared_ptr<raw_buffer>;
+using const_raw_buffer_ptr = std::shared_ptr<const raw_buffer>;
 
 // We have some difficult requirements for this buffer object:
 // 1. We want type safety in user code, but we also want to be able to treat buffers as generic.

--- a/runtime/buffer.h
+++ b/runtime/buffer.h
@@ -204,6 +204,11 @@ public:
   // Make a pointer to a buffer with an allocation for the buffer in the same allocation.
   static raw_buffer_ptr make_allocated(std::size_t elem_size, std::size_t rank, const class dim* dims);
 
+  // Like make_allocated(), but the base pointer (for the elements) is an arbitrary, unowned address
+  // that is expected to remain valid for the life of this buffer. (A typical use case for this might
+  // be if the buffer storage is in a memory-mapped file.)
+  static raw_buffer_ptr make_allocated_external(std::size_t elem_size, std::size_t rank, const class dim* dims, void* base);
+
   // Make a deep copy of another buffer, including allocating and copying the data.
   static raw_buffer_ptr make_copy(const raw_buffer& src);
 };

--- a/runtime/pipeline.cc
+++ b/runtime/pipeline.cc
@@ -8,7 +8,7 @@
 namespace slinky {
 
 pipeline::pipeline(std::vector<var> args, std::vector<var> inputs, std::vector<var> outputs,
-    std::vector<std::pair<symbol_id, const raw_buffer*>> constants, stmt body)
+    std::vector<std::pair<symbol_id, const_raw_buffer_ptr>> constants, stmt body)
     : args_(std::move(args)), inputs_(std::move(inputs)), outputs_(std::move(outputs)), constants_(std::move(constants)), body_(std::move(body)) {}
 
 index_t pipeline::evaluate(scalars args, buffers inputs, buffers outputs, eval_context& ctx) const {
@@ -26,7 +26,7 @@ index_t pipeline::evaluate(scalars args, buffers inputs, buffers outputs, eval_c
     ctx[outputs_[i]] = reinterpret_cast<index_t>(outputs[i]);
   }
   for (const auto& i : constants_) {
-    ctx[i.first] = reinterpret_cast<index_t>(i.second);
+    ctx[i.first] = reinterpret_cast<index_t>(i.second.get());
   }
 
   return slinky::evaluate(body_, ctx);

--- a/runtime/pipeline.h
+++ b/runtime/pipeline.h
@@ -14,13 +14,13 @@ class pipeline {
   std::vector<var> args_;
   std::vector<var> inputs_;
   std::vector<var> outputs_;
-  std::vector<std::pair<symbol_id, const raw_buffer*>> constants_;
+  std::vector<std::pair<symbol_id, const_raw_buffer_ptr>> constants_;
 
   stmt body_;
 
 public:
   pipeline(std::vector<var> args, std::vector<var> inputs, std::vector<var> outputs,
-      std::vector<std::pair<symbol_id, const raw_buffer*>> constants, stmt body);
+      std::vector<std::pair<symbol_id, const_raw_buffer_ptr>> constants, stmt body);
 
   using scalars = span<const index_t>;
   using buffers = span<const raw_buffer*>;


### PR DESCRIPTION
- The buffer_expr::make() methods that created constant buffers now take a `raw_buffer_ptr` instead of `raw_buffer*`, this allows them to take ownership of the raw buffers. Also renamed them to `make_constant()` to make the nature of the call more obvious at the call site.
- Added raw_buffer::make_allocated_external() to support the case of an all-in-one raw buffer but with element storage from elsewhere (eg memory mapped file)
- Updated tests