### PR TITLE
Revert "Don't override -c dbg/-c opt with --config=asan"

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -12,4 +12,7 @@ test --force_pic
 build:asan --strip=never
 build:asan --copt -fsanitize=address
 build:asan --copt -DADDRESS_SANITIZER
+build:asan --copt -O1
+build:asan --copt -g
+build:asan --copt -fno-omit-frame-pointer
 build:asan --linkopt -fsanitize=address


### PR DESCRIPTION
Reverts dsharlet/slinky#171

Testing to see if this is why CIs started timing out.