### PR TITLE
Add more buffer helpers

### DIFF
--- a/runtime/buffer.h
+++ b/runtime/buffer.h
@@ -409,7 +409,7 @@ void fill(const raw_buffer& dst, const void* value);
 
 // Returns true if the two dimensions can be fused.
 inline bool can_fuse(const dim& inner, const dim& outer) {
-  if (outer.fold_factor() != dim::unfolded || inner.fold_factor() != dim::unfolded) return false;
+  if (inner.fold_factor() != dim::unfolded) return false;
   if (inner.stride() * inner.extent() != outer.stride()) return false;
   return true;
 }
@@ -448,7 +448,9 @@ bool same_rank(const raw_buffer& buf0, const raw_buffer& buf1, const Bufs&... bu
   return buf0.rank == buf1.rank && same_rank(buf1, bufs...);
 }
 
-inline bool same_bounds(const dim& a, const dim& b) { return a.min() == b.min() && a.extent() == b.extent(); }
+inline bool same_bounds(const dim& a, const dim& b) {
+  return a.min() == b.min() && a.extent() == b.extent() && a.fold_factor() == b.fold_factor();
+}
 
 // Returns true if all buffers have the same bounds in dimension d.
 inline bool same_bounds(int, const raw_buffer&) { return true; }

--- a/runtime/buffer.h
+++ b/runtime/buffer.h
@@ -367,7 +367,7 @@ public:
   auto& operator()(span<const index_t> indices) const { return at(indices); }
 
   // Insert a new dimension `dim` at index d, increasing the rank by 1.
-  raw_buffer& unslice(std::size_t d, const slinky::dim& dim) {
+  buffer<T, DimsSize>& unslice(std::size_t d, const slinky::dim& dim) {
     assert(d <= rank);
     if (d == 0) {
       assert(&dims_storage[0] <= dims - 1 && dims < &dims_storage[DimsSize]);

--- a/runtime/evaluate.cc
+++ b/runtime/evaluate.cc
@@ -504,18 +504,7 @@ public:
       old_bounds[d].min = old_min;
       old_bounds[d].max = old_max;
 
-      // Allow these expressions to be undefined, and if so, they default to their existing values.
-      index_t min = std::max(old_min, eval_expr(op->bounds[d].min, old_min));
-      index_t max = std::min(old_max, eval_expr(op->bounds[d].max, old_max));
-
-      if (max >= min) {
-        index_t offset = dim.flat_offset_bytes(min);
-        // Crops can't span a folding boundary if they move the base pointer.
-        assert(offset == 0 || (max - old_min) / dim.fold_factor() == (min - old_min) / dim.fold_factor());
-        buffer->base = offset_bytes(buffer->base, offset);
-      }
-
-      dim.set_bounds(min, max);
+      buffer->crop(d, eval_expr(op->bounds[d].min, old_min), eval_expr(op->bounds[d].max, old_max));
     }
 
     visit(op->body);
@@ -533,19 +522,9 @@ public:
     slinky::dim& dim = buffer->dims[op->dim];
     index_t old_min = dim.min();
     index_t old_max = dim.max();
-
-    index_t min = std::max(old_min, eval_expr(op->bounds.min, old_min));
-    index_t max = std::min(old_max, eval_expr(op->bounds.max, old_max));
-
     void* old_base = buffer->base;
-    if (max >= min) {
-      buffer->base = offset_bytes(buffer->base, dim.flat_offset_bytes(min));
-      // Crops can't span a folding boundary if they move the base pointer.
-      assert(buffer->base == old_base || (max - old_min) / dim.fold_factor() == (min - old_min) / dim.fold_factor());
-    }
 
-    dim.set_bounds(min, max);
-
+    buffer->crop(op->dim, eval_expr(op->bounds.min, old_min), eval_expr(op->bounds.max, old_max));
     visit(op->body);
 
     buffer->base = old_base;
@@ -585,29 +564,15 @@ public:
     raw_buffer* buffer = reinterpret_cast<raw_buffer*>(*context.lookup(op->sym));
     assert(buffer);
 
-    // The rank of the result is equal to the current rank, less any sliced dimensions.
-    dim* old_dims = buffer->dims;
-
-    buffer->dims = SLINKY_ALLOCA(dim, buffer->rank - 1);
-
-    index_t at = eval_expr(op->at);
-    index_t offset = old_dims[op->dim].flat_offset_bytes(at);
     void* old_base = buffer->base;
-    buffer->base = offset_bytes(buffer->base, offset);
+    // Remember the dim we are deleting.
+    dim old_dim = buffer->dim(op->dim);
 
-    for (int d = 0; d < op->dim; ++d) {
-      buffer->dims[d] = old_dims[d];
-    }
-    for (int d = op->dim + 1; d < static_cast<int>(buffer->rank); ++d) {
-      buffer->dims[d - 1] = old_dims[d];
-    }
-    buffer->rank -= 1;
-
+    buffer->slice(op->dim, eval_expr(op->at));
     visit(op->body);
 
     buffer->base = old_base;
-    buffer->rank += 1;
-    buffer->dims = old_dims;
+    buffer->unslice(op->dim, old_dim);
   }
 
   void visit(const truncate_rank* op) override {


### PR DESCRIPTION
- Add slice/crop helpers for buffers, and use them in `evaluate`
- Expose part of the can_fuse and fuse helpers