### PR TITLE
Let `for_each_contiguous_slice` implicitly broadcast missing dimensions

### DIFF
--- a/runtime/buffer.h
+++ b/runtime/buffer.h
@@ -531,10 +531,8 @@ void for_each_index(const raw_buffer& buf, const F& f) {
 // Call `f(void* base, index_t extent[, void* other_bases, ...])` for each contiguous slice in the domain of `buf[,
 // other_bufs...]`. This function attempts to be efficient to support production quality implementations of callbacks.
 //
-// When additional buffers are passed, they will be sliced in tandem with the 'main' buffer.
-//
-// All additional buffers must be of identical rank to the main, and must cover (at least) the same area in each
-// dimension.
+// When additional buffers are passed, they will be sliced in tandem with the 'main' buffer. Additional buffers can be
+// lower rank than the main buffer, these "missing" dimensions are not sliced (i.e. broadcasting in this dimension).
 template <typename F, typename... Args>
 SLINKY_NO_STACK_PROTECTOR void for_each_contiguous_slice(const raw_buffer& buf, const F& f, const Args&... other_bufs) {
   constexpr std::size_t NumBufs = sizeof...(Args) + 1;

--- a/runtime/util.h
+++ b/runtime/util.h
@@ -174,8 +174,8 @@ public:
 
   const value_type& operator[](std::size_t i) const { return data_[i]; }
 
-  span subspan(std::size_t offset) { return span(data_ + offset, size_ - offset); }
-  span subspan(std::size_t offset, std::size_t size) { return span(data_ + offset, size); }
+  span subspan(std::size_t offset) const { return span(data_ + offset, size_ - offset); }
+  span subspan(std::size_t offset, std::size_t size) const { return span(data_ + offset, size); }
 };
 
 // Base class for reference counted objects.


### PR DESCRIPTION
I'd rather implement this by callers explicitly adding stride 0 dimensions, but doing that as needed could be relatively expensive/inconvenient. Related to #122.