### PR TITLE
Add `name` to call attributes

### DIFF
--- a/builder/optimizations.cc
+++ b/builder/optimizations.cc
@@ -138,6 +138,8 @@ public:
           return stmt();
         }
         // Make a call to `pad`.
+        call_stmt::attributes pad_attrs;
+        pad_attrs.name = "pad";
         return call_stmt::make(
             [padding = *op->padding](const call_stmt* op, const eval_context& ctx) -> index_t {
               const raw_buffer* src_buf = ctx.lookup_buffer(op->inputs[0]);
@@ -145,7 +147,7 @@ public:
               ctx.pad(src_buf->dims, *dst_buf, padding.data());
               return 0;
             },
-            {src}, {dst}, {});
+            {src}, {dst}, std::move(pad_attrs));
       });
 
       if (pad_result.same_as(result)) {
@@ -307,6 +309,8 @@ stmt alias_buffers(const stmt& s) { return buffer_aliaser().mutate(s); }
 
 stmt implement_copy(const copy_stmt* op, node_context& ctx) {
   // Start by making a call to copy.
+  call_stmt::attributes copy_attrs;
+  copy_attrs.name = "copy";
   stmt result = call_stmt::make(
       [padding = op->padding](const call_stmt* op, const eval_context& ctx) -> index_t {
         const raw_buffer* src_buf = ctx.lookup_buffer(op->inputs[0]);
@@ -315,7 +319,7 @@ stmt implement_copy(const copy_stmt* op, node_context& ctx) {
         ctx.copy(*src_buf, *dst_buf, pad_value);
         return 0;
       },
-      {op->src}, {op->dst}, {});
+      {op->src}, {op->dst}, std::move(copy_attrs));
 
   std::vector<expr> src_x = op->src_x;
   std::vector<dim_expr> src_dims;

--- a/builder/pipeline.cc
+++ b/builder/pipeline.cc
@@ -88,7 +88,7 @@ box_expr buffer_expr::bounds() const {
 }
 
 func::func(
-    call_stmt::callable impl, std::vector<input> inputs, std::vector<output> outputs, call_stmt::callable_attrs attrs)
+    call_stmt::callable impl, std::vector<input> inputs, std::vector<output> outputs, call_stmt::attributes attrs)
     : impl_(std::move(impl)), attrs_(attrs), inputs_(std::move(inputs)), outputs_(std::move(outputs)) {
   add_this_to_buffers();
 }

--- a/builder/pipeline.cc
+++ b/builder/pipeline.cc
@@ -849,8 +849,11 @@ stmt inject_traces(const stmt& s, node_context& ctx, std::set<buffer_expr_ptr>& 
     }
 
     expr get_trace_arg(const call_stmt* op) {
-      // TODO: If we add some kind of description to call_stmt::attrs, use it here.
-      return get_trace_arg("call");
+      if (!op->attrs.name.empty()) {
+        return get_trace_arg(op->attrs.name);
+      } else {
+        return get_trace_arg("call");
+      }
     }
 
     stmt add_trace(stmt s, expr trace_arg) {

--- a/builder/pipeline.cc
+++ b/builder/pipeline.cc
@@ -89,7 +89,7 @@ box_expr buffer_expr::bounds() const {
 
 func::func(
     call_stmt::callable impl, std::vector<input> inputs, std::vector<output> outputs, call_stmt::attributes attrs)
-    : impl_(std::move(impl)), attrs_(attrs), inputs_(std::move(inputs)), outputs_(std::move(outputs)) {
+    : impl_(std::move(impl)), attrs_(std::move(attrs)), inputs_(std::move(inputs)), outputs_(std::move(outputs)) {
   add_this_to_buffers();
 }
 
@@ -110,6 +110,7 @@ func& func::operator=(func&& m) noexcept {
   loops_ = std::move(m.loops_);
   compute_at_ = std::move(m.compute_at_);
   padding_ = std::move(m.padding_);
+  attrs_ = std::move(m.attrs_);
   add_this_to_buffers();
   return *this;
 }

--- a/builder/pipeline.h
+++ b/builder/pipeline.h
@@ -217,7 +217,7 @@ public:
       return call_impl<T...>(impl, ctx, op, std::make_index_sequence<sizeof...(T)>());
     };
 
-    return func(std::move(wrapper), std::move(inputs), std::move(outputs), attrs);
+    return func(std::move(wrapper), std::move(inputs), std::move(outputs), std::move(attrs));
   }
 
   // Version for lambdas
@@ -231,7 +231,7 @@ public:
 
     using std_function_type = typename sig::std_function_type;
     std_function_type impl = std::move(lambda);
-    return make(std::move(impl), std::move(inputs), std::move(outputs), attrs);
+    return make(std::move(impl), std::move(inputs), std::move(outputs), std::move(attrs));
   }
 
   // Version for plain old function ptrs
@@ -239,7 +239,7 @@ public:
   static func make(index_t (*fn)(const buffer<T>&...), std::vector<input> inputs, std::vector<output> outputs,
       call_stmt::attributes attrs = {}) {
     callable<T...> impl = fn;
-    return make(std::move(impl), std::move(inputs), std::move(outputs), attrs);
+    return make(std::move(impl), std::move(inputs), std::move(outputs), std::move(attrs));
   }
 
   // Make a copy from a single input to a single output.

--- a/builder/pipeline.h
+++ b/builder/pipeline.h
@@ -138,7 +138,7 @@ public:
 
 private:
   call_stmt::callable impl_;
-  call_stmt::callable_attrs attrs_;
+  call_stmt::attributes attrs_;
   std::vector<input> inputs_;
   std::vector<output> outputs_;
 
@@ -153,7 +153,7 @@ private:
 public:
   func() = default;
   func(call_stmt::callable impl, std::vector<input> inputs, std::vector<output> outputs,
-      call_stmt::callable_attrs attrs = {});
+      call_stmt::attributes attrs = {});
   func(std::vector<input> inputs, output out);
   func(input input, output out, std::optional<std::vector<char>> padding = std::nullopt);
   func(func&&) noexcept;
@@ -209,7 +209,7 @@ public:
   // Version for std::function
   template <typename... T>
   static func make(callable<T...>&& fn, std::vector<input> inputs, std::vector<output> outputs,
-      call_stmt::callable_attrs attrs = {}) {
+      call_stmt::attributes attrs = {}) {
     callable<T...> impl = std::move(fn);
     assert(sizeof...(T) == inputs.size() + outputs.size());
 
@@ -223,7 +223,7 @@ public:
   // Version for lambdas
   template <typename Lambda>
   static func make(
-      Lambda&& lambda, std::vector<input> inputs, std::vector<output> outputs, call_stmt::callable_attrs attrs = {}) {
+      Lambda&& lambda, std::vector<input> inputs, std::vector<output> outputs, call_stmt::attributes attrs = {}) {
     // Verify that the lambda returns an index_t; a different return type will fail to match
     // the std::function call and just call this same function in an endless death spiral.
     using sig = lambda_call_signature<Lambda>;
@@ -237,7 +237,7 @@ public:
   // Version for plain old function ptrs
   template <typename... T>
   static func make(index_t (*fn)(const buffer<T>&...), std::vector<input> inputs, std::vector<output> outputs,
-      call_stmt::callable_attrs attrs = {}) {
+      call_stmt::attributes attrs = {}) {
     callable<T...> impl = fn;
     return make(std::move(impl), std::move(inputs), std::move(outputs), attrs);
   }

--- a/builder/slide_and_fold_storage.cc
+++ b/builder/slide_and_fold_storage.cc
@@ -468,6 +468,8 @@ public:
         interval_expr sem_bounds = {0, stage_count - 1};
 
         index_t sem_size = sizeof(index_t);
+        call_stmt::attributes init_sems_attrs;
+        init_sems_attrs.name = "init_semaphores";
         stmt init_sems = call_stmt::make(
             [stage_count](const call_stmt* s, eval_context& ctx) -> index_t {
               buffer<index_t>& sems = *reinterpret_cast<buffer<index_t>*>(*ctx.lookup(s->outputs[0]));
@@ -481,7 +483,7 @@ public:
               std::fill_n(&sems(0), stage_count, 1);
               return 0;
             },
-            {}, {l.semaphores}, {});
+            {}, {l.semaphores}, std::move(init_sems_attrs));
         // We can fold the semaphores array by the number of threads we'll use.
         // TODO: Use the loop index and not the loop variable directly for semaphores so we don't need to do this.
         expr sem_fold_factor = stage_count * op->step;

--- a/builder/test/elementwise.cc
+++ b/builder/test/elementwise.cc
@@ -88,7 +88,7 @@ public:
       return 0;
     };
     func r = func::make<const T, const T, T>(
-        std::move(fn), {{a, bounds}, {b, bounds}}, {{result, dims}}, call_stmt::callable_attrs{.allow_in_place = true});
+        std::move(fn), {{a, bounds}, {b, bounds}}, {{result, dims}}, call_stmt::attributes{.allow_in_place = true});
     result_funcs.push_back(std::move(r));
   }
 
@@ -125,7 +125,7 @@ public:
       return 0;
     };
     func r = func::make<const T, const T, const T, T>(std::move(fn), {{c, bounds}, {t, bounds}, {f, bounds}},
-        {{result, dims}}, call_stmt::callable_attrs{.allow_in_place = true});
+        {{result, dims}}, call_stmt::attributes{.allow_in_place = true});
     result_funcs.push_back(std::move(r));
   }
 

--- a/builder/test/pipeline.cc
+++ b/builder/test/pipeline.cc
@@ -258,7 +258,7 @@ TEST_P(trivial, pipeline) {
   var x(ctx, "x");
 
   func mul =
-      func::make(multiply_2<int>, {{in, {point(x)}}}, {{out, {x}}}, call_stmt::callable_attrs{.allow_in_place = true});
+      func::make(multiply_2<int>, {{in, {point(x)}}}, {{out, {x}}}, call_stmt::attributes{.allow_in_place = true});
   if (split > 0) {
     mul.loops({{x, split, max_workers}});
   }
@@ -317,9 +317,9 @@ TEST_P(elementwise, pipeline_1d) {
   func::callable<const int, int> a1 = add_1<int>;
 
   func mul =
-      func::make(std::move(m2), {{in, {point(x)}}}, {{intm, {x}}}, call_stmt::callable_attrs{.allow_in_place = true});
+      func::make(std::move(m2), {{in, {point(x)}}}, {{intm, {x}}}, call_stmt::attributes{.allow_in_place = true});
   func add =
-      func::make(std::move(a1), {{intm, {point(x)}}}, {{out, {x}}}, call_stmt::callable_attrs{.allow_in_place = true});
+      func::make(std::move(a1), {{intm, {point(x)}}}, {{out, {x}}}, call_stmt::attributes{.allow_in_place = true});
 
   if (split > 0) {
     add.loops({{x, split, max_workers}});
@@ -379,9 +379,9 @@ TEST_P(elementwise, pipeline_2d) {
   auto a1 = [](const buffer<const int>& a, const buffer<int>& b) -> index_t { return add_1<int>(a, b); };
 
   func mul = func::make(
-      std::move(m2), {{in, {point(x), point(y)}}}, {{intm, {x, y}}}, call_stmt::callable_attrs{.allow_in_place = true});
+      std::move(m2), {{in, {point(x), point(y)}}}, {{intm, {x, y}}}, call_stmt::attributes{.allow_in_place = true});
   func add = func::make(std::move(a1), {{intm, {point(x), point(y)}}}, {{out, {x, y}}},
-      call_stmt::callable_attrs{.allow_in_place = true});
+      call_stmt::attributes{.allow_in_place = true});
 
   if (split > 0) {
     add.loops({{x, split, max_workers}, {y, split, max_workers}});
@@ -1164,13 +1164,13 @@ TEST(unrelated, pipeline) {
     var y(ctx, "y");
 
     func add1 = func::make(add_1<short>, {{in1, {point(x), point(y)}}}, {{intm1, {x, y}}},
-        call_stmt::callable_attrs{.allow_in_place = true});
+        call_stmt::attributes{.allow_in_place = true});
     func stencil1 = func::make(sum3x3<short>, {{intm1, {bounds(-1, 1) + x, bounds(-1, 1) + y}}}, {{out1, {x, y}}});
 
     func mul2 = func::make(
-        multiply_2<int>, {{in2, {point(x)}}}, {{intm2, {x}}}, call_stmt::callable_attrs{.allow_in_place = true});
+        multiply_2<int>, {{in2, {point(x)}}}, {{intm2, {x}}}, call_stmt::attributes{.allow_in_place = true});
     func add2 =
-        func::make(add_1<int>, {{intm2, {point(x)}}}, {{out2, {x}}}, call_stmt::callable_attrs{.allow_in_place = true});
+        func::make(add_1<int>, {{intm2, {point(x)}}}, {{out2, {x}}}, call_stmt::attributes{.allow_in_place = true});
 
     stencil1.loops({{y, 2}});
 

--- a/builder/test/pipeline.cc
+++ b/builder/test/pipeline.cc
@@ -2,8 +2,8 @@
 
 #include <algorithm>
 #include <cassert>
-#include <numeric>
 #include <fstream>
+#include <numeric>
 
 #include "builder/pipeline.h"
 #include "builder/replica_pipeline.h"
@@ -380,8 +380,8 @@ TEST_P(elementwise, pipeline_2d) {
 
   func mul = func::make(
       std::move(m2), {{in, {point(x), point(y)}}}, {{intm, {x, y}}}, call_stmt::attributes{.allow_in_place = true});
-  func add = func::make(std::move(a1), {{intm, {point(x), point(y)}}}, {{out, {x, y}}},
-      call_stmt::attributes{.allow_in_place = true});
+  func add = func::make(
+      std::move(a1), {{intm, {point(x), point(y)}}}, {{out, {x, y}}}, call_stmt::attributes{.allow_in_place = true});
 
   if (split > 0) {
     add.loops({{x, split, max_workers}, {y, split, max_workers}});
@@ -845,9 +845,12 @@ TEST_P(stencil_chain, pipeline) {
   var x(ctx, "x");
   var y(ctx, "y");
 
-  func add = func::make(add_1<short>, {{in, {point(x), point(y)}}}, {{intm, {x, y}}});
-  func stencil1 = func::make(sum3x3<short>, {{intm, {bounds(-1, 1) + x, bounds(-1, 1) + y}}}, {{intm2, {x, y}}});
-  func stencil2 = func::make(sum3x3<short>, {{intm2, {bounds(-1, 1) + x, bounds(-1, 1) + y}}}, {{out, {x, y}}});
+  func add =
+      func::make(add_1<short>, {{in, {point(x), point(y)}}}, {{intm, {x, y}}}, call_stmt::attributes{.name = "add_1"});
+  func stencil1 = func::make(sum3x3<short>, {{intm, {bounds(-1, 1) + x, bounds(-1, 1) + y}}}, {{intm2, {x, y}}},
+      call_stmt::attributes{.name = "sum3x3"});
+  func stencil2 = func::make(sum3x3<short>, {{intm2, {bounds(-1, 1) + x, bounds(-1, 1) + y}}}, {{out, {x, y}}},
+      call_stmt::attributes{.name = "sum3x3"});
 
   if (split > 0) {
     stencil2.loops({{y, split, max_workers}});
@@ -1163,12 +1166,12 @@ TEST(unrelated, pipeline) {
     var x(ctx, "x");
     var y(ctx, "y");
 
-    func add1 = func::make(add_1<short>, {{in1, {point(x), point(y)}}}, {{intm1, {x, y}}},
-        call_stmt::attributes{.allow_in_place = true});
+    func add1 = func::make(
+        add_1<short>, {{in1, {point(x), point(y)}}}, {{intm1, {x, y}}}, call_stmt::attributes{.allow_in_place = true});
     func stencil1 = func::make(sum3x3<short>, {{intm1, {bounds(-1, 1) + x, bounds(-1, 1) + y}}}, {{out1, {x, y}}});
 
-    func mul2 = func::make(
-        multiply_2<int>, {{in2, {point(x)}}}, {{intm2, {x}}}, call_stmt::attributes{.allow_in_place = true});
+    func mul2 =
+        func::make(multiply_2<int>, {{in2, {point(x)}}}, {{intm2, {x}}}, call_stmt::attributes{.allow_in_place = true});
     func add2 =
         func::make(add_1<int>, {{intm2, {point(x)}}}, {{out2, {x}}}, call_stmt::attributes{.allow_in_place = true});
 

--- a/builder/test/visualize/stencil_chain_split_serial_split_0.html
+++ b/builder/test/visualize/stencil_chain_split_serial_split_0.html
@@ -260,7 +260,7 @@ function trace_end(x) { return 1; }
 let __trace_names = allocate('__trace_names', 1, [{bounds:{min:0, max:0}, stride:1, fold_factor:1}], true);
 function pipeline(__in, out) {
   {
-    let __trace_token = trace_begin(buffer_at(__trace_names, 5));
+    let __trace_token = trace_begin(buffer_at(__trace_names, 13));
     check((__in != 0));
     check((buffer_rank(__in) == 2));
     check((buffer_elem_size(__in) == 2));
@@ -290,7 +290,7 @@ function pipeline(__in, out) {
           check(trace_end(__trace_token));
         }
         {
-          let __trace_token = trace_begin(buffer_at(__trace_names, 0));
+          let __trace_token = trace_begin(buffer_at(__trace_names, 6));
           consume(add_result);
           produce(stencil1_result);
           check(trace_end(__trace_token));
@@ -298,7 +298,7 @@ function pipeline(__in, out) {
         free(add_result);
       }
       {
-        let __trace_token = trace_begin(buffer_at(__trace_names, 0));
+        let __trace_token = trace_begin(buffer_at(__trace_names, 6));
         consume(stencil1_result);
         produce(out);
         check(trace_end(__trace_token));

--- a/builder/test/visualize/stencil_chain_split_serial_split_1.html
+++ b/builder/test/visualize/stencil_chain_split_serial_split_1.html
@@ -260,7 +260,7 @@ function trace_end(x) { return 1; }
 let __trace_names = allocate('__trace_names', 1, [{bounds:{min:0, max:0}, stride:1, fold_factor:1}], true);
 function pipeline(__in, out) {
   {
-    let __trace_token = trace_begin(buffer_at(__trace_names, 29));
+    let __trace_token = trace_begin(buffer_at(__trace_names, 37));
     check((__in != 0));
     check((buffer_rank(__in) == 2));
     check((buffer_elem_size(__in) == 2));
@@ -301,7 +301,7 @@ function pipeline(__in, out) {
                   }
                   { let __stencil1_result = crop_dim(stencil1_result, 1, {min:(y + 1), max:(y + 1)});
                     {
-                      let __trace_token = trace_begin(buffer_at(__trace_names, 24));
+                      let __trace_token = trace_begin(buffer_at(__trace_names, 30));
                       consume(add_result_uncropped);
                       produce(stencil1_result);
                       check(trace_end(__trace_token));
@@ -310,7 +310,7 @@ function pipeline(__in, out) {
                   }
                   { let __out = crop_dim(out, 1, {min:y, max:y});
                     {
-                      let __trace_token = trace_begin(buffer_at(__trace_names, 24));
+                      let __trace_token = trace_begin(buffer_at(__trace_names, 30));
                       consume(stencil1_result_uncropped);
                       produce(out);
                       check(trace_end(__trace_token));

--- a/builder/test/visualize/stencil_chain_split_serial_split_2.html
+++ b/builder/test/visualize/stencil_chain_split_serial_split_2.html
@@ -260,7 +260,7 @@ function trace_end(x) { return 1; }
 let __trace_names = allocate('__trace_names', 1, [{bounds:{min:0, max:0}, stride:1, fold_factor:1}], true);
 function pipeline(__in, out) {
   {
-    let __trace_token = trace_begin(buffer_at(__trace_names, 29));
+    let __trace_token = trace_begin(buffer_at(__trace_names, 37));
     check((__in != 0));
     check((buffer_rank(__in) == 2));
     check((buffer_elem_size(__in) == 2));
@@ -301,7 +301,7 @@ function pipeline(__in, out) {
                   }
                   { let __stencil1_result = crop_dim(stencil1_result, 1, {min:(y + 1), max:(min((y + 1), buffer_max(out, 1)) + 1)});
                     {
-                      let __trace_token = trace_begin(buffer_at(__trace_names, 24));
+                      let __trace_token = trace_begin(buffer_at(__trace_names, 30));
                       consume(add_result_uncropped);
                       produce(stencil1_result);
                       check(trace_end(__trace_token));
@@ -310,7 +310,7 @@ function pipeline(__in, out) {
                   }
                   { let __out = crop_dim(out, 1, {min:y, max:(y + 1)});
                     {
-                      let __trace_token = trace_begin(buffer_at(__trace_names, 24));
+                      let __trace_token = trace_begin(buffer_at(__trace_names, 30));
                       consume(stencil1_result_uncropped);
                       produce(out);
                       check(trace_end(__trace_token));

--- a/runtime/expr_stmt.cc
+++ b/runtime/expr_stmt.cc
@@ -313,7 +313,7 @@ stmt call_stmt::make(call_stmt::callable target, symbol_list inputs, symbol_list
   n->target = std::move(target);
   n->inputs = std::move(inputs);
   n->outputs = std::move(outputs);
-  n->attrs = attrs;
+  n->attrs = std::move(attrs);
   return n;
 }
 

--- a/runtime/expr_stmt.cc
+++ b/runtime/expr_stmt.cc
@@ -308,7 +308,7 @@ expr call::make(slinky::intrinsic i, std::vector<expr> args) {
   return n;
 }
 
-stmt call_stmt::make(call_stmt::callable target, symbol_list inputs, symbol_list outputs, callable_attrs attrs) {
+stmt call_stmt::make(call_stmt::callable target, symbol_list inputs, symbol_list outputs, attributes attrs) {
   auto n = new call_stmt();
   n->target = std::move(target);
   n->inputs = std::move(inputs);

--- a/runtime/print.cc
+++ b/runtime/print.cc
@@ -214,7 +214,13 @@ public:
   }
 
   void visit(const call_stmt* n) override {
-    *this << indent() << "call(<fn>, {" << n->inputs << "}, {" << n->outputs << "})\n";
+    *this << indent() << "call(";
+    if (!n->attrs.name.empty()) {
+      *this << n->attrs.name;
+    } else {
+      *this << "<anonymous function>";
+    }
+    *this << ", {" << n->inputs << "}, {" << n->outputs << "})\n";
   }
 
   void visit(const copy_stmt* n) override {

--- a/runtime/stmt.h
+++ b/runtime/stmt.h
@@ -88,7 +88,7 @@ public:
   using callable = std::function<index_t(const call_stmt*, eval_context&)>;
   using symbol_list = std::vector<var>;
 
-  struct callable_attrs {
+  struct attributes {
     // Allow inputs and outputs to this call to be aliased to the same buffer.
     bool allow_in_place = false;
   };
@@ -98,11 +98,11 @@ public:
   // accessed (and how) by the callable.
   symbol_list inputs;
   symbol_list outputs;
-  callable_attrs attrs;
+  attributes attrs;
 
   void accept(stmt_visitor* v) const override;
 
-  static stmt make(callable target, symbol_list inputs, symbol_list outputs, callable_attrs attrs);
+  static stmt make(callable target, symbol_list inputs, symbol_list outputs, attributes attrs);
 
   static constexpr stmt_node_type static_type = stmt_node_type::call_stmt;
 };

--- a/runtime/stmt.h
+++ b/runtime/stmt.h
@@ -91,6 +91,10 @@ public:
   struct attributes {
     // Allow inputs and outputs to this call to be aliased to the same buffer.
     bool allow_in_place = false;
+
+    // A name for the callable. This is only a tag that is passed through slinky and used for printing, it doesn't
+    // affect any slinky logic.
+    std::string name;
   };
 
   callable target;


### PR DESCRIPTION
This is helpful for making printed out slinky code easier to read.