### PR TITLE
Remove `buffer_extent`

### DIFF
--- a/builder/optimizations.cc
+++ b/builder/optimizations.cc
@@ -365,7 +365,6 @@ stmt implement_copy(const copy_stmt* op, node_context& ctx) {
   for (int d = 0; d < static_cast<index_t>(op->dst_x.size()); ++d) {
     do_substitute(buffer_min(dst_var, d));
     do_substitute(buffer_max(dst_var, d));
-    do_substitute(buffer_extent(dst_var, d));
     do_substitute(buffer_stride(dst_var, d));
     do_substitute(buffer_fold_factor(dst_var, d));
   }

--- a/builder/pipeline.cc
+++ b/builder/pipeline.cc
@@ -529,10 +529,7 @@ class pipeline_builder {
           substitutions.emplace_back(buffer_max(alloc_var, d), bounds_d.max);
           substitutions.emplace_back(buffer_stride(alloc_var, d), stride);
 
-          // We didn't initially set up the buffer with an extent, but the user might have used it.
-          expr extent = bounds_d.extent();
-          substitutions.emplace_back(buffer_extent(alloc_var, d), extent);
-          stride *= min(extent, buffer_fold_factor(alloc_var, d));
+          stride *= min(bounds_d.extent(), buffer_fold_factor(alloc_var, d));
         }
         std::vector<dim_expr> dims = substitute_from_map(b->dims(), substitutions);
 

--- a/builder/rewrite.h
+++ b/builder/rewrite.h
@@ -371,9 +371,6 @@ inline auto buffer_min(const pattern_wildcard& buf, const pattern_wildcard& dim)
 inline auto buffer_max(const pattern_wildcard& buf, const pattern_wildcard& dim) {
   return buffer_dim_meta{intrinsic::buffer_max, {buf, dim}};
 }
-inline auto buffer_extent(const pattern_wildcard& buf, const pattern_wildcard& dim) {
-  return buffer_dim_meta{intrinsic::buffer_extent, {buf, dim}};
-}
 
 template <typename T>
 auto eval(const T& x) {

--- a/builder/simplify_exprs.cc
+++ b/builder/simplify_exprs.cc
@@ -221,10 +221,6 @@ expr simplify(const add* op, expr a, expr b) {
       r.rewrite(select(x, c0 - y, z + c1) + c2, select(x, eval(c0 + c2) - y, z + eval(c1 + c2))) ||
       r.rewrite(select(x, y + c0, c1 - z) + c2, select(x, y + eval(c0 + c2), eval(c1 + c2) - z)) ||
       r.rewrite(select(x, c0 - y, c1 - z) + c2, select(x, eval(c0 + c2) - y, eval(c1 + c2) - z)) ||
-
-      r.rewrite(buffer_min(x, y) + buffer_extent(x, y), buffer_max(x, y) + 1) ||
-      r.rewrite((z - buffer_max(x, y)) + buffer_min(x, y), (z - buffer_extent(x, y)) + 1) ||
-      r.rewrite((z - buffer_min(x, y)) + buffer_max(x, y), (z + buffer_extent(x, y)) + -1) || 
       false) {
     return r.result;
   }
@@ -291,10 +287,6 @@ expr simplify(const sub* op, expr a, expr b) {
     
       r.rewrite(max(x, y) - min(x, y), abs(x - y)) ||
       r.rewrite(min(x, y) - max(x, y), -abs(x - y)) ||
-
-      r.rewrite(buffer_max(x, y) - buffer_min(x, y), buffer_extent(x, y) + -1) ||
-      r.rewrite(buffer_max(x, y) - (z + buffer_min(x, y)), (buffer_extent(x, y) - z) + -1) ||
-      r.rewrite((z + buffer_max(x, y)) - buffer_min(x, y), (z + buffer_extent(x, y)) + -1) ||
       false) {
     return r.result;
   }
@@ -497,9 +489,6 @@ expr simplify(const less* op, expr a, expr b) {
       r.rewrite(min(x, y) < max(x, y), x != y) ||
       r.rewrite(max(x, y) < min(x, y), false) ||
       r.rewrite(min(x, y) < min(x, z), y < min(x, z)) ||
-
-      r.rewrite(buffer_extent(x, y) < c0, false, eval(c0 <= 0)) ||
-      r.rewrite(c0 < buffer_extent(x, y), true, eval(c0 < 0)) ||
       false) {
     return r.result;
   }
@@ -728,7 +717,6 @@ expr simplify(const call* op, intrinsic fn, std::vector<expr> args) {
   if (r.rewrite(abs(x * c0), abs(x) * c0, c0 > 0) ||
       r.rewrite(abs(x * c0), abs(x) * eval(-c0), c0 < 0) ||
       r.rewrite(abs(c0 - x), abs(x + eval(-c0))) ||
-      r.rewrite(abs(buffer_extent(x, y)), buffer_extent(x, y)) ||
       false) {
     return r.result;
   }

--- a/builder/simplify_test.cc
+++ b/builder/simplify_test.cc
@@ -165,11 +165,7 @@ TEST(simplify, let) {
 }
 
 TEST(simplify, buffer_intrinsics) {
-  test_simplify(buffer_extent(x, 0) >= 0, true);
-  test_simplify((buffer_max(x, 0) - buffer_min(x, 0) + 1) * 4, buffer_extent(x, 0) * 4);
-  test_simplify(buffer_max(x, 0) - buffer_min(x, 1) + 1, buffer_max(x, 0) - buffer_min(x, 1) + 1);
   test_simplify(max(buffer_max(x, 0) + 1, buffer_min(x, 0) - 1), buffer_max(x, 0) + 1);
-  test_simplify(buffer_max(x, 1) - buffer_min(x, 1) + 1 <= y, buffer_extent(x, 1) <= y);
 }
 
 TEST(simplify, bounds) {
@@ -327,10 +323,9 @@ constexpr int max_abs_constant = 256;
 index_t random_constant() { return (rand() & (2 * max_abs_constant - 1)) - max_abs_constant; }
 
 expr random_buffer_intrinsic() {
-  switch (rand() % 3) {
+  switch (rand() % 2) {
   case 0: return buffer_min(random_pick(bufs), rand() % max_rank);
-  case 1: return buffer_extent(random_pick(bufs), rand() % max_rank);
-  case 2: return buffer_max(random_pick(bufs), rand() % max_rank);
+  case 1: return buffer_max(random_pick(bufs), rand() % max_rank);
   default: return buffer_at(random_pick(bufs));
   }
 }

--- a/builder/substitute.cc
+++ b/builder/substitute.cc
@@ -759,7 +759,6 @@ public:
     case intrinsic::buffer_max:
     case intrinsic::buffer_stride:
     case intrinsic::buffer_fold_factor:
-    case intrinsic::buffer_extent:
       if (is_variable(op->args[0], sym)) {
         const index_t* dim = as_constant(op->args[1]);
         assert(dim);

--- a/builder/visualize/concatenate_0.html
+++ b/builder/visualize/concatenate_0.html
@@ -265,37 +265,37 @@ function pipeline(in1, in2, out) {
   check((out != 0));
   check((buffer_rank(out) == 2));
   check((buffer_elem_size(out) == 2));
-  check((buffer_extent(out, 0) <= buffer_fold_factor(out, 0)));
-  check((buffer_extent(out, 1) <= buffer_fold_factor(out, 1)));
+  check((((buffer_max(out, 0) - buffer_min(out, 0)) + 1) <= buffer_fold_factor(out, 0)));
+  check((((buffer_max(out, 1) - buffer_min(out, 1)) + 1) <= buffer_fold_factor(out, 1)));
   check((buffer_min(in1, 0) <= buffer_min(out, 0)));
   check((buffer_max(out, 0) <= buffer_max(in1, 0)));
-  check((buffer_extent(out, 0) <= buffer_fold_factor(in1, 0)));
+  check((((buffer_max(out, 0) - buffer_min(out, 0)) + 1) <= buffer_fold_factor(in1, 0)));
   check((buffer_min(in1, 1) <= max(buffer_min(out, 1), 0)));
-  check((min((buffer_extent(in1, 1) + -1), buffer_max(out, 1)) <= buffer_max(in1, 1)));
-  check((((min((buffer_extent(in1, 1) + -1), buffer_max(out, 1)) - max(buffer_min(out, 1), 0)) + 1) <= buffer_fold_factor(in1, 1)));
+  check((min((buffer_max(in1, 1) - buffer_min(in1, 1)), buffer_max(out, 1)) <= buffer_max(in1, 1)));
+  check((((min((buffer_max(in1, 1) - buffer_min(in1, 1)), buffer_max(out, 1)) - max(buffer_min(out, 1), 0)) + 1) <= buffer_fold_factor(in1, 1)));
   check((buffer_min(in2, 0) <= buffer_min(out, 0)));
   check((buffer_max(out, 0) <= buffer_max(in2, 0)));
-  check((buffer_extent(out, 0) <= buffer_fold_factor(in2, 0)));
-  check((buffer_min(in2, 1) <= (max(buffer_extent(in1, 1), buffer_min(out, 1)) - buffer_extent(in1, 1))));
-  check(((min((buffer_extent(out, 1) + -1), buffer_max(out, 1)) - buffer_extent(in1, 1)) <= buffer_max(in2, 1)));
-  check((((min((buffer_extent(out, 1) + -1), buffer_max(out, 1)) - max(buffer_extent(in1, 1), buffer_min(out, 1))) + 1) <= buffer_fold_factor(in2, 1)));
+  check((((buffer_max(out, 0) - buffer_min(out, 0)) + 1) <= buffer_fold_factor(in2, 0)));
+  check((buffer_min(in2, 1) <= (max((buffer_min(out, 1) - (buffer_max(in1, 1) - buffer_min(in1, 1))), 1) + -1)));
+  check((((min((buffer_max(out, 1) - buffer_min(out, 1)), buffer_max(out, 1)) - (buffer_max(in1, 1) - buffer_min(in1, 1))) + -1) <= buffer_max(in2, 1)));
+  check(((((min((buffer_max(out, 1) - buffer_min(out, 1)), buffer_max(out, 1)) - (buffer_max(in1, 1) - buffer_min(in1, 1))) - max((buffer_min(out, 1) - (buffer_max(in1, 1) - buffer_min(in1, 1))), 1)) + 1) <= buffer_fold_factor(in2, 1)));
   {
     let __base = buffer_at(out, NaN, max(buffer_min(out, 1), 0));
     let __elem_size = 2;
     let __dims = [
         {bounds:{min:buffer_min(out, 0), max:buffer_max(out, 0)}, stride:buffer_stride(out, 0), fold_factor:buffer_fold_factor(out, 0)},
-        {bounds:{min:max(buffer_min(out, 1), 0), max:min((buffer_extent(in1, 1) + -1), buffer_max(out, 1))}, stride:buffer_stride(out, 1), fold_factor:buffer_fold_factor(out, 1)}
+        {bounds:{min:max(buffer_min(out, 1), 0), max:min((buffer_max(in1, 1) - buffer_min(in1, 1)), buffer_max(out, 1))}, stride:buffer_stride(out, 1), fold_factor:buffer_fold_factor(out, 1)}
     ];
     { let intm1 = make_buffer('intm1', __base, __elem_size, __dims);      consume(in1);
       produce(intm1);
     }
   }
   {
-    let __base = buffer_at(out, NaN, max((buffer_min(out, 1) + buffer_extent(in1, 1)), (max(buffer_extent(in1, 1), buffer_min(out, 1)) - buffer_extent(in1, 1))));
+    let __base = buffer_at(out, NaN, (max(((buffer_min(out, 1) - (buffer_min(in1, 1) - buffer_max(in1, 1))) + 2), max((buffer_min(out, 1) - (buffer_max(in1, 1) - buffer_min(in1, 1))), 1)) + -1));
     let __elem_size = 2;
     let __dims = [
         {bounds:{min:buffer_min(out, 0), max:buffer_max(out, 0)}, stride:buffer_stride(out, 0), fold_factor:buffer_fold_factor(out, 0)},
-        {bounds:{min:max((max(buffer_extent(in1, 1), buffer_min(out, 1)) - buffer_extent(in1, 1)), buffer_min(out, 1)), max:min((min((buffer_extent(out, 1) + -1), buffer_max(out, 1)) - buffer_extent(in1, 1)), buffer_max(out, 1))}, stride:buffer_stride(out, 1), fold_factor:buffer_fold_factor(out, 1)}
+        {bounds:{min:max((max((buffer_min(out, 1) - (buffer_max(in1, 1) - buffer_min(in1, 1))), 1) + -1), buffer_min(out, 1)), max:min(((min((buffer_max(out, 1) - buffer_min(out, 1)), buffer_max(out, 1)) - (buffer_max(in1, 1) - buffer_min(in1, 1))) + -1), buffer_max(out, 1))}, stride:buffer_stride(out, 1), fold_factor:buffer_fold_factor(out, 1)}
     ];
     { let intm2 = make_buffer('intm2', __base, __elem_size, __dims);      consume(in2);
       produce(intm2);

--- a/builder/visualize/concatenate_1.html
+++ b/builder/visualize/concatenate_1.html
@@ -265,27 +265,27 @@ function pipeline(in1, in2, out) {
   check((out != 0));
   check((buffer_rank(out) == 2));
   check((buffer_elem_size(out) == 2));
-  check((buffer_extent(out, 0) <= buffer_fold_factor(out, 0)));
-  check((buffer_extent(out, 1) <= buffer_fold_factor(out, 1)));
+  check((((buffer_max(out, 0) - buffer_min(out, 0)) + 1) <= buffer_fold_factor(out, 0)));
+  check((((buffer_max(out, 1) - buffer_min(out, 1)) + 1) <= buffer_fold_factor(out, 1)));
   check((buffer_min(in1, 0) <= buffer_min(out, 0)));
   check((buffer_max(out, 0) <= buffer_max(in1, 0)));
-  check((buffer_extent(out, 0) <= buffer_fold_factor(in1, 0)));
+  check((((buffer_max(out, 0) - buffer_min(out, 0)) + 1) <= buffer_fold_factor(in1, 0)));
   check((buffer_min(in1, 1) <= max(buffer_min(out, 1), 0)));
-  check((min((buffer_extent(in1, 1) + -1), buffer_max(out, 1)) <= buffer_max(in1, 1)));
-  check((((min((buffer_extent(in1, 1) + -1), buffer_max(out, 1)) - max(buffer_min(out, 1), 0)) + 1) <= buffer_fold_factor(in1, 1)));
+  check((min((buffer_max(in1, 1) - buffer_min(in1, 1)), buffer_max(out, 1)) <= buffer_max(in1, 1)));
+  check((((min((buffer_max(in1, 1) - buffer_min(in1, 1)), buffer_max(out, 1)) - max(buffer_min(out, 1), 0)) + 1) <= buffer_fold_factor(in1, 1)));
   check((buffer_min(in2, 0) <= buffer_min(out, 0)));
   check((buffer_max(out, 0) <= buffer_max(in2, 0)));
-  check((buffer_extent(out, 0) <= buffer_fold_factor(in2, 0)));
-  check((buffer_min(in2, 1) <= (max(buffer_extent(in1, 1), buffer_min(out, 1)) - buffer_extent(in1, 1))));
-  check(((min((buffer_extent(out, 1) + -1), buffer_max(out, 1)) - buffer_extent(in1, 1)) <= buffer_max(in2, 1)));
-  check((((min((buffer_extent(out, 1) + -1), buffer_max(out, 1)) - max(buffer_extent(in1, 1), buffer_min(out, 1))) + 1) <= buffer_fold_factor(in2, 1)));
+  check((((buffer_max(out, 0) - buffer_min(out, 0)) + 1) <= buffer_fold_factor(in2, 0)));
+  check((buffer_min(in2, 1) <= (max((buffer_min(out, 1) - (buffer_max(in1, 1) - buffer_min(in1, 1))), 1) + -1)));
+  check((((min((buffer_max(out, 1) - buffer_min(out, 1)), buffer_max(out, 1)) - (buffer_max(in1, 1) - buffer_min(in1, 1))) + -1) <= buffer_max(in2, 1)));
+  check(((((min((buffer_max(out, 1) - buffer_min(out, 1)), buffer_max(out, 1)) - (buffer_max(in1, 1) - buffer_min(in1, 1))) - max((buffer_min(out, 1) - (buffer_max(in1, 1) - buffer_min(in1, 1))), 1)) + 1) <= buffer_fold_factor(in2, 1)));
   { let intm2 = allocate('intm2', 2, [
       {bounds:{min:buffer_min(out, 0), max:buffer_max(out, 0)}, stride:2, fold_factor:9223372036854775807},
-      {bounds:{min:(max(buffer_extent(in1, 1), buffer_min(out, 1)) - buffer_extent(in1, 1)), max:(min((buffer_extent(out, 1) + -1), buffer_max(out, 1)) - buffer_extent(in1, 1))}, stride:(buffer_extent(out, 0) * 2), fold_factor:9223372036854775807}
+      {bounds:{min:(max((buffer_min(out, 1) - (buffer_max(in1, 1) - buffer_min(in1, 1))), 1) + -1), max:((min((buffer_max(out, 1) - buffer_min(out, 1)), buffer_max(out, 1)) - (buffer_max(in1, 1) - buffer_min(in1, 1))) + -1)}, stride:(((buffer_max(out, 0) - buffer_min(out, 0)) * 2) + 2), fold_factor:9223372036854775807}
     ]);
     { let intm1 = allocate('intm1', 2, [
         {bounds:{min:buffer_min(out, 0), max:buffer_max(out, 0)}, stride:2, fold_factor:9223372036854775807},
-        {bounds:{min:max(buffer_min(out, 1), 0), max:min((buffer_extent(in1, 1) + -1), buffer_max(out, 1))}, stride:(buffer_extent(out, 0) * 2), fold_factor:9223372036854775807}
+        {bounds:{min:max(buffer_min(out, 1), 0), max:min((buffer_max(in1, 1) - buffer_min(in1, 1)), buffer_max(out, 1))}, stride:(((buffer_max(out, 0) - buffer_min(out, 0)) * 2) + 2), fold_factor:9223372036854775807}
       ]);
       consume(in1);
       produce(intm1);
@@ -296,14 +296,17 @@ function pipeline(in1, in2, out) {
       free(intm1);
     }
     {
-      let __base = buffer_at(intm2, buffer_min(out, 0), (max(buffer_extent(in1, 1), buffer_min(out, 1)) - buffer_extent(in1, 1)));
-      let __elem_size = buffer_elem_size(intm2);
-      let __dims = [
-          {bounds:{min:buffer_min(out, 0), max:buffer_max(out, 0)}, stride:buffer_stride(intm2, 0), fold_factor:buffer_fold_factor(intm2, 0)},
-          {bounds:{min:max(buffer_extent(in1, 1), buffer_min(out, 1)), max:min((buffer_extent(out, 1) + -1), buffer_max(out, 1))}, stride:buffer_stride(intm2, 1), fold_factor:buffer_fold_factor(intm2, 1)}
-      ];
-      { let intm2 = make_buffer('intm2', __base, __elem_size, __dims);        consume(intm2);
-        produce(out);
+      let _6 = buffer_min(out, 1);
+      {
+        let __base = buffer_at(intm2, buffer_min(out, 0), (max((_6 + (buffer_min(in1, 1) - buffer_max(in1, 1))), max((buffer_min(out, 1) - (buffer_max(in1, 1) - buffer_min(in1, 1))), 1)) + -1));
+        let __elem_size = buffer_elem_size(intm2);
+        let __dims = [
+            {bounds:{min:buffer_min(out, 0), max:buffer_max(out, 0)}, stride:buffer_stride(intm2, 0), fold_factor:buffer_fold_factor(intm2, 0)},
+            {bounds:{min:max(_6, (max((buffer_min(out, 1) - (buffer_max(in1, 1) - buffer_min(in1, 1))), 1) - (buffer_min(in1, 1) - buffer_max(in1, 1)))), max:min(((min((buffer_max(out, 1) - buffer_min(out, 1)), buffer_max(out, 1)) - (buffer_max(in1, 1) - buffer_min(in1, 1))) - (buffer_min(in1, 1) - buffer_max(in1, 1))), buffer_max(out, 1))}, stride:buffer_stride(intm2, 1), fold_factor:buffer_fold_factor(intm2, 1)}
+        ];
+        { let intm2 = make_buffer('intm2', __base, __elem_size, __dims);          consume(intm2);
+          produce(out);
+        }
       }
     }
     free(intm2);

--- a/builder/visualize/padded_stencil_0.html
+++ b/builder/visualize/padded_stencil_0.html
@@ -262,13 +262,13 @@ function pipeline(__in, out) {
   check((out != 0));
   check((buffer_rank(out) == 2));
   check((buffer_elem_size(out) == 2));
-  check((buffer_extent(out, 0) <= buffer_fold_factor(out, 0)));
-  check((buffer_extent(out, 1) <= buffer_fold_factor(out, 1)));
+  check((((buffer_max(out, 0) - buffer_min(out, 0)) + 1) <= buffer_fold_factor(out, 0)));
+  check((((buffer_max(out, 1) - buffer_min(out, 1)) + 1) <= buffer_fold_factor(out, 1)));
   check((((min((buffer_max(out, 0) + 1), buffer_max(__in, 0)) - max((buffer_min(out, 0) + -1), buffer_min(__in, 0))) + 1) <= buffer_fold_factor(__in, 0)));
   check((((min((buffer_max(out, 1) + 1), buffer_max(__in, 1)) - max((buffer_min(out, 1) + -1), buffer_min(__in, 1))) + 1) <= buffer_fold_factor(__in, 1)));
   { let padded_intm = allocate('padded_intm', 2, [
       {bounds:{min:(buffer_min(out, 0) + -1), max:(buffer_max(out, 0) + 1)}, stride:2, fold_factor:9223372036854775807},
-      {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:((buffer_extent(out, 0) * 2) + 4), fold_factor:9223372036854775807}
+      {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:(((buffer_max(out, 0) - buffer_min(out, 0)) * 2) + 6), fold_factor:9223372036854775807}
     ]);
     {
       let __base = buffer_at(padded_intm, max((buffer_min(out, 0) + -1), buffer_min(__in, 0)), max((buffer_min(out, 1) + -1), buffer_min(__in, 1)));

--- a/builder/visualize/padded_stencil_1.html
+++ b/builder/visualize/padded_stencil_1.html
@@ -262,13 +262,13 @@ function pipeline(__in, out) {
   check((out != 0));
   check((buffer_rank(out) == 2));
   check((buffer_elem_size(out) == 2));
-  check((buffer_extent(out, 0) <= buffer_fold_factor(out, 0)));
-  check((buffer_extent(out, 1) <= buffer_fold_factor(out, 1)));
+  check((((buffer_max(out, 0) - buffer_min(out, 0)) + 1) <= buffer_fold_factor(out, 0)));
+  check((((buffer_max(out, 1) - buffer_min(out, 1)) + 1) <= buffer_fold_factor(out, 1)));
   check((((min((buffer_max(out, 0) + 1), buffer_max(__in, 0)) - max((buffer_min(out, 0) + -1), buffer_min(__in, 0))) + 1) <= buffer_fold_factor(__in, 0)));
   check((((min((buffer_max(out, 1) + 1), buffer_max(__in, 1)) - max((buffer_min(out, 1) + -1), buffer_min(__in, 1))) + 1) <= buffer_fold_factor(__in, 1)));
   { let padded_intm = allocate('padded_intm', 2, [
       {bounds:{min:(buffer_min(out, 0) + -1), max:(buffer_max(out, 0) + 1)}, stride:2, fold_factor:9223372036854775807},
-      {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:((buffer_extent(out, 0) * 2) + 4), fold_factor:9223372036854775807}
+      {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:(((buffer_max(out, 0) - buffer_min(out, 0)) * 2) + 6), fold_factor:9223372036854775807}
     ]);
     {
       let __base = buffer_at(padded_intm, max((buffer_min(out, 0) + -1), buffer_min(__in, 0)), max((buffer_min(out, 1) + -1), buffer_min(__in, 1)));

--- a/builder/visualize/padded_stencil_2.html
+++ b/builder/visualize/padded_stencil_2.html
@@ -262,13 +262,13 @@ function pipeline(__in, out) {
   check((out != 0));
   check((buffer_rank(out) == 2));
   check((buffer_elem_size(out) == 2));
-  check((buffer_extent(out, 0) <= buffer_fold_factor(out, 0)));
-  check((buffer_extent(out, 1) <= buffer_fold_factor(out, 1)));
+  check((((buffer_max(out, 0) - buffer_min(out, 0)) + 1) <= buffer_fold_factor(out, 0)));
+  check((((buffer_max(out, 1) - buffer_min(out, 1)) + 1) <= buffer_fold_factor(out, 1)));
   check((((min((buffer_max(out, 0) + 1), buffer_max(__in, 0)) - max((buffer_min(out, 0) + -1), buffer_min(__in, 0))) + 1) <= buffer_fold_factor(__in, 0)));
   check((((min((buffer_max(out, 1) + 1), buffer_max(__in, 1)) - max((buffer_min(out, 1) + -1), buffer_min(__in, 1))) + 1) <= buffer_fold_factor(__in, 1)));
   { let padded_intm = allocate('padded_intm', 2, [
       {bounds:{min:(buffer_min(out, 0) + -1), max:(buffer_max(out, 0) + 1)}, stride:2, fold_factor:9223372036854775807},
-      {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:((buffer_extent(out, 0) * 2) + 4), fold_factor:3}
+      {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:(((buffer_max(out, 0) - buffer_min(out, 0)) * 2) + 6), fold_factor:3}
     ]);
     { let padded_intm_uncropped = clone_buffer(padded_intm);
       { let intm = allocate('intm', 2, [

--- a/builder/visualize/parallel_stencils_0.html
+++ b/builder/visualize/parallel_stencils_0.html
@@ -265,38 +265,38 @@ function pipeline(in1, in2, out) {
   check((out != 0));
   check((buffer_rank(out) == 2));
   check((buffer_elem_size(out) == 2));
-  check((buffer_extent(out, 0) <= buffer_fold_factor(out, 0)));
-  check((buffer_extent(out, 1) <= buffer_fold_factor(out, 1)));
+  check((((buffer_max(out, 0) - buffer_min(out, 0)) + 1) <= buffer_fold_factor(out, 0)));
+  check((((buffer_max(out, 1) - buffer_min(out, 1)) + 1) <= buffer_fold_factor(out, 1)));
   check((buffer_min(in1, 0) <= (buffer_min(out, 0) + -1)));
   check(((buffer_max(out, 0) + 1) <= buffer_max(in1, 0)));
-  check(((buffer_extent(out, 0) + 2) <= buffer_fold_factor(in1, 0)));
+  check((((buffer_max(out, 0) - buffer_min(out, 0)) + 3) <= buffer_fold_factor(in1, 0)));
   check((buffer_min(in1, 1) <= (buffer_min(out, 1) + -1)));
   check(((buffer_max(out, 1) + 1) <= buffer_max(in1, 1)));
-  check(((buffer_extent(out, 1) + 2) <= buffer_fold_factor(in1, 1)));
+  check((((buffer_max(out, 1) - buffer_min(out, 1)) + 3) <= buffer_fold_factor(in1, 1)));
   check((buffer_min(in2, 0) <= (buffer_min(out, 0) + -2)));
   check(((buffer_max(out, 0) + 2) <= buffer_max(in2, 0)));
-  check(((buffer_extent(out, 0) + 4) <= buffer_fold_factor(in2, 0)));
+  check((((buffer_max(out, 0) - buffer_min(out, 0)) + 5) <= buffer_fold_factor(in2, 0)));
   check((buffer_min(in2, 1) <= (buffer_min(out, 1) + -2)));
   check(((buffer_max(out, 1) + 2) <= buffer_max(in2, 1)));
-  check(((buffer_extent(out, 1) + 4) <= buffer_fold_factor(in2, 1)));
+  check((((buffer_max(out, 1) - buffer_min(out, 1)) + 5) <= buffer_fold_factor(in2, 1)));
   { let intm4 = allocate('intm4', 2, [
       {bounds:{min:buffer_min(out, 0), max:buffer_max(out, 0)}, stride:2, fold_factor:9223372036854775807},
-      {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:(buffer_extent(out, 0) * 2), fold_factor:1}
+      {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:(((buffer_max(out, 0) - buffer_min(out, 0)) * 2) + 2), fold_factor:1}
     ]);
     { let intm4_uncropped = clone_buffer(intm4);
       { let intm2 = allocate('intm2', 2, [
           {bounds:{min:(buffer_min(out, 0) + -2), max:(buffer_max(out, 0) + 2)}, stride:2, fold_factor:9223372036854775807},
-          {bounds:{min:(buffer_min(out, 1) + -2), max:(buffer_max(out, 1) + 2)}, stride:((buffer_extent(out, 0) * 2) + 8), fold_factor:5}
+          {bounds:{min:(buffer_min(out, 1) + -2), max:(buffer_max(out, 1) + 2)}, stride:(((buffer_max(out, 0) - buffer_min(out, 0)) * 2) + 10), fold_factor:5}
         ]);
         { let intm2_uncropped = clone_buffer(intm2);
           { let intm3 = allocate('intm3', 2, [
               {bounds:{min:buffer_min(out, 0), max:buffer_max(out, 0)}, stride:2, fold_factor:9223372036854775807},
-              {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:(buffer_extent(out, 0) * 2), fold_factor:1}
+              {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:(((buffer_max(out, 0) - buffer_min(out, 0)) * 2) + 2), fold_factor:1}
             ]);
             { let intm3_uncropped = clone_buffer(intm3);
               { let intm1 = allocate('intm1', 2, [
                   {bounds:{min:(buffer_min(out, 0) + -1), max:(buffer_max(out, 0) + 1)}, stride:2, fold_factor:9223372036854775807},
-                  {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:((buffer_extent(out, 0) * 2) + 4), fold_factor:3}
+                  {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:(((buffer_max(out, 0) - buffer_min(out, 0)) * 2) + 6), fold_factor:3}
                 ]);
                 { let intm1_uncropped = clone_buffer(intm1);
                   for(let y = (buffer_min(out, 1) + -6); y <= buffer_max(out, 1); y += 1) {

--- a/builder/visualize/parallel_stencils_1.html
+++ b/builder/visualize/parallel_stencils_1.html
@@ -265,38 +265,38 @@ function pipeline(in1, in2, out) {
   check((out != 0));
   check((buffer_rank(out) == 2));
   check((buffer_elem_size(out) == 2));
-  check((buffer_extent(out, 0) <= buffer_fold_factor(out, 0)));
-  check((buffer_extent(out, 1) <= buffer_fold_factor(out, 1)));
+  check((((buffer_max(out, 0) - buffer_min(out, 0)) + 1) <= buffer_fold_factor(out, 0)));
+  check((((buffer_max(out, 1) - buffer_min(out, 1)) + 1) <= buffer_fold_factor(out, 1)));
   check((buffer_min(in1, 0) <= (buffer_min(out, 0) + -1)));
   check(((buffer_max(out, 0) + 1) <= buffer_max(in1, 0)));
-  check(((buffer_extent(out, 0) + 2) <= buffer_fold_factor(in1, 0)));
+  check((((buffer_max(out, 0) - buffer_min(out, 0)) + 3) <= buffer_fold_factor(in1, 0)));
   check((buffer_min(in1, 1) <= (buffer_min(out, 1) + -1)));
   check(((buffer_max(out, 1) + 1) <= buffer_max(in1, 1)));
-  check(((buffer_extent(out, 1) + 2) <= buffer_fold_factor(in1, 1)));
+  check((((buffer_max(out, 1) - buffer_min(out, 1)) + 3) <= buffer_fold_factor(in1, 1)));
   check((buffer_min(in2, 0) <= (buffer_min(out, 0) + -2)));
   check(((buffer_max(out, 0) + 2) <= buffer_max(in2, 0)));
-  check(((buffer_extent(out, 0) + 4) <= buffer_fold_factor(in2, 0)));
+  check((((buffer_max(out, 0) - buffer_min(out, 0)) + 5) <= buffer_fold_factor(in2, 0)));
   check((buffer_min(in2, 1) <= (buffer_min(out, 1) + -2)));
   check(((buffer_max(out, 1) + 2) <= buffer_max(in2, 1)));
-  check(((buffer_extent(out, 1) + 4) <= buffer_fold_factor(in2, 1)));
+  check((((buffer_max(out, 1) - buffer_min(out, 1)) + 5) <= buffer_fold_factor(in2, 1)));
   { let intm4 = allocate('intm4', 2, [
       {bounds:{min:buffer_min(out, 0), max:buffer_max(out, 0)}, stride:2, fold_factor:9223372036854775807},
-      {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:(buffer_extent(out, 0) * 2), fold_factor:2}
+      {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:(((buffer_max(out, 0) - buffer_min(out, 0)) * 2) + 2), fold_factor:2}
     ]);
     { let intm4_uncropped = clone_buffer(intm4);
       { let intm2 = allocate('intm2', 2, [
           {bounds:{min:(buffer_min(out, 0) + -2), max:(buffer_max(out, 0) + 2)}, stride:2, fold_factor:9223372036854775807},
-          {bounds:{min:(buffer_min(out, 1) + -2), max:(buffer_max(out, 1) + 2)}, stride:((buffer_extent(out, 0) * 2) + 8), fold_factor:6}
+          {bounds:{min:(buffer_min(out, 1) + -2), max:(buffer_max(out, 1) + 2)}, stride:(((buffer_max(out, 0) - buffer_min(out, 0)) * 2) + 10), fold_factor:6}
         ]);
         { let intm2_uncropped = clone_buffer(intm2);
           { let intm3 = allocate('intm3', 2, [
               {bounds:{min:buffer_min(out, 0), max:buffer_max(out, 0)}, stride:2, fold_factor:9223372036854775807},
-              {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:(buffer_extent(out, 0) * 2), fold_factor:2}
+              {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:(((buffer_max(out, 0) - buffer_min(out, 0)) * 2) + 2), fold_factor:2}
             ]);
             { let intm3_uncropped = clone_buffer(intm3);
               { let intm1 = allocate('intm1', 2, [
                   {bounds:{min:(buffer_min(out, 0) + -1), max:(buffer_max(out, 0) + 1)}, stride:2, fold_factor:9223372036854775807},
-                  {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:((buffer_extent(out, 0) * 2) + 4), fold_factor:9223372036854775807}
+                  {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:(((buffer_max(out, 0) - buffer_min(out, 0)) * 2) + 6), fold_factor:9223372036854775807}
                 ]);
                 consume(in1);
                 produce(intm1);

--- a/builder/visualize/parallel_stencils_2.html
+++ b/builder/visualize/parallel_stencils_2.html
@@ -265,38 +265,38 @@ function pipeline(in1, in2, out) {
   check((out != 0));
   check((buffer_rank(out) == 2));
   check((buffer_elem_size(out) == 2));
-  check((buffer_extent(out, 0) <= buffer_fold_factor(out, 0)));
-  check((buffer_extent(out, 1) <= buffer_fold_factor(out, 1)));
+  check((((buffer_max(out, 0) - buffer_min(out, 0)) + 1) <= buffer_fold_factor(out, 0)));
+  check((((buffer_max(out, 1) - buffer_min(out, 1)) + 1) <= buffer_fold_factor(out, 1)));
   check((buffer_min(in1, 0) <= (buffer_min(out, 0) + -1)));
   check(((buffer_max(out, 0) + 1) <= buffer_max(in1, 0)));
-  check(((buffer_extent(out, 0) + 2) <= buffer_fold_factor(in1, 0)));
+  check((((buffer_max(out, 0) - buffer_min(out, 0)) + 3) <= buffer_fold_factor(in1, 0)));
   check((buffer_min(in1, 1) <= (buffer_min(out, 1) + -1)));
   check(((buffer_max(out, 1) + 1) <= buffer_max(in1, 1)));
-  check(((buffer_extent(out, 1) + 2) <= buffer_fold_factor(in1, 1)));
+  check((((buffer_max(out, 1) - buffer_min(out, 1)) + 3) <= buffer_fold_factor(in1, 1)));
   check((buffer_min(in2, 0) <= (buffer_min(out, 0) + -2)));
   check(((buffer_max(out, 0) + 2) <= buffer_max(in2, 0)));
-  check(((buffer_extent(out, 0) + 4) <= buffer_fold_factor(in2, 0)));
+  check((((buffer_max(out, 0) - buffer_min(out, 0)) + 5) <= buffer_fold_factor(in2, 0)));
   check((buffer_min(in2, 1) <= (buffer_min(out, 1) + -2)));
   check(((buffer_max(out, 1) + 2) <= buffer_max(in2, 1)));
-  check(((buffer_extent(out, 1) + 4) <= buffer_fold_factor(in2, 1)));
+  check((((buffer_max(out, 1) - buffer_min(out, 1)) + 5) <= buffer_fold_factor(in2, 1)));
   { let intm4 = allocate('intm4', 2, [
       {bounds:{min:buffer_min(out, 0), max:buffer_max(out, 0)}, stride:2, fold_factor:9223372036854775807},
-      {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:(buffer_extent(out, 0) * 2), fold_factor:2}
+      {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:(((buffer_max(out, 0) - buffer_min(out, 0)) * 2) + 2), fold_factor:2}
     ]);
     { let intm4_uncropped = clone_buffer(intm4);
       { let intm2 = allocate('intm2', 2, [
           {bounds:{min:(buffer_min(out, 0) + -2), max:(buffer_max(out, 0) + 2)}, stride:2, fold_factor:9223372036854775807},
-          {bounds:{min:(buffer_min(out, 1) + -2), max:(buffer_max(out, 1) + 2)}, stride:((buffer_extent(out, 0) * 2) + 8), fold_factor:6}
+          {bounds:{min:(buffer_min(out, 1) + -2), max:(buffer_max(out, 1) + 2)}, stride:(((buffer_max(out, 0) - buffer_min(out, 0)) * 2) + 10), fold_factor:6}
         ]);
         { let intm2_uncropped = clone_buffer(intm2);
           { let intm3 = allocate('intm3', 2, [
               {bounds:{min:buffer_min(out, 0), max:buffer_max(out, 0)}, stride:2, fold_factor:9223372036854775807},
-              {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:(buffer_extent(out, 0) * 2), fold_factor:2}
+              {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:(((buffer_max(out, 0) - buffer_min(out, 0)) * 2) + 2), fold_factor:2}
             ]);
             { let intm3_uncropped = clone_buffer(intm3);
               { let intm1 = allocate('intm1', 2, [
                   {bounds:{min:(buffer_min(out, 0) + -1), max:(buffer_max(out, 0) + 1)}, stride:2, fold_factor:9223372036854775807},
-                  {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:((buffer_extent(out, 0) * 2) + 4), fold_factor:4}
+                  {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:(((buffer_max(out, 0) - buffer_min(out, 0)) * 2) + 6), fold_factor:4}
                 ]);
                 { let intm1_uncropped = clone_buffer(intm1);
                   for(let y = (buffer_min(out, 1) + -6); y <= buffer_max(out, 1); y += 2) {

--- a/builder/visualize/stencil_chain_split_0.html
+++ b/builder/visualize/stencil_chain_split_0.html
@@ -262,21 +262,21 @@ function pipeline(__in, out) {
   check((out != 0));
   check((buffer_rank(out) == 2));
   check((buffer_elem_size(out) == 2));
-  check((buffer_extent(out, 0) <= buffer_fold_factor(out, 0)));
-  check((buffer_extent(out, 1) <= buffer_fold_factor(out, 1)));
+  check((((buffer_max(out, 0) - buffer_min(out, 0)) + 1) <= buffer_fold_factor(out, 0)));
+  check((((buffer_max(out, 1) - buffer_min(out, 1)) + 1) <= buffer_fold_factor(out, 1)));
   check((buffer_min(__in, 0) <= (buffer_min(out, 0) + -2)));
   check(((buffer_max(out, 0) + 2) <= buffer_max(__in, 0)));
-  check(((buffer_extent(out, 0) + 4) <= buffer_fold_factor(__in, 0)));
+  check((((buffer_max(out, 0) - buffer_min(out, 0)) + 5) <= buffer_fold_factor(__in, 0)));
   check((buffer_min(__in, 1) <= (buffer_min(out, 1) + -2)));
   check(((buffer_max(out, 1) + 2) <= buffer_max(__in, 1)));
-  check(((buffer_extent(out, 1) + 4) <= buffer_fold_factor(__in, 1)));
+  check((((buffer_max(out, 1) - buffer_min(out, 1)) + 5) <= buffer_fold_factor(__in, 1)));
   { let stencil1_result = allocate('stencil1_result', 2, [
       {bounds:{min:(buffer_min(out, 0) + -1), max:(buffer_max(out, 0) + 1)}, stride:2, fold_factor:9223372036854775807},
-      {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:((buffer_extent(out, 0) * 2) + 4), fold_factor:9223372036854775807}
+      {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:(((buffer_max(out, 0) - buffer_min(out, 0)) * 2) + 6), fold_factor:9223372036854775807}
     ]);
     { let add_result = allocate('add_result', 2, [
         {bounds:{min:(buffer_min(out, 0) + -2), max:(buffer_max(out, 0) + 2)}, stride:2, fold_factor:9223372036854775807},
-        {bounds:{min:(buffer_min(out, 1) + -2), max:(buffer_max(out, 1) + 2)}, stride:((buffer_extent(out, 0) * 2) + 8), fold_factor:9223372036854775807}
+        {bounds:{min:(buffer_min(out, 1) + -2), max:(buffer_max(out, 1) + 2)}, stride:(((buffer_max(out, 0) - buffer_min(out, 0)) * 2) + 10), fold_factor:9223372036854775807}
       ]);
       consume(__in);
       produce(add_result);

--- a/builder/visualize/stencil_chain_split_1.html
+++ b/builder/visualize/stencil_chain_split_1.html
@@ -262,22 +262,22 @@ function pipeline(__in, out) {
   check((out != 0));
   check((buffer_rank(out) == 2));
   check((buffer_elem_size(out) == 2));
-  check((buffer_extent(out, 0) <= buffer_fold_factor(out, 0)));
-  check((buffer_extent(out, 1) <= buffer_fold_factor(out, 1)));
+  check((((buffer_max(out, 0) - buffer_min(out, 0)) + 1) <= buffer_fold_factor(out, 0)));
+  check((((buffer_max(out, 1) - buffer_min(out, 1)) + 1) <= buffer_fold_factor(out, 1)));
   check((buffer_min(__in, 0) <= (buffer_min(out, 0) + -2)));
   check(((buffer_max(out, 0) + 2) <= buffer_max(__in, 0)));
-  check(((buffer_extent(out, 0) + 4) <= buffer_fold_factor(__in, 0)));
+  check((((buffer_max(out, 0) - buffer_min(out, 0)) + 5) <= buffer_fold_factor(__in, 0)));
   check((buffer_min(__in, 1) <= (buffer_min(out, 1) + -2)));
   check(((buffer_max(out, 1) + 2) <= buffer_max(__in, 1)));
-  check(((buffer_extent(out, 1) + 4) <= buffer_fold_factor(__in, 1)));
+  check((((buffer_max(out, 1) - buffer_min(out, 1)) + 5) <= buffer_fold_factor(__in, 1)));
   { let stencil1_result = allocate('stencil1_result', 2, [
       {bounds:{min:(buffer_min(out, 0) + -1), max:(buffer_max(out, 0) + 1)}, stride:2, fold_factor:9223372036854775807},
-      {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:((buffer_extent(out, 0) * 2) + 4), fold_factor:3}
+      {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:(((buffer_max(out, 0) - buffer_min(out, 0)) * 2) + 6), fold_factor:3}
     ]);
     { let stencil1_result_uncropped = clone_buffer(stencil1_result);
       { let add_result = allocate('add_result', 2, [
           {bounds:{min:(buffer_min(out, 0) + -2), max:(buffer_max(out, 0) + 2)}, stride:2, fold_factor:9223372036854775807},
-          {bounds:{min:(buffer_min(out, 1) + -2), max:(buffer_max(out, 1) + 2)}, stride:((buffer_extent(out, 0) * 2) + 8), fold_factor:3}
+          {bounds:{min:(buffer_min(out, 1) + -2), max:(buffer_max(out, 1) + 2)}, stride:(((buffer_max(out, 0) - buffer_min(out, 0)) * 2) + 10), fold_factor:3}
         ]);
         { let add_result_uncropped = clone_buffer(add_result);
           for(let y = (buffer_min(out, 1) + -4); y <= buffer_max(out, 1); y += 1) {

--- a/builder/visualize/stencil_chain_split_2.html
+++ b/builder/visualize/stencil_chain_split_2.html
@@ -262,22 +262,22 @@ function pipeline(__in, out) {
   check((out != 0));
   check((buffer_rank(out) == 2));
   check((buffer_elem_size(out) == 2));
-  check((buffer_extent(out, 0) <= buffer_fold_factor(out, 0)));
-  check((buffer_extent(out, 1) <= buffer_fold_factor(out, 1)));
+  check((((buffer_max(out, 0) - buffer_min(out, 0)) + 1) <= buffer_fold_factor(out, 0)));
+  check((((buffer_max(out, 1) - buffer_min(out, 1)) + 1) <= buffer_fold_factor(out, 1)));
   check((buffer_min(__in, 0) <= (buffer_min(out, 0) + -2)));
   check(((buffer_max(out, 0) + 2) <= buffer_max(__in, 0)));
-  check(((buffer_extent(out, 0) + 4) <= buffer_fold_factor(__in, 0)));
+  check((((buffer_max(out, 0) - buffer_min(out, 0)) + 5) <= buffer_fold_factor(__in, 0)));
   check((buffer_min(__in, 1) <= (buffer_min(out, 1) + -2)));
   check(((buffer_max(out, 1) + 2) <= buffer_max(__in, 1)));
-  check(((buffer_extent(out, 1) + 4) <= buffer_fold_factor(__in, 1)));
+  check((((buffer_max(out, 1) - buffer_min(out, 1)) + 5) <= buffer_fold_factor(__in, 1)));
   { let stencil1_result = allocate('stencil1_result', 2, [
       {bounds:{min:(buffer_min(out, 0) + -1), max:(buffer_max(out, 0) + 1)}, stride:2, fold_factor:9223372036854775807},
-      {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:((buffer_extent(out, 0) * 2) + 4), fold_factor:4}
+      {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:(((buffer_max(out, 0) - buffer_min(out, 0)) * 2) + 6), fold_factor:4}
     ]);
     { let stencil1_result_uncropped = clone_buffer(stencil1_result);
       { let add_result = allocate('add_result', 2, [
           {bounds:{min:(buffer_min(out, 0) + -2), max:(buffer_max(out, 0) + 2)}, stride:2, fold_factor:9223372036854775807},
-          {bounds:{min:(buffer_min(out, 1) + -2), max:(buffer_max(out, 1) + 2)}, stride:((buffer_extent(out, 0) * 2) + 8), fold_factor:4}
+          {bounds:{min:(buffer_min(out, 1) + -2), max:(buffer_max(out, 1) + 2)}, stride:(((buffer_max(out, 0) - buffer_min(out, 0)) * 2) + 10), fold_factor:4}
         ]);
         { let add_result_uncropped = clone_buffer(add_result);
           for(let y = (buffer_min(out, 1) + -4); y <= buffer_max(out, 1); y += 2) {

--- a/builder/visualize/stencil_split_0.html
+++ b/builder/visualize/stencil_split_0.html
@@ -262,17 +262,17 @@ function pipeline(__in, out) {
   check((out != 0));
   check((buffer_rank(out) == 2));
   check((buffer_elem_size(out) == 2));
-  check((buffer_extent(out, 0) <= buffer_fold_factor(out, 0)));
-  check((buffer_extent(out, 1) <= buffer_fold_factor(out, 1)));
+  check((((buffer_max(out, 0) - buffer_min(out, 0)) + 1) <= buffer_fold_factor(out, 0)));
+  check((((buffer_max(out, 1) - buffer_min(out, 1)) + 1) <= buffer_fold_factor(out, 1)));
   check((buffer_min(__in, 0) <= (buffer_min(out, 0) + -1)));
   check(((buffer_max(out, 0) + 1) <= buffer_max(__in, 0)));
-  check(((buffer_extent(out, 0) + 2) <= buffer_fold_factor(__in, 0)));
+  check((((buffer_max(out, 0) - buffer_min(out, 0)) + 3) <= buffer_fold_factor(__in, 0)));
   check((buffer_min(__in, 1) <= (buffer_min(out, 1) + -1)));
   check(((buffer_max(out, 1) + 1) <= buffer_max(__in, 1)));
-  check(((buffer_extent(out, 1) + 2) <= buffer_fold_factor(__in, 1)));
+  check((((buffer_max(out, 1) - buffer_min(out, 1)) + 3) <= buffer_fold_factor(__in, 1)));
   { let intm = allocate('intm', 2, [
       {bounds:{min:(buffer_min(out, 0) + -1), max:(buffer_max(out, 0) + 1)}, stride:2, fold_factor:9223372036854775807},
-      {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:((buffer_extent(out, 0) * 2) + 4), fold_factor:9223372036854775807}
+      {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:(((buffer_max(out, 0) - buffer_min(out, 0)) * 2) + 6), fold_factor:9223372036854775807}
     ]);
     consume(__in);
     produce(intm);

--- a/builder/visualize/stencil_split_1.html
+++ b/builder/visualize/stencil_split_1.html
@@ -262,17 +262,17 @@ function pipeline(__in, out) {
   check((out != 0));
   check((buffer_rank(out) == 2));
   check((buffer_elem_size(out) == 2));
-  check((buffer_extent(out, 0) <= buffer_fold_factor(out, 0)));
-  check((buffer_extent(out, 1) <= buffer_fold_factor(out, 1)));
+  check((((buffer_max(out, 0) - buffer_min(out, 0)) + 1) <= buffer_fold_factor(out, 0)));
+  check((((buffer_max(out, 1) - buffer_min(out, 1)) + 1) <= buffer_fold_factor(out, 1)));
   check((buffer_min(__in, 0) <= (buffer_min(out, 0) + -1)));
   check(((buffer_max(out, 0) + 1) <= buffer_max(__in, 0)));
-  check(((buffer_extent(out, 0) + 2) <= buffer_fold_factor(__in, 0)));
+  check((((buffer_max(out, 0) - buffer_min(out, 0)) + 3) <= buffer_fold_factor(__in, 0)));
   check((buffer_min(__in, 1) <= (buffer_min(out, 1) + -1)));
   check(((buffer_max(out, 1) + 1) <= buffer_max(__in, 1)));
-  check(((buffer_extent(out, 1) + 2) <= buffer_fold_factor(__in, 1)));
+  check((((buffer_max(out, 1) - buffer_min(out, 1)) + 3) <= buffer_fold_factor(__in, 1)));
   { let intm = allocate('intm', 2, [
       {bounds:{min:(buffer_min(out, 0) + -1), max:(buffer_max(out, 0) + 1)}, stride:2, fold_factor:9223372036854775807},
-      {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:((buffer_extent(out, 0) * 2) + 4), fold_factor:3}
+      {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:(((buffer_max(out, 0) - buffer_min(out, 0)) * 2) + 6), fold_factor:3}
     ]);
     { let intm_uncropped = clone_buffer(intm);
       for(let y = (buffer_min(out, 1) + -2); y <= buffer_max(out, 1); y += 1) {

--- a/builder/visualize/stencil_split_2.html
+++ b/builder/visualize/stencil_split_2.html
@@ -262,17 +262,17 @@ function pipeline(__in, out) {
   check((out != 0));
   check((buffer_rank(out) == 2));
   check((buffer_elem_size(out) == 2));
-  check((buffer_extent(out, 0) <= buffer_fold_factor(out, 0)));
-  check((buffer_extent(out, 1) <= buffer_fold_factor(out, 1)));
+  check((((buffer_max(out, 0) - buffer_min(out, 0)) + 1) <= buffer_fold_factor(out, 0)));
+  check((((buffer_max(out, 1) - buffer_min(out, 1)) + 1) <= buffer_fold_factor(out, 1)));
   check((buffer_min(__in, 0) <= (buffer_min(out, 0) + -1)));
   check(((buffer_max(out, 0) + 1) <= buffer_max(__in, 0)));
-  check(((buffer_extent(out, 0) + 2) <= buffer_fold_factor(__in, 0)));
+  check((((buffer_max(out, 0) - buffer_min(out, 0)) + 3) <= buffer_fold_factor(__in, 0)));
   check((buffer_min(__in, 1) <= (buffer_min(out, 1) + -1)));
   check(((buffer_max(out, 1) + 1) <= buffer_max(__in, 1)));
-  check(((buffer_extent(out, 1) + 2) <= buffer_fold_factor(__in, 1)));
+  check((((buffer_max(out, 1) - buffer_min(out, 1)) + 3) <= buffer_fold_factor(__in, 1)));
   { let intm = allocate('intm', 2, [
       {bounds:{min:(buffer_min(out, 0) + -1), max:(buffer_max(out, 0) + 1)}, stride:2, fold_factor:9223372036854775807},
-      {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:((buffer_extent(out, 0) * 2) + 4), fold_factor:4}
+      {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:(((buffer_max(out, 0) - buffer_min(out, 0)) * 2) + 6), fold_factor:4}
     ]);
     { let intm_uncropped = clone_buffer(intm);
       for(let y = (buffer_min(out, 1) + -2); y <= buffer_max(out, 1); y += 2) {

--- a/builder/visualize/stencil_split_3.html
+++ b/builder/visualize/stencil_split_3.html
@@ -262,17 +262,17 @@ function pipeline(__in, out) {
   check((out != 0));
   check((buffer_rank(out) == 2));
   check((buffer_elem_size(out) == 2));
-  check((buffer_extent(out, 0) <= buffer_fold_factor(out, 0)));
-  check((buffer_extent(out, 1) <= buffer_fold_factor(out, 1)));
+  check((((buffer_max(out, 0) - buffer_min(out, 0)) + 1) <= buffer_fold_factor(out, 0)));
+  check((((buffer_max(out, 1) - buffer_min(out, 1)) + 1) <= buffer_fold_factor(out, 1)));
   check((buffer_min(__in, 0) <= (buffer_min(out, 0) + -1)));
   check(((buffer_max(out, 0) + 1) <= buffer_max(__in, 0)));
-  check(((buffer_extent(out, 0) + 2) <= buffer_fold_factor(__in, 0)));
+  check((((buffer_max(out, 0) - buffer_min(out, 0)) + 3) <= buffer_fold_factor(__in, 0)));
   check((buffer_min(__in, 1) <= (buffer_min(out, 1) + -1)));
   check(((buffer_max(out, 1) + 1) <= buffer_max(__in, 1)));
-  check(((buffer_extent(out, 1) + 2) <= buffer_fold_factor(__in, 1)));
+  check((((buffer_max(out, 1) - buffer_min(out, 1)) + 3) <= buffer_fold_factor(__in, 1)));
   { let intm = allocate('intm', 2, [
       {bounds:{min:(buffer_min(out, 0) + -1), max:(buffer_max(out, 0) + 1)}, stride:2, fold_factor:9223372036854775807},
-      {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:((buffer_extent(out, 0) * 2) + 4), fold_factor:6}
+      {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:(((buffer_max(out, 0) - buffer_min(out, 0)) * 2) + 6), fold_factor:6}
     ]);
     { let intm_uncropped = clone_buffer(intm);
       for(let y = (buffer_min(out, 1) + -2); y <= buffer_max(out, 1); y += 3) {

--- a/runtime/evaluate.cc
+++ b/runtime/evaluate.cc
@@ -180,7 +180,6 @@ public:
     switch (op->intrinsic) {
     case intrinsic::buffer_min: return dim.min();
     case intrinsic::buffer_max: return dim.max();
-    case intrinsic::buffer_extent: return dim.extent();
     case intrinsic::buffer_stride: return dim.stride();
     case intrinsic::buffer_fold_factor: return dim.fold_factor();
     default: std::abort();
@@ -218,7 +217,6 @@ public:
 
     case intrinsic::buffer_min:
     case intrinsic::buffer_max:
-    case intrinsic::buffer_extent:
     case intrinsic::buffer_stride:
     case intrinsic::buffer_fold_factor: result = eval_dim_metadata(op); return;
 

--- a/runtime/expr.h
+++ b/runtime/expr.h
@@ -68,7 +68,6 @@ enum class intrinsic {
   buffer_max,
   buffer_stride,
   buffer_fold_factor,
-  buffer_extent,
 
   buffer_at,
 };
@@ -516,7 +515,6 @@ inline bool is_positive(const expr& x) {
 
 inline bool is_non_negative(const expr& x) {
   if (is_positive_infinity(x)) return true;
-  if (is_intrinsic(x, intrinsic::buffer_extent)) return true;
   const index_t* c = as_constant(x);
   return c ? *c >= 0 : false;
 }

--- a/runtime/expr_stmt.cc
+++ b/runtime/expr_stmt.cc
@@ -490,7 +490,7 @@ expr buffer_elem_size(expr buf) { return call::make(intrinsic::buffer_elem_size,
 expr buffer_min(expr buf, expr dim) { return call::make(intrinsic::buffer_min, {std::move(buf), std::move(dim)}); }
 expr buffer_max(expr buf, expr dim) { return call::make(intrinsic::buffer_max, {std::move(buf), std::move(dim)}); }
 expr buffer_extent(expr buf, expr dim) {
-  return call::make(intrinsic::buffer_extent, {std::move(buf), std::move(dim)});
+  return (buffer_max(buf, dim) - buffer_min(buf, dim)) + 1;
 }
 expr buffer_stride(expr buf, expr dim) {
   return call::make(intrinsic::buffer_stride, {std::move(buf), std::move(dim)});
@@ -543,7 +543,6 @@ bool is_buffer_intrinsic(intrinsic fn) {
   case intrinsic::buffer_max:
   case intrinsic::buffer_stride:
   case intrinsic::buffer_fold_factor:
-  case intrinsic::buffer_extent:
   case intrinsic::buffer_at: return true;
   default: return false;
   }

--- a/runtime/print.cc
+++ b/runtime/print.cc
@@ -30,7 +30,6 @@ std::string to_string(intrinsic fn) {
   case intrinsic::buffer_max: return "buffer_max";
   case intrinsic::buffer_stride: return "buffer_stride";
   case intrinsic::buffer_fold_factor: return "buffer_fold_factor";
-  case intrinsic::buffer_extent: return "buffer_extent";
   case intrinsic::buffer_at: return "buffer_at";
 
   default: return "<invalid intrinsic>";


### PR DESCRIPTION
`buffer_extent` is too much of a headache to deal with properly. For example, when substituting `buffer_min(x, y)` to be something else, `buffer_extent(x, y)` should change...somehow too, and vice versa for `buffer_extent` affecting `buffer_max`. Rather than deal with that problem, we can just get rid of it.