### PR TITLE
Just use the repo path when running outside bazel

### DIFF
--- a/builder/bazel_util.h
+++ b/builder/bazel_util.h
@@ -9,16 +9,21 @@ namespace slinky {
 
 // Get the path to a file relative to the root of the repo in the current bazel invocation.
 inline std::string get_bazel_file_path(const std::string& repo_path) {
-  using bazel::tools::cpp::runfiles::Runfiles;
+  if (getenv("BAZEL_TEST") != nullptr) {
+    using bazel::tools::cpp::runfiles::Runfiles;
 
-  std::string error;
-  std::unique_ptr<Runfiles> runfiles(Runfiles::CreateForTest(BAZEL_CURRENT_REPOSITORY, &error));
-  if (runfiles == nullptr) {
-    std::cerr << "Can't find runfile directory: " << error;
-    std::abort();
+    std::string error;
+    std::unique_ptr<Runfiles> runfiles(Runfiles::CreateForTest(BAZEL_CURRENT_REPOSITORY, &error));
+    if (runfiles == nullptr) {
+      std::cerr << "Can't find runfile directory: " << error;
+      std::abort();
+    }
+
+    return runfiles->Rlocation("_main/" + repo_path);
+  } else {
+    // When running without bazel, just assume we're in the repo root.
+    return repo_path;
   }
-
-  return runfiles->Rlocation("_main/" + repo_path);
 }
 
 }  // namespace slinky


### PR DESCRIPTION
This makes it possible to run the tests in gdb without failing on the replica golden check