### PR TITLE
Simplify commute_bit logic

### DIFF
--- a/builder/rewrite.h
+++ b/builder/rewrite.h
@@ -106,7 +106,7 @@ SLINKY_ALWAYS_INLINE inline expr_node_type pattern_type(const pattern_binary<T, 
 }
 
 template <typename T, typename A, typename B>
-int commute_bit(const pattern_binary<T, A, B>& p, match_context& ctx) {
+bool match_binary(const pattern_binary<T, A, B>& p, const expr& a, const expr& b, match_context& ctx) {
   int this_bit = -1;
   if (T::commutative) {
     expr_node_type ta = pattern_type(p.a);
@@ -117,11 +117,6 @@ int commute_bit(const pattern_binary<T, A, B>& p, match_context& ctx) {
       this_bit = ctx.variant_bits++;
     }
   }
-  return this_bit;
-}
-
-template <typename T, typename A, typename B>
-bool match_binary(const pattern_binary<T, A, B>& p, int this_bit, const expr& a, const expr& b, match_context& ctx) {
   if (this_bit >= 0 && (ctx.variant & (1 << this_bit)) != 0) {
     // We should commute in this variant.
     return match(p.a, b, ctx) && match(p.b, a, ctx);
@@ -132,10 +127,8 @@ bool match_binary(const pattern_binary<T, A, B>& p, int this_bit, const expr& a,
 
 template <typename T, typename A, typename B>
 bool match(const pattern_binary<T, A, B>& p, const expr& x, match_context& ctx) {
-  int this_bit = commute_bit(p, ctx);
-
   if (const T* t = x.as<T>()) {
-    return match_binary(p, this_bit, t->a, t->b, ctx);
+    return match_binary(p, t->a, t->b, ctx);
   } else {
     return false;
   }
@@ -144,7 +137,7 @@ bool match(const pattern_binary<T, A, B>& p, const expr& x, match_context& ctx) 
 template <typename T, typename A, typename B>
 bool match(
     const pattern_binary<T, A, B>& p, const pattern_binary<T, pattern_expr, pattern_expr>& x, match_context& ctx) {
-  return match_binary(p, commute_bit(p, ctx), x.a.e, x.b.e, ctx);
+  return match_binary(p, x.a.e, x.b.e, ctx);
 }
 
 template <typename T, typename A, typename B>

--- a/builder/simplify_exprs.cc
+++ b/builder/simplify_exprs.cc
@@ -446,16 +446,7 @@ expr simplify(const less* op, expr a, expr b) {
       r.rewrite(x + y < x + z, y < z) ||
       r.rewrite(x - y < x - z, z < y) ||
       r.rewrite(x - y < z - y, x < z) ||
-
-      r.rewrite(min(x, y) < x, y < x) ||
-      r.rewrite(min(x, min(y, z)) < y, min(x, z) < y) ||
-      r.rewrite(max(x, y) < x, false) ||
-      r.rewrite(x < max(x, y), x < y) ||
-      r.rewrite(x < min(x, y), false) ||
-      r.rewrite(min(x, y) < max(x, y), x != y) ||
-      r.rewrite(max(x, y) < min(x, y), false) ||
-      r.rewrite(min(x, y) < min(x, z), y < min(x, z)) ||
-    
+        
       // The following rules are taken from
       // https://github.com/halide/Halide/blob/7636c44acc2954a7c20275618093973da6767359/src/Simplify_LT.cpp#L186-L263
       // with adjustments for the simplifier implementation here.
@@ -482,9 +473,9 @@ expr simplify(const less* op, expr a, expr b) {
 
       // Special cases where c0 == c1 == 0
       r.rewrite(min(x, y) < x, y < x) ||
-      r.rewrite(min(y, x) < x, y < x) ||
+      r.rewrite(max(x, y) < x, false) ||
       r.rewrite(x < max(x, y), x < y) ||
-      r.rewrite(x < max(y, x), x < y) ||
+      r.rewrite(x < min(x, y), false) ||
 
       // Special case where x is constant
       r.rewrite(min(y, c0) < c1, y < c1 || eval(c0 < c1)) ||
@@ -500,7 +491,12 @@ expr simplify(const less* op, expr a, expr b) {
 
       // Equivalents with max
       r.rewrite(max(z, y) < max(x, y), max(z, y) < x) ||
-      r.rewrite(max(y, z) < max(x, y), max(z, y) < x) ||
+
+    
+      r.rewrite(min(x, min(y, z)) < y, min(x, z) < y) ||
+      r.rewrite(min(x, y) < max(x, y), x != y) ||
+      r.rewrite(max(x, y) < min(x, y), false) ||
+      r.rewrite(min(x, y) < min(x, z), y < min(x, z)) ||
 
       r.rewrite(buffer_extent(x, y) < c0, false, eval(c0 <= 0)) ||
       r.rewrite(c0 < buffer_extent(x, y), true, eval(c0 < 0)) ||


### PR DESCRIPTION
After realizing we don't need to attempt to enumerate all the variants regardless of match state (which didn't work anyways, fixed in #178), this could be simplified further, and it's also a pretty big optimization (10%+ speedup of simplify fuzz test)