### PR TITLE
Buffer cleanups

### DIFF
--- a/apps/performance.cc
+++ b/apps/performance.cc
@@ -43,9 +43,9 @@ pipeline make_pipeline(bool explicit_y) {
   // Make the pipeline
   node_context ctx;
 
-  auto in = buffer_expr::make(ctx, "in", sizeof(char), 2);
-  auto out = buffer_expr::make(ctx, "out", sizeof(char), 2);
-  auto intm = buffer_expr::make(ctx, "intm", sizeof(char), 2);
+  auto in = buffer_expr::make(ctx, "in", 2, sizeof(char));
+  auto out = buffer_expr::make(ctx, "out", 2, sizeof(char));
+  auto intm = buffer_expr::make(ctx, "intm", 2, sizeof(char));
 
   var x(ctx, "x");
   var y(ctx, "y");

--- a/builder/checks_test.cc
+++ b/builder/checks_test.cc
@@ -21,8 +21,8 @@ TEST(pipeline, checks) {
   // Make the pipeline
   node_context ctx;
 
-  auto in = buffer_expr::make(ctx, "in", sizeof(int), 1);
-  auto out = buffer_expr::make(ctx, "out", sizeof(int), 1);
+  auto in = buffer_expr::make(ctx, "in", 1, sizeof(int));
+  auto out = buffer_expr::make(ctx, "out", 1, sizeof(int));
 
   var x(ctx, "x");
 

--- a/builder/copy_test.cc
+++ b/builder/copy_test.cc
@@ -40,8 +40,8 @@ TEST(copy, trivial_scalar) {
   // Make the pipeline
   node_context ctx;
 
-  auto in = buffer_expr::make(ctx, "in", sizeof(int), 0);
-  auto out = buffer_expr::make(ctx, "out", sizeof(int), 0);
+  auto in = buffer_expr::make(ctx, "in", 0, sizeof(int));
+  auto out = buffer_expr::make(ctx, "out", 0, sizeof(int));
 
   var x(ctx, "x");
 
@@ -69,8 +69,8 @@ TEST(copy, trivial_1d) {
   // Make the pipeline
   node_context ctx;
 
-  auto in = buffer_expr::make(ctx, "in", sizeof(int), 1);
-  auto out = buffer_expr::make(ctx, "out", sizeof(int), 1);
+  auto in = buffer_expr::make(ctx, "in", 1, sizeof(int));
+  auto out = buffer_expr::make(ctx, "out", 1, sizeof(int));
 
   var x(ctx, "x");
 
@@ -112,8 +112,8 @@ TEST(copy, trivial_2d) {
   // Make the pipeline
   node_context ctx;
 
-  auto in = buffer_expr::make(ctx, "in", sizeof(int), 2);
-  auto out = buffer_expr::make(ctx, "out", sizeof(int), 2);
+  auto in = buffer_expr::make(ctx, "in", 2, sizeof(int));
+  auto out = buffer_expr::make(ctx, "out", 2, sizeof(int));
 
   var x(ctx, "x");
   var y(ctx, "y");
@@ -159,8 +159,8 @@ TEST(copy, trivial_3d) {
   // Make the pipeline
   node_context ctx;
 
-  auto in = buffer_expr::make(ctx, "in", sizeof(int), 3);
-  auto out = buffer_expr::make(ctx, "out", sizeof(int), 3);
+  auto in = buffer_expr::make(ctx, "in", 3, sizeof(int));
+  auto out = buffer_expr::make(ctx, "out", 3, sizeof(int));
 
   var x(ctx, "x");
   var y(ctx, "y");
@@ -198,8 +198,8 @@ TEST(copy, padded) {
   // Make the pipeline
   node_context ctx;
 
-  auto in = buffer_expr::make(ctx, "in", sizeof(int), 2);
-  auto out = buffer_expr::make(ctx, "out", sizeof(int), 2);
+  auto in = buffer_expr::make(ctx, "in", 2, sizeof(int));
+  auto out = buffer_expr::make(ctx, "out", 2, sizeof(int));
 
   var x(ctx, "x");
   var y(ctx, "y");
@@ -248,8 +248,8 @@ TEST(copy, flip_x) {
   // Make the pipeline
   node_context ctx;
 
-  auto in = buffer_expr::make(ctx, "in", sizeof(int), 1);
-  auto out = buffer_expr::make(ctx, "out", sizeof(int), 1);
+  auto in = buffer_expr::make(ctx, "in", 1, sizeof(int));
+  auto out = buffer_expr::make(ctx, "out", 1, sizeof(int));
 
   var x(ctx, "x");
 
@@ -281,8 +281,8 @@ TEST(copy, flip_y) {
     // Make the pipeline
     node_context ctx;
 
-    auto in = buffer_expr::make(ctx, "in", sizeof(int), 3);
-    auto out = buffer_expr::make(ctx, "out", sizeof(int), 3);
+    auto in = buffer_expr::make(ctx, "in", 3, sizeof(int));
+    auto out = buffer_expr::make(ctx, "out", 3, sizeof(int));
 
     var x(ctx, "x");
     var y(ctx, "y");
@@ -328,8 +328,8 @@ TEST(copy, upsample_y) {
     // Make the pipeline
     node_context ctx;
 
-    auto in = buffer_expr::make(ctx, "in", sizeof(int), 2);
-    auto out = buffer_expr::make(ctx, "out", sizeof(int), 2);
+    auto in = buffer_expr::make(ctx, "in", 2, sizeof(int));
+    auto out = buffer_expr::make(ctx, "out", 2, sizeof(int));
 
     var x(ctx, "x");
     var y(ctx, "y");
@@ -370,8 +370,8 @@ TEST(copy, transpose) {
   // Make the pipeline
   node_context ctx;
 
-  auto in = buffer_expr::make(ctx, "in", sizeof(int), 3);
-  auto out = buffer_expr::make(ctx, "out", sizeof(int), 3);
+  auto in = buffer_expr::make(ctx, "in", 3, sizeof(int));
+  auto out = buffer_expr::make(ctx, "out", 3, sizeof(int));
 
   var x(ctx, "x");
   var y(ctx, "y");
@@ -411,8 +411,8 @@ TEST(copy, broadcast) {
     // Make the pipeline
     node_context ctx;
 
-    auto in = buffer_expr::make(ctx, "in", sizeof(int), 3);
-    auto out = buffer_expr::make(ctx, "out", sizeof(int), 3);
+    auto in = buffer_expr::make(ctx, "in", 3, sizeof(int));
+    auto out = buffer_expr::make(ctx, "out", 3, sizeof(int));
 
     var x(ctx, "x");
     var y(ctx, "y");
@@ -460,8 +460,8 @@ TEST(copy, broadcast_sliced) {
     // Make the pipeline
     node_context ctx;
 
-    auto in = buffer_expr::make(ctx, "in", sizeof(int), 2);
-    auto out = buffer_expr::make(ctx, "out", sizeof(int), 3);
+    auto in = buffer_expr::make(ctx, "in", 2, sizeof(int));
+    auto out = buffer_expr::make(ctx, "out", 3, sizeof(int));
 
     var x(ctx, "x");
     var y(ctx, "y");
@@ -510,9 +510,9 @@ TEST(copy, concatenate) {
   // Make the pipeline
   node_context ctx;
 
-  auto in1 = buffer_expr::make(ctx, "in1", sizeof(int), 3);
-  auto in2 = buffer_expr::make(ctx, "in2", sizeof(int), 3);
-  auto out = buffer_expr::make(ctx, "out", sizeof(int), 3);
+  auto in1 = buffer_expr::make(ctx, "in1", 3, sizeof(int));
+  auto in2 = buffer_expr::make(ctx, "in2", 3, sizeof(int));
+  auto out = buffer_expr::make(ctx, "out", 3, sizeof(int));
 
   var x(ctx, "x");
   var y(ctx, "y");
@@ -555,9 +555,9 @@ TEST(copy, stack) {
   // Make the pipeline
   node_context ctx;
 
-  auto in1 = buffer_expr::make(ctx, "in1", sizeof(int), 2);
-  auto in2 = buffer_expr::make(ctx, "in2", sizeof(int), 2);
-  auto out = buffer_expr::make(ctx, "out", sizeof(int), 3);
+  auto in1 = buffer_expr::make(ctx, "in1", 2, sizeof(int));
+  auto in2 = buffer_expr::make(ctx, "in2", 2, sizeof(int));
+  auto out = buffer_expr::make(ctx, "out", 3, sizeof(int));
 
   var x(ctx, "x");
   var y(ctx, "y");
@@ -597,8 +597,8 @@ TEST(copy, reshape) {
   // Make the pipeline
   node_context ctx;
 
-  auto in = buffer_expr::make(ctx, "in", sizeof(int), 3);
-  auto out = buffer_expr::make(ctx, "out", sizeof(int), 3);
+  auto in = buffer_expr::make(ctx, "in", 3, sizeof(int));
+  auto out = buffer_expr::make(ctx, "out", 3, sizeof(int));
 
   // To be a reshape that we can optimize, we need the buffers to be dense (strides equal to the product of extents of
   // prior dimensions).
@@ -653,8 +653,8 @@ TEST(copy, batch_reshape) {
   // Make the pipeline
   node_context ctx;
 
-  auto in = buffer_expr::make(ctx, "in", sizeof(int), 4);
-  auto out = buffer_expr::make(ctx, "out", sizeof(int), 4);
+  auto in = buffer_expr::make(ctx, "in", 4, sizeof(int));
+  auto out = buffer_expr::make(ctx, "out", 4, sizeof(int));
 
   // To be a reshape that we can optimize, we need the buffers to be dense (strides equal to the product of extents of
   // prior dimensions).

--- a/builder/elementwise_test.cc
+++ b/builder/elementwise_test.cc
@@ -55,7 +55,7 @@ public:
       result = i->second;
       return;
     }
-    result = buffer_expr::make(v->sym, sizeof(T), Rank);
+    result = buffer_expr::make(v->sym, Rank, sizeof(T));
     inputs.push_back(result);
     vars[v->sym] = result;
   }
@@ -67,7 +67,7 @@ public:
       dims[d].set_bounds(std::numeric_limits<index_t>::min() / 2 + 1, std::numeric_limits<index_t>::max() / 2);
     }
 
-    auto value = raw_buffer::make_allocated(sizeof(T), Rank, dims);
+    auto value = raw_buffer::make_allocated(Rank, sizeof(T), dims);
     assert(value->size_bytes() == sizeof(T));
     memcpy(value->base, &c->value, sizeof(T));
     result = buffer_expr::make_constant(ctx, "c" + std::to_string(c->value), std::move(value));
@@ -81,7 +81,7 @@ public:
 
   template <typename Impl>
   void visit_binary(const char* fn_name, const buffer_expr_ptr& a, const buffer_expr_ptr& b, const Impl& impl) {
-    result = buffer_expr::make(ctx, name(a) + fn_name + name(b), sizeof(T), Rank);
+    result = buffer_expr::make(ctx, name(a) + fn_name + name(b), Rank, sizeof(T));
     func::callable<const T, const T, T> fn = [=](const buffer<const T>& a, const buffer<const T>& b,
                                                  const buffer<T>& c) {
       for_each_index(c, [&](auto i) { c(i) = impl(a(i), b(i)); });
@@ -118,7 +118,7 @@ public:
     buffer_expr_ptr c = visit_expr(op->condition);
     buffer_expr_ptr t = visit_expr(op->true_value);
     buffer_expr_ptr f = visit_expr(op->false_value);
-    result = buffer_expr::make(ctx, "select_" + name(c) + "_" + name(t) + "_" + name(f), sizeof(T), Rank);
+    result = buffer_expr::make(ctx, "select_" + name(c) + "_" + name(t) + "_" + name(f), Rank, sizeof(T));
     func::callable<const T, const T, const T, T> fn = [](const buffer<const T>& c, const buffer<const T>& t,
                                                           const buffer<const T>& f, const buffer<T>& r) -> index_t {
       for_each_index(c, [&](auto i) { r(i) = c(i) != 0 ? t(i) : f(i); });

--- a/builder/pipeline.cc
+++ b/builder/pipeline.cc
@@ -25,7 +25,7 @@
 
 namespace slinky {
 
-buffer_expr::buffer_expr(symbol_id sym, index_t elem_size, std::size_t rank)
+buffer_expr::buffer_expr(symbol_id sym, std::size_t rank, index_t elem_size)
     : sym_(sym), elem_size_(elem_size), producer_(nullptr), constant_(nullptr) {
   dims_.reserve(rank);
   auto var = variable::make(sym);
@@ -51,12 +51,12 @@ buffer_expr::buffer_expr(symbol_id sym, const_raw_buffer_ptr constant_buffer)
   }
 }
 
-buffer_expr_ptr buffer_expr::make(symbol_id sym, index_t elem_size, std::size_t rank) {
-  return buffer_expr_ptr(new buffer_expr(sym, elem_size, rank));
+buffer_expr_ptr buffer_expr::make(symbol_id sym, std::size_t rank, index_t elem_size) {
+  return buffer_expr_ptr(new buffer_expr(sym, rank, elem_size));
 }
 
-buffer_expr_ptr buffer_expr::make(node_context& ctx, const std::string& sym, index_t elem_size, std::size_t rank) {
-  return buffer_expr_ptr(new buffer_expr(ctx.insert_unique(sym), elem_size, rank));
+buffer_expr_ptr buffer_expr::make(node_context& ctx, const std::string& sym, std::size_t rank, index_t elem_size) {
+  return buffer_expr_ptr(new buffer_expr(ctx.insert_unique(sym), rank, elem_size));
 }
 
 buffer_expr_ptr buffer_expr::make_constant(symbol_id sym, const_raw_buffer_ptr constant_buffer) {

--- a/builder/pipeline.h
+++ b/builder/pipeline.h
@@ -33,7 +33,7 @@ class buffer_expr : public ref_counted<buffer_expr> {
   memory_type storage_ = memory_type::heap;
   std::optional<loop_id> store_at_;
 
-  buffer_expr(symbol_id sym, index_t elem_size, std::size_t rank);
+  buffer_expr(symbol_id sym, std::size_t rank, index_t elem_size);
   buffer_expr(symbol_id sym, const_raw_buffer_ptr constant_buffer);
   buffer_expr(const buffer_expr&) = delete;
   buffer_expr(buffer_expr&&) = delete;
@@ -45,8 +45,8 @@ class buffer_expr : public ref_counted<buffer_expr> {
   void set_producer(func* f);
 
 public:
-  static buffer_expr_ptr make(symbol_id sym, index_t elem_size, std::size_t rank);
-  static buffer_expr_ptr make(node_context& ctx, const std::string& sym, index_t elem_size, std::size_t rank);
+  static buffer_expr_ptr make(symbol_id sym, std::size_t rank, index_t elem_size);
+  static buffer_expr_ptr make(node_context& ctx, const std::string& sym, std::size_t rank, index_t elem_size);
   // Make a constant buffer_expr. It takes ownership of the buffer from the caller.
   static buffer_expr_ptr make_constant(symbol_id sym, const_raw_buffer_ptr constant_buffer);
   static buffer_expr_ptr make_constant(node_context& ctx, const std::string& sym, const_raw_buffer_ptr constant_buffer);

--- a/builder/pipeline_test.cc
+++ b/builder/pipeline_test.cc
@@ -202,8 +202,8 @@ TEST(pipeline, trivial) {
       // Make the pipeline
       node_context ctx;
 
-      auto in = buffer_expr::make(ctx, "in", sizeof(int), 1);
-      auto out = buffer_expr::make(ctx, "out", sizeof(int), 1);
+      auto in = buffer_expr::make(ctx, "in", 1, sizeof(int));
+      auto out = buffer_expr::make(ctx, "out", 1, sizeof(int));
 
       var x(ctx, "x");
 
@@ -249,9 +249,9 @@ TEST(pipeline, elementwise_1d) {
         // Make the pipeline
         node_context ctx;
 
-        auto in = buffer_expr::make(ctx, "in", sizeof(int), 1);
-        auto out = buffer_expr::make(ctx, "out", sizeof(int), 1);
-        auto intm = buffer_expr::make(ctx, "intm", sizeof(int), 1);
+        auto in = buffer_expr::make(ctx, "in", 1, sizeof(int));
+        auto out = buffer_expr::make(ctx, "out", 1, sizeof(int));
+        auto intm = buffer_expr::make(ctx, "intm", 1, sizeof(int));
 
         var x(ctx, "x");
 
@@ -313,9 +313,9 @@ TEST(pipeline, elementwise_2d) {
         // Make the pipeline
         node_context ctx;
 
-        auto in = buffer_expr::make(ctx, "in", sizeof(int), 2);
-        auto out = buffer_expr::make(ctx, "out", sizeof(int), 2);
-        auto intm = buffer_expr::make(ctx, "intm", sizeof(int), 2);
+        auto in = buffer_expr::make(ctx, "in", 2, sizeof(int));
+        auto out = buffer_expr::make(ctx, "out", 2, sizeof(int));
+        auto intm = buffer_expr::make(ctx, "intm", 2, sizeof(int));
 
         var x(ctx, "x");
         var y(ctx, "y");
@@ -383,12 +383,12 @@ TEST(pipeline, matmuls) {
       // Make the pipeline
       node_context ctx;
 
-      auto a = buffer_expr::make(ctx, "a", sizeof(int), 2);
-      auto b = buffer_expr::make(ctx, "b", sizeof(int), 2);
-      auto c = buffer_expr::make(ctx, "c", sizeof(int), 2);
-      auto abc = buffer_expr::make(ctx, "abc", sizeof(int), 2);
+      auto a = buffer_expr::make(ctx, "a", 2, sizeof(int));
+      auto b = buffer_expr::make(ctx, "b", 2, sizeof(int));
+      auto c = buffer_expr::make(ctx, "c", 2, sizeof(int));
+      auto abc = buffer_expr::make(ctx, "abc", 2, sizeof(int));
 
-      auto ab = buffer_expr::make(ctx, "ab", sizeof(int), 2);
+      auto ab = buffer_expr::make(ctx, "ab", 2, sizeof(int));
 
       var i(ctx, "i");
       var j(ctx, "j");
@@ -491,10 +491,10 @@ TEST(pipeline, pyramid) {
   // Make the pipeline
   node_context ctx;
 
-  auto in = buffer_expr::make(ctx, "in", sizeof(int), 2);
-  auto out = buffer_expr::make(ctx, "out", sizeof(int), 2);
+  auto in = buffer_expr::make(ctx, "in", 2, sizeof(int));
+  auto out = buffer_expr::make(ctx, "out", 2, sizeof(int));
 
-  auto intm = buffer_expr::make(ctx, "intm", sizeof(int), 2);
+  auto intm = buffer_expr::make(ctx, "intm", 2, sizeof(int));
 
   var x(ctx, "x");
   var y(ctx, "y");
@@ -533,10 +533,10 @@ TEST(pipeline, stencil) {
         // Make the pipeline
         node_context ctx;
 
-        auto in = buffer_expr::make(ctx, "in", sizeof(short), 2);
-        auto out = buffer_expr::make(ctx, "out", sizeof(short), 2);
+        auto in = buffer_expr::make(ctx, "in", 2, sizeof(short));
+        auto out = buffer_expr::make(ctx, "out", 2, sizeof(short));
 
-        auto intm = buffer_expr::make(ctx, "intm", sizeof(short), 2);
+        auto intm = buffer_expr::make(ctx, "intm", 2, sizeof(short));
 
         var x(ctx, "x");
         var y(ctx, "y");
@@ -601,10 +601,10 @@ TEST(pipeline, slide_2d) {
   // Make the pipeline
   node_context ctx;
 
-  auto in = buffer_expr::make(ctx, "in", sizeof(short), 2);
-  auto out = buffer_expr::make(ctx, "out", sizeof(short), 2);
+  auto in = buffer_expr::make(ctx, "in", 2, sizeof(short));
+  auto out = buffer_expr::make(ctx, "out", 2, sizeof(short));
 
-  auto intm = buffer_expr::make(ctx, "intm", sizeof(short), 2);
+  auto intm = buffer_expr::make(ctx, "intm", 2, sizeof(short));
 
   var x(ctx, "x");
   var y(ctx, "y");
@@ -660,11 +660,11 @@ TEST(pipeline, stencil_chain) {
       // Make the pipeline
       node_context ctx;
 
-      auto in = buffer_expr::make(ctx, "in", sizeof(short), 2);
-      auto out = buffer_expr::make(ctx, "out", sizeof(short), 2);
+      auto in = buffer_expr::make(ctx, "in", 2, sizeof(short));
+      auto out = buffer_expr::make(ctx, "out", 2, sizeof(short));
 
-      auto intm = buffer_expr::make(ctx, "add_result", sizeof(short), 2);
-      auto intm2 = buffer_expr::make(ctx, "stencil1_result", sizeof(short), 2);
+      auto intm = buffer_expr::make(ctx, "add_result", 2, sizeof(short));
+      auto intm2 = buffer_expr::make(ctx, "stencil1_result", 2, sizeof(short));
 
       var x(ctx, "x");
       var y(ctx, "y");
@@ -738,9 +738,9 @@ TEST(pipeline, flip_y) {
   // Make the pipeline
   node_context ctx;
 
-  auto in = buffer_expr::make(ctx, "in", sizeof(char), 2);
-  auto out = buffer_expr::make(ctx, "out", sizeof(char), 2);
-  auto intm = buffer_expr::make(ctx, "intm", sizeof(char), 2);
+  auto in = buffer_expr::make(ctx, "in", 2, sizeof(char));
+  auto out = buffer_expr::make(ctx, "out", 2, sizeof(char));
+  auto intm = buffer_expr::make(ctx, "intm", 2, sizeof(char));
 
   var x(ctx, "x");
   var y(ctx, "y");
@@ -777,9 +777,9 @@ TEST(pipeline, padded_copy) {
   // Make the pipeline
   node_context ctx;
 
-  auto in = buffer_expr::make(ctx, "in", sizeof(char), 2);
-  auto out = buffer_expr::make(ctx, "out", sizeof(char), 2);
-  auto intm = buffer_expr::make(ctx, "intm", sizeof(char), 2);
+  auto in = buffer_expr::make(ctx, "in", 2, sizeof(char));
+  auto out = buffer_expr::make(ctx, "out", 2, sizeof(char));
+  auto intm = buffer_expr::make(ctx, "intm", 2, sizeof(char));
 
   var x(ctx, "x");
   var y(ctx, "y");
@@ -836,9 +836,9 @@ TEST(pipeline, multiple_outputs) {
       // Make the pipeline
       node_context ctx;
 
-      auto in = buffer_expr::make(ctx, "in", sizeof(int), 3);
-      auto sum_x = buffer_expr::make(ctx, "sum_x", sizeof(int), 2);
-      auto sum_xy = buffer_expr::make(ctx, "sum_xy", sizeof(int), 1);
+      auto in = buffer_expr::make(ctx, "in", 3, sizeof(int));
+      auto sum_x = buffer_expr::make(ctx, "sum_x", 2, sizeof(int));
+      auto sum_xy = buffer_expr::make(ctx, "sum_xy", 1, sizeof(int));
 
       var x(ctx, "x");
       var y(ctx, "y");
@@ -910,9 +910,9 @@ TEST(pipeline, outer_product) {
         // Make the pipeline
         node_context ctx;
 
-        auto a = buffer_expr::make(ctx, "a", sizeof(int), 1);
-        auto b = buffer_expr::make(ctx, "b", sizeof(int), 1);
-        auto out = buffer_expr::make(ctx, "out", sizeof(int), 2);
+        auto a = buffer_expr::make(ctx, "a", 1, sizeof(int));
+        auto b = buffer_expr::make(ctx, "b", 1, sizeof(int));
+        auto out = buffer_expr::make(ctx, "out", 2, sizeof(int));
 
         var i(ctx, "i");
         var j(ctx, "j");
@@ -955,13 +955,13 @@ TEST(pipeline, unrelated) {
   // Make the pipeline
   node_context ctx;
 
-  auto in1 = buffer_expr::make(ctx, "in1", sizeof(short), 2);
-  auto out1 = buffer_expr::make(ctx, "out1", sizeof(short), 2);
-  auto intm1 = buffer_expr::make(ctx, "intm1", sizeof(short), 2);
+  auto in1 = buffer_expr::make(ctx, "in1", 2, sizeof(short));
+  auto out1 = buffer_expr::make(ctx, "out1", 2, sizeof(short));
+  auto intm1 = buffer_expr::make(ctx, "intm1", 2, sizeof(short));
 
-  auto in2 = buffer_expr::make(ctx, "in2", sizeof(int), 1);
-  auto out2 = buffer_expr::make(ctx, "out2", sizeof(int), 1);
-  auto intm2 = buffer_expr::make(ctx, "intm2", sizeof(int), 1);
+  auto in2 = buffer_expr::make(ctx, "in2", 1, sizeof(int));
+  auto out2 = buffer_expr::make(ctx, "out2", 1, sizeof(int));
+  auto intm2 = buffer_expr::make(ctx, "intm2", 1, sizeof(int));
 
   var x(ctx, "x");
   var y(ctx, "y");
@@ -1030,10 +1030,10 @@ TEST(pipeline, copied_result) {
     // Make the pipeline
     node_context ctx;
 
-    auto in = buffer_expr::make(ctx, "in", sizeof(short), 2);
-    auto out = buffer_expr::make(ctx, "out", sizeof(short), 2);
+    auto in = buffer_expr::make(ctx, "in", 2, sizeof(short));
+    auto out = buffer_expr::make(ctx, "out", 2, sizeof(short));
 
-    auto intm = buffer_expr::make(ctx, "intm", sizeof(short), 2);
+    auto intm = buffer_expr::make(ctx, "intm", 2, sizeof(short));
 
     var x(ctx, "x");
     var y(ctx, "y");
@@ -1089,12 +1089,12 @@ TEST(pipeline, concatenated_result) {
     // Make the pipeline
     node_context ctx;
 
-    auto in1 = buffer_expr::make(ctx, "in1", sizeof(short), 2);
-    auto in2 = buffer_expr::make(ctx, "in2", sizeof(short), 2);
-    auto out = buffer_expr::make(ctx, "out", sizeof(short), 2);
+    auto in1 = buffer_expr::make(ctx, "in1", 2, sizeof(short));
+    auto in2 = buffer_expr::make(ctx, "in2", 2, sizeof(short));
+    auto out = buffer_expr::make(ctx, "out", 2, sizeof(short));
 
-    auto intm1 = buffer_expr::make(ctx, "intm1", sizeof(short), 2);
-    auto intm2 = buffer_expr::make(ctx, "intm2", sizeof(short), 2);
+    auto intm1 = buffer_expr::make(ctx, "intm1", 2, sizeof(short));
+    auto intm2 = buffer_expr::make(ctx, "intm2", 2, sizeof(short));
 
     var x(ctx, "x");
     var y(ctx, "y");
@@ -1143,12 +1143,12 @@ TEST(pipeline, stacked_result) {
   // Make the pipeline
   node_context ctx;
 
-  auto in1 = buffer_expr::make(ctx, "in1", sizeof(short), 2);
-  auto in2 = buffer_expr::make(ctx, "in2", sizeof(short), 2);
-  auto out = buffer_expr::make(ctx, "out", sizeof(short), 3);
+  auto in1 = buffer_expr::make(ctx, "in1", 2, sizeof(short));
+  auto in2 = buffer_expr::make(ctx, "in2", 2, sizeof(short));
+  auto out = buffer_expr::make(ctx, "out", 3, sizeof(short));
 
-  auto intm1 = buffer_expr::make(ctx, "intm1", sizeof(short), 2);
-  auto intm2 = buffer_expr::make(ctx, "intm2", sizeof(short), 2);
+  auto intm1 = buffer_expr::make(ctx, "intm1", 2, sizeof(short));
+  auto intm2 = buffer_expr::make(ctx, "intm2", 2, sizeof(short));
 
   var x(ctx, "x");
   var y(ctx, "y");
@@ -1192,11 +1192,11 @@ TEST(pipeline, padded_stencil) {
     // Make the pipeline
     node_context ctx;
 
-    auto in = buffer_expr::make(ctx, "in", sizeof(short), 2);
-    auto out = buffer_expr::make(ctx, "out", sizeof(short), 2);
+    auto in = buffer_expr::make(ctx, "in", 2, sizeof(short));
+    auto out = buffer_expr::make(ctx, "out", 2, sizeof(short));
 
-    auto intm = buffer_expr::make(ctx, "intm", sizeof(short), 2);
-    auto padded_intm = buffer_expr::make(ctx, "padded_intm", sizeof(short), 2);
+    auto intm = buffer_expr::make(ctx, "intm", 2, sizeof(short));
+    auto padded_intm = buffer_expr::make(ctx, "padded_intm", 2, sizeof(short));
 
     var x(ctx, "x");
     var y(ctx, "y");
@@ -1271,10 +1271,10 @@ TEST(pipeline, constant) {
   dims[1].set_bounds(0, H);
   dims[1].set_stride(W * sizeof(short));
 
-  auto constant_buf = raw_buffer::make_allocated(sizeof(short), 2, dims);
+  auto constant_buf = raw_buffer::make_allocated(2, sizeof(short), dims);
   fill_random<short>(*constant_buf);
 
-  auto out = buffer_expr::make(ctx, "out", sizeof(short), 2);
+  auto out = buffer_expr::make(ctx, "out", 2, sizeof(short));
 
   auto constant = buffer_expr::make_constant(ctx, "constant", std::move(constant_buf));
 
@@ -1306,13 +1306,13 @@ TEST(pipeline, parallel_stencils) {
     // Make the pipeline
     node_context ctx;
 
-    auto in1 = buffer_expr::make(ctx, "in1", sizeof(short), 2);
-    auto in2 = buffer_expr::make(ctx, "in2", sizeof(short), 2);
-    auto intm1 = buffer_expr::make(ctx, "intm1", sizeof(short), 2);
-    auto intm2 = buffer_expr::make(ctx, "intm2", sizeof(short), 2);
-    auto intm3 = buffer_expr::make(ctx, "intm3", sizeof(short), 2);
-    auto intm4 = buffer_expr::make(ctx, "intm4", sizeof(short), 2);
-    auto out = buffer_expr::make(ctx, "out", sizeof(short), 2);
+    auto in1 = buffer_expr::make(ctx, "in1", 2, sizeof(short));
+    auto in2 = buffer_expr::make(ctx, "in2", 2, sizeof(short));
+    auto intm1 = buffer_expr::make(ctx, "intm1", 2, sizeof(short));
+    auto intm2 = buffer_expr::make(ctx, "intm2", 2, sizeof(short));
+    auto intm3 = buffer_expr::make(ctx, "intm3", 2, sizeof(short));
+    auto intm4 = buffer_expr::make(ctx, "intm4", 2, sizeof(short));
+    auto out = buffer_expr::make(ctx, "out", 2, sizeof(short));
 
     var x(ctx, "x");
     var y(ctx, "y");
@@ -1391,11 +1391,11 @@ TEST(pipeline, diamond_stencils) {
     // Make the pipeline
     node_context ctx;
 
-    auto in = buffer_expr::make(ctx, "in1", sizeof(short), 2);
-    auto intm2 = buffer_expr::make(ctx, "intm2", sizeof(short), 2);
-    auto intm3 = buffer_expr::make(ctx, "intm3", sizeof(short), 2);
-    auto intm4 = buffer_expr::make(ctx, "intm4", sizeof(short), 2);
-    auto out = buffer_expr::make(ctx, "out", sizeof(short), 2);
+    auto in = buffer_expr::make(ctx, "in1", 2, sizeof(short));
+    auto intm2 = buffer_expr::make(ctx, "intm2", 2, sizeof(short));
+    auto intm3 = buffer_expr::make(ctx, "intm3", 2, sizeof(short));
+    auto intm4 = buffer_expr::make(ctx, "intm4", 2, sizeof(short));
+    auto out = buffer_expr::make(ctx, "out", 2, sizeof(short));
 
     var x(ctx, "x");
     var y(ctx, "y");
@@ -1465,10 +1465,10 @@ TEST(pipeline, Y) {
   // Make the pipeline
   node_context ctx;
 
-  auto in = buffer_expr::make(ctx, "in1", sizeof(short), 2);
-  auto intm2 = buffer_expr::make(ctx, "intm2", sizeof(short), 2);
-  auto intm3 = buffer_expr::make(ctx, "intm3", sizeof(short), 2);
-  auto intm4 = buffer_expr::make(ctx, "intm4", sizeof(short), 2);
+  auto in = buffer_expr::make(ctx, "in1", 2, sizeof(short));
+  auto intm2 = buffer_expr::make(ctx, "intm2", 2, sizeof(short));
+  auto intm3 = buffer_expr::make(ctx, "intm3", 2, sizeof(short));
+  auto intm4 = buffer_expr::make(ctx, "intm4", 2, sizeof(short));
 
   var x(ctx, "x");
   var y(ctx, "y");

--- a/runtime/buffer.h
+++ b/runtime/buffer.h
@@ -202,10 +202,10 @@ public:
   const buffer<NewT>& cast() const;
 
   // Make a pointer to a buffer with an allocation for the dims (but not elements) in the same allocation.
-  static raw_buffer_ptr make(std::size_t elem_size, std::size_t rank);
+  static raw_buffer_ptr make(std::size_t rank, std::size_t elem_size);
 
   // Make a pointer to a buffer with an allocation for the dims and the elements in the same allocation.
-  static raw_buffer_ptr make_allocated(std::size_t elem_size, std::size_t rank, const class dim* dims);
+  static raw_buffer_ptr make_allocated(std::size_t rank, std::size_t elem_size, const class dim* dims);
 
   // Make a deep copy of another buffer, including allocating and copying the data.
   static raw_buffer_ptr make_copy(const raw_buffer& src);


### PR DESCRIPTION
- Make rank, elem_size parameters always appear in that order
- Call constructor of `dim` in `raw_buffer::make`

The first point is a very unpleasant change, but we need to do it, and now is better than later.