### PR TITLE
Use bounds_of instead of substitutions

### DIFF
--- a/builder/copy_test.cc
+++ b/builder/copy_test.cc
@@ -678,7 +678,7 @@ TEST(reshape, copy) {
   box_expr bounds = {
       point(flat_out % in->dim(0).extent()),
       point((flat_out / in->dim(0).extent()) % in->dim(1).extent()),
-      point(flat_out / (in->dim(0).extent() * in->dim(1).extent())),
+      point(flat_out / (in->dim(0).extent() * in->dim(1).extent()) % in->dim(2).extent()),
   };
   func crop = func::make_copy({in, bounds}, {out, {x, y, z}});
 
@@ -735,7 +735,7 @@ TEST(batch_reshape, copy) {
   box_expr bounds = {
       point(flat_out % in->dim(0).extent()),
       point((flat_out / in->dim(0).extent()) % in->dim(1).extent()),
-      point(flat_out / (in->dim(0).extent() * in->dim(1).extent())),
+      point(flat_out / (in->dim(0).extent() * in->dim(1).extent())  % in->dim(2).extent()),
       point(w),
   };
   func crop = func::make_copy({in, bounds}, {out, {x, y, z, w}});

--- a/builder/visualize/concatenate_0.html
+++ b/builder/visualize/concatenate_0.html
@@ -270,32 +270,32 @@ function pipeline(in1, in2, out) {
   check((buffer_min(in1, 0) <= buffer_min(out, 0)));
   check((buffer_max(out, 0) <= buffer_max(in1, 0)));
   check((buffer_extent(out, 0) <= buffer_fold_factor(in1, 0)));
-  check((buffer_min(in1, 1) <= min(min((buffer_extent(in1, 1) + -1), buffer_max(out, 1)), max(buffer_min(out, 1), 0))));
-  check((max(min((buffer_extent(in1, 1) + -1), buffer_max(out, 1)), max(buffer_min(out, 1), 0)) <= buffer_max(in1, 1)));
-  check(((abs((min((buffer_extent(in1, 1) + -1), buffer_max(out, 1)) - max(buffer_min(out, 1), 0))) + 1) <= buffer_fold_factor(in1, 1)));
+  check((buffer_min(in1, 1) <= max(buffer_min(out, 1), 0)));
+  check((min((buffer_extent(in1, 1) + -1), buffer_max(out, 1)) <= buffer_max(in1, 1)));
+  check((((min((buffer_extent(in1, 1) + -1), buffer_max(out, 1)) - max(buffer_min(out, 1), 0)) + 1) <= buffer_fold_factor(in1, 1)));
   check((buffer_min(in2, 0) <= buffer_min(out, 0)));
   check((buffer_max(out, 0) <= buffer_max(in2, 0)));
   check((buffer_extent(out, 0) <= buffer_fold_factor(in2, 0)));
-  check((buffer_min(in2, 1) <= (min(min((buffer_extent(out, 1) + -1), buffer_max(out, 1)), max(buffer_extent(in1, 1), buffer_min(out, 1))) - buffer_extent(in1, 1))));
-  check(((max(min((buffer_extent(out, 1) + -1), buffer_max(out, 1)), max(buffer_extent(in1, 1), buffer_min(out, 1))) - buffer_extent(in1, 1)) <= buffer_max(in2, 1)));
-  check(((abs((min((buffer_extent(out, 1) + -1), buffer_max(out, 1)) - max(buffer_extent(in1, 1), buffer_min(out, 1)))) + 1) <= buffer_fold_factor(in2, 1)));
+  check((buffer_min(in2, 1) <= (max(buffer_extent(in1, 1), buffer_min(out, 1)) - buffer_extent(in1, 1))));
+  check(((min((buffer_extent(out, 1) + -1), buffer_max(out, 1)) - buffer_extent(in1, 1)) <= buffer_max(in2, 1)));
+  check((((min((buffer_extent(out, 1) + -1), buffer_max(out, 1)) - max(buffer_extent(in1, 1), buffer_min(out, 1))) + 1) <= buffer_fold_factor(in2, 1)));
   {
-    let __base = buffer_at(out, NaN, max(min(min((buffer_extent(in1, 1) + -1), buffer_max(out, 1)), 0), buffer_min(out, 1)));
+    let __base = buffer_at(out, NaN, max(buffer_min(out, 1), 0));
     let __elem_size = 2;
     let __dims = [
         {bounds:{min:buffer_min(out, 0), max:buffer_max(out, 0)}, stride:buffer_stride(out, 0), fold_factor:buffer_fold_factor(out, 0)},
-        {bounds:{min:max(min(min((buffer_extent(in1, 1) + -1), buffer_max(out, 1)), 0), buffer_min(out, 1)), max:min(max((buffer_extent(in1, 1) + -1), max(buffer_min(out, 1), 0)), buffer_max(out, 1))}, stride:buffer_stride(out, 1), fold_factor:buffer_fold_factor(out, 1)}
+        {bounds:{min:max(buffer_min(out, 1), 0), max:min((buffer_extent(in1, 1) + -1), buffer_max(out, 1))}, stride:buffer_stride(out, 1), fold_factor:buffer_fold_factor(out, 1)}
     ];
     { let intm1 = make_buffer('intm1', __base, __elem_size, __dims);      consume(in1);
       produce(intm1);
     }
   }
   {
-    let __base = buffer_at(out, NaN, max((buffer_min(out, 1) + buffer_extent(in1, 1)), (min(min((buffer_extent(out, 1) + -1), buffer_max(out, 1)), max(buffer_extent(in1, 1), buffer_min(out, 1))) - buffer_extent(in1, 1))));
+    let __base = buffer_at(out, NaN, max((buffer_min(out, 1) + buffer_extent(in1, 1)), (max(buffer_extent(in1, 1), buffer_min(out, 1)) - buffer_extent(in1, 1))));
     let __elem_size = 2;
     let __dims = [
         {bounds:{min:buffer_min(out, 0), max:buffer_max(out, 0)}, stride:buffer_stride(out, 0), fold_factor:buffer_fold_factor(out, 0)},
-        {bounds:{min:max((min(min((buffer_extent(out, 1) + -1), buffer_max(out, 1)), max(buffer_extent(in1, 1), buffer_min(out, 1))) - buffer_extent(in1, 1)), buffer_min(out, 1)), max:min((max(min((buffer_extent(out, 1) + -1), buffer_max(out, 1)), max(buffer_extent(in1, 1), buffer_min(out, 1))) - buffer_extent(in1, 1)), buffer_max(out, 1))}, stride:buffer_stride(out, 1), fold_factor:buffer_fold_factor(out, 1)}
+        {bounds:{min:max((max(buffer_extent(in1, 1), buffer_min(out, 1)) - buffer_extent(in1, 1)), buffer_min(out, 1)), max:min((min((buffer_extent(out, 1) + -1), buffer_max(out, 1)) - buffer_extent(in1, 1)), buffer_max(out, 1))}, stride:buffer_stride(out, 1), fold_factor:buffer_fold_factor(out, 1)}
     ];
     { let intm2 = make_buffer('intm2', __base, __elem_size, __dims);      consume(in2);
       produce(intm2);

--- a/builder/visualize/concatenate_1.html
+++ b/builder/visualize/concatenate_1.html
@@ -270,22 +270,22 @@ function pipeline(in1, in2, out) {
   check((buffer_min(in1, 0) <= buffer_min(out, 0)));
   check((buffer_max(out, 0) <= buffer_max(in1, 0)));
   check((buffer_extent(out, 0) <= buffer_fold_factor(in1, 0)));
-  check((buffer_min(in1, 1) <= min(min((buffer_extent(in1, 1) + -1), buffer_max(out, 1)), max(buffer_min(out, 1), 0))));
-  check((max(min((buffer_extent(in1, 1) + -1), buffer_max(out, 1)), max(buffer_min(out, 1), 0)) <= buffer_max(in1, 1)));
-  check(((abs((min((buffer_extent(in1, 1) + -1), buffer_max(out, 1)) - max(buffer_min(out, 1), 0))) + 1) <= buffer_fold_factor(in1, 1)));
+  check((buffer_min(in1, 1) <= max(buffer_min(out, 1), 0)));
+  check((min((buffer_extent(in1, 1) + -1), buffer_max(out, 1)) <= buffer_max(in1, 1)));
+  check((((min((buffer_extent(in1, 1) + -1), buffer_max(out, 1)) - max(buffer_min(out, 1), 0)) + 1) <= buffer_fold_factor(in1, 1)));
   check((buffer_min(in2, 0) <= buffer_min(out, 0)));
   check((buffer_max(out, 0) <= buffer_max(in2, 0)));
   check((buffer_extent(out, 0) <= buffer_fold_factor(in2, 0)));
-  check((buffer_min(in2, 1) <= (min(min((buffer_extent(out, 1) + -1), buffer_max(out, 1)), max(buffer_extent(in1, 1), buffer_min(out, 1))) - buffer_extent(in1, 1))));
-  check(((max(min((buffer_extent(out, 1) + -1), buffer_max(out, 1)), max(buffer_extent(in1, 1), buffer_min(out, 1))) - buffer_extent(in1, 1)) <= buffer_max(in2, 1)));
-  check(((abs((min((buffer_extent(out, 1) + -1), buffer_max(out, 1)) - max(buffer_extent(in1, 1), buffer_min(out, 1)))) + 1) <= buffer_fold_factor(in2, 1)));
+  check((buffer_min(in2, 1) <= (max(buffer_extent(in1, 1), buffer_min(out, 1)) - buffer_extent(in1, 1))));
+  check(((min((buffer_extent(out, 1) + -1), buffer_max(out, 1)) - buffer_extent(in1, 1)) <= buffer_max(in2, 1)));
+  check((((min((buffer_extent(out, 1) + -1), buffer_max(out, 1)) - max(buffer_extent(in1, 1), buffer_min(out, 1))) + 1) <= buffer_fold_factor(in2, 1)));
   { let intm2 = allocate('intm2', 2, [
       {bounds:{min:buffer_min(out, 0), max:buffer_max(out, 0)}, stride:2, fold_factor:9223372036854775807},
-      {bounds:{min:(min(min((buffer_extent(out, 1) + -1), buffer_max(out, 1)), max(buffer_extent(in1, 1), buffer_min(out, 1))) - buffer_extent(in1, 1)), max:(max(min((buffer_extent(out, 1) + -1), buffer_max(out, 1)), max(buffer_extent(in1, 1), buffer_min(out, 1))) - buffer_extent(in1, 1))}, stride:(buffer_extent(out, 0) * 2), fold_factor:9223372036854775807}
+      {bounds:{min:(max(buffer_extent(in1, 1), buffer_min(out, 1)) - buffer_extent(in1, 1)), max:(min((buffer_extent(out, 1) + -1), buffer_max(out, 1)) - buffer_extent(in1, 1))}, stride:(buffer_extent(out, 0) * 2), fold_factor:9223372036854775807}
     ]);
     { let intm1 = allocate('intm1', 2, [
         {bounds:{min:buffer_min(out, 0), max:buffer_max(out, 0)}, stride:2, fold_factor:9223372036854775807},
-        {bounds:{min:min(min((buffer_extent(in1, 1) + -1), buffer_max(out, 1)), max(buffer_min(out, 1), 0)), max:max(min((buffer_extent(in1, 1) + -1), buffer_max(out, 1)), max(buffer_min(out, 1), 0))}, stride:(buffer_extent(out, 0) * 2), fold_factor:9223372036854775807}
+        {bounds:{min:max(buffer_min(out, 1), 0), max:min((buffer_extent(in1, 1) + -1), buffer_max(out, 1))}, stride:(buffer_extent(out, 0) * 2), fold_factor:9223372036854775807}
       ]);
       consume(in1);
       produce(intm1);
@@ -296,11 +296,11 @@ function pipeline(in1, in2, out) {
       free(intm1);
     }
     {
-      let __base = buffer_at(intm2, buffer_min(out, 0), (max(min(min((buffer_extent(out, 1) + -1), buffer_max(out, 1)), buffer_extent(in1, 1)), buffer_min(out, 1)) - buffer_extent(in1, 1)));
+      let __base = buffer_at(intm2, buffer_min(out, 0), (max(buffer_extent(in1, 1), buffer_min(out, 1)) - buffer_extent(in1, 1)));
       let __elem_size = buffer_elem_size(intm2);
       let __dims = [
           {bounds:{min:buffer_min(out, 0), max:buffer_max(out, 0)}, stride:buffer_stride(intm2, 0), fold_factor:buffer_fold_factor(intm2, 0)},
-          {bounds:{min:max(min(min((buffer_extent(out, 1) + -1), buffer_max(out, 1)), buffer_extent(in1, 1)), buffer_min(out, 1)), max:min(max((buffer_extent(out, 1) + -1), max(buffer_extent(in1, 1), buffer_min(out, 1))), buffer_max(out, 1))}, stride:buffer_stride(intm2, 1), fold_factor:buffer_fold_factor(intm2, 1)}
+          {bounds:{min:max(buffer_extent(in1, 1), buffer_min(out, 1)), max:min((buffer_extent(out, 1) + -1), buffer_max(out, 1))}, stride:buffer_stride(intm2, 1), fold_factor:buffer_fold_factor(intm2, 1)}
       ];
       { let intm2 = make_buffer('intm2', __base, __elem_size, __dims);        consume(intm2);
         produce(out);

--- a/builder/visualize/padded_stencil_0.html
+++ b/builder/visualize/padded_stencil_0.html
@@ -264,33 +264,29 @@ function pipeline(__in, out) {
   check((buffer_elem_size(out) == 2));
   check((buffer_extent(out, 0) <= buffer_fold_factor(out, 0)));
   check((buffer_extent(out, 1) <= buffer_fold_factor(out, 1)));
-  check((buffer_min(__in, 0) <= min(min((buffer_max(out, 0) + 1), buffer_max(__in, 0)), max((buffer_min(out, 0) + -1), buffer_min(__in, 0)))));
-  check((max(min((buffer_max(out, 0) + 1), buffer_max(__in, 0)), max((buffer_min(out, 0) + -1), buffer_min(__in, 0))) <= buffer_max(__in, 0)));
-  check(((abs((min((buffer_max(out, 0) + 1), buffer_max(__in, 0)) - max((buffer_min(out, 0) + -1), buffer_min(__in, 0)))) + 1) <= buffer_fold_factor(__in, 0)));
-  check((buffer_min(__in, 1) <= min(min((buffer_max(out, 1) + 1), buffer_max(__in, 1)), max((buffer_min(out, 1) + -1), buffer_min(__in, 1)))));
-  check((max(min((buffer_max(out, 1) + 1), buffer_max(__in, 1)), max((buffer_min(out, 1) + -1), buffer_min(__in, 1))) <= buffer_max(__in, 1)));
-  check(((abs((min((buffer_max(out, 1) + 1), buffer_max(__in, 1)) - max((buffer_min(out, 1) + -1), buffer_min(__in, 1)))) + 1) <= buffer_fold_factor(__in, 1)));
+  check((((min((buffer_max(out, 0) + 1), buffer_max(__in, 0)) - max((buffer_min(out, 0) + -1), buffer_min(__in, 0))) + 1) <= buffer_fold_factor(__in, 0)));
+  check((((min((buffer_max(out, 1) + 1), buffer_max(__in, 1)) - max((buffer_min(out, 1) + -1), buffer_min(__in, 1))) + 1) <= buffer_fold_factor(__in, 1)));
   { let padded_intm = allocate('padded_intm', 2, [
       {bounds:{min:(buffer_min(out, 0) + -1), max:(buffer_max(out, 0) + 1)}, stride:2, fold_factor:9223372036854775807},
       {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:((buffer_extent(out, 0) * 2) + 4), fold_factor:9223372036854775807}
     ]);
     {
-      let __base = buffer_at(padded_intm, max((buffer_min(out, 0) + -1), min(min((buffer_max(out, 0) + 1), buffer_max(__in, 0)), buffer_min(__in, 0))), max((buffer_min(out, 1) + -1), min(min((buffer_max(out, 1) + 1), buffer_max(__in, 1)), buffer_min(__in, 1))));
+      let __base = buffer_at(padded_intm, max((buffer_min(out, 0) + -1), buffer_min(__in, 0)), max((buffer_min(out, 1) + -1), buffer_min(__in, 1)));
       let __elem_size = 2;
       let __dims = [
-          {bounds:{min:max((buffer_min(out, 0) + -1), min(min((buffer_max(out, 0) + 1), buffer_max(__in, 0)), buffer_min(__in, 0))), max:min((buffer_max(out, 0) + 1), max(max((buffer_min(out, 0) + -1), buffer_min(__in, 0)), buffer_max(__in, 0)))}, stride:buffer_stride(padded_intm, 0), fold_factor:buffer_fold_factor(padded_intm, 0)},
-          {bounds:{min:max((buffer_min(out, 1) + -1), min(min((buffer_max(out, 1) + 1), buffer_max(__in, 1)), buffer_min(__in, 1))), max:min((buffer_max(out, 1) + 1), max(max((buffer_min(out, 1) + -1), buffer_min(__in, 1)), buffer_max(__in, 1)))}, stride:buffer_stride(padded_intm, 1), fold_factor:buffer_fold_factor(padded_intm, 1)}
+          {bounds:{min:max((buffer_min(out, 0) + -1), buffer_min(__in, 0)), max:min((buffer_max(out, 0) + 1), buffer_max(__in, 0))}, stride:buffer_stride(padded_intm, 0), fold_factor:buffer_fold_factor(padded_intm, 0)},
+          {bounds:{min:max((buffer_min(out, 1) + -1), buffer_min(__in, 1)), max:min((buffer_max(out, 1) + 1), buffer_max(__in, 1))}, stride:buffer_stride(padded_intm, 1), fold_factor:buffer_fold_factor(padded_intm, 1)}
       ];
       { let intm = make_buffer('intm', __base, __elem_size, __dims);        consume(__in);
         produce(intm);
       }
     }
     {
-      let __base = buffer_at(padded_intm, max((buffer_min(out, 0) + -1), min(min((buffer_max(out, 0) + 1), buffer_max(__in, 0)), buffer_min(__in, 0))), max((buffer_min(out, 1) + -1), min(min((buffer_max(out, 1) + 1), buffer_max(__in, 1)), buffer_min(__in, 1))));
+      let __base = buffer_at(padded_intm, max((buffer_min(out, 0) + -1), buffer_min(__in, 0)), max((buffer_min(out, 1) + -1), buffer_min(__in, 1)));
       let __elem_size = 2;
       let __dims = [
-          {bounds:{min:max((buffer_min(out, 0) + -1), min(min((buffer_max(out, 0) + 1), buffer_max(__in, 0)), buffer_min(__in, 0))), max:min((buffer_max(out, 0) + 1), max(max((buffer_min(out, 0) + -1), buffer_min(__in, 0)), buffer_max(__in, 0)))}, stride:buffer_stride(padded_intm, 0), fold_factor:buffer_fold_factor(padded_intm, 0)},
-          {bounds:{min:max((buffer_min(out, 1) + -1), min(min((buffer_max(out, 1) + 1), buffer_max(__in, 1)), buffer_min(__in, 1))), max:min((buffer_max(out, 1) + 1), max(max((buffer_min(out, 1) + -1), buffer_min(__in, 1)), buffer_max(__in, 1)))}, stride:buffer_stride(padded_intm, 1), fold_factor:buffer_fold_factor(padded_intm, 1)}
+          {bounds:{min:max((buffer_min(out, 0) + -1), buffer_min(__in, 0)), max:min((buffer_max(out, 0) + 1), buffer_max(__in, 0))}, stride:buffer_stride(padded_intm, 0), fold_factor:buffer_fold_factor(padded_intm, 0)},
+          {bounds:{min:max((buffer_min(out, 1) + -1), buffer_min(__in, 1)), max:min((buffer_max(out, 1) + 1), buffer_max(__in, 1))}, stride:buffer_stride(padded_intm, 1), fold_factor:buffer_fold_factor(padded_intm, 1)}
       ];
       { let intm = make_buffer('intm', __base, __elem_size, __dims);        consume(intm);
         produce(padded_intm);

--- a/builder/visualize/padded_stencil_1.html
+++ b/builder/visualize/padded_stencil_1.html
@@ -264,33 +264,29 @@ function pipeline(__in, out) {
   check((buffer_elem_size(out) == 2));
   check((buffer_extent(out, 0) <= buffer_fold_factor(out, 0)));
   check((buffer_extent(out, 1) <= buffer_fold_factor(out, 1)));
-  check((buffer_min(__in, 0) <= min(min((buffer_max(out, 0) + 1), buffer_max(__in, 0)), max((buffer_min(out, 0) + -1), buffer_min(__in, 0)))));
-  check((max(min((buffer_max(out, 0) + 1), buffer_max(__in, 0)), max((buffer_min(out, 0) + -1), buffer_min(__in, 0))) <= buffer_max(__in, 0)));
-  check(((abs((min((buffer_max(out, 0) + 1), buffer_max(__in, 0)) - max((buffer_min(out, 0) + -1), buffer_min(__in, 0)))) + 1) <= buffer_fold_factor(__in, 0)));
-  check((buffer_min(__in, 1) <= min(min((buffer_max(out, 1) + 1), buffer_max(__in, 1)), max((buffer_min(out, 1) + -1), buffer_min(__in, 1)))));
-  check((max(min((buffer_max(out, 1) + 1), buffer_max(__in, 1)), max((buffer_min(out, 1) + -1), buffer_min(__in, 1))) <= buffer_max(__in, 1)));
-  check(((abs((min((buffer_max(out, 1) + 1), buffer_max(__in, 1)) - max((buffer_min(out, 1) + -1), buffer_min(__in, 1)))) + 1) <= buffer_fold_factor(__in, 1)));
+  check((((min((buffer_max(out, 0) + 1), buffer_max(__in, 0)) - max((buffer_min(out, 0) + -1), buffer_min(__in, 0))) + 1) <= buffer_fold_factor(__in, 0)));
+  check((((min((buffer_max(out, 1) + 1), buffer_max(__in, 1)) - max((buffer_min(out, 1) + -1), buffer_min(__in, 1))) + 1) <= buffer_fold_factor(__in, 1)));
   { let padded_intm = allocate('padded_intm', 2, [
       {bounds:{min:(buffer_min(out, 0) + -1), max:(buffer_max(out, 0) + 1)}, stride:2, fold_factor:9223372036854775807},
       {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:((buffer_extent(out, 0) * 2) + 4), fold_factor:9223372036854775807}
     ]);
     {
-      let __base = buffer_at(padded_intm, max((buffer_min(out, 0) + -1), min(min((buffer_max(out, 0) + 1), buffer_max(__in, 0)), buffer_min(__in, 0))), max((buffer_min(out, 1) + -1), min(min((buffer_max(out, 1) + 1), buffer_max(__in, 1)), buffer_min(__in, 1))));
+      let __base = buffer_at(padded_intm, max((buffer_min(out, 0) + -1), buffer_min(__in, 0)), max((buffer_min(out, 1) + -1), buffer_min(__in, 1)));
       let __elem_size = 2;
       let __dims = [
-          {bounds:{min:max((buffer_min(out, 0) + -1), min(min((buffer_max(out, 0) + 1), buffer_max(__in, 0)), buffer_min(__in, 0))), max:min((buffer_max(out, 0) + 1), max(max((buffer_min(out, 0) + -1), buffer_min(__in, 0)), buffer_max(__in, 0)))}, stride:buffer_stride(padded_intm, 0), fold_factor:buffer_fold_factor(padded_intm, 0)},
-          {bounds:{min:max((buffer_min(out, 1) + -1), min(min((buffer_max(out, 1) + 1), buffer_max(__in, 1)), buffer_min(__in, 1))), max:min((buffer_max(out, 1) + 1), max(max((buffer_min(out, 1) + -1), buffer_min(__in, 1)), buffer_max(__in, 1)))}, stride:buffer_stride(padded_intm, 1), fold_factor:buffer_fold_factor(padded_intm, 1)}
+          {bounds:{min:max((buffer_min(out, 0) + -1), buffer_min(__in, 0)), max:min((buffer_max(out, 0) + 1), buffer_max(__in, 0))}, stride:buffer_stride(padded_intm, 0), fold_factor:buffer_fold_factor(padded_intm, 0)},
+          {bounds:{min:max((buffer_min(out, 1) + -1), buffer_min(__in, 1)), max:min((buffer_max(out, 1) + 1), buffer_max(__in, 1))}, stride:buffer_stride(padded_intm, 1), fold_factor:buffer_fold_factor(padded_intm, 1)}
       ];
       { let intm = make_buffer('intm', __base, __elem_size, __dims);        consume(__in);
         produce(intm);
       }
     }
     {
-      let __base = buffer_at(padded_intm, max((buffer_min(out, 0) + -1), min(min((buffer_max(out, 0) + 1), buffer_max(__in, 0)), buffer_min(__in, 0))), max((buffer_min(out, 1) + -1), min(min((buffer_max(out, 1) + 1), buffer_max(__in, 1)), buffer_min(__in, 1))));
+      let __base = buffer_at(padded_intm, max((buffer_min(out, 0) + -1), buffer_min(__in, 0)), max((buffer_min(out, 1) + -1), buffer_min(__in, 1)));
       let __elem_size = 2;
       let __dims = [
-          {bounds:{min:max((buffer_min(out, 0) + -1), min(min((buffer_max(out, 0) + 1), buffer_max(__in, 0)), buffer_min(__in, 0))), max:min((buffer_max(out, 0) + 1), max(max((buffer_min(out, 0) + -1), buffer_min(__in, 0)), buffer_max(__in, 0)))}, stride:buffer_stride(padded_intm, 0), fold_factor:buffer_fold_factor(padded_intm, 0)},
-          {bounds:{min:max((buffer_min(out, 1) + -1), min(min((buffer_max(out, 1) + 1), buffer_max(__in, 1)), buffer_min(__in, 1))), max:min((buffer_max(out, 1) + 1), max(max((buffer_min(out, 1) + -1), buffer_min(__in, 1)), buffer_max(__in, 1)))}, stride:buffer_stride(padded_intm, 1), fold_factor:buffer_fold_factor(padded_intm, 1)}
+          {bounds:{min:max((buffer_min(out, 0) + -1), buffer_min(__in, 0)), max:min((buffer_max(out, 0) + 1), buffer_max(__in, 0))}, stride:buffer_stride(padded_intm, 0), fold_factor:buffer_fold_factor(padded_intm, 0)},
+          {bounds:{min:max((buffer_min(out, 1) + -1), buffer_min(__in, 1)), max:min((buffer_max(out, 1) + 1), buffer_max(__in, 1))}, stride:buffer_stride(padded_intm, 1), fold_factor:buffer_fold_factor(padded_intm, 1)}
       ];
       { let intm = make_buffer('intm', __base, __elem_size, __dims);        consume(intm);
         produce(padded_intm);

--- a/builder/visualize/padded_stencil_2.html
+++ b/builder/visualize/padded_stencil_2.html
@@ -264,26 +264,19 @@ function pipeline(__in, out) {
   check((buffer_elem_size(out) == 2));
   check((buffer_extent(out, 0) <= buffer_fold_factor(out, 0)));
   check((buffer_extent(out, 1) <= buffer_fold_factor(out, 1)));
-  check((buffer_min(__in, 0) <= min(min((buffer_max(out, 0) + 1), buffer_max(__in, 0)), max((buffer_min(out, 0) + -1), buffer_min(__in, 0)))));
-  check((max(min((buffer_max(out, 0) + 1), buffer_max(__in, 0)), max((buffer_min(out, 0) + -1), buffer_min(__in, 0))) <= buffer_max(__in, 0)));
-  check(((abs((min((buffer_max(out, 0) + 1), buffer_max(__in, 0)) - max((buffer_min(out, 0) + -1), buffer_min(__in, 0)))) + 1) <= buffer_fold_factor(__in, 0)));
-  check((buffer_min(__in, 1) <= min(min((buffer_max(out, 1) + 1), buffer_max(__in, 1)), max((buffer_min(out, 1) + -1), buffer_min(__in, 1)))));
-  check((max(min((buffer_max(out, 1) + 1), buffer_max(__in, 1)), max((buffer_min(out, 1) + -1), buffer_min(__in, 1))) <= buffer_max(__in, 1)));
-  check(((abs((min((buffer_max(out, 1) + 1), buffer_max(__in, 1)) - max((buffer_min(out, 1) + -1), buffer_min(__in, 1)))) + 1) <= buffer_fold_factor(__in, 1)));
+  check((((min((buffer_max(out, 0) + 1), buffer_max(__in, 0)) - max((buffer_min(out, 0) + -1), buffer_min(__in, 0))) + 1) <= buffer_fold_factor(__in, 0)));
+  check((((min((buffer_max(out, 1) + 1), buffer_max(__in, 1)) - max((buffer_min(out, 1) + -1), buffer_min(__in, 1))) + 1) <= buffer_fold_factor(__in, 1)));
   { let padded_intm = allocate('padded_intm', 2, [
       {bounds:{min:(buffer_min(out, 0) + -1), max:(buffer_max(out, 0) + 1)}, stride:2, fold_factor:9223372036854775807},
       {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:((buffer_extent(out, 0) * 2) + 4), fold_factor:3}
     ]);
     { let padded_intm_uncropped = clone_buffer(padded_intm);
       { let intm = allocate('intm', 2, [
-          {bounds:{min:min(min((buffer_max(out, 0) + 1), buffer_max(__in, 0)), max((buffer_min(out, 0) + -1), buffer_min(__in, 0))), max:max(min((buffer_max(out, 0) + 1), buffer_max(__in, 0)), max((buffer_min(out, 0) + -1), buffer_min(__in, 0)))}, stride:2, fold_factor:9223372036854775807},
-          {bounds:{min:min(min((buffer_max(out, 1) + 1), buffer_max(__in, 1)), max((buffer_min(out, 1) + -1), buffer_min(__in, 1))), max:max(min((buffer_max(out, 1) + 1), buffer_max(__in, 1)), max((buffer_min(out, 1) + -1), buffer_min(__in, 1)))}, stride:((abs((min((buffer_max(out, 0) + 1), buffer_max(__in, 0)) - max((buffer_min(out, 0) + -1), buffer_min(__in, 0)))) * 2) + 2), fold_factor:9223372036854775807}
+          {bounds:{min:max((buffer_min(out, 0) + -1), buffer_min(__in, 0)), max:min((buffer_max(out, 0) + 1), buffer_max(__in, 0))}, stride:2, fold_factor:9223372036854775807},
+          {bounds:{min:max((buffer_min(out, 1) + -1), buffer_min(__in, 1)), max:min((buffer_max(out, 1) + 1), buffer_max(__in, 1))}, stride:(((min((buffer_max(out, 0) + 1), buffer_max(__in, 0)) - max((buffer_min(out, 0) + -1), buffer_min(__in, 0))) * 2) + 2), fold_factor:9223372036854775807}
         ]);
         for(let y = (buffer_min(out, 1) + -2); y <= buffer_max(out, 1); y += 1) {
-          { let __intm = crop_buffer(intm, [
-              {min:min(min((buffer_max(out, 0) + 1), max(max((buffer_min(out, 0) + -1), buffer_min(__in, 0)), buffer_max(__in, 0))), max((buffer_min(out, 0) + -1), min(min((buffer_max(out, 0) + 1), buffer_max(__in, 0)), buffer_min(__in, 0)))), max:max(min((buffer_max(out, 0) + 1), max(max((buffer_min(out, 0) + -1), buffer_min(__in, 0)), buffer_max(__in, 0))), max((buffer_min(out, 0) + -1), min(min((buffer_max(out, 0) + 1), buffer_max(__in, 0)), buffer_min(__in, 0))))},
-              {min:min(min((y + 1), max(min(max((buffer_max(out, 1) + 1), max((buffer_min(out, 1) + -1), buffer_min(__in, 1))), buffer_max(__in, 1)), max((y + -1), max(min((buffer_min(out, 1) + -1), min((buffer_max(out, 1) + 1), buffer_max(__in, 1))), buffer_min(__in, 1))))), max(max((y + -1), min(min((y + 1), min(max((buffer_max(out, 1) + 1), max((buffer_min(out, 1) + -1), buffer_min(__in, 1))), buffer_max(__in, 1))), max(min((buffer_min(out, 1) + -1), min((buffer_max(out, 1) + 1), buffer_max(__in, 1))), buffer_min(__in, 1)))), max((y + 1), min(min((y + 1), min(max((buffer_max(out, 1) + 1), max((buffer_min(out, 1) + -1), buffer_min(__in, 1))), buffer_max(__in, 1))), max((y + -1), max(min((buffer_min(out, 1) + -1), min((buffer_max(out, 1) + 1), buffer_max(__in, 1))), buffer_min(__in, 1))))))), max:max(min((y + 1), max(min(max((buffer_max(out, 1) + 1), max((buffer_min(out, 1) + -1), buffer_min(__in, 1))), buffer_max(__in, 1)), max((y + -1), max(min((buffer_min(out, 1) + -1), min((buffer_max(out, 1) + 1), buffer_max(__in, 1))), buffer_min(__in, 1))))), min(max((y + -1), min(min((y + 1), min(max((buffer_max(out, 1) + 1), max((buffer_min(out, 1) + -1), buffer_min(__in, 1))), buffer_max(__in, 1))), max(min((buffer_min(out, 1) + -1), min((buffer_max(out, 1) + 1), buffer_max(__in, 1))), buffer_min(__in, 1)))), max((y + 1), min(min((y + 1), min(max((buffer_max(out, 1) + 1), max((buffer_min(out, 1) + -1), buffer_min(__in, 1))), buffer_max(__in, 1))), max((y + -1), max(min((buffer_min(out, 1) + -1), min((buffer_max(out, 1) + 1), buffer_max(__in, 1))), buffer_min(__in, 1)))))))}
-          ]);
+          { let __intm = crop_dim(intm, 1, {min:(max(y, (max(y, buffer_min(out, 1)) + -2)) + 1), max:(y + 1)});
             consume(__in);
             produce(intm);
             intm = __intm;


### PR DESCRIPTION
All tests pass with bazel test //... --cache_test_results=no.

I think there might be a similar opportunity in slide_and_fold_storage, will look into it next.

Based on @dsharlet  branch and lot of  help from him.