### PR TITLE
Add optional description to check nodes

### DIFF
--- a/builder/node_mutator.cc
+++ b/builder/node_mutator.cc
@@ -262,7 +262,7 @@ void node_mutator::visit(const check* op) {
   if (condition.same_as(op->condition)) {
     set_result(op);
   } else {
-    set_result(check::make(std::move(condition)));
+    set_result(check::make(std::move(condition), op->description));
   }
 }
 

--- a/builder/simplify.cc
+++ b/builder/simplify.cc
@@ -1011,7 +1011,7 @@ public:
     } else if (c.same_as(op->condition)) {
       set_result(op);
     } else {
-      set_result(check::make(std::move(c)));
+      set_result(check::make(std::move(c), op->description));
     }
   }
 };

--- a/runtime/evaluate.cc
+++ b/runtime/evaluate.cc
@@ -529,6 +529,9 @@ public:
         context.check_failed(op->condition);
       } else {
         std::cerr << "Check failed: " << op->condition << std::endl;
+        if (!op->description.empty()) {
+          std::cerr << "Description: " << op->description << std::endl;
+        }
         std::cerr << "Context: " << std::endl;
         dump_context_for_expr(std::cerr, context, op->condition);
         std::abort();

--- a/runtime/expr_stmt.cc
+++ b/runtime/expr_stmt.cc
@@ -455,9 +455,10 @@ stmt truncate_rank::make(symbol_id sym, int rank, stmt body) {
   return n;
 }
 
-stmt check::make(expr condition) {
+stmt check::make(expr condition, std::string description) {
   auto n = new check();
   n->condition = std::move(condition);
+  n->description = std::move(description);
   return n;
 }
 

--- a/runtime/stmt.h
+++ b/runtime/stmt.h
@@ -316,10 +316,11 @@ public:
 class check : public stmt_node<check> {
 public:
   expr condition;
+  std::string description;
 
   void accept(stmt_visitor* v) const override;
 
-  static stmt make(expr condition);
+  static stmt make(expr condition, std::string description = "");
 
   static constexpr stmt_node_type static_type = stmt_node_type::check;
 };


### PR DESCRIPTION
I've added this patch locally a couple of times for debugging -- when adding several checks it can help narrow down the failure quickly, especially when the conditions get simplified into something that looks odd. (If we don't want to land this, I'll leave it open as a draft so I can reapply it locally when needed.)