### PR TITLE
Change `loop::mode` to `loop::max_workers`

### DIFF
--- a/builder/node_mutator.cc
+++ b/builder/node_mutator.cc
@@ -41,7 +41,7 @@ expr mutate_binary(node_mutator* this_, const T* op) {
 }  // namespace
 
 stmt clone_with_new_body(const loop* op, stmt new_body) {
-  return loop::make(op->sym, op->mode, op->bounds, op->step, std::move(new_body));
+  return loop::make(op->sym, op->max_workers, op->bounds, op->step, std::move(new_body));
 }
 stmt clone_with_new_body(const let_stmt* op, stmt new_body) { return let_stmt::make(op->lets, std::move(new_body)); }
 stmt clone_with_new_body(const allocate* op, stmt new_body) {
@@ -140,7 +140,7 @@ void node_mutator::visit(const loop* op) {
   if (bounds.same_as(op->bounds) && step.same_as(op->step) && body.same_as(op->body)) {
     set_result(op);
   } else {
-    set_result(loop::make(op->sym, op->mode, std::move(bounds), std::move(step), std::move(body)));
+    set_result(loop::make(op->sym, op->max_workers, std::move(bounds), std::move(step), std::move(body)));
   }
 }
 void node_mutator::visit(const call_stmt* op) { set_result(op); }

--- a/builder/optimizations.cc
+++ b/builder/optimizations.cc
@@ -372,7 +372,7 @@ stmt implement_copy(const copy_stmt* op, node_context& ctx) {
 
   for (const std::pair<symbol_id, int>& d : dst_x) {
     result = slice_dim::make(op->dst, d.second, var(d.first), result);
-    result = loop::make(d.first, loop_mode::serial, buffer_bounds(dst_var, d.second), 1, result);
+    result = loop::make(d.first, loop::serial, buffer_bounds(dst_var, d.second), 1, result);
   }
   return let_stmt::make(std::move(lets), result);
 }
@@ -388,7 +388,7 @@ class race_condition_fixer : public node_mutator {
 
 public:
   void visit(const loop* op) override {
-    if (op->mode != loop_mode::parallel) {
+    if (op->is_serial()) {
       node_mutator::visit(op);
       return;
     }
@@ -404,7 +404,7 @@ public:
     if (body.same_as(op->body)) {
       set_result(op);
     } else {
-      set_result(loop::make(op->sym, op->mode, op->bounds, op->step, std::move(body)));
+      set_result(loop::make(op->sym, op->max_workers, op->bounds, op->step, std::move(body)));
     }
   }
 

--- a/builder/pipeline.cc
+++ b/builder/pipeline.cc
@@ -596,7 +596,7 @@ class pipeline_builder {
       // The loop body is done, and we have an actual loop to make here. Crop the body.
       body = crop_for_loop(body, f, loop);
       // And make the actual loop.
-      body = loop::make(loop.sym(), loop.mode, get_loop_bounds(f, loop), loop.step, body);
+      body = loop::make(loop.sym(), loop.max_workers, get_loop_bounds(f, loop), loop.step, body);
 
       // Wrap loop into crops.
       for (symbol_id i : input_syms_) {

--- a/builder/pipeline.h
+++ b/builder/pipeline.h
@@ -122,10 +122,11 @@ public:
   struct loop_info {
     slinky::var var;
     expr step;
-    loop_mode mode;
+    int max_workers;
 
     loop_info() = default;
-    loop_info(slinky::var var, expr step = 1, loop_mode mode = loop_mode::serial) : var(var), step(step), mode(mode) {}
+    loop_info(slinky::var var, expr step = 1, int max_workers = loop::serial)
+        : var(var), step(step), max_workers(max_workers) {}
 
     symbol_id sym() const { return var.sym(); }
 

--- a/builder/replica_pipeline.cc
+++ b/builder/replica_pipeline.cc
@@ -140,8 +140,8 @@ public:
     }
     buffers_emitted_.insert(bep->sym());
 
-    (void)print_assignment_explicit(
-        name, "buffer_expr::make(ctx, \"", name, "\", /*rank=*/", bep->rank(), ", /*elem_size=*/", bep->elem_size(), ")");
+    (void)print_assignment_explicit(name, "buffer_expr::make(ctx, \"", name, "\", /*rank=*/", bep->rank(),
+        ", /*elem_size=*/", bep->elem_size(), ")");
 
     expr bep_sym = variable::make(bep->sym());
     for (index_t d = 0; d < static_cast<index_t>(bep->rank()); d++) {
@@ -222,13 +222,19 @@ public:
     return print_vector(fout_names);
   }
 
-  std::string print(const loop_mode& mode) { return "loop_mode::" + to_string(mode); }
+  std::string print_max_workers(int x) {
+    switch (x) {
+    case loop::serial: return "loop::serial";
+    case loop::parallel: return "loop::parallel";
+    default: return std::to_string(x);
+    }
+  }
 
   std::string print(const func::loop_info& loopinfo) {
     std::string v = print(loopinfo.var);
     std::string step = print_expr_maybe_inlined(loopinfo.step);
-    std::string mode = print(loopinfo.mode);
-    return print_string_vector({v, step, mode});
+    std::string max_workers = print_max_workers(loopinfo.max_workers);
+    return print_string_vector({v, step, max_workers});
   }
 
   std::string print(const std::vector<func::loop_info>& loopinfos) {

--- a/builder/replica_pipeline_test.cc
+++ b/builder/replica_pipeline_test.cc
@@ -57,7 +57,7 @@ auto p = []() -> ::slinky::pipeline {
     return ::slinky::internal::replica_pipeline_handler(input_buffers, output_buffers, inputs, outputs);
   };
   auto _fn_0 = func::make(std::move(_replica_fn_6), {{ab, {point(i), {(buffer_min(_5, 0)), (buffer_max(_5, 0))}}}, {c, {{(buffer_min(_5, 0)), (buffer_max(_5, 0))}, point(j)}}}, {{abc, {i, j}}});
-  _fn_0.loops({{i, 1, loop_mode::serial}});
+  _fn_0.loops({{i, 1, loop::serial}});
   auto p = build_pipeline(ctx, {}, {a, b, c}, {abc}, {});
   return p;
 };
@@ -114,7 +114,7 @@ auto p = []() -> ::slinky::pipeline {
     return ::slinky::internal::replica_pipeline_handler(input_buffers, output_buffers, inputs, outputs);
   };
   auto _fn_0 = func::make(std::move(_replica_fn_3), {{in, {point(x), point(y)}}, {intm, {{((x / 2)), ((((x + 1)) / 2))}, {((y / 2)), ((((y + 1)) / 2))}}}}, {{out, {x, y}}});
-  _fn_0.loops({{y, 1, loop_mode::serial}});
+  _fn_0.loops({{y, 1, loop::serial}});
   auto p = build_pipeline(ctx, {}, {in}, {out}, {});
   return p;
 };
@@ -157,7 +157,7 @@ auto p = []() -> ::slinky::pipeline {
   };
   auto sum_xy = buffer_expr::make(ctx, "sum_xy", /*rank=*/1, /*elem_size=*/4);
   auto _fn_0 = func::make(std::move(_replica_fn_2), {{in, {{(buffer_min(_1, 0)), (buffer_max(_1, 0))}, {(buffer_min(_1, 1)), (buffer_max(_1, 1))}, point(z)}}}, {{sum_x, {y, z}}, {sum_xy, {z}}});
-  _fn_0.loops({{z, 1, loop_mode::serial}});
+  _fn_0.loops({{z, 1, loop::serial}});
   auto p = build_pipeline(ctx, {}, {in}, {sum_x, sum_xy}, {});
   return p;
 };
@@ -208,7 +208,7 @@ auto p = []() -> ::slinky::pipeline {
     return ::slinky::internal::replica_pipeline_handler(input_buffers, output_buffers, inputs, outputs);
   };
   auto _fn_0 = func::make(std::move(_replica_fn_3), {{intm1, {{((x + -1)), ((x + 1))}, {((y + -1)), ((y + 1))}}}}, {{out1, {x, y}}});
-  _fn_0.loops({{y, 2, loop_mode::serial}});
+  _fn_0.loops({{y, 2, loop::serial}});
   auto out2 = buffer_expr::make(ctx, "out2", /*rank=*/1, /*elem_size=*/4);
   auto intm2 = buffer_expr::make(ctx, "intm2", /*rank=*/1, /*elem_size=*/4);
   auto _replica_fn_6 = [=](const buffer<const void>& i0, const buffer<void>& o0) -> index_t {
@@ -399,7 +399,7 @@ auto p = []() -> ::slinky::pipeline {
     return ::slinky::internal::replica_pipeline_handler(input_buffers, output_buffers, inputs, outputs);
   };
   auto _fn_0 = func::make(std::move(_replica_fn_5), {{padded_intm, {{((x + -1)), ((x + 1))}, {((y + -1)), ((y + 1))}}}}, {{out, {x, y}}});
-  _fn_0.loops({{y, 1, loop_mode::serial}});
+  _fn_0.loops({{y, 1, loop::serial}});
   auto p = build_pipeline(ctx, {}, {in}, {out}, {});
   return p;
 };
@@ -466,7 +466,7 @@ auto p = []() -> ::slinky::pipeline {
     return ::slinky::internal::replica_pipeline_handler(input_buffers, output_buffers, inputs, outputs);
   };
   auto _fn_0 = func::make(std::move(_replica_fn_7), {{intm3, {point(x), point(y)}}, {intm4, {point(x), point(y)}}}, {{out, {x, y}}});
-  _fn_0.loops({{y, 1, loop_mode::serial}});
+  _fn_0.loops({{y, 1, loop::serial}});
   auto p = build_pipeline(ctx, {}, {in1}, {out}, {});
   return p;
 };
@@ -525,7 +525,7 @@ auto p = []() -> ::slinky::pipeline {
     return ::slinky::internal::replica_pipeline_handler(input_buffers, output_buffers, inputs, outputs);
   };
   auto _fn_4 = func::make(std::move(_replica_fn_5), {{intm2, {point(x), point(y)}}}, {{intm4, {x, y}}});
-  _fn_4.loops({{y, 1, loop_mode::serial}});
+  _fn_4.loops({{y, 1, loop::serial}});
   auto p = build_pipeline(ctx, {}, {in1}, {intm3, intm4}, {});
   return p;
 };

--- a/builder/simplify.cc
+++ b/builder/simplify.cc
@@ -422,7 +422,7 @@ public:
       return;
     }
 
-    if (op->mode == loop_mode::serial) {
+    if (op->is_serial()) {
       // Due to either scheduling or other simplifications, we can end up with a loop that runs a single call or copy on
       // contiguous crops of a buffer. In these cases, we can drop the loop in favor of just calling the body on the
       // union of the bounds covered by the loop.
@@ -477,7 +477,7 @@ public:
     if (bounds.same_as(op->bounds) && step.same_as(op->step) && body.same_as(op->body)) {
       set_result(op);
     } else {
-      set_result(loop::make(op->sym, op->mode, std::move(bounds), std::move(step), std::move(body)));
+      set_result(loop::make(op->sym, op->max_workers, std::move(bounds), std::move(step), std::move(body)));
     }
   }
 

--- a/builder/simplify_test.cc
+++ b/builder/simplify_test.cc
@@ -141,16 +141,16 @@ TEST(simplify, let) {
   test_simplify(let::make(x.sym(), buffer_min(y, 0), x), buffer_min(y, 0));  // buffer_min, substitute
 
   test_simplify(
-    let_stmt::make(x.sym(), y, loop::make(z.sym(), loop_mode::serial, bounds(0, 3), 1, check::make(x))),
-    loop::make(z.sym(), loop_mode::serial, bounds(0, 3), 1, check::make(y)));  // Trivial value, substitute
+    let_stmt::make(x.sym(), y, loop::make(z.sym(), loop::serial, bounds(0, 3), 1, check::make(x))),
+    loop::make(z.sym(), loop::serial, bounds(0, 3), 1, check::make(y)));  // Trivial value, substitute
 
   // lets that should be kept
   test_simplify(
       let::make(x.sym(), y * 2, (x + 1) / x), let::make(x.sym(), y * 2, (x + 1) / x));  // Non-trivial, used more than once.
 
   test_simplify(
-    let_stmt::make(x.sym(), y * w, loop::make(z.sym(), loop_mode::serial, bounds(0, 3), 1, check::make(x))),
-    let_stmt::make(x.sym(), y * w, loop::make(z.sym(), loop_mode::serial, bounds(0, 3), 1, check::make(x))));  // Non-trivial, used in loop
+    let_stmt::make(x.sym(), y * w, loop::make(z.sym(), loop::serial, bounds(0, 3), 1, check::make(x))),
+    let_stmt::make(x.sym(), y * w, loop::make(z.sym(), loop::serial, bounds(0, 3), 1, check::make(x))));  // Non-trivial, used in loop
 
   test_simplify(
     let_stmt::make(x.sym(), y * w, block::make({check::make(x > 0), check::make(x < 10)})),
@@ -173,8 +173,8 @@ TEST(simplify, buffer_intrinsics) {
 }
 
 TEST(simplify, bounds) {
-  test_simplify(loop::make(x.sym(), loop_mode::serial, bounds(y - 2, z), 2, check::make(y - 2 <= x)), stmt());
-  test_simplify(loop::make(x.sym(), loop_mode::serial, min_extent(x, z), z, check::make(y)), check::make(y));
+  test_simplify(loop::make(x.sym(), loop::serial, bounds(y - 2, z), 2, check::make(y - 2 <= x)), stmt());
+  test_simplify(loop::make(x.sym(), loop::serial, min_extent(x, z), z, check::make(y)), check::make(y));
 
   test_simplify(
       allocate::make(x.sym(), memory_type::heap, 1, {{bounds(2, 3), 4, 5}}, check::make(buffer_min(x, 0) == 2)),

--- a/builder/slide_and_fold_storage.cc
+++ b/builder/slide_and_fold_storage.cc
@@ -104,10 +104,11 @@ public:
     expr orig_min;
     interval_expr bounds;
     expr step;
+    loop_mode mode;
     std::unique_ptr<symbol_map<box_expr>> buffer_bounds;
 
-    loop_info(symbol_id sym, expr orig_min, interval_expr bounds, expr step)
-        : sym(sym), orig_min(orig_min), bounds(bounds), step(step),
+    loop_info(symbol_id sym, expr orig_min, interval_expr bounds, expr step, loop_mode mode)
+        : sym(sym), orig_min(orig_min), bounds(bounds), step(step), mode(mode),
           buffer_bounds(std::make_unique<symbol_map<box_expr>>()) {}
   };
   std::vector<loop_info> loops;
@@ -118,7 +119,7 @@ public:
   symbol_map<box_expr>& current_buffer_bounds() { return *loops.back().buffer_bounds; }
 
   slide_and_fold(node_context& ctx) : ctx(ctx), x(ctx.insert_unique("_x")) {
-    loops.emplace_back(0, expr(), interval_expr::none(), expr());
+    loops.emplace_back(0, expr(), interval_expr::none(), expr(), loop_mode::serial);
   }
 
   void visit(const allocate* op) override {
@@ -161,39 +162,43 @@ public:
       // Start from 1 to skip the 'outermost' loop.
       bool did_overlapped_fold = false;
       for (std::size_t loop_index = 1; loop_index < loops.size(); ++loop_index) {
-        std::optional<box_expr>& bounds = (*loops[loop_index].buffer_bounds)[output];
+        loop_info& loop = loops[loop_index];
+        std::optional<box_expr>& bounds = (*loop.buffer_bounds)[output];
         if (!bounds) continue;
 
-        symbol_id loop_sym = loops[loop_index].sym;
-        expr loop_var = variable::make(loop_sym);
-        const expr& loop_max = loops[loop_index].bounds.max;
-        const expr& loop_step = loops[loop_index].step;
+        if (loop.mode == loop_mode::parallel) {
+          // TODO: We can handle parallel loops if we add some synchronization
+          // https://github.com/dsharlet/slinky/issues/18
+          continue;
+        }
+
+        expr loop_var = variable::make(loop.sym);
 
         for (int d = 0; d < static_cast<int>(bounds->size()); ++d) {
           interval_expr cur_bounds_d = (*bounds)[d];
-          if (!depends_on(cur_bounds_d, loop_sym).any()) {
+          if (!depends_on(cur_bounds_d, loop.sym).any()) {
             // TODO: In this case, the func is entirely computed redundantly on every iteration. We should be able to
             // just compute it once.
             continue;
           }
 
           interval_expr prev_bounds_d = {
-              substitute(cur_bounds_d.min, loop_sym, loop_var - loop_step),
-              substitute(cur_bounds_d.max, loop_sym, loop_var - loop_step),
+              substitute(cur_bounds_d.min, loop.sym, loop_var - loop.step),
+              substitute(cur_bounds_d.max, loop.sym, loop_var - loop.step),
           };
 
           // A few things here struggle to simplify when there is a min(loop_max, x) expression involved, where x is
           // some expression that is bounded by the loop bounds. This min simplifies away if we know that x <= loop_max,
           // but the simplifier can't figure that out. As a hopefully temporary workaround, we can just substitute
           // infinity for the loop max.
-          auto ignore_loop_max = [=](const expr& e) { return substitute(e, loop_max, positive_infinity()); };
+          auto ignore_loop_max = [&](const expr& e) { return substitute(e, loop.bounds.max, positive_infinity()); };
 
           interval_expr overlap = prev_bounds_d & cur_bounds_d;
           if (prove_true(ignore_loop_max(overlap.empty()))) {
             // The bounds of each loop iteration do not overlap. We can't re-use work between loop iterations, but we
             // can fold the storage.
             expr fold_factor = simplify(bounds_of(ignore_loop_max(cur_bounds_d.extent())).max);
-            if (!depends_on(fold_factor, loop_sym).any()) {
+            if (!depends_on(fold_factor, loop.sym).any()) {
               vector_at(fold_factors[output], d) = fold_factor;
             } else {
               // The fold factor didn't simplify to something that doesn't depend on the loop variable.
@@ -212,9 +217,9 @@ public:
 
             if (!did_overlapped_fold) {
               expr fold_factor = simplify(bounds_of(ignore_loop_max(cur_bounds_d.extent())).max);
-              if (!depends_on(fold_factor, loop_sym).any()) {
+              if (!depends_on(fold_factor, loop.sym).any()) {
                 // Align the fold factor to the loop step size, so it doesn't try to crop across a folding boundary.
-                fold_factor = simplify(align_up(fold_factor, loop_step));
+                fold_factor = simplify(align_up(fold_factor, loop.step));
                 vector_at(fold_factors[output], d) = fold_factor;
                 did_overlapped_fold = true;
               } else {
@@ -224,19 +229,19 @@ public:
 
             // Now that we're only computing the newly required parts of the domain, we need
             // to move the loop min back so we compute the whole required region.
-            expr new_min_at_new_loop_min = substitute(new_min, loop_sym, x);
-            expr old_min_at_loop_min = substitute(old_min, loop_sym, loops[loop_index].bounds.min);
+            expr new_min_at_new_loop_min = substitute(new_min, loop.sym, x);
+            expr old_min_at_loop_min = substitute(old_min, loop.sym, loop.bounds.min);
             expr new_loop_min =
                 where_true(ignore_loop_max(new_min_at_new_loop_min <= old_min_at_loop_min), x.sym()).max;
             if (!is_negative_infinity(new_loop_min)) {
-              loops[loop_index].bounds.min = new_loop_min;
+              loop.bounds.min = new_loop_min;
 
               (*bounds)[d].min = new_min;
             } else {
               // We couldn't find the new loop min. We need to warm up the loop on (or before) the first iteration.
               // TODO(https://github.com/dsharlet/slinky/issues/118): If there is a mix of warmup strategies, this will
               // effectively not slide while running before the original loop min.
-              (*bounds)[d].min = select(loop_var <= loops[loop_index].orig_min, old_min, new_min);
+              (*bounds)[d].min = select(loop_var <= loop.orig_min, old_min, new_min);
             }
           } else if (prove_true(ignore_loop_max(is_monotonic_decreasing))) {
             // TODO: We could also try to slide when the bounds are monotonically
@@ -329,15 +334,10 @@ public:
   void visit(const truncate_rank*) override { std::abort(); }
 
   void visit(const loop* op) override {
-    if (op->mode == loop_mode::parallel) {
-      // Don't try sliding window or storage folding on parallel loops.
-      node_mutator::visit(op);
-      return;
-    }
     var orig_min(ctx, ctx.name(op->sym) + ".min_orig");
 
     symbol_map<box_expr> last_buffer_bounds = current_buffer_bounds();
-    loops.emplace_back(op->sym, orig_min, bounds(orig_min, op->bounds.max), op->step);
+    loops.emplace_back(op->sym, orig_min, bounds(orig_min, op->bounds.max), op->step, op->mode);
     current_buffer_bounds() = last_buffer_bounds;
 
     stmt body = mutate(op->body);
@@ -380,14 +380,6 @@ public:
 
 }  // namespace
 
-stmt slide_and_fold_storage(const stmt& s, node_context& ctx) {
-  stmt result = s;
-
-  // We cannot simplify between infer_bounds and fold_storage, because we need to be able to rewrite the bounds
-  // of producers while we still understand the dependencies between stages.
-  result = slide_and_fold(ctx).mutate(result);
-
-  return result;
-}
+stmt slide_and_fold_storage(const stmt& s, node_context& ctx) { return slide_and_fold(ctx).mutate(s); }
 
 }  // namespace slinky

--- a/builder/slide_and_fold_storage.h
+++ b/builder/slide_and_fold_storage.h
@@ -1,7 +1,5 @@
-#ifndef SLINKY_BUILDER_INFER_BOUNDS_H
-#define SLINKY_BUILDER_INFER_BOUNDS_H
-
-#include <vector>
+#ifndef SLINKY_BUILDER_SLIDE_AND_FOLD_STORAGE_H
+#define SLINKY_BUILDER_SLIDE_AND_FOLD_STORAGE_H
 
 #include "runtime/stmt.h"
 
@@ -11,4 +9,4 @@ stmt slide_and_fold_storage(const stmt& s, node_context& ctx);
 
 }  // namespace slinky
 
-#endif  // SLINKY_BUILDER_INFER_BOUNDS_H
+#endif  // SLINKY_BUILDER_SLIDE_AND_FOLD_STORAGE_H

--- a/builder/substitute.cc
+++ b/builder/substitute.cc
@@ -466,7 +466,7 @@ public:
     if (bounds.same_as(op->bounds) && step.same_as(op->step) && body.same_as(op->body)) {
       set_result(op);
     } else {
-      set_result(loop::make(op->sym, op->mode, std::move(bounds), std::move(step), std::move(body)));
+      set_result(loop::make(op->sym, op->max_workers, std::move(bounds), std::move(step), std::move(body)));
     }
   }
   void visit(const allocate* op) override {

--- a/runtime/depends_on_test.cc
+++ b/runtime/depends_on_test.cc
@@ -33,7 +33,7 @@ TEST(depends_on, basic) {
   ASSERT_EQ(depends_on(x + y, x.sym()), (depends_on_result{.var = true, .ref_count = 1}));
   ASSERT_EQ(depends_on(x + x, x.sym()), (depends_on_result{.var = true, .ref_count = 2}));
 
-  stmt loop_x = loop::make(x.sym(), loop_mode::serial, {y, z}, 1, check::make(x && z));
+  stmt loop_x = loop::make(x.sym(), loop::serial, {y, z}, 1, check::make(x && z));
   ASSERT_EQ(depends_on(loop_x, x.sym()), depends_on_result{});
   ASSERT_EQ(depends_on(loop_x, y.sym()), (depends_on_result{.var = true, .ref_count = 1}));
 

--- a/runtime/evaluate.h
+++ b/runtime/evaluate.h
@@ -27,12 +27,12 @@ public:
   // Functions implementing parallelism:
   // - `enqueue_many` should enqueue the task N times for asynchronous execution, where N is the maximum number of
   // instances that could be expected to run simultaneously.
-  // - `enqueue_one` should enqueue a single task for asynchronous execution.
+  // - `enqueue` should enqueue a task N times.
   // - `wait_for` should wait until the given condition becomes true, executing tasks previously enqueued until it does.
   // These functions must be implemented if the statement being evaluated includes asynchronous nodes (parallel loops).
   using task = std::function<void()>;
   std::function<void(const task&)> enqueue_many;
-  std::function<void(task)> enqueue_one;
+  std::function<void(int, const task&)> enqueue;
   std::function<void(std::function<bool()>)> wait_for;
 
   // Functions implementing buffer data movement:

--- a/runtime/expr_stmt.cc
+++ b/runtime/expr_stmt.cc
@@ -375,10 +375,10 @@ stmt block::make(std::vector<stmt> stmts, stmt tail_stmt) {
   return make(std::move(stmts));
 }
 
-stmt loop::make(symbol_id sym, loop_mode mode, interval_expr bounds, expr step, stmt body) {
+stmt loop::make(symbol_id sym, int max_workers, interval_expr bounds, expr step, stmt body) {
   auto l = new loop();
   l->sym = sym;
-  l->mode = mode;
+  l->max_workers = max_workers;
   l->bounds = std::move(bounds);
   l->step = std::move(step);
   l->body = std::move(body);

--- a/runtime/print.cc
+++ b/runtime/print.cc
@@ -17,14 +17,6 @@ std::string to_string(memory_type type) {
   }
 }
 
-std::string to_string(loop_mode mode) {
-  switch (mode) {
-  case loop_mode::serial: return "serial";
-  case loop_mode::parallel: return "parallel";
-  default: return "<invalid loop_mode>";
-  }
-}
-
 std::string to_string(intrinsic fn) {
   switch (fn) {
   case intrinsic::positive_infinity: return "oo";
@@ -46,8 +38,6 @@ std::string to_string(intrinsic fn) {
 }
 
 std::ostream& operator<<(std::ostream& os, memory_type type) { return os << to_string(type); }
-
-std::ostream& operator<<(std::ostream& os, loop_mode mode) { return os << to_string(mode); }
 
 std::ostream& operator<<(std::ostream& os, intrinsic fn) { return os << to_string(fn); }
 
@@ -202,7 +192,13 @@ public:
   }
 
   void visit(const loop* l) override {
-    *this << indent() << l->mode << " loop(" << l->sym << " in " << l->bounds;
+    *this << indent() << "loop(" << l->sym << ", ";
+    switch (l->max_workers) {
+    case loop::serial: *this << "serial"; break;
+    case loop::parallel: *this << "parallel"; break;
+    default: *this << l->max_workers; break;
+    }
+    *this << ", " << l->bounds;
     if (l->step.defined()) {
       *this << ", " << l->step;
     }

--- a/runtime/print.h
+++ b/runtime/print.h
@@ -22,7 +22,6 @@ std::ostream& operator<<(std::ostream& os, const interval_expr& i);
 std::ostream& operator<<(std::ostream& os, const box_expr& i);
 std::ostream& operator<<(std::ostream& os, intrinsic fn);
 std::ostream& operator<<(std::ostream& os, memory_type type);
-std::ostream& operator<<(std::ostream& os, loop_mode mode);
 
 std::ostream& operator<<(std::ostream& os, const raw_buffer& buf);
 std::ostream& operator<<(std::ostream& os, const dim& d);
@@ -32,7 +31,6 @@ std::ostream& operator<<(std::ostream& os, const dim& d);
 // to_string() calls.
 std::string to_string(intrinsic fn);
 std::string to_string(memory_type type);
-std::string to_string(loop_mode mode);
 
 }  // namespace slinky
 

--- a/runtime/stmt.h
+++ b/runtime/stmt.h
@@ -30,11 +30,6 @@ enum class stmt_node_type {
   check,
 };
 
-enum class loop_mode {
-  serial,
-  parallel,
-};
-
 enum class memory_type {
   stack,
   heap,
@@ -171,14 +166,21 @@ public:
 class loop : public stmt_node<loop> {
 public:
   symbol_id sym;
-  loop_mode mode;
+  int max_workers;
   interval_expr bounds;
   expr step;
   stmt body;
 
+  static constexpr int serial = 1;
+  static constexpr int parallel = std::numeric_limits<int>::max();
+
+  bool is_serial() const { return max_workers == serial; }
+  bool is_parallel() const { return max_workers > 1; }
+
   void accept(stmt_visitor* v) const override;
 
-  static stmt make(symbol_id sym, loop_mode mode, interval_expr bounds, expr step, stmt body);
+  static stmt make(
+      symbol_id sym, int max_workers, interval_expr bounds, expr step, stmt body);
 
   static constexpr stmt_node_type static_type = stmt_node_type::loop;
 };

--- a/runtime/thread_pool.cc
+++ b/runtime/thread_pool.cc
@@ -23,29 +23,40 @@ thread_pool::~thread_pool() {
   }
 }
 
-thread_pool::task thread_pool::dequeue() {
-  auto& next = task_queue_.front();
-  if (next.first == 1) {
-    task t = std::move(next.second);
-    task_queue_.pop_front();
-    return t;
-  } else {
-    assert(next.first > 1);
-    next.first -= 1;
-    return next.second;
+bool thread_pool::dequeue(task& t, std::vector<thread_pool::task_id>& task_stack) {
+  for (auto i = task_queue_.begin(); i != task_queue_.end(); ++i) {
+    if (std::find(task_stack.begin(), task_stack.end(), std::get<2>(*i)) != task_stack.end()) {
+      // Don't enqueue the same task multiple times on the same thread.
+      continue;
+    }
+    if (std::get<0>(*i) == 1) {
+      t = std::move(std::get<1>(*i));
+      task_queue_.erase(i);
+      task_stack.push_back(0);
+      return true;
+    } else {
+      assert(std::get<0>(*i) > 1);
+      std::get<0>(*i) -= 1;
+      task_stack.push_back(std::get<2>(*i));
+      t = std::get<1>(*i);
+      return true;
+    }
   }
+  return false;
 }
 
 void thread_pool::wait_for(std::function<bool()> condition) {
+  thread_local std::vector<std::size_t> task_stack;
   std::unique_lock l(mutex_);
   while (!condition()) {
-    if (!task_queue_.empty()) {
-      task t = dequeue();
+    task t;
+    if (dequeue(t, task_stack)) {
       l.unlock();
-      task();
+      t();
+      task_stack.pop_back();
       l.lock();
-      // This is pretty inefficient. It is here to wake up threads that are waiting for a condition to become true, that
-      // may have become true due to the task completing. There may be a better way to do this.
+      // This is pretty inefficient. It is here to wake up threads that are waiting for a condition to become true,
+      // that may have become true due to the task completing. There may be a better way to do this.
       cv_.notify_all();
     } else if (!stop_) {
       cv_.wait(l);
@@ -54,14 +65,17 @@ void thread_pool::wait_for(std::function<bool()> condition) {
 }
 
 void thread_pool::enqueue(int n, const task& t) {
+  if (n <= 0) return;
   std::unique_lock l(mutex_);
-  task_queue_.push_back({n, t});
+  task_id id = next_task_id_++;
+  task_queue_.push_back({n, t, id});
   cv_.notify_all();
 }
 
 void thread_pool::enqueue(task t) {
   std::unique_lock l(mutex_);
-  task_queue_.push_back({1, std::move(t)});
+  task_id id = next_task_id_++;
+  task_queue_.push_back({1, std::move(t), id});
   cv_.notify_one();
 }
 

--- a/runtime/thread_pool.h
+++ b/runtime/thread_pool.h
@@ -20,9 +20,11 @@ private:
   std::vector<std::thread> workers_;
   std::atomic<bool> stop_;
 
-  std::deque<task> task_queue_;
+  std::deque<std::pair<int, task>> task_queue_;
   std::mutex mutex_;
   std::condition_variable cv_;
+
+  task dequeue();
 
 public:
   thread_pool(int workers = 3);

--- a/runtime/thread_pool.h
+++ b/runtime/thread_pool.h
@@ -15,16 +15,19 @@ namespace slinky {
 class thread_pool {
 public:
   using task = std::function<void()>;
+  using task_id = std::size_t;
 
 private:
   std::vector<std::thread> workers_;
   std::atomic<bool> stop_;
 
-  std::deque<std::pair<int, task>> task_queue_;
+  task_id next_task_id_ = 1;
+  using queued_task = std::tuple<int, task, task_id>;
+  std::deque<queued_task> task_queue_;
   std::mutex mutex_;
   std::condition_variable cv_;
 
-  task dequeue();
+  bool dequeue(task& t, std::vector<task_id>& task_stack);
 
 public:
   thread_pool(int workers = 3);


### PR DESCRIPTION
This is a relatively standalone change peeled off from #197. It modifies the loop mode to be a max number of workers instead (where 1 is a serial loop).