### PR TITLE
Make `make` functions more consistent

### DIFF
--- a/builder/elementwise_test.cc
+++ b/builder/elementwise_test.cc
@@ -70,7 +70,7 @@ public:
     auto value = raw_buffer::make(Rank, sizeof(T), dims);
     assert(value->size_bytes() == sizeof(T));
     memcpy(value->base, &c->value, sizeof(T));
-    result = buffer_expr::make_constant(ctx, "c" + std::to_string(c->value), std::move(value));
+    result = buffer_expr::make(ctx, "c" + std::to_string(c->value), std::move(value));
     constants.push_back(result);
   }
 

--- a/builder/elementwise_test.cc
+++ b/builder/elementwise_test.cc
@@ -67,7 +67,7 @@ public:
       dims[d].set_bounds(std::numeric_limits<index_t>::min() / 2 + 1, std::numeric_limits<index_t>::max() / 2);
     }
 
-    auto value = raw_buffer::make_allocated(Rank, sizeof(T), dims);
+    auto value = raw_buffer::make(Rank, sizeof(T), dims);
     assert(value->size_bytes() == sizeof(T));
     memcpy(value->base, &c->value, sizeof(T));
     result = buffer_expr::make_constant(ctx, "c" + std::to_string(c->value), std::move(value));

--- a/builder/pipeline.cc
+++ b/builder/pipeline.cc
@@ -59,10 +59,10 @@ buffer_expr_ptr buffer_expr::make(node_context& ctx, const std::string& sym, std
   return buffer_expr_ptr(new buffer_expr(ctx.insert_unique(sym), rank, elem_size));
 }
 
-buffer_expr_ptr buffer_expr::make_constant(symbol_id sym, const_raw_buffer_ptr constant_buffer) {
+buffer_expr_ptr buffer_expr::make(symbol_id sym, const_raw_buffer_ptr constant_buffer) {
   return buffer_expr_ptr(new buffer_expr(sym, std::move(constant_buffer)));
 }
-buffer_expr_ptr buffer_expr::make_constant(
+buffer_expr_ptr buffer_expr::make(
     node_context& ctx, const std::string& sym, const_raw_buffer_ptr constant_buffer) {
   return buffer_expr_ptr(new buffer_expr(ctx.insert_unique(sym), std::move(constant_buffer)));
 }

--- a/builder/pipeline.h
+++ b/builder/pipeline.h
@@ -48,8 +48,8 @@ public:
   static buffer_expr_ptr make(symbol_id sym, std::size_t rank, index_t elem_size);
   static buffer_expr_ptr make(node_context& ctx, const std::string& sym, std::size_t rank, index_t elem_size);
   // Make a constant buffer_expr. It takes ownership of the buffer from the caller.
-  static buffer_expr_ptr make_constant(symbol_id sym, const_raw_buffer_ptr constant_buffer);
-  static buffer_expr_ptr make_constant(node_context& ctx, const std::string& sym, const_raw_buffer_ptr constant_buffer);
+  static buffer_expr_ptr make(symbol_id sym, const_raw_buffer_ptr constant_buffer);
+  static buffer_expr_ptr make(node_context& ctx, const std::string& sym, const_raw_buffer_ptr constant_buffer);
 
   symbol_id sym() const { return sym_; }
   index_t elem_size() const { return elem_size_; }

--- a/builder/pipeline_test.cc
+++ b/builder/pipeline_test.cc
@@ -1367,7 +1367,7 @@ TEST(constant, pipeline) {
   dims[1].set_bounds(0, H);
   dims[1].set_stride(W * sizeof(short));
 
-  auto constant_buf = raw_buffer::make_allocated(2, sizeof(short), dims);
+  auto constant_buf = raw_buffer::make(2, sizeof(short), dims);
   fill_random<short>(*constant_buf);
 
   auto out = buffer_expr::make(ctx, "out", 2, sizeof(short));

--- a/builder/pipeline_test.cc
+++ b/builder/pipeline_test.cc
@@ -1372,7 +1372,7 @@ TEST(constant, pipeline) {
 
   auto out = buffer_expr::make(ctx, "out", 2, sizeof(short));
 
-  auto constant = buffer_expr::make_constant(ctx, "constant", std::move(constant_buf));
+  auto constant = buffer_expr::make(ctx, "constant", std::move(constant_buf));
 
   var x(ctx, "x");
   var y(ctx, "y");

--- a/runtime/buffer.cc
+++ b/runtime/buffer.cc
@@ -27,33 +27,29 @@ std::size_t alloc_size(std::size_t rank, std::size_t elem_size, const dim* dims)
 
 std::size_t raw_buffer::size_bytes() const { return alloc_size(rank, elem_size, dims); }
 
-raw_buffer_ptr raw_buffer::make_allocated(std::size_t rank, std::size_t elem_size, const class dim* dims) {
-  char* mem = reinterpret_cast<char*>(
-      malloc(sizeof(raw_buffer) + sizeof(slinky::dim) * rank + alloc_size(rank, elem_size, dims)));
+raw_buffer_ptr raw_buffer::make(std::size_t rank, std::size_t elem_size, const class dim* dims) {
+  std::size_t size = sizeof(raw_buffer) + sizeof(slinky::dim) * rank;
+  if (dims) {
+    size += alloc_size(rank, elem_size, dims);
+  }
+  char* mem = reinterpret_cast<char*>(malloc(size));
   raw_buffer* buf = new (mem) raw_buffer();
   mem += sizeof(raw_buffer);
   buf->rank = rank;
   buf->elem_size = elem_size;
   buf->dims = reinterpret_cast<slinky::dim*>(mem);
-  memcpy(buf->dims, dims, sizeof(slinky::dim) * rank);
-  mem += sizeof(slinky::dim) * rank;
-  buf->base = mem;
-  return raw_buffer_ptr(buf, free);
-}
-
-raw_buffer_ptr raw_buffer::make(std::size_t rank, std::size_t elem_size) {
-  char* mem = reinterpret_cast<char*>(malloc(sizeof(raw_buffer) + sizeof(slinky::dim) * rank));
-  raw_buffer* buf = new (mem) raw_buffer();
-  mem += sizeof(raw_buffer);
-  buf->rank = rank;
-  buf->elem_size = elem_size;
-  buf->dims = reinterpret_cast<slinky::dim*>(mem);
-  new (buf->dims) slinky::dim[buf->rank];
+  if (dims) {
+    memcpy(buf->dims, dims, sizeof(slinky::dim) * rank);
+    mem += sizeof(slinky::dim) * rank;
+    buf->base = mem;
+  } else {
+    new (buf->dims) slinky::dim[buf->rank];
+  }
   return raw_buffer_ptr(buf, free);
 }
 
 raw_buffer_ptr raw_buffer::make_copy(const raw_buffer& src) {
-  auto buf = make_allocated(src.rank, src.elem_size, src.dims);
+  auto buf = make(src.rank, src.elem_size, src.dims);
   copy(src, *buf);
   return buf;
 }

--- a/runtime/buffer.h
+++ b/runtime/buffer.h
@@ -201,11 +201,8 @@ public:
   template <typename NewT>
   const buffer<NewT>& cast() const;
 
-  // Make a pointer to a buffer with an allocation for the dims (but not elements) in the same allocation.
-  static raw_buffer_ptr make(std::size_t rank, std::size_t elem_size);
-
-  // Make a pointer to a buffer with an allocation for the dims and the elements in the same allocation.
-  static raw_buffer_ptr make_allocated(std::size_t rank, std::size_t elem_size, const class dim* dims);
+  // Make a pointer to a buffer with an allocation for the dims and (optionally) elements in the same allocation.
+  static raw_buffer_ptr make(std::size_t rank, std::size_t elem_size, const class dim* dims = nullptr);
 
   // Make a deep copy of another buffer, including allocating and copying the data.
   static raw_buffer_ptr make_copy(const raw_buffer& src);


### PR DESCRIPTION
I think overloading like this makes it easier to get it right the first time. Every time I go to use these functions, I get it wrong and the compiler informs me.