### PR TITLE
Allow crops to be lower rank than the buffer

### DIFF
--- a/builder/pipeline.cc
+++ b/builder/pipeline.cc
@@ -285,10 +285,11 @@ box_expr compute_input_bounds(
     }
   }
 
-  box_expr crop(std::min(i.bounds.size(), i.buffer->rank()));
-  for (std::size_t d = 0; d < crop.size(); ++d) {
+  box_expr crop(i.buffer->rank());
+  for (std::size_t d = 0; d < std::min(i.bounds.size(), crop.size()); ++d) {
     expr min = sanitizer.mutate(i.bounds[d].min);
     expr max = sanitizer.mutate(i.bounds[d].max);
+
     crop[d] = bounds_of({min, max}, output_bounds_i);
   }
 

--- a/builder/pipeline.cc
+++ b/builder/pipeline.cc
@@ -285,11 +285,10 @@ box_expr compute_input_bounds(
     }
   }
 
-  box_expr crop(i.buffer->rank());
-  for (std::size_t d = 0; d < std::min(i.bounds.size(), crop.size()); ++d) {
+  box_expr crop(std::min(i.bounds.size(), i.buffer->rank()));
+  for (std::size_t d = 0; d < crop.size(); ++d) {
     expr min = sanitizer.mutate(i.bounds[d].min);
     expr max = sanitizer.mutate(i.bounds[d].max);
-
     crop[d] = bounds_of({min, max}, output_bounds_i);
   }
 

--- a/builder/pipeline.cc
+++ b/builder/pipeline.cc
@@ -286,7 +286,7 @@ box_expr compute_input_bounds(
   }
 
   box_expr crop(i.buffer->rank());
-  for (int d = 0; d < static_cast<int>(crop.size()); ++d) {
+  for (std::size_t d = 0; d < std::min(i.bounds.size(), crop.size()); ++d) {
     expr min = sanitizer.mutate(i.bounds[d].min);
     expr max = sanitizer.mutate(i.bounds[d].max);
 


### PR DESCRIPTION
This is kinda weird, but we already degrade gracefully in this way elsewhere. The case I found this in was buggy in other ways too, but it should at least not fail here (with a vector out of bounds access).