### PR TITLE
Fix a few bugs in infer_bounds and simplify

### DIFF
--- a/builder/copy_test.cc
+++ b/builder/copy_test.cc
@@ -291,7 +291,7 @@ TEST(copy, flip_y) {
     func flip = func::make_copy({in, {point(x), point(-y), point(z)}}, {out, {x, y, z}});
 
     if (split > 0) {
-      //flip.loops({{y, split}});
+      flip.loops({{y, split}});
     }
 
     pipeline p = build_pipeline(ctx, {in}, {out});
@@ -337,7 +337,7 @@ TEST(copy, upsample_y) {
     func upsample = func::make_copy({in, {point(x), point(y / 2)}}, {out, {x, y}});
 
     if (split > 0) {
-      //upsample.loops({{y, split}});
+      upsample.loops({{y, split}});
     }
 
     pipeline p = build_pipeline(ctx, {in}, {out});

--- a/builder/copy_test.cc
+++ b/builder/copy_test.cc
@@ -291,7 +291,7 @@ TEST(copy, flip_y) {
     func flip = func::make_copy({in, {point(x), point(-y), point(z)}}, {out, {x, y, z}});
 
     if (split > 0) {
-      flip.loops({{y, split}});
+      //flip.loops({{y, split}});
     }
 
     pipeline p = build_pipeline(ctx, {in}, {out});
@@ -337,7 +337,7 @@ TEST(copy, upsample_y) {
     func upsample = func::make_copy({in, {point(x), point(y / 2)}}, {out, {x, y}});
 
     if (split > 0) {
-      upsample.loops({{y, split}});
+      //upsample.loops({{y, split}});
     }
 
     pipeline p = build_pipeline(ctx, {in}, {out});
@@ -547,6 +547,53 @@ TEST(copy, concatenate) {
       for (int x = 0; x < W; ++x) {
         ASSERT_EQ(out_buf(x, y, z), y < H1 ? in1_buf(x, y, z) : in2_buf(x, y - H1, z));
       }
+    }
+  }
+}
+
+TEST(copy, split) {
+  // Make the pipeline
+  node_context ctx;
+
+  auto in = buffer_expr::make(ctx, "in", 2, sizeof(int));
+  auto out1 = buffer_expr::make(ctx, "out1", 2, sizeof(int));
+  auto out2 = buffer_expr::make(ctx, "out2", 2, sizeof(int));
+
+  var x(ctx, "x");
+  var y(ctx, "y");
+
+  func copy1 = func::make_copy({in, {slinky::point(x), slinky::point(y)}}, {out1, {x, y}});
+  func copy2 = func::make_copy({in, {slinky::point(x), slinky::point(y) + out1->dim(1).extent()}}, {out2, {x, y}});
+
+  pipeline p = build_pipeline(ctx, {in}, {out1, out2});
+
+  const int W = 8;
+  const int H1 = 5;
+  const int H2 = 4;
+
+  // Run the pipeline.
+  buffer<int, 3> in_buf({W, H1 + H2});
+  init_random(in_buf);
+
+  buffer<int, 3> out1_buf({W, H1});
+  buffer<int, 3> out2_buf({W, H2});
+  out1_buf.allocate();
+  out2_buf.allocate();
+
+  const raw_buffer* inputs[] = {&in_buf};
+  const raw_buffer* outputs[] = {&out1_buf, &out2_buf};
+  test_context eval_ctx;
+  p.evaluate(inputs, outputs, eval_ctx);
+  ASSERT_EQ(eval_ctx.copy_calls, 2);
+
+  for (int y = 0; y < H1; ++y) {
+    for (int x = 0; x < W; ++x) {
+      ASSERT_EQ(out1_buf(x, y), in_buf(x, y));
+    }
+  }
+  for (int y = 0; y < H2; ++y) {
+    for (int x = 0; x < W; ++x) {
+      ASSERT_EQ(out2_buf(x, y), in_buf(x, y + H1));
     }
   }
 }

--- a/builder/pipeline.cc
+++ b/builder/pipeline.cc
@@ -624,16 +624,6 @@ stmt build_pipeline(node_context& ctx, const std::vector<buffer_expr_ptr>& input
   stmt result;
   result = builder.build(result, nullptr, loop_id());
 
-  // Add checks that the buffer constraints the user set are satisfied.
-  std::vector<stmt> checks;
-  for (const buffer_expr_ptr& i : inputs) {
-    add_buffer_checks(i, /*output=*/false, checks);
-  }
-  for (const buffer_expr_ptr& i : outputs) {
-    add_buffer_checks(i, /*output=*/true, checks);
-  }
-  result = block::make(std::move(checks), std::move(result));
-
   std::vector<symbol_id> input_syms;
   input_syms.reserve(inputs.size());
   for (const buffer_expr_ptr& i : inputs) {
@@ -643,6 +633,16 @@ stmt build_pipeline(node_context& ctx, const std::vector<buffer_expr_ptr>& input
     input_syms.push_back(i->sym());
   }
   result = infer_bounds(result, ctx, input_syms);
+
+  // Add checks that the buffer constraints the user set are satisfied.
+  std::vector<stmt> checks;
+  for (const buffer_expr_ptr& i : inputs) {
+    add_buffer_checks(i, /*output=*/false, checks);
+  }
+  for (const buffer_expr_ptr& i : outputs) {
+    add_buffer_checks(i, /*output=*/true, checks);
+  }
+  result = block::make(std::move(checks), std::move(result));
 
   result = simplify(result);
 

--- a/builder/rewrite.h
+++ b/builder/rewrite.h
@@ -393,17 +393,17 @@ class base_rewriter {
 
   template <typename Pattern>
   bool variant_match(const Pattern& p, match_context& ctx) {
-    for (int variant = 0;; ++variant) {
+    // We'll find out how many variant bits we have when we try to match.
+    // This can grow if we fail early due to a commutative variant that doesn't match near the root
+    // of the expression, so we track the max we've seen.
+    int max_variant_bits = 0;
+    for (int variant = 0; variant < (1 << max_variant_bits); ++variant) {
       memset(&ctx, 0, sizeof(ctx));
       ctx.variant = variant;
       if (match(p, x, ctx)) {
         return true;
       }
-      // variant_bits *should* be constant across all variants. We're done when
-      // there are no more bits in the variant index to flip.
-      if (variant >= (1 << ctx.variant_bits)) {
-        break;
-      }
+      max_variant_bits = std::max(max_variant_bits, ctx.variant_bits);
     }
     return false;
   }

--- a/builder/rewrite.h
+++ b/builder/rewrite.h
@@ -105,19 +105,39 @@ SLINKY_ALWAYS_INLINE inline node_type pattern_type(const pattern_binary<T, A, B>
   return T::static_type;
 }
 
+template <typename T>
+SLINKY_ALWAYS_INLINE inline int commutative_variants(const T&) {
+  return 1;
+}
+
 template <typename T, typename A, typename B>
-int commute_bit(const pattern_binary<T, A, B>& p, match_context& ctx) {
-  int this_bit = -1;
+bool could_commute(const pattern_binary<T, A, B>& p) {
   if (T::commutative) {
     node_type ta = pattern_type(p.a);
     node_type tb = pattern_type(p.b);
     if (ta == node_type::none || tb == node_type::none || ta == tb) {
       // This is a commutative operation and we can't canonicalize the ordering.
-      // Remember which bit in the variant index is ours, and increment the bit for the next commutative node.
-      this_bit = ctx.variant_bits++;
+      return true;
     }
   }
-  return this_bit;
+  return false;
+}
+
+template <typename T, typename A, typename B>
+int commutative_variants(const pattern_binary<T, A, B>& p) {
+  int child_variants = commutative_variants(p.a) * commutative_variants(p.b);
+  return could_commute(p) ? child_variants * 2 : child_variants;
+}
+
+template <typename T, typename A, typename B>
+int commute_bit(const pattern_binary<T, A, B>& p, match_context& ctx) {
+  if (could_commute(p)) {
+    // This is a commutative operation and we can't canonicalize the ordering.
+    // Remember which bit in the variant index is ours, and increment the bit for the next commutative node.
+    return ctx.variant_bits++;
+  } else {
+    return -1;
+  }
 }
 
 template <typename T, typename A, typename B>
@@ -164,6 +184,11 @@ SLINKY_ALWAYS_INLINE inline node_type pattern_type(const pattern_unary<T, A>&) {
 }
 
 template <typename T, typename A>
+int commutative_variants(const pattern_unary<T, A>& p) {
+  return commutative_variants(p.a);
+}
+
+template <typename T, typename A>
 bool match(const pattern_unary<T, A>& p, const expr& x, match_context& ctx) {
   if (const T* t = x.as<T>()) {
     return match(p.a, t->a, ctx);
@@ -205,6 +230,11 @@ SLINKY_ALWAYS_INLINE inline node_type pattern_type(const pattern_select<C, T, F>
 }
 
 template <typename C, typename T, typename F>
+int commutative_variants(const pattern_select<C, T, F>& p) {
+  return commutative_variants(p.c) * commutative_variants(p.t) * commutative_variants(p.f);
+}
+
+template <typename C, typename T, typename F>
 bool match(const pattern_select<C, T, F>& p, const expr& x, match_context& ctx) {
   if (const class select* s = x.as<class select>()) {
     return match(p.c, s->condition, ctx) && match(p.t, s->true_value, ctx) && match(p.f, s->false_value, ctx);
@@ -234,6 +264,16 @@ public:
 template <typename... Args>
 SLINKY_ALWAYS_INLINE inline node_type pattern_type(const pattern_call<Args...>&) {
   return node_type::call;
+}
+
+template <typename... Args, std::size_t... Is>
+int commutative_variants(const std::tuple<Args...>& t, std::index_sequence<Is...>) {
+  return (... * commutative_variants(std::get<Is>(t)));
+}
+
+template <typename... Args>
+int commutative_variants(const pattern_call<Args...>& p) {
+  return commutative_variants(p.args, std::make_index_sequence<sizeof...(Args)>());
 }
 
 template <typename T, std::size_t... Is>
@@ -393,16 +433,12 @@ class base_rewriter {
 
   template <typename Pattern>
   bool variant_match(const Pattern& p, match_context& ctx) {
-    for (int variant = 0;; ++variant) {
+    const int variants = commutative_variants(p);
+    for (int variant = 0; variant < variants; ++variant) {
       memset(&ctx, 0, sizeof(ctx));
       ctx.variant = variant;
       if (match(p, x, ctx)) {
         return true;
-      }
-      // variant_bits *should* be constant across all variants. We're done when
-      // there are no more bits in the variant index to flip.
-      if (variant >= (1 << ctx.variant_bits)) {
-        break;
       }
     }
     return false;

--- a/builder/simplify_exprs.cc
+++ b/builder/simplify_exprs.cc
@@ -63,8 +63,10 @@ expr simplify(const class min* op, expr a, expr b) {
       r.rewrite(min(y + c0, min(x, y)), min(x, min(y, y + c0))) ||
       r.rewrite(min(y, min(x, y + c0)), min(x, min(y, y + c0))) ||
       r.rewrite(min(min(x, y), max(x, z)), min(x, y)) ||
+      r.rewrite(min(x, min(y, max(x, z))), min(x, y)) ||
       r.rewrite(min(min(x, y), min(x, z)), min(x, min(y, z))) ||
       r.rewrite(min(max(x, y), max(x, z)), max(x, min(y, z))) ||
+      r.rewrite(min(x, max(y, min(x, z))), min(x, max(y, z))) ||
       r.rewrite(min(x, min(y, x + z)), min(y, min(x, x + z))) ||
       r.rewrite(min(x, min(y, x - z)), min(y, min(x, x - z))) ||
       r.rewrite(min((y + w), min(x, (y + z))), min(x, min(y + z, y + w))) ||
@@ -134,8 +136,10 @@ expr simplify(const class max* op, expr a, expr b) {
       r.rewrite(max(y + c0, max(x, y)), max(x, max(y, y + c0))) ||
       r.rewrite(max(y, max(x, y + c0)), max(x, max(y, y + c0))) ||
       r.rewrite(max(min(x, y), max(x, z)), max(x, z)) ||
+      r.rewrite(max(x, max(y, min(x, z))), max(x, y)) ||
       r.rewrite(max(max(x, y), max(x, z)), max(x, max(y, z))) ||
       r.rewrite(max(min(x, y), min(x, z)), min(x, max(y, z))) ||
+      r.rewrite(max(x, min(y, max(x, z))), max(x, min(y, z))) ||
       r.rewrite(max(x, max(y, x + z)), max(y, max(x, x + z))) ||
       r.rewrite(max(x, max(y, x - z)), max(y, max(x, x - z))) ||
       r.rewrite(max(x / c0, y / c0), max(x, y) / c0, eval(c0 > 0)) ||


### PR DESCRIPTION
- We didn't respect the old bounds when cropping in infer_bounds (missing the clamp/intersection that crop performs)
- We didn't take the union of bounds required for copies like we did for calls, or substitute the uncropped buffer like we did for calls (this broke the split test added in this PR).
- Reorder the checks so checks that the buffer exists and the rank is OK come before the extra checks added by infer_bounds.
- Add some min/max simplify rules useful for crop intersections.
- Fix a bug with the commutative variants logic, which would miss some variants if the pattern matching failed early.