### PR TITLE
Relax asserts to enable broadcasting

### DIFF
--- a/runtime/buffer.cc
+++ b/runtime/buffer.cc
@@ -348,8 +348,14 @@ namespace {
 bool can_slice_with(const raw_buffer& buf, const raw_buffer& other_buf) {
   if (other_buf.rank != buf.rank) return false;
   for (std::size_t d = 0; d < buf.rank; d++) {
-    if (other_buf.dims[d].min() > buf.dims[d].min()) return false;
-    if (other_buf.dims[d].max() < buf.dims[d].max()) return false;
+    const dim& other_dim = other_buf.dim(d);
+    
+    // Allow stride 0 dimensions to be accessed "out of bounds". 
+    if (other_dim.stride() == 0) continue;
+
+    const dim& buf_dim = buf.dim(d);
+    if (other_dim.min() > buf_dim.min()) return false;
+    if (other_dim.max() < buf_dim.max()) return false;
   }
   return true;
 }

--- a/runtime/buffer.h
+++ b/runtime/buffer.h
@@ -69,8 +69,11 @@ public:
   bool contains(index_t x) const { return min() <= x && x <= max(); }
 
   std::ptrdiff_t flat_offset_bytes(index_t i) const {
-    assert(i >= min_);
-    assert(i <= max());
+    // Conceptually, accesses may be out of bounds, but in practice, if the stride is 0, the accesses will not read
+    // invalid memory. It's a bit messy to allow this, but this assert feels really overzealous when attempting to
+    // implement broadcasting in callbacks.
+    assert(i >= min_ || stride_ == 0);
+    assert(i <= max() || stride_ == 0);
     if (fold_factor_ == unfolded) {
       return (i - min_) * stride_;
     } else {

--- a/runtime/buffer_test.cc
+++ b/runtime/buffer_test.cc
@@ -48,10 +48,15 @@ void randomize_strides_and_padding(buffer<T, N>& buf, const randomize_options& o
     // Expand the bounds randomly.
     dim.set_bounds(dim.min() - random(options.padding_min, options.padding_max),
         dim.max() + random(options.padding_min, options.padding_max));
-    assert(dim.extent() > 0);
+    if (dim.extent() <= 0) {
+      dim.set_extent(1);
+    }
     if (options.allow_broadcast && random(0, 9) == 0) {
       // Make this a broadcast.
       dim.set_stride(0);
+      if (random(0, 2) == 0) {
+        dim.set_min_extent(0, 1);
+      }
     } else {
       dim.set_stride(stride);
       // Add some extra random padding.

--- a/runtime/buffer_test.cc
+++ b/runtime/buffer_test.cc
@@ -21,8 +21,12 @@ template <typename T, std::size_t N>
 void init_random(buffer<T, N>& buf) {
   buf.allocate();
   std::size_t flat_size = buf.size_bytes();
-  for (std::size_t i = 0; i < flat_size; ++i) {
-    reinterpret_cast<char*>(buf.base())[i] = random(0, 255);
+  std::size_t i = 0;
+  for (; i + 3 < flat_size; i += 4) {
+    reinterpret_cast<int*>(buf.base())[i >> 2] = rng()();
+  }
+  for (; i < flat_size; ++i) {
+    reinterpret_cast<char*>(buf.base())[i] = rng()();
   }
 }
 
@@ -54,9 +58,6 @@ void randomize_strides_and_padding(buffer<T, N>& buf, const randomize_options& o
     if (options.allow_broadcast && random(0, 9) == 0) {
       // Make this a broadcast.
       dim.set_stride(0);
-      if (random(0, 2) == 0) {
-        dim.set_min_extent(0, 1);
-      }
     } else {
       dim.set_stride(stride);
       // Add some extra random padding.
@@ -219,7 +220,7 @@ void test_for_each_contiguous_slice_fill() {
 }
 
 TEST(buffer, for_each_contiguous_slice_fill) {
-  for (int cases = 0; cases < 100; ++cases) {
+  for (int cases = 0; cases < 1000; ++cases) {
     test_for_each_contiguous_slice_fill<char>();
     test_for_each_contiguous_slice_fill<int>();
   }
@@ -248,7 +249,7 @@ void test_for_each_contiguous_slice_copy() {
 }
 
 TEST(buffer, for_each_contiguous_slice_copy) {
-  for (int cases = 0; cases < 100; ++cases) {
+  for (int cases = 0; cases < 10000; ++cases) {
     test_for_each_contiguous_slice_copy<char, char>();
     test_for_each_contiguous_slice_copy<short, int>();
     test_for_each_contiguous_slice_copy<int, int>();
@@ -292,7 +293,7 @@ void test_for_each_contiguous_slice_add() {
 }
 
 TEST(buffer, for_each_contiguous_slice_add) {
-  for (int cases = 0; cases < 100; ++cases) {
+  for (int cases = 0; cases < 1000; ++cases) {
     test_for_each_contiguous_slice_add<int, int, int>();
     test_for_each_contiguous_slice_add<short, int, int>();
     test_for_each_contiguous_slice_add<short, short, int>();
@@ -493,7 +494,7 @@ void set_strides(buffer<T, N>& buf, int* permutation = nullptr, index_t* padding
 
 TEST(buffer, copy) {
   constexpr int max_rank = 4;
-  for (int cases = 0; cases < 1000; ++cases) {
+  for (int cases = 0; cases < 10000; ++cases) {
     int rank = random(0, max_rank);
     int elem_size = random(1, 12);
 


### PR DESCRIPTION
Conceptually, this isn't very clean, but when you look strictly at the address arithmetic, it makes sense.