### PR TITLE
Speed up simplify a lot by avoiding generating bounds of points

### DIFF
--- a/builder/simplify.cc
+++ b/builder/simplify.cc
@@ -320,15 +320,6 @@ public:
           return;
         }
       }
-    } else if (op->intrinsic == intrinsic::abs) {
-      assert(args.size() == 1);
-      if (is_non_negative(args_bounds[0].min)) {
-        set_result(args[0], std::move(args_bounds[0]));
-        return;
-      } else if (is_non_positive(args_bounds[0].max)) {
-        mutate_and_set_result(-args[0]);
-        return;
-      }
     }
 
     expr e = simplify(op, op->intrinsic, std::move(args));

--- a/builder/simplify_exprs.cc
+++ b/builder/simplify_exprs.cc
@@ -700,6 +700,15 @@ expr simplify(const call* op, intrinsic fn, std::vector<expr> args) {
     }
   }
 
+  if (fn == intrinsic::abs) {
+    assert(args.size() == 1);
+    if (is_non_negative(args[0])) {
+      return args[0];
+    } else if (is_non_positive(args[0])) {
+      return simplify(static_cast<const sub*>(nullptr), 0, std::move(args[0]));
+    }
+  }
+
   expr e;
   if (!changed) {
     assert(op);

--- a/builder/test/visualize/parallel_stencils_1.html
+++ b/builder/test/visualize/parallel_stencils_1.html
@@ -284,7 +284,7 @@ function pipeline(in1, in2, out) {
   check((((buffer_max(out, 1) - buffer_min(out, 1)) + 5) <= buffer_fold_factor(in2, 1)));
   { let intm4 = allocate('intm4', 2, [
       {bounds:{min:buffer_min(out, 0), max:buffer_max(out, 0)}, stride:2, fold_factor:9223372036854775807},
-      {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:(((buffer_max(out, 0) - buffer_min(out, 0)) * 2) + 2), fold_factor:2}
+      {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:(((buffer_max(out, 0) - buffer_min(out, 0)) * 2) + 2), fold_factor:(min((buffer_max(out, 1) - buffer_min(out, 1)), 1) + 1)}
     ]);
     { let intm4_uncropped = clone_buffer(intm4);
       { let intm2 = allocate('intm2', 2, [
@@ -294,7 +294,7 @@ function pipeline(in1, in2, out) {
         { let intm2_uncropped = clone_buffer(intm2);
           { let intm3 = allocate('intm3', 2, [
               {bounds:{min:buffer_min(out, 0), max:buffer_max(out, 0)}, stride:2, fold_factor:9223372036854775807},
-              {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:(((buffer_max(out, 0) - buffer_min(out, 0)) * 2) + 2), fold_factor:2}
+              {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:(((buffer_max(out, 0) - buffer_min(out, 0)) * 2) + 2), fold_factor:((buffer_max(out, 1) - buffer_min(out, 1)) + 1)}
             ]);
             { let intm3_uncropped = clone_buffer(intm3);
               { let intm1 = allocate('intm1', 2, [

--- a/builder/test/visualize/parallel_stencils_2.html
+++ b/builder/test/visualize/parallel_stencils_2.html
@@ -284,7 +284,7 @@ function pipeline(in1, in2, out) {
   check((((buffer_max(out, 1) - buffer_min(out, 1)) + 5) <= buffer_fold_factor(in2, 1)));
   { let intm4 = allocate('intm4', 2, [
       {bounds:{min:buffer_min(out, 0), max:buffer_max(out, 0)}, stride:2, fold_factor:9223372036854775807},
-      {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:(((buffer_max(out, 0) - buffer_min(out, 0)) * 2) + 2), fold_factor:2}
+      {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:(((buffer_max(out, 0) - buffer_min(out, 0)) * 2) + 2), fold_factor:(min((buffer_max(out, 1) - buffer_min(out, 1)), 1) + 1)}
     ]);
     { let intm4_uncropped = clone_buffer(intm4);
       { let intm2 = allocate('intm2', 2, [
@@ -294,7 +294,7 @@ function pipeline(in1, in2, out) {
         { let intm2_uncropped = clone_buffer(intm2);
           { let intm3 = allocate('intm3', 2, [
               {bounds:{min:buffer_min(out, 0), max:buffer_max(out, 0)}, stride:2, fold_factor:9223372036854775807},
-              {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:(((buffer_max(out, 0) - buffer_min(out, 0)) * 2) + 2), fold_factor:2}
+              {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:(((buffer_max(out, 0) - buffer_min(out, 0)) * 2) + 2), fold_factor:(min((buffer_max(out, 1) - buffer_min(out, 1)), 1) + 1)}
             ]);
             { let intm3_uncropped = clone_buffer(intm3);
               { let intm1 = allocate('intm1', 2, [

--- a/runtime/expr.h
+++ b/runtime/expr.h
@@ -526,9 +526,9 @@ inline bool is_true(const expr& x) {
 SLINKY_ALWAYS_INLINE inline bool is_false(const expr& x) { return is_zero(x); }
 
 // Check if `x` is a call to the intrinsic `fn`.
-inline bool is_intrinsic(const expr& x, intrinsic fn) {
+inline const call* is_intrinsic(const expr& x, intrinsic fn) {
   const call* c = x.as<call>();
-  return c ? c->intrinsic == fn : false;
+  return c && c->intrinsic == fn ? c : nullptr;
 }
 bool is_buffer_min(const expr& x, var sym, int dim);
 bool is_buffer_max(const expr& x, var sym, int dim);
@@ -552,12 +552,14 @@ const expr& indeterminate();
 
 inline bool is_positive(const expr& x) {
   if (is_positive_infinity(x)) return true;
+  if (const call* c = is_intrinsic(x, intrinsic::abs)) return is_positive(c);
   const index_t* c = as_constant(x);
   return c ? *c > 0 : false;
 }
 
 inline bool is_non_negative(const expr& x) {
   if (is_positive_infinity(x)) return true;
+  if (is_intrinsic(x, intrinsic::abs)) return true;
   const index_t* c = as_constant(x);
   return c ? *c >= 0 : false;
 }


### PR DESCRIPTION
This PR was a bit of a rabbit hole:
- Discovered that simplify can be *much* faster if we avoid generating unnecessary intervals when we already have points.
- This tightened bounds of mod (and probably other things too), which made pyramid storage folding fail.
- The fix is to track bounds of exprs and use them in storage folding. This made some interesting changes (tightening the bounds of parallel_stencils storage folding). They look like a regression, but they're tighter expressions (probably pointlessly so in this case).

@vksnk *might* be relevant for #225 storage folding issues.