### PR TITLE
Minor replica pipeline cleanups

### DIFF
--- a/builder/replica_pipeline.cc
+++ b/builder/replica_pipeline.cc
@@ -140,31 +140,24 @@ public:
     }
     buffers_emitted_.insert(bep->sym());
 
-    std::string size_code;
-    switch (bep->elem_size()) {
-    case 1: size_code = "sizeof(uint8_t)"; break;
-    case 2: size_code = "sizeof(uint16_t)"; break;
-    case 4: size_code = "sizeof(uint32_t)"; break;
-    case 8: size_code = "sizeof(uint64_t)"; break;
-    default: size_code = to_string(bep->elem_size()); break;
-    }
+    (void)print_assignment_explicit(
+        name, "buffer_expr::make(ctx, \"", name, "\", /*rank=*/", bep->rank(), ", /*elem_size=*/", bep->elem_size(), ")");
 
-    (void)print_assignment_explicit(name, "buffer_expr::make(ctx, \"", name, "\", ", bep->rank(), ", ", size_code, ")");
-
-    for (std::size_t d = 0; d < bep->rank(); d++) {
-      if (!match(bep->dim(d).bounds.min, buffer_min(variable::make(bep->sym()), static_cast<index_t>(d)))) {
+    expr bep_sym = variable::make(bep->sym());
+    for (index_t d = 0; d < static_cast<index_t>(bep->rank()); d++) {
+      if (!match(bep->dim(d).bounds.min, buffer_min(bep_sym, d))) {
         std::string e = print_expr_inlined(bep->dim(d).bounds.min);
         os_ << "  " << name << "->dim(" << d << ").min = " << e << ";\n";
       }
-      if (!match(bep->dim(d).bounds.max, buffer_max(variable::make(bep->sym()), static_cast<index_t>(d)))) {
+      if (!match(bep->dim(d).bounds.max, buffer_max(bep_sym, d))) {
         std::string e = print_expr_inlined(bep->dim(d).bounds.max);
         os_ << "  " << name << "->dim(" << d << ").max = " << e << ";\n";
       }
-      if (!match(bep->dim(d).stride, buffer_stride(variable::make(bep->sym()), static_cast<index_t>(d)))) {
+      if (!match(bep->dim(d).stride, buffer_stride(bep_sym, d))) {
         std::string e = print_expr_inlined(bep->dim(d).stride);
         os_ << "  " << name << "->dim(" << d << ").stride = " << e << ";\n";
       }
-      if (!match(bep->dim(d).fold_factor, buffer_fold_factor(variable::make(bep->sym()), static_cast<index_t>(d)))) {
+      if (!match(bep->dim(d).fold_factor, buffer_fold_factor(bep_sym, d))) {
         std::string e = print_expr_inlined(bep->dim(d).fold_factor);
         os_ << "  " << name << "->dim(" << d << ").fold_factor = " << e << ";\n";
       }

--- a/builder/replica_pipeline.cc
+++ b/builder/replica_pipeline.cc
@@ -95,28 +95,11 @@ public:
   void visit(const class select* op) override { fail("unimplemented select"); }
 
   void visit(const call* op) override {
-    std::string call_name;
-    switch (op->intrinsic) {
-    case intrinsic::positive_infinity: call_name = "positive_infinity"; break;
-    case intrinsic::negative_infinity: call_name = "negative_infinity"; break;
-    case intrinsic::indeterminate: call_name = "indeterminate"; break;
-    case intrinsic::abs: call_name = "abs"; break;
-    case intrinsic::buffer_rank: call_name = "buffer_rank"; break;
-    case intrinsic::buffer_elem_size: call_name = "buffer_elem_size"; break;
-    case intrinsic::buffer_size_bytes: call_name = "buffer_size_bytes"; break;
-    case intrinsic::buffer_min: call_name = "buffer_min"; break;
-    case intrinsic::buffer_max: call_name = "buffer_max"; break;
-    case intrinsic::buffer_extent: call_name = "buffer_extent"; break;
-    case intrinsic::buffer_stride: call_name = "buffer_stride"; break;
-    case intrinsic::buffer_fold_factor: call_name = "buffer_fold_factor"; break;
-    case intrinsic::buffer_at: call_name = "buffer_at"; break;
-    default: std::cerr << "Unknown intrinsic: " << op->intrinsic << std::endl; std::abort();
-    }
     std::vector<std::string> args;
     for (const auto& arg : op->args) {
       args.push_back(print_expr_maybe_inlined(arg));
     }
-    name_ = print_expr_maybe_inlined(call_name, "(", print_vector_elements(args), ")");
+    name_ = print_expr_maybe_inlined(to_string(op->intrinsic), "(", print_vector_elements(args), ")");
   }
 
   std::string print(const var& v) {

--- a/builder/replica_pipeline_test.cc
+++ b/builder/replica_pipeline_test.cc
@@ -25,17 +25,17 @@ TEST(replica, matmuls) {
 auto p = []() -> ::slinky::pipeline {
   using std::abs, std::min, std::max;
   node_context ctx;
-  auto a = buffer_expr::make(ctx, "a", 2, sizeof(uint32_t));
+  auto a = buffer_expr::make(ctx, "a", /*rank=*/2, /*elem_size=*/4);
   a->dim(1).stride = 4;
-  auto b = buffer_expr::make(ctx, "b", 2, sizeof(uint32_t));
+  auto b = buffer_expr::make(ctx, "b", /*rank=*/2, /*elem_size=*/4);
   b->dim(1).stride = 4;
-  auto c = buffer_expr::make(ctx, "c", 2, sizeof(uint32_t));
+  auto c = buffer_expr::make(ctx, "c", /*rank=*/2, /*elem_size=*/4);
   c->dim(1).stride = 4;
-  auto abc = buffer_expr::make(ctx, "abc", 2, sizeof(uint32_t));
+  auto abc = buffer_expr::make(ctx, "abc", /*rank=*/2, /*elem_size=*/4);
   abc->dim(1).stride = 4;
   auto i = var(ctx, "i");
   auto j = var(ctx, "j");
-  auto ab = buffer_expr::make(ctx, "ab", 2, sizeof(uint32_t));
+  auto ab = buffer_expr::make(ctx, "ab", /*rank=*/2, /*elem_size=*/4);
   auto _1 = variable::make(ab->sym());
   ab->dim(0).stride = (((((((buffer_max(_1, 1)) - (buffer_min(_1, 1)))) + 1)) * 4));
   ab->dim(1).stride = 4;
@@ -93,11 +93,11 @@ TEST(replica, pyramid) {
 auto p = []() -> ::slinky::pipeline {
   using std::abs, std::min, std::max;
   node_context ctx;
-  auto in = buffer_expr::make(ctx, "in", 2, sizeof(uint32_t));
-  auto out = buffer_expr::make(ctx, "out", 2, sizeof(uint32_t));
+  auto in = buffer_expr::make(ctx, "in", /*rank=*/2, /*elem_size=*/4);
+  auto out = buffer_expr::make(ctx, "out", /*rank=*/2, /*elem_size=*/4);
   auto x = var(ctx, "x");
   auto y = var(ctx, "y");
-  auto intm = buffer_expr::make(ctx, "intm", 2, sizeof(uint32_t));
+  auto intm = buffer_expr::make(ctx, "intm", /*rank=*/2, /*elem_size=*/4);
   auto _replica_fn_2 = [=](const buffer<const void>& i0, const buffer<void>& o0) -> index_t {
     const buffer<const void>* input_buffers[] = {&i0};
     const buffer<void>* output_buffers[] = {&o0};
@@ -143,8 +143,8 @@ TEST(replica, multiple_outputs) {
 auto p = []() -> ::slinky::pipeline {
   using std::abs, std::min, std::max;
   node_context ctx;
-  auto in = buffer_expr::make(ctx, "in", 3, sizeof(uint32_t));
-  auto sum_x = buffer_expr::make(ctx, "sum_x", 2, sizeof(uint32_t));
+  auto in = buffer_expr::make(ctx, "in", /*rank=*/3, /*elem_size=*/4);
+  auto sum_x = buffer_expr::make(ctx, "sum_x", /*rank=*/2, /*elem_size=*/4);
   auto y = var(ctx, "y");
   auto z = var(ctx, "z");
   auto _1 = variable::make(in->sym());
@@ -155,7 +155,7 @@ auto p = []() -> ::slinky::pipeline {
     const std::vector<var> outputs[] = {{y, z}, {z}};
     return ::slinky::internal::replica_pipeline_handler(input_buffers, output_buffers, inputs, outputs);
   };
-  auto sum_xy = buffer_expr::make(ctx, "sum_xy", 1, sizeof(uint32_t));
+  auto sum_xy = buffer_expr::make(ctx, "sum_xy", /*rank=*/1, /*elem_size=*/4);
   auto _fn_0 = func::make(std::move(_replica_fn_2), {{in, {{(buffer_min(_1, 0)), (buffer_max(_1, 0))}, {(buffer_min(_1, 1)), (buffer_max(_1, 1))}, point(z)}}}, {{sum_x, {y, z}}, {sum_xy, {z}}});
   _fn_0.loops({{z, 1, loop_mode::serial}});
   auto p = build_pipeline(ctx, {}, {in}, {sum_x, sum_xy}, {});
@@ -186,12 +186,12 @@ TEST(replica, unrelated) {
 auto p = []() -> ::slinky::pipeline {
   using std::abs, std::min, std::max;
   node_context ctx;
-  auto in1 = buffer_expr::make(ctx, "in1", 2, sizeof(uint16_t));
-  auto in2 = buffer_expr::make(ctx, "in2", 1, sizeof(uint32_t));
-  auto out1 = buffer_expr::make(ctx, "out1", 2, sizeof(uint16_t));
+  auto in1 = buffer_expr::make(ctx, "in1", /*rank=*/2, /*elem_size=*/2);
+  auto in2 = buffer_expr::make(ctx, "in2", /*rank=*/1, /*elem_size=*/4);
+  auto out1 = buffer_expr::make(ctx, "out1", /*rank=*/2, /*elem_size=*/2);
   auto x = var(ctx, "x");
   auto y = var(ctx, "y");
-  auto intm1 = buffer_expr::make(ctx, "intm1", 2, sizeof(uint16_t));
+  auto intm1 = buffer_expr::make(ctx, "intm1", /*rank=*/2, /*elem_size=*/2);
   auto _replica_fn_2 = [=](const buffer<const void>& i0, const buffer<void>& o0) -> index_t {
     const buffer<const void>* input_buffers[] = {&i0};
     const buffer<void>* output_buffers[] = {&o0};
@@ -209,8 +209,8 @@ auto p = []() -> ::slinky::pipeline {
   };
   auto _fn_0 = func::make(std::move(_replica_fn_3), {{intm1, {{((x + -1)), ((x + 1))}, {((y + -1)), ((y + 1))}}}}, {{out1, {x, y}}});
   _fn_0.loops({{y, 2, loop_mode::serial}});
-  auto out2 = buffer_expr::make(ctx, "out2", 1, sizeof(uint32_t));
-  auto intm2 = buffer_expr::make(ctx, "intm2", 1, sizeof(uint32_t));
+  auto out2 = buffer_expr::make(ctx, "out2", /*rank=*/1, /*elem_size=*/4);
+  auto intm2 = buffer_expr::make(ctx, "intm2", /*rank=*/1, /*elem_size=*/4);
   auto _replica_fn_6 = [=](const buffer<const void>& i0, const buffer<void>& o0) -> index_t {
     const buffer<const void>* input_buffers[] = {&i0};
     const buffer<void>* output_buffers[] = {&o0};
@@ -265,10 +265,10 @@ TEST(replica, concatenated_result) {
 auto p = []() -> ::slinky::pipeline {
   using std::abs, std::min, std::max;
   node_context ctx;
-  auto in1 = buffer_expr::make(ctx, "in1", 2, sizeof(uint16_t));
-  auto in2 = buffer_expr::make(ctx, "in2", 2, sizeof(uint16_t));
-  auto out = buffer_expr::make(ctx, "out", 2, sizeof(uint16_t));
-  auto intm1 = buffer_expr::make(ctx, "intm1", 2, sizeof(uint16_t));
+  auto in1 = buffer_expr::make(ctx, "in1", /*rank=*/2, /*elem_size=*/2);
+  auto in2 = buffer_expr::make(ctx, "in2", /*rank=*/2, /*elem_size=*/2);
+  auto out = buffer_expr::make(ctx, "out", /*rank=*/2, /*elem_size=*/2);
+  auto intm1 = buffer_expr::make(ctx, "intm1", /*rank=*/2, /*elem_size=*/2);
   auto x = var(ctx, "x");
   auto y = var(ctx, "y");
   auto _replica_fn_2 = [=](const buffer<const void>& i0, const buffer<void>& o0) -> index_t {
@@ -280,7 +280,7 @@ auto p = []() -> ::slinky::pipeline {
   };
   auto _fn_1 = func::make(std::move(_replica_fn_2), {{in1, {point(x), point(y)}}}, {{intm1, {x, y}}});
   auto _3 = variable::make(in1->sym());
-  auto intm2 = buffer_expr::make(ctx, "intm2", 2, sizeof(uint16_t));
+  auto intm2 = buffer_expr::make(ctx, "intm2", /*rank=*/2, /*elem_size=*/2);
   auto _replica_fn_5 = [=](const buffer<const void>& i0, const buffer<void>& o0) -> index_t {
     const buffer<const void>* input_buffers[] = {&i0};
     const buffer<void>* output_buffers[] = {&o0};
@@ -321,10 +321,10 @@ TEST(replica, stacked_result) {
 auto p = []() -> ::slinky::pipeline {
   using std::abs, std::min, std::max;
   node_context ctx;
-  auto in1 = buffer_expr::make(ctx, "in1", 2, sizeof(uint16_t));
-  auto in2 = buffer_expr::make(ctx, "in2", 2, sizeof(uint16_t));
-  auto out = buffer_expr::make(ctx, "out", 3, sizeof(uint16_t));
-  auto intm1 = buffer_expr::make(ctx, "intm1", 2, sizeof(uint16_t));
+  auto in1 = buffer_expr::make(ctx, "in1", /*rank=*/2, /*elem_size=*/2);
+  auto in2 = buffer_expr::make(ctx, "in2", /*rank=*/2, /*elem_size=*/2);
+  auto out = buffer_expr::make(ctx, "out", /*rank=*/3, /*elem_size=*/2);
+  auto intm1 = buffer_expr::make(ctx, "intm1", /*rank=*/2, /*elem_size=*/2);
   auto x = var(ctx, "x");
   auto y = var(ctx, "y");
   auto _replica_fn_2 = [=](const buffer<const void>& i0, const buffer<void>& o0) -> index_t {
@@ -335,7 +335,7 @@ auto p = []() -> ::slinky::pipeline {
     return ::slinky::internal::replica_pipeline_handler(input_buffers, output_buffers, inputs, outputs);
   };
   auto _fn_1 = func::make(std::move(_replica_fn_2), {{in1, {point(x), point(y)}}}, {{intm1, {x, y}}});
-  auto intm2 = buffer_expr::make(ctx, "intm2", 2, sizeof(uint16_t));
+  auto intm2 = buffer_expr::make(ctx, "intm2", /*rank=*/2, /*elem_size=*/2);
   auto _replica_fn_4 = [=](const buffer<const void>& i0, const buffer<void>& o0) -> index_t {
     const buffer<const void>* input_buffers[] = {&i0};
     const buffer<void>* output_buffers[] = {&o0};
@@ -374,12 +374,12 @@ TEST(replica, padded_stencil) {
 auto p = []() -> ::slinky::pipeline {
   using std::abs, std::min, std::max;
   node_context ctx;
-  auto in = buffer_expr::make(ctx, "in", 2, sizeof(uint16_t));
-  auto out = buffer_expr::make(ctx, "out", 2, sizeof(uint16_t));
+  auto in = buffer_expr::make(ctx, "in", /*rank=*/2, /*elem_size=*/2);
+  auto out = buffer_expr::make(ctx, "out", /*rank=*/2, /*elem_size=*/2);
   auto x = var(ctx, "x");
   auto y = var(ctx, "y");
-  auto padded_intm = buffer_expr::make(ctx, "padded_intm", 2, sizeof(uint16_t));
-  auto intm = buffer_expr::make(ctx, "intm", 2, sizeof(uint16_t));
+  auto padded_intm = buffer_expr::make(ctx, "padded_intm", /*rank=*/2, /*elem_size=*/2);
+  auto intm = buffer_expr::make(ctx, "intm", /*rank=*/2, /*elem_size=*/2);
   auto _replica_fn_3 = [=](const buffer<const void>& i0, const buffer<void>& o0) -> index_t {
     const buffer<const void>* input_buffers[] = {&i0};
     const buffer<void>* output_buffers[] = {&o0};
@@ -427,12 +427,12 @@ TEST(replica, diamond_stencils) {
 auto p = []() -> ::slinky::pipeline {
   using std::abs, std::min, std::max;
   node_context ctx;
-  auto in1 = buffer_expr::make(ctx, "in1", 2, sizeof(uint16_t));
-  auto out = buffer_expr::make(ctx, "out", 2, sizeof(uint16_t));
+  auto in1 = buffer_expr::make(ctx, "in1", /*rank=*/2, /*elem_size=*/2);
+  auto out = buffer_expr::make(ctx, "out", /*rank=*/2, /*elem_size=*/2);
   auto x = var(ctx, "x");
   auto y = var(ctx, "y");
-  auto intm3 = buffer_expr::make(ctx, "intm3", 2, sizeof(uint16_t));
-  auto intm2 = buffer_expr::make(ctx, "intm2", 2, sizeof(uint16_t));
+  auto intm3 = buffer_expr::make(ctx, "intm3", /*rank=*/2, /*elem_size=*/2);
+  auto intm2 = buffer_expr::make(ctx, "intm2", /*rank=*/2, /*elem_size=*/2);
   auto _replica_fn_3 = [=](const buffer<const void>& i0, const buffer<void>& o0) -> index_t {
     const buffer<const void>* input_buffers[] = {&i0};
     const buffer<void>* output_buffers[] = {&o0};
@@ -449,7 +449,7 @@ auto p = []() -> ::slinky::pipeline {
     return ::slinky::internal::replica_pipeline_handler(input_buffers, output_buffers, inputs, outputs);
   };
   auto _fn_1 = func::make(std::move(_replica_fn_4), {{intm2, {{((x + -1)), ((x + 1))}, {((y + -1)), ((y + 1))}}}}, {{intm3, {x, y}}});
-  auto intm4 = buffer_expr::make(ctx, "intm4", 2, sizeof(uint16_t));
+  auto intm4 = buffer_expr::make(ctx, "intm4", /*rank=*/2, /*elem_size=*/2);
   auto _replica_fn_6 = [=](const buffer<const void>& i0, const buffer<void>& o0) -> index_t {
     const buffer<const void>* input_buffers[] = {&i0};
     const buffer<void>* output_buffers[] = {&o0};
@@ -495,11 +495,11 @@ TEST(replica, Y) {
 auto p = []() -> ::slinky::pipeline {
   using std::abs, std::min, std::max;
   node_context ctx;
-  auto in1 = buffer_expr::make(ctx, "in1", 2, sizeof(uint16_t));
-  auto intm3 = buffer_expr::make(ctx, "intm3", 2, sizeof(uint16_t));
+  auto in1 = buffer_expr::make(ctx, "in1", /*rank=*/2, /*elem_size=*/2);
+  auto intm3 = buffer_expr::make(ctx, "intm3", /*rank=*/2, /*elem_size=*/2);
   auto x = var(ctx, "x");
   auto y = var(ctx, "y");
-  auto intm2 = buffer_expr::make(ctx, "intm2", 2, sizeof(uint16_t));
+  auto intm2 = buffer_expr::make(ctx, "intm2", /*rank=*/2, /*elem_size=*/2);
   auto _replica_fn_2 = [=](const buffer<const void>& i0, const buffer<void>& o0) -> index_t {
     const buffer<const void>* input_buffers[] = {&i0};
     const buffer<void>* output_buffers[] = {&o0};
@@ -516,7 +516,7 @@ auto p = []() -> ::slinky::pipeline {
     return ::slinky::internal::replica_pipeline_handler(input_buffers, output_buffers, inputs, outputs);
   };
   auto _fn_0 = func::make(std::move(_replica_fn_3), {{intm2, {point(x), point(y)}}}, {{intm3, {x, y}}});
-  auto intm4 = buffer_expr::make(ctx, "intm4", 2, sizeof(uint16_t));
+  auto intm4 = buffer_expr::make(ctx, "intm4", /*rank=*/2, /*elem_size=*/2);
   auto _replica_fn_5 = [=](const buffer<const void>& i0, const buffer<void>& o0) -> index_t {
     const buffer<const void>* input_buffers[] = {&i0};
     const buffer<void>* output_buffers[] = {&o0};


### PR DESCRIPTION
I have run into two things recently trying to make unrelated changes:
- Trying to make `elem_size` an expr instead of a constant ran into issues with this sizeof(T) thing
- Adding a new `intrinsic` type led me to the to_string switch that we already have.