### PR TITLE
Clean up `symbol_id` and `var`

### DIFF
--- a/builder/copy_test.cc
+++ b/builder/copy_test.cc
@@ -506,7 +506,6 @@ TEST_P(broadcast, copy_sliced) {
   p.evaluate(inputs, outputs, eval_ctx);
   ASSERT_EQ(eval_ctx.copy_calls, 1);
 
-
   for (int z = 0; z < D; ++z) {
     for (int y = 0; y < H; ++y) {
       for (int x = 0; x < W; ++x) {
@@ -735,7 +734,7 @@ TEST(batch_reshape, copy) {
   box_expr bounds = {
       point(flat_out % in->dim(0).extent()),
       point((flat_out / in->dim(0).extent()) % in->dim(1).extent()),
-      point(flat_out / (in->dim(0).extent() * in->dim(1).extent())  % in->dim(2).extent()),
+      point(flat_out / (in->dim(0).extent() * in->dim(1).extent()) % in->dim(2).extent()),
       point(w),
   };
   func crop = func::make_copy({in, bounds}, {out, {x, y, z, w}});

--- a/builder/elementwise_test.cc
+++ b/builder/elementwise_test.cc
@@ -34,7 +34,7 @@ class elementwise_pipeline_builder : public expr_visitor {
 
   std::string name(const buffer_expr_ptr& b) const { return ctx.name(b->sym()); }
 
-  std::map<symbol_id, buffer_expr_ptr> vars;
+  std::map<var, buffer_expr_ptr> vars;
   std::vector<buffer_expr_ptr> constants;
 
 public:

--- a/builder/node_mutator.cc
+++ b/builder/node_mutator.cc
@@ -11,7 +11,7 @@ namespace {
 
 template <typename T>
 auto mutate_let(node_mutator* this_, const T* op) {
-  std::vector<std::pair<symbol_id, expr>> lets;
+  std::vector<std::pair<var, expr>> lets;
   lets.reserve(op->lets.size());
   bool changed = false;
   for (const auto& s : op->lets) {

--- a/builder/optimizations.cc
+++ b/builder/optimizations.cc
@@ -108,8 +108,8 @@ public:
           dims[d].bounds &= op->dims[d].bounds;
         }
       }
-      stmt result = make_buffer::make(
-          op->sym, buffer_at(target_var, at), op->elem_size, std::move(dims), std::move(body));
+      stmt result =
+          make_buffer::make(op->sym, buffer_at(target_var, at), op->elem_size, std::move(dims), std::move(body));
       // If we aliased the source and destination of a copy, replace the copy with a pad.
       stmt pad_result = recursive_mutate<copy_stmt>(result, [src = op->sym, dst = target_var](const copy_stmt* op) {
         if (op->src != src || op->dst != dst) {

--- a/builder/pipeline.h
+++ b/builder/pipeline.h
@@ -24,7 +24,7 @@ struct loop_id {
 
 // Represents a symbolic buffer in a pipeline.
 class buffer_expr : public ref_counted<buffer_expr> {
-  symbol_id sym_;
+  var sym_;
   expr elem_size_;
   std::vector<dim_expr> dims_;
 
@@ -34,8 +34,8 @@ class buffer_expr : public ref_counted<buffer_expr> {
   memory_type storage_ = memory_type::heap;
   std::optional<loop_id> store_at_;
 
-  buffer_expr(symbol_id sym, std::size_t rank, expr elem_size);
-  buffer_expr(symbol_id sym, const_raw_buffer_ptr constant_buffer);
+  buffer_expr(var sym, std::size_t rank, expr elem_size);
+  buffer_expr(var sym, const_raw_buffer_ptr constant_buffer);
   buffer_expr(const buffer_expr&) = delete;
   buffer_expr(buffer_expr&&) = delete;
   buffer_expr& operator=(const buffer_expr&) = delete;
@@ -46,15 +46,15 @@ class buffer_expr : public ref_counted<buffer_expr> {
   void set_producer(func* f);
 
 public:
-  static buffer_expr_ptr make(symbol_id sym, std::size_t rank, expr elem_size);
-  static buffer_expr_ptr make(symbol_id sym, std::size_t rank, index_t elem_size);
+  static buffer_expr_ptr make(var sym, std::size_t rank, expr elem_size);
+  static buffer_expr_ptr make(var sym, std::size_t rank, index_t elem_size);
   static buffer_expr_ptr make(node_context& ctx, const std::string& sym, std::size_t rank, expr elem_size);
   static buffer_expr_ptr make(node_context& ctx, const std::string& sym, std::size_t rank, index_t elem_size);
   // Make a constant buffer_expr. It takes ownership of the buffer from the caller.
-  static buffer_expr_ptr make(symbol_id sym, const_raw_buffer_ptr constant_buffer);
+  static buffer_expr_ptr make(var sym, const_raw_buffer_ptr constant_buffer);
   static buffer_expr_ptr make(node_context& ctx, const std::string& sym, const_raw_buffer_ptr constant_buffer);
 
-  symbol_id sym() const { return sym_; }
+  var sym() const { return sym_; }
   expr elem_size() const { return elem_size_; }
   std::size_t rank() const { return dims_.size(); }
   const std::vector<dim_expr>& dims() const { return dims_; }
@@ -111,7 +111,7 @@ public:
     // Slices to apply to the output while consuming this input. Only used by copies.
     std::vector<expr> output_slice;
 
-    symbol_id sym() const { return buffer->sym(); }
+    var sym() const { return buffer->sym(); }
   };
 
   struct output {
@@ -119,7 +119,7 @@ public:
 
     std::vector<var> dims;
 
-    symbol_id sym() const { return buffer->sym(); }
+    var sym() const { return buffer->sym(); }
   };
 
   struct loop_info {
@@ -131,7 +131,7 @@ public:
     loop_info(slinky::var var, expr step = 1, int max_workers = loop::serial)
         : var(var), step(step), max_workers(max_workers) {}
 
-    symbol_id sym() const { return var; }
+    slinky::var sym() const { return var; }
 
     bool defined() const { return var.defined() && step.defined(); }
   };

--- a/builder/pipeline.h
+++ b/builder/pipeline.h
@@ -18,7 +18,8 @@ struct loop_id {
   slinky::var var;
 
   bool root() const { return !func; }
-  symbol_id sym() const { return var.sym(); }
+  // TODO: Deprecated
+  slinky::var sym() const { return var; }
 };
 
 // Represents a symbolic buffer in a pipeline.
@@ -130,7 +131,7 @@ public:
     loop_info(slinky::var var, expr step = 1, int max_workers = loop::serial)
         : var(var), step(step), max_workers(max_workers) {}
 
-    symbol_id sym() const { return var.sym(); }
+    symbol_id sym() const { return var; }
 
     bool defined() const { return var.defined() && step.defined(); }
   };

--- a/builder/pipeline_test.cc
+++ b/builder/pipeline_test.cc
@@ -74,12 +74,12 @@ public:
   memory_info heap;
 
   test_context() {
-    allocate = [this](symbol_id, raw_buffer* b) {
+    allocate = [this](var, raw_buffer* b) {
       void* allocation = b->allocate();
       heap.track_allocate(b->size_bytes());
       return allocation;
     };
-    free = [this](symbol_id, raw_buffer* b, void* allocation) {
+    free = [this](var, raw_buffer* b, void* allocation) {
       ::free(allocation);
       heap.track_free(b->size_bytes());
     };

--- a/builder/replica_pipeline.cc
+++ b/builder/replica_pipeline.cc
@@ -107,13 +107,13 @@ public:
       return "var()";
     }
 
-    auto it = vars_emitted_.find(v.sym());
+    auto it = vars_emitted_.find(v);
     if (it != vars_emitted_.end()) {
       return it->second;
     }
 
-    const auto& name = ctx_.name(v.sym());
-    vars_emitted_[v.sym()] = name;
+    const auto& name = ctx_.name(v);
+    vars_emitted_[v] = name;
     return print_assignment_explicit(name, "var(ctx, \"", name, "\")");
   }
 

--- a/builder/replica_pipeline.cc
+++ b/builder/replica_pipeline.cc
@@ -362,9 +362,9 @@ private:
   std::ostringstream os_;
   std::string name_;
   uint32_t next_id_ = 0;
-  std::set<symbol_id> buffers_emitted_;
-  std::map<symbol_id, std::string> buffer_variables_emitted_;
-  std::map<symbol_id, std::string> vars_emitted_;
+  std::set<var> buffers_emitted_;
+  std::map<var, std::string> buffer_variables_emitted_;
+  std::map<var, std::string> vars_emitted_;
   std::map<const func*, std::string> funcs_emitted_;
   bool exprs_inlined_ = false;
 

--- a/builder/replica_pipeline.h
+++ b/builder/replica_pipeline.h
@@ -13,7 +13,8 @@ std::string define_replica_pipeline(node_context& ctx, const std::vector<var>& a
     const std::vector<buffer_expr_ptr>& inputs, const std::vector<buffer_expr_ptr>& outputs,
     const build_options& options = build_options(), const std::string& fname = "p");
 std::string define_replica_pipeline(node_context& ctx, const std::vector<buffer_expr_ptr>& inputs,
-    const std::vector<buffer_expr_ptr>& outputs, const build_options& options = build_options(), const std::string& fname = "p");
+    const std::vector<buffer_expr_ptr>& outputs, const build_options& options = build_options(),
+    const std::string& fname = "p");
 
 namespace internal {
 

--- a/builder/simplify.cc
+++ b/builder/simplify.cc
@@ -280,7 +280,7 @@ public:
 
     if (op->intrinsic == intrinsic::buffer_min || op->intrinsic == intrinsic::buffer_max) {
       assert(op->args.size() == 2);
-      const symbol_id* buf = as_variable(op->args[0]);
+      const var* buf = as_variable(op->args[0]);
       const index_t* dim = as_constant(op->args[1]);
       assert(buf);
       assert(dim);
@@ -318,7 +318,7 @@ public:
 
   template <typename T>
   void visit_let(const T* op) {
-    std::vector<std::pair<symbol_id, expr>> lets;
+    std::vector<std::pair<var, expr>> lets;
     lets.reserve(op->lets.size());
 
     using sv_type = scoped_value_in_symbol_map<interval_expr>;
@@ -375,13 +375,13 @@ public:
   void visit(const let* op) override { visit_let(op); }
   void visit(const let_stmt* op) override { visit_let(op); }
 
-  stmt mutate_with_bounds(stmt body, symbol_id buf, std::optional<box_expr> bounds) {
+  stmt mutate_with_bounds(stmt body, var buf, std::optional<box_expr> bounds) {
     auto set_bounds = set_value_in_scope(buffer_bounds, buf, std::move(bounds));
     return mutate(body);
   }
 
-  stmt mutate_with_bounds(stmt body, symbol_id var, interval_expr bounds) {
-    auto set_bounds = set_value_in_scope(expr_bounds, var, std::move(bounds));
+  stmt mutate_with_bounds(stmt body, var v, interval_expr bounds) {
+    auto set_bounds = set_value_in_scope(expr_bounds, v, std::move(bounds));
     return mutate(body);
   }
 
@@ -410,7 +410,7 @@ public:
       // contiguous crops of a buffer. In these cases, we can drop the loop in favor of just calling the body on the
       // union of the bounds covered by the loop.
       stmt result = body;
-      std::vector<std::tuple<symbol_id, int, interval_expr>> new_crops;
+      std::vector<std::tuple<var, int, interval_expr>> new_crops;
       bool drop_loop = true;
       while (true) {
         // For now, we only handle crop_dim. I don't think crop_buffer can ever yield this simplification?
@@ -482,11 +482,11 @@ public:
 
   // Assuming that we've entered the body of a declaration of `sym`, remove any references to `sym` from the bounds (as
   // if they came from outside the body).
-  static void clear_shadowed_bounds(symbol_id sym, interval_expr& bounds) {
+  static void clear_shadowed_bounds(var sym, interval_expr& bounds) {
     if (depends_on(bounds.min, sym).buffer_meta_read) bounds.min = expr();
     if (depends_on(bounds.max, sym).buffer_meta_read) bounds.max = expr();
   }
-  static void clear_shadowed_bounds(symbol_id sym, box_expr& bounds) {
+  static void clear_shadowed_bounds(var sym, box_expr& bounds) {
     for (interval_expr& i : bounds) {
       clear_shadowed_bounds(sym, i);
     }
@@ -567,7 +567,7 @@ public:
     if (const call* bc = base.as<call>()) {
       if (bc->intrinsic == intrinsic::buffer_at && bc->args.size() == 1) {
         // Check if this make_buffer is truncate_rank, or a clone.
-        const symbol_id* src_buf = as_variable(bc->args[0]);
+        const var* src_buf = as_variable(bc->args[0]);
         if (src_buf) {
           if (match(elem_size, buffer_elem_size(*src_buf))) {
             bool is_clone = true;
@@ -657,7 +657,7 @@ public:
   }
 
   // Crop bounds like min(buffer_max(x, d), y) can be rewritten to just y because the crop will clamp anyways.
-  static expr simplify_crop_bound(expr x, symbol_id sym, int dim) {
+  static expr simplify_crop_bound(expr x, var sym, int dim) {
     if (const class max* m = x.as<class max>()) {
       if (is_buffer_min(m->a, sym, dim)) return simplify_crop_bound(m->b, sym, dim);
       if (is_buffer_min(m->b, sym, dim)) return simplify_crop_bound(m->a, sym, dim);
@@ -668,7 +668,7 @@ public:
     return x;
   }
 
-  static interval_expr simplify_crop_bounds(interval_expr i, symbol_id sym, int dim) {
+  static interval_expr simplify_crop_bounds(interval_expr i, var sym, int dim) {
     return {simplify_crop_bound(i.min, sym, dim), simplify_crop_bound(i.max, sym, dim)};
   }
 
@@ -828,14 +828,14 @@ public:
     }
   }
 
-  static void update_sliced_buffer_metadata(bounds_map& bounds, symbol_id sym, span<const int> sliced) {
+  static void update_sliced_buffer_metadata(bounds_map& bounds, var sym, span<const int> sliced) {
     for (std::optional<interval_expr>& i : bounds) {
       if (!i) continue;
       i->min = slinky::update_sliced_buffer_metadata(i->min, sym, sliced);
       i->max = slinky::update_sliced_buffer_metadata(i->max, sym, sliced);
     }
   }
-  static void update_sliced_buffer_metadata(symbol_map<box_expr>& bounds, symbol_id sym, span<const int> sliced) {
+  static void update_sliced_buffer_metadata(symbol_map<box_expr>& bounds, var sym, span<const int> sliced) {
     for (std::optional<box_expr>& i : bounds) {
       if (!i) continue;
       for (interval_expr& j : *i) {
@@ -1032,7 +1032,7 @@ bool prove_false(const expr& condition, const bounds_map& expr_bounds) {
   return s.prove_false(condition);
 }
 
-interval_expr where_true(const expr& condition, symbol_id var) {
+interval_expr where_true(const expr& condition, var x) {
   // TODO: This needs a proper implementation. For now, a ridiculous hack: trial and error.
   // We use the leaves of the expression as guesses around which to search.
   // We could use every node in the expression...
@@ -1063,11 +1063,11 @@ interval_expr where_true(const expr& condition, symbol_id var) {
     for (const expr& j : offsets) {
       if (!result_i.min.defined()) {
         // Find the first offset where the expression is true.
-        if (prove_true(substitute(condition, var, i + j))) {
+        if (prove_true(substitute(condition, x, i + j))) {
           result_i.min = i + j;
           result_i.max = result_i.min;
         }
-      } else if (prove_true(substitute(condition, var, i + j))) {
+      } else if (prove_true(substitute(condition, x, i + j))) {
         // Find the last offset where the expression is true.
         result_i.max = i + j;
       }

--- a/builder/simplify.h
+++ b/builder/simplify.h
@@ -22,7 +22,7 @@ bool prove_true(const expr& condition, const bounds_map& bounds = bounds_map());
 bool prove_false(const expr& condition, const bounds_map& bounds = bounds_map());
 
 // Find the interval for `var` that makes `e` true.
-interval_expr where_true(const expr& condition, symbol_id var);
+interval_expr where_true(const expr& condition, var x);
 
 // Helpers for producing simplified versions of ops. These do not recursively simplify their
 // operands. `op` is an existing node that may be returned if op is equivalent. `op` may be null.

--- a/builder/simplify_test.cc
+++ b/builder/simplify_test.cc
@@ -32,7 +32,7 @@ void dump_symbol_map(std::ostream& s, const symbol_map<T>& m) {
   for (std::size_t n = 0; n < m.size(); ++n) {
     const std::optional<T>& value = m[n];
     if (value) {
-      s << "  " << symbols.name(symbol_id(n)) << " = " << *value << std::endl;
+      s << "  " << symbols.name(var(n)) << " = " << *value << std::endl;
     }
   }
 }
@@ -273,8 +273,8 @@ TEST(simplify, bounds_of) {
   }
 }
 
-void test_where(const expr& test, symbol_id var, const interval_expr& expected) {
-  interval_expr result = where_true(test, var);
+void test_where(const expr& test, var x, const interval_expr& expected) {
+  interval_expr result = where_true(test, x);
   if (!match(result, expected)) {
     std::cout << "where_true failed " << std::endl;
     std::cout << test << std::endl;
@@ -286,8 +286,8 @@ void test_where(const expr& test, symbol_id var, const interval_expr& expected) 
   }
 }
 
-void test_where_true(const expr& test, symbol_id var, const interval_expr& expected) {
-  test_where(test, var, expected);
+void test_where_true(const expr& test, var x, const interval_expr& expected) {
+  test_where(test, x, expected);
 }
 
 TEST(simplify, where_true) {

--- a/builder/simplify_test.cc
+++ b/builder/simplify_test.cc
@@ -132,36 +132,34 @@ TEST(simplify, basic) {
 
 TEST(simplify, let) {
   // lets that should be removed
-  test_simplify(let::make(x.sym(), y, z), z);                                // Dead let
-  test_simplify(let::make(x.sym(), y * 2, x), y * 2);                        // Single use, substitute
-  test_simplify(let::make(x.sym(), y * w, x), y * w);                        // Single use, substitute
-  test_simplify(let::make(x.sym(), y, (x + 1) / x), (y + 1) / y);            // Trivial value, substitute
-  test_simplify(let::make(x.sym(), 10, x / x), 1);                           // Trivial value, substitute
-  test_simplify(let::make(x.sym(), buffer_max(y, 0), x), buffer_max(y, 0));  // buffer_max, substitute
-  test_simplify(let::make(x.sym(), buffer_min(y, 0), x), buffer_min(y, 0));  // buffer_min, substitute
+  test_simplify(let::make(x, y, z), z);                                // Dead let
+  test_simplify(let::make(x, y * 2, x), y * 2);                        // Single use, substitute
+  test_simplify(let::make(x, y * w, x), y * w);                        // Single use, substitute
+  test_simplify(let::make(x, y, (x + 1) / x), (y + 1) / y);            // Trivial value, substitute
+  test_simplify(let::make(x, 10, x / x), 1);                           // Trivial value, substitute
+  test_simplify(let::make(x, buffer_max(y, 0), x), buffer_max(y, 0));  // buffer_max, substitute
+  test_simplify(let::make(x, buffer_min(y, 0), x), buffer_min(y, 0));  // buffer_min, substitute
 
-  test_simplify(
-    let_stmt::make(x.sym(), y, loop::make(z.sym(), loop::serial, bounds(0, 3), 1, check::make(x))),
-    loop::make(z.sym(), loop::serial, bounds(0, 3), 1, check::make(y)));  // Trivial value, substitute
+  test_simplify(let_stmt::make(x, y, loop::make(z, loop::serial, bounds(0, 3), 1, check::make(x))),
+      loop::make(z, loop::serial, bounds(0, 3), 1, check::make(y)));  // Trivial value, substitute
 
   // lets that should be kept
   test_simplify(
-      let::make(x.sym(), y * 2, (x + 1) / x), let::make(x.sym(), y * 2, (x + 1) / x));  // Non-trivial, used more than once.
+      let::make(x, y * 2, (x + 1) / x), let::make(x, y * 2, (x + 1) / x));  // Non-trivial, used more than once.
 
-  test_simplify(
-    let_stmt::make(x.sym(), y * w, loop::make(z.sym(), loop::serial, bounds(0, 3), 1, check::make(x))),
-    let_stmt::make(x.sym(), y * w, loop::make(z.sym(), loop::serial, bounds(0, 3), 1, check::make(x))));  // Non-trivial, used in loop
+  test_simplify(let_stmt::make(x, y * w, loop::make(z, loop::serial, bounds(0, 3), 1, check::make(x))),
+      let_stmt::make(
+          x, y * w, loop::make(z, loop::serial, bounds(0, 3), 1, check::make(x))));  // Non-trivial, used in loop
 
-  test_simplify(
-    let_stmt::make(x.sym(), y * w, block::make({check::make(x > 0), check::make(x < 10)})),
-    let_stmt::make(x.sym(), y * w, block::make({check::make(x > 0), check::make(x < 10)})));  // Non-trivial, used twice
+  test_simplify(let_stmt::make(x, y * w, block::make({check::make(x > 0), check::make(x < 10)})),
+      let_stmt::make(x, y * w, block::make({check::make(x > 0), check::make(x < 10)})));  // Non-trivial, used twice
 
   // Compound lets with dependencies between let values.
-  test_simplify(let::make({{x.sym(), y}, {z.sym(), x}}, z), y);
-  test_simplify(let::make({{x.sym(), y}, {z.sym(), x * 2}}, z), y * 2);
-  test_simplify(let::make({{x.sym(), y * 2}, {z.sym(), x}}, z), y * 2);
-  test_simplify(let::make({{x.sym(), y * 2}, {z.sym(), y}}, z), y);
-  test_simplify(let::make({{x.sym(), y}, {z.sym(), (x + 1) / x}}, (z + 1) / z), let::make({{z.sym(), (y + 1) / y}}, (z + 1) / z));
+  test_simplify(let::make({{x, y}, {z, x}}, z), y);
+  test_simplify(let::make({{x, y}, {z, x * 2}}, z), y * 2);
+  test_simplify(let::make({{x, y * 2}, {z, x}}, z), y * 2);
+  test_simplify(let::make({{x, y * 2}, {z, y}}, z), y);
+  test_simplify(let::make({{x, y}, {z, (x + 1) / x}}, (z + 1) / z), let::make({{z, (y + 1) / y}}, (z + 1) / z));
 }
 
 TEST(simplify, buffer_intrinsics) {
@@ -169,36 +167,33 @@ TEST(simplify, buffer_intrinsics) {
 }
 
 TEST(simplify, bounds) {
-  test_simplify(loop::make(x.sym(), loop::serial, bounds(y - 2, z), 2, check::make(y - 2 <= x)), stmt());
-  test_simplify(loop::make(x.sym(), loop::serial, min_extent(x, z), z, check::make(y)), check::make(y));
+  test_simplify(loop::make(x, loop::serial, bounds(y - 2, z), 2, check::make(y - 2 <= x)), stmt());
+  test_simplify(loop::make(x, loop::serial, min_extent(x, z), z, check::make(y)), check::make(y));
 
   test_simplify(
-      allocate::make(x.sym(), memory_type::heap, 1, {{bounds(2, 3), 4, 5}}, check::make(buffer_min(x, 0) == 2)),
+      allocate::make(x, memory_type::heap, 1, {{bounds(2, 3), 4, 5}}, check::make(buffer_min(x, 0) == 2)), stmt());
+  test_simplify(allocate::make(x, memory_type::heap, 1, {{bounds(2, 3), 4, 5}},
+                    clone_buffer::make(y, x, check::make(buffer_min(y, 0) == 2))),
       stmt());
-  test_simplify(
-      allocate::make(x.sym(), memory_type::heap, 1, {{bounds(2, 3), 4, 5}}, clone_buffer::make(y.sym(), x.sym(), check::make(buffer_min(y, 0) == 2))),
+  test_simplify(allocate::make(x, memory_type::heap, 1, {{bounds(2, 3), 4, 5}},
+                    crop_dim::make(x, 0, bounds(1, 4), check::make(buffer_min(x, 0) == 2))),
       stmt());
-  test_simplify(allocate::make(x.sym(), memory_type::heap, 1, {{bounds(2, 3), 4, 5}},
-                    crop_dim::make(x.sym(), 0, bounds(1, 4), check::make(buffer_min(x, 0) == 2))),
-      stmt());
-  test_simplify(allocate::make(x.sym(), memory_type::heap, 1, {{bounds(y, z), 4, 5}},
-                    crop_dim::make(x.sym(), 0, bounds(y - 1, z + 1), check::make(buffer_min(x, 0) == 2))),
-      allocate::make(x.sym(), memory_type::heap, 1, {{bounds(y, z), 4, 5}}, check::make(y == 2)));
+  test_simplify(allocate::make(x, memory_type::heap, 1, {{bounds(y, z), 4, 5}},
+                    crop_dim::make(x, 0, bounds(y - 1, z + 1), check::make(buffer_min(x, 0) == 2))),
+      allocate::make(x, memory_type::heap, 1, {{bounds(y, z), 4, 5}}, check::make(y == 2)));
 }
 
 TEST(simplify, allocate) {
   // Pull statements that don't use the buffer out of allocate nodes.
-  test_simplify(allocate::make(x.sym(), memory_type::heap, 1, {{bounds(2, 3), 4, 5}},
+  test_simplify(allocate::make(x, memory_type::heap, 1, {{bounds(2, 3), 4, 5}},
                     block::make({check::make(y), check::make(x), check::make(z)})),
-      block::make({check::make(y),
-          allocate::make(x.sym(), memory_type::heap, 1, {{bounds(2, 3), 4, 5}}, check::make(x)), check::make(z)}));
+      block::make({check::make(y), allocate::make(x, memory_type::heap, 1, {{bounds(2, 3), 4, 5}}, check::make(x)),
+          check::make(z)}));
 
   // Make sure clone_buffer doesn't hide uses of buffers or bounds.
-  test_simplify(allocate::make(x.sym(), memory_type::heap, 1, {{bounds(2, 3), 4, 5}},
-                    block::make({check::make(y), clone_buffer::make(w.sym(), x.sym(), check::make(w)), check::make(z)})),
-      block::make({check::make(y),
-          allocate::make(x.sym(), memory_type::heap, 1, {{bounds(2, 3), 4, 5}},
-              check::make(x)),
+  test_simplify(allocate::make(x, memory_type::heap, 1, {{bounds(2, 3), 4, 5}},
+                    block::make({check::make(y), clone_buffer::make(w, x, check::make(w)), check::make(z)})),
+      block::make({check::make(y), allocate::make(x, memory_type::heap, 1, {{bounds(2, 3), 4, 5}}, check::make(x)),
           check::make(z)}));
 }
 
@@ -296,14 +291,14 @@ void test_where_true(const expr& test, symbol_id var, const interval_expr& expec
 }
 
 TEST(simplify, where_true) {
-  test_where_true(x < 5, x.sym(), bounds(negative_infinity(), 4));
-  test_where_true(x < buffer_min(y, 0), x.sym(), bounds(negative_infinity(), buffer_min(y, 0) + -1));
-  test_where_true(x / 2 < 7, x.sym(), bounds(negative_infinity(), 13));
-  test_where_true(min(x, 6) < 7, x.sym(), bounds(negative_infinity(), positive_infinity()));
-  test_where_true(-10 <= x && x < 5, x.sym(), bounds(-10, 4));
-  test_where_true(-x < 5, x.sym(), bounds(-4, positive_infinity()));
-  test_where_true(3 * x < 5, x.sym(), bounds(negative_infinity(), 1));
-  test_where_true(3 * (x + 2) < 5, x.sym(), bounds(negative_infinity(), -1));
+  test_where_true(x < 5, x, bounds(negative_infinity(), 4));
+  test_where_true(x < buffer_min(y, 0), x, bounds(negative_infinity(), buffer_min(y, 0) + -1));
+  test_where_true(x / 2 < 7, x, bounds(negative_infinity(), 13));
+  test_where_true(min(x, 6) < 7, x, bounds(negative_infinity(), positive_infinity()));
+  test_where_true(-10 <= x && x < 5, x, bounds(-10, 4));
+  test_where_true(-x < 5, x, bounds(-4, positive_infinity()));
+  test_where_true(3 * x < 5, x, bounds(negative_infinity(), 1));
+  test_where_true(3 * (x + 2) < 5, x, bounds(negative_infinity(), -1));
 }
 
 std::vector<var> vars = {x, y, z};

--- a/builder/simplify_test.cc
+++ b/builder/simplify_test.cc
@@ -286,9 +286,7 @@ void test_where(const expr& test, var x, const interval_expr& expected) {
   }
 }
 
-void test_where_true(const expr& test, var x, const interval_expr& expected) {
-  test_where(test, x, expected);
-}
+void test_where_true(const expr& test, var x, const interval_expr& expected) { test_where(test, x, expected); }
 
 TEST(simplify, where_true) {
   test_where_true(x < 5, x, bounds(negative_infinity(), 4));

--- a/builder/simplify_test.cc
+++ b/builder/simplify_test.cc
@@ -29,10 +29,10 @@ var w(symbols, "w");
 
 template <typename T>
 void dump_symbol_map(std::ostream& s, const symbol_map<T>& m) {
-  for (symbol_id n = 0; n < m.size(); ++n) {
+  for (std::size_t n = 0; n < m.size(); ++n) {
     const std::optional<T>& value = m[n];
     if (value) {
-      s << "  " << symbols.name(n) << " = " << *value << std::endl;
+      s << "  " << symbols.name(symbol_id(n)) << " = " << *value << std::endl;
     }
   }
 }
@@ -296,14 +296,14 @@ void test_where_true(const expr& test, symbol_id var, const interval_expr& expec
 }
 
 TEST(simplify, where_true) {
-  test_where_true(x < 5, 0, bounds(negative_infinity(), 4));
-  test_where_true(x < buffer_min(y, 0), 0, bounds(negative_infinity(), buffer_min(y, 0) + -1));
-  test_where_true(x / 2 < 7, 0, bounds(negative_infinity(), 13));
-  test_where_true(min(x, 6) < 7, 0, bounds(negative_infinity(), positive_infinity()));
-  test_where_true(-10 <= x && x < 5, 0, bounds(-10, 4));
-  test_where_true(-x < 5, 0, bounds(-4, positive_infinity()));
-  test_where_true(3 * x < 5, 0, bounds(negative_infinity(), 1));
-  test_where_true(3 * (x + 2) < 5, 0, bounds(negative_infinity(), -1));
+  test_where_true(x < 5, x.sym(), bounds(negative_infinity(), 4));
+  test_where_true(x < buffer_min(y, 0), x.sym(), bounds(negative_infinity(), buffer_min(y, 0) + -1));
+  test_where_true(x / 2 < 7, x.sym(), bounds(negative_infinity(), 13));
+  test_where_true(min(x, 6) < 7, x.sym(), bounds(negative_infinity(), positive_infinity()));
+  test_where_true(-10 <= x && x < 5, x.sym(), bounds(-10, 4));
+  test_where_true(-x < 5, x.sym(), bounds(-4, positive_infinity()));
+  test_where_true(3 * x < 5, x.sym(), bounds(negative_infinity(), 1));
+  test_where_true(3 * (x + 2) < 5, x.sym(), bounds(negative_infinity(), -1));
 }
 
 std::vector<var> vars = {x, y, z};

--- a/builder/slide_and_fold_storage.cc
+++ b/builder/slide_and_fold_storage.cc
@@ -83,11 +83,11 @@ std::vector<dim_expr> recursive_substitute(
 }
 
 void substitute_bounds(box_expr& bounds, const symbol_map<box_expr>& buffers) {
-  for (symbol_id i = 0; i < buffers.size(); ++i) {
+  for (std::size_t i = 0; i < buffers.size(); ++i) {
     if (!buffers[i]) continue;
     for (interval_expr& j : bounds) {
-      if (j.min.defined()) j.min = substitute_bounds(j.min, i, *buffers[i]);
-      if (j.max.defined()) j.max = substitute_bounds(j.max, i, *buffers[i]);
+      if (j.min.defined()) j.min = substitute_bounds(j.min, symbol_id(i), *buffers[i]);
+      if (j.max.defined()) j.max = substitute_bounds(j.max, symbol_id(i), *buffers[i]);
     }
   }
 }
@@ -119,7 +119,7 @@ public:
   symbol_map<box_expr>& current_buffer_bounds() { return *loops.back().buffer_bounds; }
 
   slide_and_fold(node_context& ctx) : ctx(ctx), x(ctx.insert_unique("_x")) {
-    loops.emplace_back(0, expr(), interval_expr::none(), expr(), loop::serial);
+    loops.emplace_back(symbol_id(), expr(), interval_expr::none(), expr(), loop::serial);
   }
 
   void visit(const allocate* op) override {

--- a/builder/slide_and_fold_storage.cc
+++ b/builder/slide_and_fold_storage.cc
@@ -231,8 +231,7 @@ public:
             // to move the loop min back so we compute the whole required region.
             expr new_min_at_new_loop_min = substitute(new_min, loop.sym, x);
             expr old_min_at_loop_min = substitute(old_min, loop.sym, loop.bounds.min);
-            expr new_loop_min =
-                where_true(ignore_loop_max(new_min_at_new_loop_min <= old_min_at_loop_min), x.sym()).max;
+            expr new_loop_min = where_true(ignore_loop_max(new_min_at_new_loop_min <= old_min_at_loop_min), x).max;
             if (!is_negative_infinity(new_loop_min)) {
               loop.bounds.min = new_loop_min;
 
@@ -348,10 +347,10 @@ public:
       loop_min = op->bounds.min;
     }
 
-    if (!is_variable(loop_min, orig_min.sym()) || depends_on(body, orig_min.sym()).any()) {
+    if (!is_variable(loop_min, orig_min) || depends_on(body, orig_min).any()) {
       // We rewrote or used the loop min.
       stmt result = loop::make(op->sym, op->max_workers, {loop_min, op->bounds.max}, op->step, std::move(body));
-      set_result(let_stmt::make(orig_min.sym(), op->bounds.min, result));
+      set_result(let_stmt::make(orig_min, op->bounds.min, result));
       return;
     }
 

--- a/builder/substitute.cc
+++ b/builder/substitute.cc
@@ -352,7 +352,7 @@ bool match(const dim_expr& a, const dim_expr& b) {
   return match(a.bounds, b.bounds) && match(a.stride, b.stride) && match(a.fold_factor, b.fold_factor);
 }
 
-int compare(const var& a, const var& b) { 
+int compare(const var& a, const var& b) {
   matcher m;
   m.try_match(a, b);
   return m.match;

--- a/builder/substitute.cc
+++ b/builder/substitute.cc
@@ -33,7 +33,7 @@ public:
     assert(match == 0);
     if (self < op) {
       match = -1;
-    } else if (self > op) {
+    } else if (op < self) {
       match = 1;
     }
     return match == 0;
@@ -360,7 +360,7 @@ namespace {
 
 class substitutor : public node_mutator {
   const symbol_map<expr>* replacements = nullptr;
-  symbol_id target_var = -1;
+  symbol_id target_var;
   expr replacement;
   span<const std::pair<expr, expr>> expr_replacements;
 

--- a/builder/substitute.cc
+++ b/builder/substitute.cc
@@ -41,9 +41,9 @@ public:
 
   bool try_match(const var& self, const var& op) {
     assert(match == 0);
-    if (self.s < op.s) {
+    if (self.id < op.id) {
       match = -1;
-    } else if (op.s < self.s) {
+    } else if (op.id < self.id) {
       match = 1;
     }
     return match == 0;

--- a/builder/substitute.h
+++ b/builder/substitute.h
@@ -17,25 +17,27 @@ bool match(const dim_expr& a, const dim_expr& b);
 
 expr substitute(const expr& e, const symbol_map<expr>& replacements);
 stmt substitute(const stmt& s, const symbol_map<expr>& replacements);
-expr substitute(const expr& e, symbol_id target, const expr& replacement);
-stmt substitute(const stmt& s, symbol_id target, const expr& replacement);
+expr substitute(const expr& e, var target, const expr& replacement);
+stmt substitute(const stmt& s, var target, const expr& replacement);
 expr substitute(const expr& e, const expr& target, const expr& replacement);
 stmt substitute(const stmt& s, const expr& target, const expr& replacement);
-expr substitute_bounds(const expr& e, symbol_id buffer, const box_expr& bounds);
-stmt substitute_bounds(const stmt& s, symbol_id buffer, const box_expr& bounds);
-expr substitute_bounds(const expr& e, symbol_id buffer, int dim, const interval_expr& bounds);
-stmt substitute_bounds(const stmt& s, symbol_id buffer, int dim, const interval_expr& bounds);
+expr substitute_bounds(const expr& e, var buffer, const box_expr& bounds);
+stmt substitute_bounds(const stmt& s, var buffer, const box_expr& bounds);
+expr substitute_bounds(const expr& e, var buffer, int dim, const interval_expr& bounds);
+stmt substitute_bounds(const stmt& s, var buffer, int dim, const interval_expr& bounds);
 
 // Compute a sort ordering of two nodes based on their structure (not their values).
+int compare(const var& a, const var& b);
 int compare(const expr& a, const expr& b);
 int compare(const base_expr_node* a, const base_expr_node* b);
 int compare(const stmt& a, const stmt& b);
 
 // Update buffer metadata expressions to account for a slice that has occurred.
-expr update_sliced_buffer_metadata(const expr& e, symbol_id buf, span<const int> slices);
+expr update_sliced_buffer_metadata(const expr& e, var buf, span<const int> slices);
 
 // A comparator suitable for using expr/stmt as keys in an std::map/std::set.
 struct node_less {
+  bool operator()(const var& a, const var& b) const { return compare(a, b) < 0; }
   bool operator()(const expr& a, const expr& b) const { return compare(a, b) < 0; }
   bool operator()(const stmt& a, const stmt& b) const { return compare(a, b) < 0; }
 };

--- a/builder/substitute_test.cc
+++ b/builder/substitute_test.cc
@@ -50,40 +50,36 @@ void test_substitute(const stmt& test, T target, const expr& replacement, const 
 }
 
 TEST(substitute, basic) {
-  test_substitute(x + y, x.sym(), z, z + y);
-  test_substitute(check::make(y == buffer_min(x, 3)), buffer_min(x, 3), z, check::make(y == z));
+  test_substitute(x + y, x, z, z + y);
+  test_substitute(check::make(y == buffer_min(x, 3)), buffer_min(x, 3), z, check::make(expr(y) == expr(z)));
 }
 
 TEST(substitute, shadowed) {
-  test_substitute(let::make(x.sym(), y, x + z), x.sym(), w, let::make(x.sym(), y, x + z));
-  test_substitute(let::make({{x.sym(), 1}, {y.sym(), 2}}, z + 1), z.sym(), z + w,
-      let::make({{x.sym(), 1}, {y.sym(), 2}}, z + w + 1));
+  test_substitute(let::make(x, y, x + z), x, w, let::make(x, y, x + z));
+  test_substitute(let::make({{x, 1}, {y, 2}}, z + 1), z, z + w, let::make({{x, 1}, {y, 2}}, z + w + 1));
 
-  test_substitute(crop_dim::make(x.sym(), 1, {y, z}, check::make(0 < buffer_min(x, 1))), buffer_min(x, 1), w,
-      crop_dim::make(x.sym(), 1, {max(y, w), z}, check::make(0 < buffer_min(x, 1))));
+  test_substitute(crop_dim::make(x, 1, {y, z}, check::make(0 < buffer_min(x, 1))), buffer_min(x, 1), w,
+      crop_dim::make(x, 1, {max(y, w), z}, check::make(0 < buffer_min(x, 1))));
 
-  test_substitute(slice_dim::make(x.sym(), 2, 0, check::make(buffer_min(x, 3) == 0)), buffer_min(x, 3), 1,
-      slice_dim::make(x.sym(), 2, 0, check::make(buffer_min(x, 3) == 0)));
-  test_substitute(slice_dim::make(x.sym(), 2, 0, check::make(y == buffer_min(x, 3))), y, buffer_max(x, 3),
-      slice_dim::make(x.sym(), 2, 0, check::make(buffer_max(x, 2) == buffer_min(x, 3))));
-  test_substitute(slice_dim::make(x.sym(), 2, 0, check::make(y == buffer_min(x, 3))), y, buffer_max(x, 2),
-      slice_dim::make(x.sym(), 2, 0, check::make(expr() == buffer_min(x, 3))));
-  test_substitute(slice_dim::make(x.sym(), 2, 0, check::make(y == buffer_min(x, 3))), y, buffer_max(x, 1),
-      slice_dim::make(x.sym(), 2, 0, check::make(buffer_max(x, 1) == buffer_min(x, 3))));
+  test_substitute(slice_dim::make(x, 2, 0, check::make(buffer_min(x, 3) == 0)), buffer_min(x, 3), 1,
+      slice_dim::make(x, 2, 0, check::make(buffer_min(x, 3) == 0)));
+  test_substitute(slice_dim::make(x, 2, 0, check::make(y == buffer_min(x, 3))), y, buffer_max(x, 3),
+      slice_dim::make(x, 2, 0, check::make(buffer_max(x, 2) == buffer_min(x, 3))));
+  test_substitute(slice_dim::make(x, 2, 0, check::make(y == buffer_min(x, 3))), y, buffer_max(x, 2),
+      slice_dim::make(x, 2, 0, check::make(expr() == buffer_min(x, 3))));
+  test_substitute(slice_dim::make(x, 2, 0, check::make(y == buffer_min(x, 3))), y, buffer_max(x, 1),
+      slice_dim::make(x, 2, 0, check::make(buffer_max(x, 1) == buffer_min(x, 3))));
 
-  test_substitute(copy_stmt::make(x.sym(), {y, z}, w.sym(), {y.sym(), z.sym()}, {}), y, z,
-      copy_stmt::make(x.sym(), {y, z}, w.sym(), {y.sym(), z.sym()}, {}));
-  test_substitute(copy_stmt::make(x.sym(), {y}, w.sym(), {y.sym()}, {}), y, z,
-      copy_stmt::make(x.sym(), {y}, w.sym(), {y.sym()}, {}));
-  test_substitute(copy_stmt::make(x.sym(), {y}, w.sym(), {z.sym()}, {}), y, u,
-      copy_stmt::make(x.sym(), {u}, w.sym(), {z.sym()}, {}));
+  test_substitute(copy_stmt::make(x, {y, z}, w, {y, z}, {}), y, z, copy_stmt::make(x, {y, z}, w, {y, z}, {}));
+  test_substitute(copy_stmt::make(x, {y}, w, {y}, {}), y, z, copy_stmt::make(x, {y}, w, {y}, {}));
+  test_substitute(copy_stmt::make(x, {y}, w, {z}, {}), y, u, copy_stmt::make(x, {u}, w, {z}, {}));
 }
 
 TEST(substitute, implicit_bounds) {
-  test_substitute(crop_dim::make(x.sym(), 0, bounds(y, z), check::make(x)), buffer_min(x, 0), w,
-      crop_dim::make(x.sym(), 0, bounds(max(y, w), z), check::make(x)));
-  test_substitute(crop_dim::make(x.sym(), 0, bounds(y, z), check::make(x)), buffer_max(x, 0), w,
-      crop_dim::make(x.sym(), 0, bounds(y, min(z, w)), check::make(x)));
+  test_substitute(crop_dim::make(x, 0, bounds(y, z), check::make(x)), buffer_min(x, 0), w,
+      crop_dim::make(x, 0, bounds(max(y, w), z), check::make(x)));
+  test_substitute(crop_dim::make(x, 0, bounds(y, z), check::make(x)), buffer_max(x, 0), w,
+      crop_dim::make(x, 0, bounds(y, min(z, w)), check::make(x)));
   test_substitute(buffer_at(x), buffer_min(x, 2), y, buffer_at(x, std::vector<expr>{expr(), expr(), expr(y)}));
 }
 

--- a/runtime/buffer.cc
+++ b/runtime/buffer.cc
@@ -390,8 +390,8 @@ bool any_folded(const raw_buffer* const* bufs, std::size_t size, int d) {
 static dim stride_0_dim;
 
 template <bool SkipContiguous, std::size_t BufsSize>
-index_t make_for_each_slice_dims_impl(const raw_buffer* const* bufs, void** bases,
-    std::size_t bufs_size_dynamic, for_each_slice_dim* slice_dims, dim_or_stride* dims) {
+index_t make_for_each_slice_dims_impl(const raw_buffer* const* bufs, void** bases, std::size_t bufs_size_dynamic,
+    for_each_slice_dim* slice_dims, dim_or_stride* dims) {
   std::size_t bufs_size = BufsSize == 0 ? bufs_size_dynamic : BufsSize;
   const auto* buf = bufs[0];
   for (std::size_t n = 0; n < bufs_size; ++n) {
@@ -474,8 +474,8 @@ index_t make_for_each_contiguous_slice_dims(
   }
 }
 
-bool make_for_each_slice_dims(span<const raw_buffer*> bufs, void** bases,
-    for_each_slice_dim* slice_dims, dim_or_stride* dims) {
+bool make_for_each_slice_dims(
+    span<const raw_buffer*> bufs, void** bases, for_each_slice_dim* slice_dims, dim_or_stride* dims) {
   for (std::size_t n = 1; n < bufs.size(); n++) {
     assert(can_slice_with(*bufs[0], *bufs[n]));
   }
@@ -487,8 +487,7 @@ bool make_for_each_slice_dims(span<const raw_buffer*> bufs, void** bases,
   case 1: return make_for_each_slice_dims_impl<false, 1>(bufs.data(), bases, 0, slice_dims, dims) >= 0;
   case 2: return make_for_each_slice_dims_impl<false, 2>(bufs.data(), bases, 0, slice_dims, dims) >= 0;
   case 3: return make_for_each_slice_dims_impl<false, 3>(bufs.data(), bases, 0, slice_dims, dims) >= 0;
-  default:
-    return make_for_each_slice_dims_impl<false, 0>(bufs.data(), bases, bufs.size(), slice_dims, dims) >= 0;
+  default: return make_for_each_slice_dims_impl<false, 0>(bufs.data(), bases, bufs.size(), slice_dims, dims) >= 0;
   }
 }
 

--- a/runtime/depends_on.cc
+++ b/runtime/depends_on.cc
@@ -11,13 +11,13 @@ namespace {
 
 class dependencies : public recursive_node_visitor {
 public:
-  span<const std::pair<symbol_id, depends_on_result&>> var_deps;
-  std::vector<symbol_id> shadowed;
+  span<const std::pair<var, depends_on_result&>> var_deps;
+  std::vector<var> shadowed;
 
-  dependencies(span<const std::pair<symbol_id, depends_on_result&>> var_deps) : var_deps(var_deps) {}
+  dependencies(span<const std::pair<var, depends_on_result&>> var_deps) : var_deps(var_deps) {}
 
   template <typename Fn>
-  void update_deps(symbol_id i, Fn fn) {
+  void update_deps(var i, Fn fn) {
     if (std::find(shadowed.begin(), shadowed.end(), i) != shadowed.end()) return;
     for (const auto& v : var_deps) {
       if (v.first == i) {
@@ -33,7 +33,7 @@ public:
   void visit(const call* op) override {
     if (is_buffer_intrinsic(op->intrinsic)) {
       assert(op->args.size() >= 1);
-      const symbol_id* buf = as_variable(op->args[0]);
+      const var* buf = as_variable(op->args[0]);
       assert(buf);
       update_deps(*buf, [](depends_on_result& deps) { deps.buffer_meta_read = true; });
 
@@ -85,13 +85,13 @@ public:
   }
 
   void visit(const call_stmt* op) override {
-    for (symbol_id i : op->inputs) {
+    for (var i : op->inputs) {
       update_deps(i, [](depends_on_result& deps) {
         deps.buffer_input = true;
         deps.buffer_meta_read = true;
       });
     }
-    for (symbol_id i : op->outputs) {
+    for (var i : op->outputs) {
       update_deps(i, [](depends_on_result& deps) {
         deps.buffer_output = true;
         deps.buffer_meta_read = true;
@@ -179,60 +179,60 @@ public:
 
 }  // namespace
 
-void depends_on(const expr& e, span<const std::pair<symbol_id, depends_on_result&>> var_deps) {
+void depends_on(const expr& e, span<const std::pair<var, depends_on_result&>> var_deps) {
   dependencies v(var_deps);
   if (e.defined()) e.accept(&v);
 }
 
-void depends_on(const stmt& s, span<const std::pair<symbol_id, depends_on_result&>> var_deps) {
+void depends_on(const stmt& s, span<const std::pair<var, depends_on_result&>> var_deps) {
   dependencies v(var_deps);
   if (s.defined()) s.accept(&v);
 }
 
-void depends_on(const expr& e, symbol_id var, depends_on_result& deps) {
-  std::pair<symbol_id, depends_on_result&> var_deps[] = {{var, deps}};
+void depends_on(const expr& e, var x, depends_on_result& deps) {
+  std::pair<var, depends_on_result&> var_deps[] = {{x, deps}};
   depends_on(e, var_deps);
 }
 
-void depends_on(const stmt& s, symbol_id var, depends_on_result& deps) {
-  std::pair<symbol_id, depends_on_result&> var_deps[] = {{var, deps}};
+void depends_on(const stmt& s, var x, depends_on_result& deps) {
+  std::pair<var, depends_on_result&> var_deps[] = {{x, deps}};
   depends_on(s, var_deps);
 }
 
-depends_on_result depends_on(const expr& e, symbol_id var) {
+depends_on_result depends_on(const expr& e, var x) {
   depends_on_result r;
-  depends_on(e, var, r);
+  depends_on(e, x, r);
   return r;
 }
 
-depends_on_result depends_on(const interval_expr& e, symbol_id var) {
+depends_on_result depends_on(const interval_expr& e, var x) {
   depends_on_result r;
-  depends_on(e.min, var, r);
-  depends_on(e.max, var, r);
+  depends_on(e.min, x, r);
+  depends_on(e.max, x, r);
   return r;
 }
 
-depends_on_result depends_on(const stmt& s, symbol_id var) {
+depends_on_result depends_on(const stmt& s, var x) {
   depends_on_result r;
-  depends_on(s, var, r);
+  depends_on(s, x, r);
   return r;
 }
 
-depends_on_result depends_on(const expr& e, span<const symbol_id> vars) {
+depends_on_result depends_on(const expr& e, span<const var> xs) {
   depends_on_result r;
-  std::vector<std::pair<symbol_id, depends_on_result&>> var_deps;
-  for (symbol_id i : vars) {
-    var_deps.push_back({i, r});
+  std::vector<std::pair<var, depends_on_result&>> var_deps;
+  for (var x : xs) {
+    var_deps.push_back({x, r});
   }
   depends_on(e, var_deps);
   return r;
 }
 
-depends_on_result depends_on(const stmt& s, span<const symbol_id> vars) {
+depends_on_result depends_on(const stmt& s, span<const var> xs) {
   depends_on_result r;
-  std::vector<std::pair<symbol_id, depends_on_result&>> var_deps;
-  for (symbol_id i : vars) {
-    var_deps.push_back({i, r});
+  std::vector<std::pair<var, depends_on_result&>> var_deps;
+  for (var x : xs) {
+    var_deps.push_back({x, r});
   }
   depends_on(s, var_deps);
   return r;

--- a/runtime/depends_on.h
+++ b/runtime/depends_on.h
@@ -37,15 +37,15 @@ struct depends_on_result {
 
 // Check if the node depends on a symbol or set of symbols.
 
-void depends_on(const expr& e, span<const std::pair<symbol_id, depends_on_result&>> var_deps);
-void depends_on(const stmt& s, span<const std::pair<symbol_id, depends_on_result&>> var_deps);
-void depends_on(const expr& e, symbol_id var, depends_on_result& deps);
-void depends_on(const stmt& s, symbol_id var, depends_on_result& deps);
-depends_on_result depends_on(const expr& e, symbol_id var);
-depends_on_result depends_on(const interval_expr& e, symbol_id var);
-depends_on_result depends_on(const stmt& s, symbol_id var);
-depends_on_result depends_on(const expr& e, span<const symbol_id> vars);
-depends_on_result depends_on(const stmt& s, span<const symbol_id> vars);
+void depends_on(const expr& e, span<const std::pair<var, depends_on_result&>> var_deps);
+void depends_on(const stmt& s, span<const std::pair<var, depends_on_result&>> var_deps);
+void depends_on(const expr& e, var x, depends_on_result& deps);
+void depends_on(const stmt& s, var x, depends_on_result& deps);
+depends_on_result depends_on(const expr& e, var x);
+depends_on_result depends_on(const interval_expr& e, var x);
+depends_on_result depends_on(const stmt& s, var x);
+depends_on_result depends_on(const expr& e, span<const var> xs);
+depends_on_result depends_on(const stmt& s, span<const var> xs);
 
 }  // namespace slinky
 

--- a/runtime/depends_on_test.cc
+++ b/runtime/depends_on_test.cc
@@ -30,27 +30,27 @@ bool operator==(const depends_on_result& l, const depends_on_result& r) {
 }
 
 TEST(depends_on, basic) {
-  ASSERT_EQ(depends_on(x + y, x.sym()), (depends_on_result{.var = true, .ref_count = 1}));
-  ASSERT_EQ(depends_on(x + x, x.sym()), (depends_on_result{.var = true, .ref_count = 2}));
+  ASSERT_EQ(depends_on(x + y, x), (depends_on_result{.var = true, .ref_count = 1}));
+  ASSERT_EQ(depends_on(x + x, x), (depends_on_result{.var = true, .ref_count = 2}));
 
-  stmt loop_x = loop::make(x.sym(), loop::serial, {y, z}, 1, check::make(x && z));
-  ASSERT_EQ(depends_on(loop_x, x.sym()), depends_on_result{});
-  ASSERT_EQ(depends_on(loop_x, y.sym()), (depends_on_result{.var = true, .ref_count = 1}));
+  stmt loop_x = loop::make(x, loop::serial, {y, z}, 1, check::make(x && z));
+  ASSERT_EQ(depends_on(loop_x, x), depends_on_result{});
+  ASSERT_EQ(depends_on(loop_x, y), (depends_on_result{.var = true, .ref_count = 1}));
 
-  stmt call = call_stmt::make(nullptr, {x.sym()}, {y.sym()}, {});
+  stmt call = call_stmt::make(nullptr, {x}, {y}, {});
   ASSERT_EQ(
-      depends_on(call, x.sym()), (depends_on_result{.buffer_input = true, .buffer_meta_read = true, .ref_count = 1}));
+      depends_on(call, x), (depends_on_result{.buffer_input = true, .buffer_meta_read = true, .ref_count = 1}));
   ASSERT_EQ(
-      depends_on(call, y.sym()), (depends_on_result{.buffer_output = true, .buffer_meta_read = true, .ref_count = 1}));
+      depends_on(call, y), (depends_on_result{.buffer_output = true, .buffer_meta_read = true, .ref_count = 1}));
 
-  stmt crop = crop_dim::make(x.sym(), 1, {y, z}, check::make(y));
-  ASSERT_EQ(depends_on(crop, x.sym()),
+  stmt crop = crop_dim::make(x, 1, {y, z}, check::make(y));
+  ASSERT_EQ(depends_on(crop, x),
       (depends_on_result{.buffer_meta_read = true, .buffer_meta_mutated = true, .ref_count = 1}));
 
-  stmt make_buffer = make_buffer::make(x.sym(), 0, 1, {{{y, z}, w}}, check::make(x && z));
-  ASSERT_EQ(depends_on(make_buffer, x.sym()), (depends_on_result{}));
-  ASSERT_EQ(depends_on(make_buffer, y.sym()), (depends_on_result{.var = true, .ref_count = 1}));
-  ASSERT_EQ(depends_on(make_buffer, z.sym()), (depends_on_result{.var = true, .ref_count = 2}));
+  stmt make_buffer = make_buffer::make(x, 0, 1, {{{y, z}, w}}, check::make(x && z));
+  ASSERT_EQ(depends_on(make_buffer, x), (depends_on_result{}));
+  ASSERT_EQ(depends_on(make_buffer, y), (depends_on_result{.var = true, .ref_count = 1}));
+  ASSERT_EQ(depends_on(make_buffer, z), (depends_on_result{.var = true, .ref_count = 2}));
 }
 
 }  // namespace slinky

--- a/runtime/depends_on_test.cc
+++ b/runtime/depends_on_test.cc
@@ -38,14 +38,12 @@ TEST(depends_on, basic) {
   ASSERT_EQ(depends_on(loop_x, y), (depends_on_result{.var = true, .ref_count = 1}));
 
   stmt call = call_stmt::make(nullptr, {x}, {y}, {});
-  ASSERT_EQ(
-      depends_on(call, x), (depends_on_result{.buffer_input = true, .buffer_meta_read = true, .ref_count = 1}));
-  ASSERT_EQ(
-      depends_on(call, y), (depends_on_result{.buffer_output = true, .buffer_meta_read = true, .ref_count = 1}));
+  ASSERT_EQ(depends_on(call, x), (depends_on_result{.buffer_input = true, .buffer_meta_read = true, .ref_count = 1}));
+  ASSERT_EQ(depends_on(call, y), (depends_on_result{.buffer_output = true, .buffer_meta_read = true, .ref_count = 1}));
 
   stmt crop = crop_dim::make(x, 1, {y, z}, check::make(y));
-  ASSERT_EQ(depends_on(crop, x),
-      (depends_on_result{.buffer_meta_read = true, .buffer_meta_mutated = true, .ref_count = 1}));
+  ASSERT_EQ(
+      depends_on(crop, x), (depends_on_result{.buffer_meta_read = true, .buffer_meta_mutated = true, .ref_count = 1}));
 
   stmt make_buffer = make_buffer::make(x, 0, 1, {{{y, z}, w}}, check::make(x && z));
   ASSERT_EQ(depends_on(make_buffer, x), (depends_on_result{}));

--- a/runtime/evaluate.cc
+++ b/runtime/evaluate.cc
@@ -34,8 +34,8 @@ bool can_evaluate(intrinsic fn) {
 void dump_context_for_expr(
     std::ostream& s, const symbol_map<index_t>& ctx, const expr& deps_of, const node_context* symbols = nullptr) {
   for (std::size_t i = 0; i < ctx.size(); ++i) {
-    std::string sym = symbols ? symbols->name(symbol_id(i)) : "<" + std::to_string(i) + ">";
-    auto deps = depends_on(deps_of, symbol_id(i));
+    std::string sym = symbols ? symbols->name(var(i)) : "<" + std::to_string(i) + ">";
+    auto deps = depends_on(deps_of, var(i));
     if (!deps_of.defined() || deps.var) {
       if (ctx[i]) {
         s << "  " << sym << " = " << *ctx[i] << std::endl;
@@ -313,7 +313,7 @@ public:
     } else {
       // TODO(https://github.com/dsharlet/slinky/issues/3): We don't get a reference to context[op->sym] here
       // because the context could grow and invalidate the reference. This could be fixed by having evaluate
-      // fully traverse the expression to find the max symbol_id, and pre-allocate the context up front. It's
+      // fully traverse the expression to find the max var, and pre-allocate the context up front. It's
       // not clear this optimization is necessary yet.
       std::optional<index_t> old_value = context[op->sym];
       for (index_t i = min; result == 0 && min <= i && i <= max; i += step) {

--- a/runtime/evaluate.cc
+++ b/runtime/evaluate.cc
@@ -33,18 +33,18 @@ bool can_evaluate(intrinsic fn) {
 
 void dump_context_for_expr(
     std::ostream& s, const symbol_map<index_t>& ctx, const expr& deps_of, const node_context* symbols = nullptr) {
-  for (symbol_id i = 0; i < ctx.size(); ++i) {
-    std::string sym = symbols ? symbols->name(i) : "<" + std::to_string(i) + ">";
-    auto deps = depends_on(deps_of, i);
+  for (std::size_t i = 0; i < ctx.size(); ++i) {
+    std::string sym = symbols ? symbols->name(symbol_id(i)) : "<" + std::to_string(i) + ">";
+    auto deps = depends_on(deps_of, symbol_id(i));
     if (!deps_of.defined() || deps.var) {
-      if (ctx.contains(i)) {
-        s << "  " << sym << " = " << *ctx.lookup(i) << std::endl;
+      if (ctx[i]) {
+        s << "  " << sym << " = " << *ctx[i] << std::endl;
       } else {
         s << "  " << sym << " = <>" << std::endl;
       }
     } else if (!deps_of.defined() || deps.buffer_meta_read) {
-      if (ctx.contains(i)) {
-        const raw_buffer* buf = reinterpret_cast<const raw_buffer*>(*ctx.lookup(i));
+      if (ctx[i]) {
+        const raw_buffer* buf = reinterpret_cast<const raw_buffer*>(*ctx[i]);
         s << "  " << sym << " = " << *buf << std::endl;
       }
     }

--- a/runtime/evaluate.cc
+++ b/runtime/evaluate.cc
@@ -199,7 +199,6 @@ public:
     return result;
   }
 
-
   void visit(const call* op) override {
     switch (op->intrinsic) {
     case intrinsic::positive_infinity: std::cerr << "Cannot evaluate positive_infinity" << std::endl; std::abort();

--- a/runtime/evaluate.h
+++ b/runtime/evaluate.h
@@ -15,8 +15,8 @@ public:
   // passing the result of `allocate` in addition to the buffer.
   // If these functions are not defined, the default handler will call
   // `raw_buffer::allocate` and `::free`.
-  std::function<void*(symbol_id, raw_buffer*)> allocate;
-  std::function<void(symbol_id, raw_buffer*, void*)> free;
+  std::function<void*(var, raw_buffer*)> allocate;
+  std::function<void(var, raw_buffer*, void*)> free;
 
   // Functions called when there is a failure in the pipeline.
   // If these functions are not defined, the default handler will write a
@@ -41,7 +41,7 @@ public:
   std::function<void(const raw_buffer& src, const raw_buffer& dst, const void* padding)> copy = slinky::copy;
   std::function<void(const dim* in_bounds, const raw_buffer& dst, const void* padding)> pad = slinky::pad;
 
-  const raw_buffer* lookup_buffer(symbol_id id) const { return reinterpret_cast<const raw_buffer*>(*lookup(id)); }
+  const raw_buffer* lookup_buffer(var id) const { return reinterpret_cast<const raw_buffer*>(*lookup(id)); }
 };
 
 index_t evaluate(const expr& e, eval_context& context);

--- a/runtime/evaluate_benchmark.cc
+++ b/runtime/evaluate_benchmark.cc
@@ -56,7 +56,7 @@ BENCHMARK(BM_call);
 
 void BM_let(benchmark::State& state) {
   std::atomic<int> calls = 0;
-  std::vector<std::pair<symbol_id, expr>> values = {{y, x}, {z, y}, {w, z}};
+  std::vector<std::pair<var, expr>> values = {{y, x}, {z, y}, {w, z}};
   values.resize(state.range(0));
   stmt body = make_loop(let_stmt::make(values, make_call_counter(calls)));
 

--- a/runtime/evaluate_benchmark.cc
+++ b/runtime/evaluate_benchmark.cc
@@ -30,7 +30,7 @@ stmt make_call_counter(std::atomic<int>& calls) {
       {}, {}, {});
 }
 
-stmt make_loop(stmt body) { return loop::make(x.sym(), loop::serial, range(0, iterations), 1, body); }
+stmt make_loop(stmt body) { return loop::make(x, loop::serial, range(0, iterations), 1, body); }
 
 // For nodes that need a buffer, we can add a buffer outside that loop, the cost of constructing it will be negligible.
 stmt make_buf(int rank, stmt body) {
@@ -38,7 +38,7 @@ stmt make_buf(int rank, stmt body) {
   for (int i = 0; i < rank; ++i) {
     dims.push_back({{0, 100}, i, dim::unfolded});
   }
-  return make_buffer::make(buf.sym(), 0, 1, dims, body);
+  return make_buffer::make(buf, 0, 1, dims, body);
 }
 
 void BM_call(benchmark::State& state) {
@@ -56,7 +56,7 @@ BENCHMARK(BM_call);
 
 void BM_let(benchmark::State& state) {
   std::atomic<int> calls = 0;
-  std::vector<std::pair<symbol_id, expr>> values = {{y.sym(), x}, {z.sym(), y}, {w.sym(), z}};
+  std::vector<std::pair<symbol_id, expr>> values = {{y, x}, {z, y}, {w, z}};
   values.resize(state.range(0));
   stmt body = make_loop(let_stmt::make(values, make_call_counter(calls)));
 
@@ -85,7 +85,7 @@ BENCHMARK(BM_block)->RangeMultiplier(2)->Range(2, 16);
 
 void BM_crop_dim(benchmark::State& state) {
   std::atomic<int> calls = 0;
-  stmt c = crop_dim::make(buf.sym(), 0, {1, 10}, make_call_counter(calls));
+  stmt c = crop_dim::make(buf, 0, {1, 10}, make_call_counter(calls));
   stmt l = make_loop(c);
   stmt body = make_buf(3, l);
 
@@ -100,7 +100,7 @@ BENCHMARK(BM_crop_dim);
 
 void BM_crop_buffer(benchmark::State& state) {
   std::atomic<int> calls = 0;
-  stmt c = crop_buffer::make(buf.sym(), {{1, 10}, {}, {2, 20}}, make_call_counter(calls));
+  stmt c = crop_buffer::make(buf, {{1, 10}, {}, {2, 20}}, make_call_counter(calls));
   stmt l = make_loop(c);
   stmt body = make_buf(3, l);
 
@@ -115,7 +115,7 @@ BENCHMARK(BM_crop_buffer);
 
 void BM_slice_dim(benchmark::State& state) {
   std::atomic<int> calls = 0;
-  stmt c = slice_dim::make(buf.sym(), 1, 10, make_call_counter(calls));
+  stmt c = slice_dim::make(buf, 1, 10, make_call_counter(calls));
   stmt l = make_loop(c);
   stmt body = make_buf(3, l);
 
@@ -130,7 +130,7 @@ BENCHMARK(BM_slice_dim);
 
 void BM_slice_buffer(benchmark::State& state) {
   std::atomic<int> calls = 0;
-  stmt c = slice_buffer::make(buf.sym(), {10, {}, 20}, make_call_counter(calls));
+  stmt c = slice_buffer::make(buf, {10, {}, 20}, make_call_counter(calls));
   stmt l = make_loop(c);
   stmt body = make_buf(3, l);
 
@@ -145,7 +145,7 @@ BENCHMARK(BM_slice_buffer);
 
 void BM_allocate(benchmark::State& state) {
   std::atomic<int> calls = 0;
-  stmt c = allocate::make(buf.sym(), memory_type::stack, 1, {{{0, 100}, 1, dim::unfolded}}, make_call_counter(calls));
+  stmt c = allocate::make(buf, memory_type::stack, 1, {{{0, 100}, 1, dim::unfolded}}, make_call_counter(calls));
   stmt body = make_loop(c);
 
   for (auto _ : state) {
@@ -173,7 +173,7 @@ BENCHMARK(BM_make_buffer);
 void BM_buffer_metadata(benchmark::State& state) {
   std::atomic<int> calls = 0;
   std::vector<dim_expr> dims = {buffer_dim(buf, 0), buffer_dim(buf, 1), buffer_dim(buf, 2)};
-  stmt clone = make_buffer::make(buf2.sym(), buffer_at(buf), buffer_elem_size(buf), dims, make_call_counter(calls));
+  stmt clone = make_buffer::make(buf2, buffer_at(buf), buffer_elem_size(buf), dims, make_call_counter(calls));
   stmt body = make_buf(3, make_loop(clone));
 
   for (auto _ : state) {
@@ -187,7 +187,7 @@ BENCHMARK(BM_buffer_metadata);
 
 void BM_parallel_loop(benchmark::State& state) {
   std::atomic<int> calls = 0;
-  stmt body = loop::make(x.sym(), loop::parallel, range(0, iterations), 1, make_call_counter(calls));
+  stmt body = loop::make(x, loop::parallel, range(0, iterations), 1, make_call_counter(calls));
 
   thread_pool t(state.range(0));
 

--- a/runtime/evaluate_test.cc
+++ b/runtime/evaluate_test.cc
@@ -76,7 +76,7 @@ TEST(evaluate, loop) {
         },
         {}, {}, {});
 
-    stmt l = loop::make(x.sym(), max_workers, range(2, 12), 3, c);
+    stmt l = loop::make(x, max_workers, range(2, 12), 3, c);
 
     int result = evaluate(l, eval_ctx);
     ASSERT_EQ(result, 0);

--- a/runtime/expr.h
+++ b/runtime/expr.h
@@ -32,6 +32,8 @@ public:
 
   expr operator-() const;
 
+  // TODO: This are risky. Someone could write var(x) == var(y) expecting to get an `expr` that compares the values of
+  // the variables when evaluated, but this compares the variable ids instead.
   bool operator==(var r) const { return id == r.id; }
   bool operator!=(var r) const { return id != r.id; }
   bool operator<(var r) const { return id < r.id; }
@@ -650,8 +652,7 @@ public:
     old_value_ = std::move(ctx_value);
     ctx_value = std::move(value);
   }
-  scoped_value_in_symbol_map(symbol_map<T>& context, var sym, std::optional<T> value)
-      : context_(&context), sym_(sym) {
+  scoped_value_in_symbol_map(symbol_map<T>& context, var sym, std::optional<T> value) : context_(&context), sym_(sym) {
     std::optional<T>& ctx_value = context[sym];
     old_value_ = std::move(ctx_value);
     ctx_value = std::move(value);

--- a/runtime/expr.h
+++ b/runtime/expr.h
@@ -22,19 +22,19 @@ public:
 
   static constexpr type invalid = -1;
 
-  type s;
+  type id;
 
-  var() : s(invalid) {}
-  explicit var(type s) : s(s) {}
+  var() : id(invalid) {}
+  explicit var(type id) : id(id) {}
   var(node_context& ctx, const std::string& name);
 
-  bool defined() const { return s != invalid; }
+  bool defined() const { return id != invalid; }
 
   expr operator-() const;
 
-  bool operator==(var r) const { return s == r.s; }
-  bool operator!=(var r) const { return s != r.s; }
-  bool operator<(var r) const { return s < r.s; }
+  bool operator==(var r) const { return id == r.id; }
+  bool operator!=(var r) const { return id != r.id; }
+  bool operator<(var r) const { return id < r.id; }
 };
 
 // We don't want to be doing string lookups in the inner loops. A node_context
@@ -593,30 +593,30 @@ public:
   }
 
   std::optional<T> lookup(var v) const {
-    if (v.s < values.size()) {
-      return values[v.s];
+    if (v.id < values.size()) {
+      return values[v.id];
     }
     return std::nullopt;
   }
 
   const T& lookup(var v, const T& def) const {
-    if (v.s < values.size() && values[v.s]) {
-      return *values[v.s];
+    if (v.id < values.size() && values[v.id]) {
+      return *values[v.id];
     }
     return def;
   }
 
   std::optional<T> operator[](var v) const { return lookup(v); }
   std::optional<T>& operator[](var v) {
-    grow(v.s);
-    return values[v.s];
+    grow(v.id);
+    return values[v.id];
   }
 
   bool contains(var v) const {
-    if (v.s >= values.size()) {
+    if (v.id >= values.size()) {
       return false;
     }
-    return !!values[v.s];
+    return !!values[v.id];
   }
 
   std::optional<T> operator[](std::size_t i) const {

--- a/runtime/expr.h
+++ b/runtime/expr.h
@@ -151,6 +151,7 @@ public:
   // Make a new constant expression.
   expr(index_t x);
   expr(int x) : expr(static_cast<index_t>(x)) {}
+  expr(symbol_id sym);
 
   // Make an `expr` referencing an existing node.
   expr(const base_expr_node* n) : n_(n) {}

--- a/runtime/expr_stmt.cc
+++ b/runtime/expr_stmt.cc
@@ -95,6 +95,7 @@ const constant* make_constant(index_t value) {
 }
 
 expr::expr(index_t x) : expr(make_constant(x)) {}
+expr::expr(symbol_id sym) : expr(make_variable(sym)) {}
 
 expr variable::make(symbol_id sym) { return make_variable(sym); }
 

--- a/runtime/expr_stmt.cc
+++ b/runtime/expr_stmt.cc
@@ -41,12 +41,12 @@ symbol_id node_context::insert_unique(const std::string& prefix) {
 }
 std::optional<symbol_id> node_context::lookup(const std::string& name) const {
   // TODO: At some point we might need a better data structure than doing this linear search.
-  for (symbol_id i = 0; i < sym_to_name.size(); ++i) {
+  for (std::size_t i = 0; i < sym_to_name.size(); ++i) {
     if (sym_to_name[i] == name) {
-      return i;
+      return symbol_id(i);
     }
   }
-  return {};
+  return std::nullopt;
 }
 
 template <typename T>

--- a/runtime/expr_stmt.cc
+++ b/runtime/expr_stmt.cc
@@ -16,17 +16,17 @@
 namespace slinky {
 
 std::string node_context::name(symbol_id i) const {
-  if (i < sym_to_name.size()) {
-    return sym_to_name[i];
+  if (i.s < sym_to_name.size()) {
+    return sym_to_name[i.s];
   } else {
-    return "<" + std::to_string(i) + ">";
+    return "<" + std::to_string(i.s) + ">";
   }
 }
 
 symbol_id node_context::insert(const std::string& name) {
   std::optional<symbol_id> sym = lookup(name);
   if (!sym) {
-    sym = sym_to_name.size();
+    sym = symbol_id(sym_to_name.size());
     sym_to_name.push_back(name);
   }
   return *sym;
@@ -582,7 +582,7 @@ var::var() : sym_(undef_var) {}
 var::var(symbol_id sym) : sym_(sym) {}
 var::var(node_context& ctx, const std::string& sym) : sym_(ctx.insert(sym)) {}
 
-bool var::defined() const { return sym_ != undef_var; }
+bool var::defined() const { return sym_.defined(); }
 
 symbol_id var::sym() const {
   assert(defined());
@@ -590,7 +590,7 @@ symbol_id var::sym() const {
 }
 
 var::operator expr() const {
-  assert(sym_ != undef_var);
+  assert(defined());
   return expr(variable::make(sym_));
 }
 

--- a/runtime/expr_stmt.cc
+++ b/runtime/expr_stmt.cc
@@ -15,6 +15,10 @@
 
 namespace slinky {
 
+var::var(node_context& ctx, const std::string& name) : var(ctx.insert_unique(name)) {}
+
+expr var::operator-() const { return -expr(*this); }
+
 std::string node_context::name(symbol_id i) const {
   if (i.s < sym_to_name.size()) {
     return sym_to_name[i.s];
@@ -571,28 +575,6 @@ bool is_buffer_max(const expr& x, symbol_id sym, int dim) {
 
   assert(c->args.size() == 2);
   return is_variable(c->args[0], sym) && is_constant(c->args[1], dim);
-}
-
-namespace {
-
-symbol_id undef_var = std::numeric_limits<symbol_id>::max();
-
-}
-
-var::var() : sym_(undef_var) {}
-var::var(symbol_id sym) : sym_(sym) {}
-var::var(node_context& ctx, const std::string& sym) : sym_(ctx.insert(sym)) {}
-
-bool var::defined() const { return sym_.defined(); }
-
-symbol_id var::sym() const {
-  assert(defined());
-  return sym_;
-}
-
-var::operator expr() const {
-  assert(defined());
-  return expr(variable::make(sym_));
 }
 
 void recursive_node_visitor::visit(const variable*) {}

--- a/runtime/expr_stmt.cc
+++ b/runtime/expr_stmt.cc
@@ -317,8 +317,8 @@ stmt call_stmt::make(call_stmt::callable target, symbol_list inputs, symbol_list
   return n;
 }
 
-stmt copy_stmt::make(var src, std::vector<expr> src_x, var dst, std::vector<var> dst_x,
-    std::optional<std::vector<char>> padding) {
+stmt copy_stmt::make(
+    var src, std::vector<expr> src_x, var dst, std::vector<var> dst_x, std::optional<std::vector<char>> padding) {
   auto n = new copy_stmt();
   n->src = src;
   n->src_x = std::move(src_x);
@@ -466,10 +466,7 @@ stmt check::make(expr condition) {
   return n;
 }
 
-namespace {
-
-
-}  // namespace
+namespace {}  // namespace
 
 const expr& positive_infinity() {
   static expr e = call::make(intrinsic::positive_infinity, {});
@@ -494,9 +491,7 @@ expr buffer_rank(expr buf) { return call::make(intrinsic::buffer_rank, {std::mov
 expr buffer_elem_size(expr buf) { return call::make(intrinsic::buffer_elem_size, {std::move(buf)}); }
 expr buffer_min(expr buf, expr dim) { return call::make(intrinsic::buffer_min, {std::move(buf), std::move(dim)}); }
 expr buffer_max(expr buf, expr dim) { return call::make(intrinsic::buffer_max, {std::move(buf), std::move(dim)}); }
-expr buffer_extent(expr buf, expr dim) {
-  return (buffer_max(buf, dim) - buffer_min(buf, dim)) + 1;
-}
+expr buffer_extent(expr buf, expr dim) { return (buffer_max(buf, dim) - buffer_min(buf, dim)) + 1; }
 expr buffer_stride(expr buf, expr dim) {
   return call::make(intrinsic::buffer_stride, {std::move(buf), std::move(dim)});
 }

--- a/runtime/expr_stmt.cc
+++ b/runtime/expr_stmt.cc
@@ -19,11 +19,11 @@ var::var(node_context& ctx, const std::string& name) : var(ctx.insert_unique(nam
 
 expr var::operator-() const { return -expr(*this); }
 
-std::string node_context::name(var i) const {
-  if (i.s < sym_to_name.size()) {
-    return sym_to_name[i.s];
+std::string node_context::name(var v) const {
+  if (v.id < sym_to_name.size()) {
+    return sym_to_name[v.id];
   } else {
-    return "<" + std::to_string(i.s) + ">";
+    return "<" + std::to_string(v.id) + ">";
   }
 }
 

--- a/runtime/pipeline.h
+++ b/runtime/pipeline.h
@@ -13,10 +13,10 @@ class eval_context;
 // This object essentially only stores the mapping of arguments to symbols.
 class pipeline {
 public:
-  std::vector<symbol_id> args;
-  std::vector<symbol_id> inputs;
-  std::vector<symbol_id> outputs;
-  std::vector<std::pair<symbol_id, const_raw_buffer_ptr>> constants;
+  std::vector<var> args;
+  std::vector<var> inputs;
+  std::vector<var> outputs;
+  std::vector<std::pair<var, const_raw_buffer_ptr>> constants;
 
   stmt body;
 

--- a/runtime/pipeline.h
+++ b/runtime/pipeline.h
@@ -13,9 +13,9 @@ class eval_context;
 // This object essentially only stores the mapping of arguments to symbols.
 class pipeline {
 public:
-  std::vector<var> args;
-  std::vector<var> inputs;
-  std::vector<var> outputs;
+  std::vector<symbol_id> args;
+  std::vector<symbol_id> inputs;
+  std::vector<symbol_id> outputs;
   std::vector<std::pair<symbol_id, const_raw_buffer_ptr>> constants;
 
   stmt body;

--- a/runtime/print.cc
+++ b/runtime/print.cc
@@ -10,7 +10,7 @@
 namespace slinky {
 
 std::string to_string(var sym) {
-  return "<" + std::to_string(sym.s) + ">";
+  return "<" + std::to_string(sym.id) + ">";
 }
 
 std::string to_string(memory_type type) {

--- a/runtime/print.cc
+++ b/runtime/print.cc
@@ -79,7 +79,7 @@ public:
     if (context) {
       os << context->name(sym);
     } else {
-      os << "<" << sym << ">";
+      os << sym;
     }
     return *this;
   }

--- a/runtime/print.cc
+++ b/runtime/print.cc
@@ -9,7 +9,7 @@
 
 namespace slinky {
 
-std::string to_string(symbol_id sym) {
+std::string to_string(var sym) {
   return "<" + std::to_string(sym.s) + ">";
 }
 
@@ -40,7 +40,7 @@ std::string to_string(intrinsic fn) {
   }
 }
 
-std::ostream& operator<<(std::ostream& os, symbol_id sym) { return os << to_string(sym); }
+std::ostream& operator<<(std::ostream& os, var sym) { return os << to_string(sym); }
 std::ostream& operator<<(std::ostream& os, memory_type type) { return os << to_string(type); }
 std::ostream& operator<<(std::ostream& os, intrinsic fn) { return os << to_string(fn); }
 
@@ -75,7 +75,7 @@ public:
     return *this;
   }
 
-  printer& operator<<(symbol_id sym) {
+  printer& operator<<(var sym) {
     if (context) {
       os << context->name(sym);
     } else {
@@ -99,7 +99,7 @@ public:
     return *this << "{" << d.bounds << ", " << d.stride << ", " << d.fold_factor << "}";
   }
 
-  printer& operator<<(const std::pair<symbol_id, expr>& let) { return *this << let.first << " = " << let.second; }
+  printer& operator<<(const std::pair<var, expr>& let) { return *this << let.first << " = " << let.second; }
 
   template <typename T>
   void print_vector(const std::vector<T>& v, const std::string& sep = ", ") {

--- a/runtime/print.cc
+++ b/runtime/print.cc
@@ -9,6 +9,10 @@
 
 namespace slinky {
 
+std::string to_string(symbol_id sym) {
+  return "<" + std::to_string(sym.s) + ">";
+}
+
 std::string to_string(memory_type type) {
   switch (type) {
   case memory_type::stack: return "stack";
@@ -36,8 +40,8 @@ std::string to_string(intrinsic fn) {
   }
 }
 
+std::ostream& operator<<(std::ostream& os, symbol_id sym) { return os << to_string(sym); }
 std::ostream& operator<<(std::ostream& os, memory_type type) { return os << to_string(type); }
-
 std::ostream& operator<<(std::ostream& os, intrinsic fn) { return os << to_string(fn); }
 
 std::ostream& operator<<(std::ostream& os, const interval_expr& i) {

--- a/runtime/print.cc
+++ b/runtime/print.cc
@@ -9,9 +9,7 @@
 
 namespace slinky {
 
-std::string to_string(var sym) {
-  return "<" + std::to_string(sym.id) + ">";
-}
+std::string to_string(var sym) { return "<" + std::to_string(sym.id) + ">"; }
 
 std::string to_string(memory_type type) {
   switch (type) {

--- a/runtime/print.h
+++ b/runtime/print.h
@@ -18,6 +18,7 @@ std::ostream& operator<<(std::ostream& os, const stmt& s);
 std::ostream& operator<<(std::ostream& os, const std::tuple<const expr&, const node_context&>& e);
 std::ostream& operator<<(std::ostream& os, const std::tuple<const stmt&, const node_context&>& s);
 
+std::ostream& operator<<(std::ostream& os, symbol_id sym);
 std::ostream& operator<<(std::ostream& os, const interval_expr& i);
 std::ostream& operator<<(std::ostream& os, const box_expr& i);
 std::ostream& operator<<(std::ostream& os, intrinsic fn);
@@ -29,6 +30,7 @@ std::ostream& operator<<(std::ostream& os, const dim& d);
 // It's not legal to overload std::to_string(), or anything else in std;
 // intended usage here is to do `using std::to_string;` followed by naked
 // to_string() calls.
+std::string to_string(symbol_id sym);
 std::string to_string(intrinsic fn);
 std::string to_string(memory_type type);
 

--- a/runtime/print.h
+++ b/runtime/print.h
@@ -18,7 +18,7 @@ std::ostream& operator<<(std::ostream& os, const stmt& s);
 std::ostream& operator<<(std::ostream& os, const std::tuple<const expr&, const node_context&>& e);
 std::ostream& operator<<(std::ostream& os, const std::tuple<const stmt&, const node_context&>& s);
 
-std::ostream& operator<<(std::ostream& os, symbol_id sym);
+std::ostream& operator<<(std::ostream& os, var sym);
 std::ostream& operator<<(std::ostream& os, const interval_expr& i);
 std::ostream& operator<<(std::ostream& os, const box_expr& i);
 std::ostream& operator<<(std::ostream& os, intrinsic fn);
@@ -30,7 +30,7 @@ std::ostream& operator<<(std::ostream& os, const dim& d);
 // It's not legal to overload std::to_string(), or anything else in std;
 // intended usage here is to do `using std::to_string;` followed by naked
 // to_string() calls.
-std::string to_string(symbol_id sym);
+std::string to_string(var sym);
 std::string to_string(intrinsic fn);
 std::string to_string(memory_type type);
 

--- a/runtime/stmt.h
+++ b/runtime/stmt.h
@@ -120,8 +120,8 @@ public:
 
   void accept(stmt_visitor* v) const override;
 
-  static stmt make(var src, std::vector<expr> src_x, var dst, std::vector<var> dst_x,
-      std::optional<std::vector<char>> padding);
+  static stmt make(
+      var src, std::vector<expr> src_x, var dst, std::vector<var> dst_x, std::optional<std::vector<char>> padding);
 
   static constexpr stmt_node_type static_type = stmt_node_type::copy_stmt;
 };
@@ -179,8 +179,7 @@ public:
 
   void accept(stmt_visitor* v) const override;
 
-  static stmt make(
-      var sym, int max_workers, interval_expr bounds, expr step, stmt body);
+  static stmt make(var sym, int max_workers, interval_expr bounds, expr step, stmt body);
 
   static constexpr stmt_node_type static_type = stmt_node_type::loop;
 };

--- a/runtime/visualize.cc
+++ b/runtime/visualize.cc
@@ -580,7 +580,7 @@ void visualize(std::ostream& dst, const pipeline& p, pipeline::scalars args, pip
 
   // Print function declaration.
   dst << "function pipeline(";
-  std::vector<var> symbols = p.args;
+  std::vector<symbol_id> symbols = p.args;
   symbols.insert(symbols.end(), p.inputs.begin(), p.inputs.end());
   symbols.insert(symbols.end(), p.outputs.begin(), p.outputs.end());
   jsp.print_vector(symbols);
@@ -597,13 +597,13 @@ void visualize(std::ostream& dst, const pipeline& p, pipeline::scalars args, pip
     jsp << "let " << p.args[i] << " = " << args[i] << ";\n";
   }
   for (index_t i = 0; i < static_cast<index_t>(p.inputs.size()); ++i) {
-    jsp << "let " << p.inputs[i] << " = allocate('" << jsp.name(p.inputs[i].sym()) << "', "
+    jsp << "let " << p.inputs[i] << " = allocate('" << jsp.name(p.inputs[i]) << "', "
         << static_cast<index_t>(inputs[i]->elem_size) << ", [";
     jsp.print_vector(span<dim>(inputs[i]->dims, inputs[i]->rank));
     jsp << "], true);\n";
   }
   for (index_t i = 0; i < static_cast<index_t>(p.outputs.size()); ++i) {
-    jsp << "let " << p.outputs[i] << " = allocate('" << jsp.name(p.outputs[i].sym()) << "', "
+    jsp << "let " << p.outputs[i] << " = allocate('" << jsp.name(p.outputs[i]) << "', "
         << static_cast<index_t>(outputs[i]->elem_size) << ", [";
     jsp.print_vector(span<dim>(outputs[i]->dims, outputs[i]->rank));
     jsp << "]);\n";

--- a/runtime/visualize.cc
+++ b/runtime/visualize.cc
@@ -53,7 +53,7 @@ public:
     if (context) {
       return context->name(sym);
     } else {
-      return "_" + std::to_string(sym);
+      return "_" + std::to_string(sym.s);
     }
   }
 

--- a/runtime/visualize.cc
+++ b/runtime/visualize.cc
@@ -53,7 +53,7 @@ public:
     if (context) {
       return context->name(v);
     } else {
-      return "_" + std::to_string(v.s);
+      return "_" + std::to_string(v.id);
     }
   }
 

--- a/runtime/visualize.cc
+++ b/runtime/visualize.cc
@@ -49,19 +49,18 @@ public:
     return s;
   }
 
-  std::string name(symbol_id sym) const {
+  std::string name(var v) const {
     if (context) {
-      return context->name(sym);
+      return context->name(v);
     } else {
-      return "_" + std::to_string(sym.s);
+      return "_" + std::to_string(v.s);
     }
   }
 
-  js_printer& operator<<(symbol_id sym) {
-    os << sanitize(name(sym));
+  js_printer& operator<<(var v) {
+    os << sanitize(name(v));
     return *this;
   }
-  js_printer& operator<<(const var& v) { return *this << v.sym(); }
 
   js_printer& operator<<(const expr& e) {
     if (e.defined()) {

--- a/runtime/visualize.cc
+++ b/runtime/visualize.cc
@@ -199,10 +199,10 @@ public:
   }
 
   void visit(const call_stmt* n) override {
-    for (symbol_id i : n->inputs) {
+    for (var i : n->inputs) {
       *this << indent() << "consume(" << i << ");\n";
     }
-    for (symbol_id i : n->outputs) {
+    for (var i : n->outputs) {
       *this << indent() << "produce(" << i << ");\n";
     }
   }
@@ -579,7 +579,7 @@ void visualize(std::ostream& dst, const pipeline& p, pipeline::scalars args, pip
 
   // Print function declaration.
   dst << "function pipeline(";
-  std::vector<symbol_id> symbols = p.args;
+  std::vector<var> symbols = p.args;
   symbols.insert(symbols.end(), p.inputs.begin(), p.inputs.end());
   symbols.insert(symbols.end(), p.outputs.begin(), p.outputs.end());
   jsp.print_vector(symbols);


### PR DESCRIPTION
A few things have bothered me for a while:
- Lack of strong typing for `symbol_id`, it allowed doing arithmetic and implicit conversions to ints (and then maybe `expr` as an integer and not a variable).
- `var` was a hacky wrapper to fix the first thing.

This PR *maybe* cleans this up by replacing `symbol_id` with `var`. This means we can now safely define `expr(var)`, and we can get rid of a lot of boilerplate.