### PR TITLE
Simplify unnecessary `clone_buffer`s

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
 
     steps:
       - uses: actions/checkout@v3

--- a/builder/simplify.cc
+++ b/builder/simplify.cc
@@ -500,8 +500,8 @@ public:
   // Assuming that we've entered the body of a declaration of `sym`, remove any references to `sym` from the bounds (as
   // if they came from outside the body).
   static void clear_shadowed_bounds(symbol_id sym, interval_expr& bounds) {
-    if (depends_on(bounds.min, sym).buffer) bounds.min = expr();
-    if (depends_on(bounds.max, sym).buffer) bounds.max = expr();
+    if (depends_on(bounds.min, sym).buffer_meta_read) bounds.min = expr();
+    if (depends_on(bounds.max, sym).buffer_meta_read) bounds.max = expr();
   }
   static void clear_shadowed_bounds(symbol_id sym, box_expr& bounds) {
     for (interval_expr& i : bounds) {

--- a/builder/simplify.cc
+++ b/builder/simplify.cc
@@ -978,9 +978,8 @@ public:
 
     if (!depends_on(body, op->sym).any()) {
       set_result(std::move(body));
-    } else if (!depends_on(body, op->src).any()) {
-      // We didn't use the original buffer. We can just use that instead.
-      // TODO: We could do this even if the buffer is used, as long as it is not mutated.
+    } else if (!depends_on(body, op->src).buffer_meta_mutated) {
+      // We didn't mutate the original buffer. We can just use that instead.
       set_result(substitute(body, op->sym, variable::make(op->src)));
     } else if (const block* b = body.as<block>()) {
       std::vector<stmt> stmts;

--- a/runtime/depends_on.h
+++ b/runtime/depends_on.h
@@ -10,8 +10,6 @@ struct depends_on_result {
   // True if the node depends on the symbol as a variable.
   bool var = false;
 
-  // The remaining fields all indicate the symbol is used as a buffer.
-  bool buffer = false;
   // True if the buffer is used as a call input or output, respectively.
   bool buffer_input = false;
   bool buffer_output = false;
@@ -19,13 +17,21 @@ struct depends_on_result {
   bool buffer_src = false;
   bool buffer_dst = false;
 
+  // True if the buffer metadata is read or written.
+  bool buffer_meta_read = false;
+  bool buffer_meta_mutated = false;
+
   // How many references there are.
   int ref_count = 0;
 
   // True if any reference is in a loop.
   bool used_in_loop = false;
 
-  bool any() const { return var || buffer; }
+  bool buffer_data() const { return buffer_input || buffer_output || buffer_src || buffer_dst; }
+  bool buffer_meta() const { return buffer_meta_read || buffer_meta_mutated; }
+  bool buffer() const { return buffer_data() || buffer_meta(); }
+
+  bool any() const { return var || buffer(); }
 };
 
 // Check if the node depends on a symbol or set of symbols.

--- a/runtime/evaluate.cc
+++ b/runtime/evaluate.cc
@@ -38,7 +38,7 @@ void dump_context_for_expr(
       } else {
         s << "  " << sym << " = <>" << std::endl;
       }
-    } else if (!deps_of.defined() || deps.buffer) {
+    } else if (!deps_of.defined() || deps.buffer_meta_read) {
       if (ctx.contains(i)) {
         const raw_buffer* buf = reinterpret_cast<const raw_buffer*>(*ctx.lookup(i));
         s << "  " << sym << " = " << *buf << std::endl;


### PR DESCRIPTION
`clone_buffer` ops that don't mutate the cloned buffer metadata in the body can be substituted and removed.