### PR TITLE
Make `pipeline` "editable" by clients

### DIFF
--- a/builder/elementwise_test.cc
+++ b/builder/elementwise_test.cc
@@ -265,9 +265,9 @@ void test_expr_pipeline(node_context& ctx, const expr& e) {
   }
 
   std::vector<const raw_buffer*> inputs;
-  std::vector<buffer<T, Rank>> input_bufs(p.inputs().size());
+  std::vector<buffer<T, Rank>> input_bufs(p.inputs.size());
 
-  for (std::size_t i = 0; i < p.inputs().size(); ++i) {
+  for (std::size_t i = 0; i < p.inputs.size(); ++i) {
     index_t stride = sizeof(T);
     for (std::size_t d = 0; d < Rank; ++d) {
       input_bufs[i].dims[d].set_min_extent(0, extents[d]);
@@ -275,7 +275,7 @@ void test_expr_pipeline(node_context& ctx, const expr& e) {
       stride *= extents[d];
     }
   }
-  for (std::size_t i = 0; i < p.inputs().size(); ++i) {
+  for (std::size_t i = 0; i < p.inputs.size(); ++i) {
     init_random(input_bufs[i]);
     inputs.push_back(&input_bufs[i]);
   }
@@ -291,7 +291,7 @@ void test_expr_pipeline(node_context& ctx, const expr& e) {
   elementwise_pipeline_evaluator<T, Rank> eval;
   eval.extents = extents;
   for (std::size_t i = 0; i < inputs.size(); ++i) {
-    eval.vars[p.inputs()[i]] = &input_bufs[i];
+    eval.vars[p.inputs[i]] = &input_bufs[i];
   }
   e.accept(&eval);
 

--- a/builder/pipeline.cc
+++ b/builder/pipeline.cc
@@ -634,7 +634,13 @@ pipeline build_pipeline(node_context& ctx, std::vector<var> args, const std::vec
     const std::vector<buffer_expr_ptr>& outputs, const build_options& options) {
   std::set<buffer_expr_ptr> constants;
   stmt body = build_pipeline(ctx, inputs, outputs, constants, options);
-  return pipeline(std::move(args), vars(inputs), vars(outputs), constant_map(constants), std::move(body));
+  pipeline p;
+  p.args = std::move(args);
+  p.inputs = vars(inputs);
+  p.outputs = vars(outputs);
+  p.constants = constant_map(constants);
+  p.body = std::move(body);
+  return p;
 }
 
 pipeline build_pipeline(node_context& ctx, const std::vector<buffer_expr_ptr>& inputs,

--- a/runtime/pipeline.cc
+++ b/runtime/pipeline.cc
@@ -7,29 +7,25 @@
 
 namespace slinky {
 
-pipeline::pipeline(std::vector<var> args, std::vector<var> inputs, std::vector<var> outputs,
-    std::vector<std::pair<symbol_id, const_raw_buffer_ptr>> constants, stmt body)
-    : args_(std::move(args)), inputs_(std::move(inputs)), outputs_(std::move(outputs)), constants_(std::move(constants)), body_(std::move(body)) {}
-
 index_t pipeline::evaluate(scalars args, buffers inputs, buffers outputs, eval_context& ctx) const {
-  assert(args.size() == args_.size());
-  assert(inputs.size() == inputs_.size());
-  assert(outputs.size() == outputs_.size());
+  assert(args.size() == this->args.size());
+  assert(inputs.size() == this->inputs.size());
+  assert(outputs.size() == this->outputs.size());
 
   for (std::size_t i = 0; i < args.size(); ++i) {
-    ctx[args_[i]] = args[i];
+    ctx[this->args[i]] = args[i];
   }
   for (std::size_t i = 0; i < inputs.size(); ++i) {
-    ctx[inputs_[i]] = reinterpret_cast<index_t>(inputs[i]);
+    ctx[this->inputs[i]] = reinterpret_cast<index_t>(inputs[i]);
   }
   for (std::size_t i = 0; i < outputs.size(); ++i) {
-    ctx[outputs_[i]] = reinterpret_cast<index_t>(outputs[i]);
+    ctx[this->outputs[i]] = reinterpret_cast<index_t>(outputs[i]);
   }
-  for (const auto& i : constants_) {
+  for (const auto& i : constants) {
     ctx[i.first] = reinterpret_cast<index_t>(i.second.get());
   }
 
-  return slinky::evaluate(body_, ctx);
+  return slinky::evaluate(body, ctx);
 }
 
 index_t pipeline::evaluate(buffers inputs, buffers outputs, eval_context& ctx) const {

--- a/runtime/pipeline.h
+++ b/runtime/pipeline.h
@@ -11,16 +11,13 @@ class eval_context;
 
 // This object essentially only stores the mapping of arguments to symbols.
 class pipeline {
-  std::vector<var> args_;
-  std::vector<var> inputs_;
-  std::vector<var> outputs_;
-  std::vector<std::pair<symbol_id, const_raw_buffer_ptr>> constants_;
-
-  stmt body_;
-
 public:
-  pipeline(std::vector<var> args, std::vector<var> inputs, std::vector<var> outputs,
-      std::vector<std::pair<symbol_id, const_raw_buffer_ptr>> constants, stmt body);
+  std::vector<var> args;
+  std::vector<var> inputs;
+  std::vector<var> outputs;
+  std::vector<std::pair<symbol_id, const_raw_buffer_ptr>> constants;
+
+  stmt body;
 
   using scalars = span<const index_t>;
   using buffers = span<const raw_buffer*>;
@@ -29,11 +26,6 @@ public:
   index_t evaluate(buffers inputs, buffers outputs, eval_context& ctx) const;
   index_t evaluate(scalars args, buffers inputs, buffers outputs) const;
   index_t evaluate(buffers inputs, buffers outputs) const;
-
-  const std::vector<var>& args() const { return args_; }
-  const std::vector<var>& inputs() const { return inputs_; }
-  const std::vector<var>& outputs() const { return outputs_; }
-  const stmt& body() const { return body_; }
 };
 
 }  // namespace slinky

--- a/runtime/visualize.cc
+++ b/runtime/visualize.cc
@@ -580,30 +580,30 @@ void visualize(const std::string& filename, const pipeline& p, pipeline::scalars
 
   // Print function declaration.
   file << "function pipeline(";
-  std::vector<var> symbols = p.args();
-  symbols.insert(symbols.end(), p.inputs().begin(), p.inputs().end());
-  symbols.insert(symbols.end(), p.outputs().begin(), p.outputs().end());
+  std::vector<var> symbols = p.args;
+  symbols.insert(symbols.end(), p.inputs.begin(), p.inputs.end());
+  symbols.insert(symbols.end(), p.outputs.begin(), p.outputs.end());
   jsp.print_vector(symbols);
   file << ") {\n";
 
   // Print body.
   jsp.depth++;
-  jsp << p.body();
+  jsp << p.body;
   jsp.depth--;
   file << "}\n";
 
   // Define arguments.
-  for (index_t i = 0; i < static_cast<index_t>(p.args().size()); ++i) {
-    jsp << "let " << p.args()[i] << " = " << args[i] << ";\n";
+  for (index_t i = 0; i < static_cast<index_t>(p.args.size()); ++i) {
+    jsp << "let " << p.args[i] << " = " << args[i] << ";\n";
   }
-  for (index_t i = 0; i < static_cast<index_t>(p.inputs().size()); ++i) {
-    jsp << "let " << p.inputs()[i] << " = allocate('" << jsp.name(p.inputs()[i].sym()) << "', "
+  for (index_t i = 0; i < static_cast<index_t>(p.inputs.size()); ++i) {
+    jsp << "let " << p.inputs[i] << " = allocate('" << jsp.name(p.inputs[i].sym()) << "', "
         << static_cast<index_t>(inputs[i]->elem_size) << ", [";
     jsp.print_vector(span<dim>(inputs[i]->dims, inputs[i]->rank));
     jsp << "], true);\n";
   }
-  for (index_t i = 0; i < static_cast<index_t>(p.outputs().size()); ++i) {
-    jsp << "let " << p.outputs()[i] << " = allocate('" << jsp.name(p.outputs()[i].sym()) << "', "
+  for (index_t i = 0; i < static_cast<index_t>(p.outputs.size()); ++i) {
+    jsp << "let " << p.outputs[i] << " = allocate('" << jsp.name(p.outputs[i].sym()) << "', "
         << static_cast<index_t>(outputs[i]->elem_size) << ", [";
     jsp.print_vector(span<dim>(outputs[i]->dims, outputs[i]->rank));
     jsp << "]);\n";


### PR DESCRIPTION
I have some cases where I'd like to modify the generated pipeline in some simple ways, e.g. adding extra checks. This is doable by making a new pipeline with edits (if we expose `constants` which is currently inaccessible), but I'm not sure the immutable style really makes sense for this.