### PR TITLE
Change `elem_size` from `size_t` to `expr`

### DIFF
--- a/builder/node_mutator.cc
+++ b/builder/node_mutator.cc
@@ -159,6 +159,7 @@ void node_mutator::visit(const copy_stmt* op) {
   }
 }
 void node_mutator::visit(const allocate* op) {
+  expr elem_size = mutate(op->elem_size);
   std::vector<dim_expr> dims;
   dims.reserve(op->dims.size());
   bool changed = false;
@@ -168,10 +169,10 @@ void node_mutator::visit(const allocate* op) {
     changed = changed || !dims.back().same_as(i);
   }
   stmt body = mutate(op->body);
-  if (!changed && body.same_as(op->body)) {
+  if (!changed && elem_size.same_as(op->elem_size) && body.same_as(op->body)) {
     set_result(op);
   } else {
-    set_result(allocate::make(op->sym, op->storage, op->elem_size, std::move(dims), std::move(body)));
+    set_result(allocate::make(op->sym, op->storage, std::move(elem_size), std::move(dims), std::move(body)));
   }
 }
 void node_mutator::visit(const make_buffer* op) {

--- a/builder/optimizations.cc
+++ b/builder/optimizations.cc
@@ -109,7 +109,7 @@ public:
         }
       }
       stmt result = make_buffer::make(
-          op->sym, buffer_at(target_var, at), static_cast<index_t>(op->elem_size), std::move(dims), std::move(body));
+          op->sym, buffer_at(target_var, at), op->elem_size, std::move(dims), std::move(body));
       // If we aliased the source and destination of a copy, replace the copy with a pad.
       stmt pad_result = recursive_mutate<copy_stmt>(result, [src = op->sym, dst = target.first](const copy_stmt* op) {
         if (op->src != src || op->dst != dst) {

--- a/builder/pipeline.h
+++ b/builder/pipeline.h
@@ -24,7 +24,7 @@ struct loop_id {
 // Represents a symbolic buffer in a pipeline.
 class buffer_expr : public ref_counted<buffer_expr> {
   symbol_id sym_;
-  index_t elem_size_;
+  expr elem_size_;
   std::vector<dim_expr> dims_;
 
   func* producer_;
@@ -33,7 +33,7 @@ class buffer_expr : public ref_counted<buffer_expr> {
   memory_type storage_ = memory_type::heap;
   std::optional<loop_id> store_at_;
 
-  buffer_expr(symbol_id sym, std::size_t rank, index_t elem_size);
+  buffer_expr(symbol_id sym, std::size_t rank, expr elem_size);
   buffer_expr(symbol_id sym, const_raw_buffer_ptr constant_buffer);
   buffer_expr(const buffer_expr&) = delete;
   buffer_expr(buffer_expr&&) = delete;
@@ -45,14 +45,16 @@ class buffer_expr : public ref_counted<buffer_expr> {
   void set_producer(func* f);
 
 public:
+  static buffer_expr_ptr make(symbol_id sym, std::size_t rank, expr elem_size);
   static buffer_expr_ptr make(symbol_id sym, std::size_t rank, index_t elem_size);
+  static buffer_expr_ptr make(node_context& ctx, const std::string& sym, std::size_t rank, expr elem_size);
   static buffer_expr_ptr make(node_context& ctx, const std::string& sym, std::size_t rank, index_t elem_size);
   // Make a constant buffer_expr. It takes ownership of the buffer from the caller.
   static buffer_expr_ptr make_constant(symbol_id sym, const_raw_buffer_ptr constant_buffer);
   static buffer_expr_ptr make_constant(node_context& ctx, const std::string& sym, const_raw_buffer_ptr constant_buffer);
 
   symbol_id sym() const { return sym_; }
-  index_t elem_size() const { return elem_size_; }
+  expr elem_size() const { return elem_size_; }
   std::size_t rank() const { return dims_.size(); }
   const std::vector<dim_expr>& dims() const { return dims_; }
   dim_expr& dim(int i) { return dims_[i]; }

--- a/builder/replica_pipeline.cc
+++ b/builder/replica_pipeline.cc
@@ -140,24 +140,25 @@ public:
     }
     buffers_emitted_.insert(bep->sym());
 
+    std::string elem_size = print_expr_inlined(bep->elem_size());
     (void)print_assignment_explicit(
-        name, "buffer_expr::make(ctx, \"", name, "\", /*rank=*/", bep->rank(), ", /*elem_size=*/", bep->elem_size(), ")");
+        name, "buffer_expr::make(ctx, \"", name, "\", /*rank=*/", bep->rank(), ", /*elem_size=*/", elem_size, ")");
 
-    expr bep_sym = variable::make(bep->sym());
-    for (index_t d = 0; d < static_cast<index_t>(bep->rank()); d++) {
-      if (!match(bep->dim(d).bounds.min, buffer_min(bep_sym, d))) {
+    expr bep_var = variable::make(bep->sym());
+    for (std::size_t d = 0; d < bep->rank(); d++) {
+      if (!match(bep->dim(d).bounds.min, buffer_min(bep_var, static_cast<index_t>(d)))) {
         std::string e = print_expr_inlined(bep->dim(d).bounds.min);
         os_ << "  " << name << "->dim(" << d << ").min = " << e << ";\n";
       }
-      if (!match(bep->dim(d).bounds.max, buffer_max(bep_sym, d))) {
+      if (!match(bep->dim(d).bounds.max, buffer_max(bep_var, static_cast<index_t>(d)))) {
         std::string e = print_expr_inlined(bep->dim(d).bounds.max);
         os_ << "  " << name << "->dim(" << d << ").max = " << e << ";\n";
       }
-      if (!match(bep->dim(d).stride, buffer_stride(bep_sym, d))) {
+      if (!match(bep->dim(d).stride, buffer_stride(bep_var, static_cast<index_t>(d)))) {
         std::string e = print_expr_inlined(bep->dim(d).stride);
         os_ << "  " << name << "->dim(" << d << ").stride = " << e << ";\n";
       }
-      if (!match(bep->dim(d).fold_factor, buffer_fold_factor(bep_sym, d))) {
+      if (!match(bep->dim(d).fold_factor, buffer_fold_factor(bep_var, static_cast<index_t>(d)))) {
         std::string e = print_expr_inlined(bep->dim(d).fold_factor);
         os_ << "  " << name << "->dim(" << d << ").fold_factor = " << e << ";\n";
       }

--- a/builder/simplify.cc
+++ b/builder/simplify.cc
@@ -510,6 +510,7 @@ public:
   }
 
   void visit(const allocate* op) override {
+    expr elem_size = mutate(op->elem_size);
     std::vector<dim_expr> dims;
     box_expr bounds;
     dims.reserve(op->dims.size());
@@ -549,9 +550,9 @@ public:
       }
     }
 
-    if (changed || !body.same_as(op->body)) {
+    if (changed || !elem_size.same_as(op->elem_size) || !body.same_as(op->body)) {
       set_result(block::make({std::move(before),
-          allocate::make(op->sym, op->storage, op->elem_size, std::move(dims), std::move(body)), std::move(after)}));
+          allocate::make(op->sym, op->storage, std::move(elem_size), std::move(dims), std::move(body)), std::move(after)}));
     } else {
       set_result(op);
     }

--- a/builder/substitute.cc
+++ b/builder/substitute.cc
@@ -470,6 +470,7 @@ public:
     }
   }
   void visit(const allocate* op) override {
+    expr elem_size = mutate(op->elem_size);
     std::vector<dim_expr> dims;
     dims.reserve(op->dims.size());
     bool changed = false;
@@ -479,10 +480,10 @@ public:
       changed = changed || !dims.back().same_as(i);
     }
     stmt body = mutate_decl_body(op->sym, op->body);
-    if (!changed && body.same_as(op->body)) {
+    if (!changed && elem_size.same_as(op->elem_size) && body.same_as(op->body)) {
       set_result(op);
     } else {
-      set_result(allocate::make(op->sym, op->storage, op->elem_size, std::move(dims), std::move(body)));
+      set_result(allocate::make(op->sym, op->storage, std::move(elem_size), std::move(dims), std::move(body)));
     }
   }
   void visit(const make_buffer* op) override {

--- a/runtime/depends_on.cc
+++ b/runtime/depends_on.cc
@@ -119,6 +119,7 @@ public:
   }
 
   void visit(const allocate* op) override {
+    op->elem_size.accept(this);
     for (const dim_expr& i : op->dims) {
       i.bounds.min.accept(this);
       i.bounds.max.accept(this);

--- a/runtime/evaluate.cc
+++ b/runtime/evaluate.cc
@@ -314,7 +314,7 @@ public:
   void visit(const allocate* op) override {
     std::size_t rank = op->dims.size();
     raw_buffer* buffer = SLINKY_ALLOCA(raw_buffer, 1);
-    buffer->elem_size = op->elem_size;
+    buffer->elem_size = eval_expr(op->elem_size);
     buffer->rank = rank;
     buffer->dims = SLINKY_ALLOCA(dim, rank);
 

--- a/runtime/expr_stmt.cc
+++ b/runtime/expr_stmt.cc
@@ -385,11 +385,11 @@ stmt loop::make(symbol_id sym, loop_mode mode, interval_expr bounds, expr step, 
   return l;
 }
 
-stmt allocate::make(symbol_id sym, memory_type storage, std::size_t elem_size, std::vector<dim_expr> dims, stmt body) {
+stmt allocate::make(symbol_id sym, memory_type storage, expr elem_size, std::vector<dim_expr> dims, stmt body) {
   auto n = new allocate();
   n->sym = sym;
   n->storage = storage;
-  n->elem_size = elem_size;
+  n->elem_size = std::move(elem_size);
   n->dims = std::move(dims);
   n->body = std::move(body);
   return n;
@@ -664,6 +664,7 @@ void recursive_node_visitor::visit(const copy_stmt* op) {
   }
 }
 void recursive_node_visitor::visit(const allocate* op) {
+  op->elem_size.accept(this);
   for (const dim_expr& i : op->dims) {
     i.bounds.min.accept(this);
     i.bounds.max.accept(this);

--- a/runtime/print.cc
+++ b/runtime/print.cc
@@ -224,8 +224,7 @@ public:
   }
 
   void visit(const allocate* n) override {
-    *this << indent() << n->sym << " = allocate(" << n->storage << ", " << static_cast<index_t>(n->elem_size)
-          << ", {\n";
+    *this << indent() << n->sym << " = allocate(" << n->storage << ", " << n->elem_size << ", {\n";
     *this << indent(2);
     print_vector(n->dims, ",\n" + indent(2));
     *this << "\n";

--- a/runtime/stmt.h
+++ b/runtime/stmt.h
@@ -190,13 +190,13 @@ class allocate : public stmt_node<allocate> {
 public:
   memory_type storage;
   symbol_id sym;
-  std::size_t elem_size;
+  expr elem_size;
   std::vector<dim_expr> dims;
   stmt body;
 
   void accept(stmt_visitor* v) const override;
 
-  static stmt make(symbol_id sym, memory_type storage, std::size_t elem_size, std::vector<dim_expr> dims, stmt body);
+  static stmt make(symbol_id sym, memory_type storage, expr elem_size, std::vector<dim_expr> dims, stmt body);
 
   static constexpr stmt_node_type static_type = stmt_node_type::allocate;
 };

--- a/runtime/visualize.cc
+++ b/runtime/visualize.cc
@@ -214,8 +214,7 @@ public:
   }
 
   void visit(const allocate* n) override {
-    *this << indent() << "{ let " << n->sym << " = allocate('" << name(n->sym) << "', "
-          << static_cast<index_t>(n->elem_size) << ", [\n";
+    *this << indent() << "{ let " << n->sym << " = allocate('" << name(n->sym) << "', " << n->elem_size << ", [\n";
     *this << indent(2);
     print_vector(n->dims, ",\n" + indent(2));
     *this << "\n";


### PR DESCRIPTION
The thing that motivated this is now abandoned, but I think this is a good change anyways. It should not affect performance significantly, it is more flexible this way, and it eliminates a use of size_t in the API. `make_buffer` already necessarily uses `expr elem_size` too, so this makes things more consistent.