### PR TITLE
Don't override -c dbg/-c opt with --config=asan

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -12,7 +12,4 @@ test --force_pic
 build:asan --strip=never
 build:asan --copt -fsanitize=address
 build:asan --copt -DADDRESS_SANITIZER
-build:asan --copt -O1
-build:asan --copt -g
-build:asan --copt -fno-omit-frame-pointer
 build:asan --linkopt -fsanitize=address


### PR DESCRIPTION
This speeds up builds a lot, and seems like it should be independent options anyways. Tests are slower, but not slower enough to outweigh the absurdly slow builds.