### PR TITLE
Buffer helper improvements

### DIFF
--- a/runtime/buffer.h
+++ b/runtime/buffer.h
@@ -324,12 +324,13 @@ public:
     elem_size = c.elem_size;
     assign_dims(c.rank, c.dims);
   }
-  void operator=(const buffer& c) {
-    if (this == &c) return;
+  buffer& operator=(const buffer& c) {
+    if (this == &c) return *this;
     free();
     raw_buffer::base = c.base();
     elem_size = c.elem_size;
     assign_dims(c.rank, c.dims);
+    return *this;
   }
 
   buffer(buffer&& m) { *this = std::move(m); }
@@ -337,10 +338,7 @@ public:
     if (this == &m) return *this;
     free();
     memcpy(static_cast<raw_buffer*>(this), static_cast<const raw_buffer*>(&m), sizeof(raw_buffer));
-    if (DimsSize > 0) {
-      memcpy(dims_storage, m.dims_storage, DimsSize * sizeof(slinky::dim));
-      dims = dims_storage;
-    }
+    assign_dims(m.rank, m.dims);
     // Take ownership of the data.
     to_free = m.to_free;
     m.to_free = nullptr;

--- a/runtime/buffer.h
+++ b/runtime/buffer.h
@@ -421,6 +421,7 @@ void fill(const raw_buffer& dst, const void* value);
 
 // Returns true if the two dimensions can be fused.
 inline bool can_fuse(const dim& inner, const dim& outer) {
+  if (outer.extent() == 1) return true;
   if (inner.fold_factor() != dim::unfolded) return false;
   if (inner.stride() * inner.extent() != outer.stride()) return false;
   return true;

--- a/runtime/buffer.h
+++ b/runtime/buffer.h
@@ -266,6 +266,10 @@ template <>
 struct default_elem_size<void> {
   static constexpr std::size_t value = 0;
 };
+template <>
+struct default_elem_size<const void> {
+  static constexpr std::size_t value = 0;
+};
 
 }  // namespace internal
 

--- a/runtime/buffer.h
+++ b/runtime/buffer.h
@@ -457,6 +457,10 @@ inline void fuse(fuse_type type, int inner, int outer, raw_buffer& buf) {
   dim& od = buf.dim(outer);
   assert(can_fuse(id, od));
   id.set_min_extent(od.min() * id.extent(), od.extent() * id.extent());
+  if (od.extent() != 1 && od.fold_factor() != dim::unfolded) {
+    assert(id.fold_factor() == dim::unfolded);
+    id.set_fold_factor(od.fold_factor() * id.extent());
+  }
   if (type == fuse_type::keep) {
     od.set_min_extent(0, 1);
   } else if (type == fuse_type::remove) {

--- a/runtime/buffer.h
+++ b/runtime/buffer.h
@@ -280,11 +280,13 @@ private:
     this->rank = rank;
     if (DimsSize > 0) {
       dims = dims_storage;
+      if (src) {
+        memcpy(dims, src, rank * sizeof(slinky::dim));
+      } else {
+        new (dims) slinky::dim[rank];
+      }
     } else {
       dims = nullptr;
-    }
-    if (src) {
-      memcpy(dims, src, rank * sizeof(slinky::dim));
     }
   }
 
@@ -378,8 +380,8 @@ public:
   // Insert a new dimension `dim` at index d, increasing the rank by 1.
   buffer<T, DimsSize>& unslice(std::size_t d, const slinky::dim& dim) {
     assert(d <= rank);
-    if (d == 0) {
-      assert(&dims_storage[0] <= dims - 1 && dims < &dims_storage[DimsSize]);
+    if (d == 0 && &dims_storage[0] <= dims - 1) {
+      assert(dims < &dims_storage[DimsSize]);
       dims -= 1;
     } else {
       assert(&dims_storage[0] <= dims && dims + 1 < &dims_storage[DimsSize]);

--- a/runtime/test/buffer.cc
+++ b/runtime/test/buffer.cc
@@ -137,6 +137,19 @@ TEST(buffer, shallow_copy) {
   ASSERT_NE(buf.dims, buf2.dims);
 }
 
+TEST(buffer, shallow_copy_different_capacity) {
+  buffer<int, 2> buf({10, 20});
+  init_random(buf);
+  buffer<int, 3> buf2 = buf;
+  ASSERT_EQ(buf.base(), buf2.base());
+  ASSERT_EQ(buf.elem_size, buf2.elem_size);
+  ASSERT_EQ(buf.rank, buf2.rank);
+  ASSERT_EQ(buf.dim(0), buf2.dim(0));
+  ASSERT_EQ(buf.dim(1), buf2.dim(1));
+
+  ASSERT_NE(buf.dims, buf2.dims);
+}
+
 TEST(buffer, folded) {
   buffer<char, 2> buf({10, 20});
   ASSERT_EQ(buf.size_bytes(), 10 * 20);


### PR DESCRIPTION
- `slice` of more than one dimension at once.
- Allow constructing `buffer<T, N>` from `buffer<T, M>`
- Always allow fusing extent 1 dimensions.