### PR TITLE
Another instance to use bounds_of

### DIFF
--- a/builder/pipeline.cc
+++ b/builder/pipeline.cc
@@ -291,12 +291,9 @@ box_expr compute_input_bounds(
     expr min = sanitizer.mutate(i.bounds[d].min);
     expr max = sanitizer.mutate(i.bounds[d].max);
 
-    interval_expr bounds_of_min = bounds_of(min, output_bounds_i);
-    interval_expr bounds_of_max = bounds_of(max, output_bounds_i);
-
-    crop[d].min = simplify(static_cast<const class min*>(nullptr), bounds_of_min.min, bounds_of_max.min);
-    crop[d].max = simplify(static_cast<const class max*>(nullptr), bounds_of_min.max, bounds_of_max.max);
+    crop[d] = bounds_of({min, max}, output_bounds_i);
   }
+
   return crop;
 }
 

--- a/builder/simplify.cc
+++ b/builder/simplify.cc
@@ -422,16 +422,16 @@ public:
           };
           if (prove_true(crop->bounds.max + 1 >= next_iter.min || next_iter.max + 1 >= crop->bounds.min)) {
             result = crop->body;
-            // If the crop negates the loop variable, the min could become the max. Just do both and take the union.
-            interval_expr new_crop_a = {
-                substitute(crop->bounds.min, op->sym, bounds.min),
-                substitute(crop->bounds.max, op->sym, bounds.max),
-            };
-            interval_expr new_crop_b = {
-                substitute(crop->bounds.min, op->sym, bounds.max),
-                substitute(crop->bounds.max, op->sym, bounds.min),
-            };
-            new_crops.emplace_back(crop->sym, crop->dim, new_crop_a | new_crop_b);
+
+            interval_expr bounds_of_min = bounds_of(crop->bounds.min, {{op->sym, bounds}});
+            interval_expr bounds_of_max = bounds_of(crop->bounds.max, {{op->sym, bounds}});
+
+            interval_expr new_crop;
+
+            new_crop.min = simplify(static_cast<const class min*>(nullptr), bounds_of_min.min, bounds_of_max.min);
+            new_crop.max = simplify(static_cast<const class max*>(nullptr), bounds_of_min.max, bounds_of_max.max);
+
+            new_crops.emplace_back(crop->sym, crop->dim, new_crop);
           } else {
             // This crop was not contiguous, we can't drop the loop.
             drop_loop = false;

--- a/builder/simplify.cc
+++ b/builder/simplify.cc
@@ -1016,10 +1016,10 @@ interval_expr bounds_of(const interval_expr& x, const bounds_map& expr_bounds) {
 
   interval_expr bounds;
 
-  bounds.min = simplify(static_cast<const class min*>(nullptr), bounds_of_min.min, bounds_of_max.min);
-  bounds.max = simplify(static_cast<const class max*>(nullptr), bounds_of_min.max, bounds_of_max.max);
-
-  return bounds;
+  return {
+    simplify(static_cast<const class min*>(nullptr), bounds_of_min.min, bounds_of_max.min),
+    simplify(static_cast<const class max*>(nullptr), bounds_of_min.max, bounds_of_max.max),
+  };
 }
 
 std::optional<bool> attempt_to_prove(const expr& condition, const bounds_map& expr_bounds) {

--- a/builder/simplify.cc
+++ b/builder/simplify.cc
@@ -422,15 +422,7 @@ public:
           };
           if (prove_true(crop->bounds.max + 1 >= next_iter.min || next_iter.max + 1 >= crop->bounds.min)) {
             result = crop->body;
-
-            interval_expr bounds_of_min = bounds_of(crop->bounds.min, {{op->sym, bounds}});
-            interval_expr bounds_of_max = bounds_of(crop->bounds.max, {{op->sym, bounds}});
-
-            interval_expr new_crop;
-
-            new_crop.min = simplify(static_cast<const class min*>(nullptr), bounds_of_min.min, bounds_of_max.min);
-            new_crop.max = simplify(static_cast<const class max*>(nullptr), bounds_of_min.max, bounds_of_max.max);
-
+            interval_expr new_crop = bounds_of(crop->bounds, {{op->sym, bounds}});
             new_crops.emplace_back(crop->sym, crop->dim, new_crop);
           } else {
             // This crop was not contiguous, we can't drop the loop.
@@ -1015,6 +1007,18 @@ interval_expr bounds_of(const expr& x, const bounds_map& expr_bounds) {
   simplifier s(expr_bounds);
   interval_expr bounds;
   s.mutate(x, &bounds);
+  return bounds;
+}
+
+interval_expr bounds_of(const interval_expr& x, const bounds_map& expr_bounds) {
+  interval_expr bounds_of_min = bounds_of(x.min, expr_bounds);
+  interval_expr bounds_of_max = bounds_of(x.max, expr_bounds);
+
+  interval_expr bounds;
+
+  bounds.min = simplify(static_cast<const class min*>(nullptr), bounds_of_min.min, bounds_of_max.min);
+  bounds.max = simplify(static_cast<const class max*>(nullptr), bounds_of_min.max, bounds_of_max.max);
+
   return bounds;
 }
 

--- a/builder/simplify.cc
+++ b/builder/simplify.cc
@@ -1014,8 +1014,6 @@ interval_expr bounds_of(const interval_expr& x, const bounds_map& expr_bounds) {
   interval_expr bounds_of_min = bounds_of(x.min, expr_bounds);
   interval_expr bounds_of_max = bounds_of(x.max, expr_bounds);
 
-  interval_expr bounds;
-
   return {
     simplify(static_cast<const class min*>(nullptr), bounds_of_min.min, bounds_of_max.min),
     simplify(static_cast<const class max*>(nullptr), bounds_of_min.max, bounds_of_max.max),

--- a/builder/simplify.h
+++ b/builder/simplify.h
@@ -15,6 +15,7 @@ interval_expr simplify(const interval_expr& e, const bounds_map& bounds = bounds
 
 // Determine an interval such that e is always inside the interval.
 interval_expr bounds_of(const expr& x, const bounds_map& bounds = bounds_map());
+interval_expr bounds_of(const interval_expr& x, const bounds_map& bounds = bounds_map());
 
 // Attempts to determine if e can be proven to be always true or false.
 std::optional<bool> attempt_to_prove(const expr& condition, const bounds_map& bounds = bounds_map());


### PR DESCRIPTION
Tested with bazel test //... --cache_test_results=no