### PR TITLE
Replica PIpelines should preserve `call_stmt::attributes` (#246)

### DIFF
--- a/builder/pipeline.h
+++ b/builder/pipeline.h
@@ -261,6 +261,7 @@ public:
   const call_stmt::callable& impl() const { return impl_; }
   const std::vector<input>& inputs() const { return inputs_; }
   const std::vector<output>& outputs() const { return outputs_; }
+  const call_stmt::attributes& attrs() const { return attrs_; }
   const std::optional<std::vector<char>>& padding() const { return padding_; }
 
   stmt make_call() const;

--- a/builder/replica_pipeline.cc
+++ b/builder/replica_pipeline.cc
@@ -246,6 +246,18 @@ public:
     return print_vector(loopinfos_vec);
   }
 
+  std::string print(const call_stmt::attributes& attrs) {
+    std::string a;
+    if (attrs.allow_in_place != false) {
+      a += ".allow_in_place = true";
+    }
+    if (!attrs.name.empty()) {
+      if (!a.empty()) a += ", ";
+      a += ".name = \"" + attrs.name + "\"";
+    }
+    return "{" + a + "}";
+  }
+
   std::string print(const loop_id& loopid) {
     if (!loopid.func && !loopid.var.defined()) {
       return "<root>";
@@ -299,8 +311,9 @@ public:
       std::string callback = print_callback(f.inputs(), f.outputs());
       std::string func_inputs = print(f.inputs());
       std::string func_outputs = print(f.outputs());
+      std::string func_attrs = print(f.attrs());
       (void)print_assignment_explicit(
-          fn_name, "func::make(std::move(", callback, "), ", func_inputs, ", ", func_outputs, ")");
+          fn_name, "func::make(std::move(", callback, "), ", func_inputs, ", ", func_outputs, ", ", func_attrs, ")");
     }
     if (!f.loops().empty()) {
       std::string li = print(f.loops());

--- a/builder/test/pipeline.cc
+++ b/builder/test/pipeline.cc
@@ -906,6 +906,10 @@ TEST_P(stencil_chain, pipeline) {
     }
   }
 
+  if (split == 1 && max_workers == loop::serial) {
+    check_replica_pipeline(define_replica_pipeline(ctx, {in}, {out}));
+  }
+
   // Also visualize this pipeline.
   if (max_workers == loop::serial) {
     check_visualize(test_name + ".html", p, inputs, outputs, &ctx);

--- a/builder/test/pipeline.cc
+++ b/builder/test/pipeline.cc
@@ -906,10 +906,6 @@ TEST_P(stencil_chain, pipeline) {
     }
   }
 
-  if (split == 1 && max_workers == loop::serial) {
-    check_replica_pipeline(define_replica_pipeline(ctx, {in}, {out}));
-  }
-
   // Also visualize this pipeline.
   if (max_workers == loop::serial) {
     check_visualize(test_name + ".html", p, inputs, outputs, &ctx);
@@ -1170,14 +1166,14 @@ TEST(unrelated, pipeline) {
     var x(ctx, "x");
     var y(ctx, "y");
 
-    func add1 = func::make(
-        add_1<short>, {{in1, {point(x), point(y)}}}, {{intm1, {x, y}}}, call_stmt::attributes{.allow_in_place = true});
+    func add1 = func::make(add_1<short>, {{in1, {point(x), point(y)}}}, {{intm1, {x, y}}},
+        call_stmt::attributes{.allow_in_place = true, .name = "add1"});
     func stencil1 = func::make(sum3x3<short>, {{intm1, {bounds(-1, 1) + x, bounds(-1, 1) + y}}}, {{out1, {x, y}}});
 
-    func mul2 =
-        func::make(multiply_2<int>, {{in2, {point(x)}}}, {{intm2, {x}}}, call_stmt::attributes{.allow_in_place = true});
-    func add2 =
-        func::make(add_1<int>, {{intm2, {point(x)}}}, {{out2, {x}}}, call_stmt::attributes{.allow_in_place = true});
+    func mul2 = func::make(multiply_2<int>, {{in2, {point(x)}}}, {{intm2, {x}}},
+        call_stmt::attributes{.allow_in_place = true, .name = "mul2"});
+    func add2 = func::make(add_1<int>, {{intm2, {point(x)}}}, {{out2, {x}}},
+        call_stmt::attributes{.allow_in_place = true, .name = "add2"});
 
     stencil1.loops({{y, 2}});
 

--- a/builder/test/replica_pipeline.cc
+++ b/builder/test/replica_pipeline.cc
@@ -47,7 +47,7 @@ auto p = []() -> ::slinky::pipeline {
     const std::vector<var> outputs[] = {{i, j}};
     return ::slinky::internal::replica_pipeline_handler(input_buffers, output_buffers, inputs, outputs);
   };
-  auto _fn_2 = func::make(std::move(_replica_fn_4), {{a, {point(i), {(buffer_min(_3, 1)), (buffer_max(_3, 1))}}}, {b, {{(buffer_min(_3, 1)), (buffer_max(_3, 1))}, point(j)}}}, {{ab, {i, j}}});
+  auto _fn_2 = func::make(std::move(_replica_fn_4), {{a, {point(i), {(buffer_min(_3, 1)), (buffer_max(_3, 1))}}}, {b, {{(buffer_min(_3, 1)), (buffer_max(_3, 1))}, point(j)}}}, {{ab, {i, j}}}, {});
   auto _5 = variable::make(c->sym());
   auto _replica_fn_6 = [=](const buffer<const void>& i0, const buffer<const void>& i1, const buffer<void>& o0) -> index_t {
     const buffer<const void>* input_buffers[] = {&i0, &i1};
@@ -56,7 +56,7 @@ auto p = []() -> ::slinky::pipeline {
     const std::vector<var> outputs[] = {{i, j}};
     return ::slinky::internal::replica_pipeline_handler(input_buffers, output_buffers, inputs, outputs);
   };
-  auto _fn_0 = func::make(std::move(_replica_fn_6), {{ab, {point(i), {(buffer_min(_5, 0)), (buffer_max(_5, 0))}}}, {c, {{(buffer_min(_5, 0)), (buffer_max(_5, 0))}, point(j)}}}, {{abc, {i, j}}});
+  auto _fn_0 = func::make(std::move(_replica_fn_6), {{ab, {point(i), {(buffer_min(_5, 0)), (buffer_max(_5, 0))}}}, {c, {{(buffer_min(_5, 0)), (buffer_max(_5, 0))}, point(j)}}}, {{abc, {i, j}}}, {});
   _fn_0.loops({{i, 1, loop::serial}});
   auto p = build_pipeline(ctx, {}, {a, b, c}, {abc}, {});
   return p;
@@ -105,7 +105,7 @@ auto p = []() -> ::slinky::pipeline {
     const std::vector<var> outputs[] = {{x, y}};
     return ::slinky::internal::replica_pipeline_handler(input_buffers, output_buffers, inputs, outputs);
   };
-  auto _fn_1 = func::make(std::move(_replica_fn_2), {{in, {{((((x * 2)) + 0)), ((((x * 2)) + 1))}, {((((y * 2)) + 0)), ((((y * 2)) + 1))}}}}, {{intm, {x, y}}});
+  auto _fn_1 = func::make(std::move(_replica_fn_2), {{in, {{((((x * 2)) + 0)), ((((x * 2)) + 1))}, {((((y * 2)) + 0)), ((((y * 2)) + 1))}}}}, {{intm, {x, y}}}, {});
   auto _replica_fn_3 = [=](const buffer<const void>& i0, const buffer<const void>& i1, const buffer<void>& o0) -> index_t {
     const buffer<const void>* input_buffers[] = {&i0, &i1};
     const buffer<void>* output_buffers[] = {&o0};
@@ -113,7 +113,7 @@ auto p = []() -> ::slinky::pipeline {
     const std::vector<var> outputs[] = {{x, y}};
     return ::slinky::internal::replica_pipeline_handler(input_buffers, output_buffers, inputs, outputs);
   };
-  auto _fn_0 = func::make(std::move(_replica_fn_3), {{in, {point(x), point(y)}}, {intm, {{((x / 2)), ((((x + 1)) / 2))}, {((y / 2)), ((((y + 1)) / 2))}}}}, {{out, {x, y}}});
+  auto _fn_0 = func::make(std::move(_replica_fn_3), {{in, {point(x), point(y)}}, {intm, {{((x / 2)), ((((x + 1)) / 2))}, {((y / 2)), ((((y + 1)) / 2))}}}}, {{out, {x, y}}}, {});
   _fn_0.loops({{y, 1, loop::serial}});
   auto p = build_pipeline(ctx, {}, {in}, {out}, {});
   return p;
@@ -156,7 +156,7 @@ auto p = []() -> ::slinky::pipeline {
     return ::slinky::internal::replica_pipeline_handler(input_buffers, output_buffers, inputs, outputs);
   };
   auto sum_xy = buffer_expr::make(ctx, "sum_xy", /*rank=*/1, /*elem_size=*/4);
-  auto _fn_0 = func::make(std::move(_replica_fn_2), {{in, {{(buffer_min(_1, 0)), (buffer_max(_1, 0))}, {(buffer_min(_1, 1)), (buffer_max(_1, 1))}, point(z)}}}, {{sum_x, {y, z}}, {sum_xy, {z}}});
+  auto _fn_0 = func::make(std::move(_replica_fn_2), {{in, {{(buffer_min(_1, 0)), (buffer_max(_1, 0))}, {(buffer_min(_1, 1)), (buffer_max(_1, 1))}, point(z)}}}, {{sum_x, {y, z}}, {sum_xy, {z}}}, {});
   _fn_0.loops({{z, 1, loop::serial}});
   auto p = build_pipeline(ctx, {}, {in}, {sum_x, sum_xy}, {});
   return p;
@@ -199,7 +199,7 @@ auto p = []() -> ::slinky::pipeline {
     const std::vector<var> outputs[] = {{x, y}};
     return ::slinky::internal::replica_pipeline_handler(input_buffers, output_buffers, inputs, outputs);
   };
-  auto _fn_1 = func::make(std::move(_replica_fn_2), {{in1, {point(x), point(y)}}}, {{intm1, {x, y}}});
+  auto _fn_1 = func::make(std::move(_replica_fn_2), {{in1, {point(x), point(y)}}}, {{intm1, {x, y}}}, {.allow_in_place = true});
   auto _replica_fn_3 = [=](const buffer<const void>& i0, const buffer<void>& o0) -> index_t {
     const buffer<const void>* input_buffers[] = {&i0};
     const buffer<void>* output_buffers[] = {&o0};
@@ -207,7 +207,7 @@ auto p = []() -> ::slinky::pipeline {
     const std::vector<var> outputs[] = {{x, y}};
     return ::slinky::internal::replica_pipeline_handler(input_buffers, output_buffers, inputs, outputs);
   };
-  auto _fn_0 = func::make(std::move(_replica_fn_3), {{intm1, {{((x + -1)), ((x + 1))}, {((y + -1)), ((y + 1))}}}}, {{out1, {x, y}}});
+  auto _fn_0 = func::make(std::move(_replica_fn_3), {{intm1, {{((x + -1)), ((x + 1))}, {((y + -1)), ((y + 1))}}}}, {{out1, {x, y}}}, {});
   _fn_0.loops({{y, 2, loop::serial}});
   auto out2 = buffer_expr::make(ctx, "out2", /*rank=*/1, /*elem_size=*/4);
   auto intm2 = buffer_expr::make(ctx, "intm2", /*rank=*/1, /*elem_size=*/4);
@@ -218,7 +218,7 @@ auto p = []() -> ::slinky::pipeline {
     const std::vector<var> outputs[] = {{x}};
     return ::slinky::internal::replica_pipeline_handler(input_buffers, output_buffers, inputs, outputs);
   };
-  auto _fn_5 = func::make(std::move(_replica_fn_6), {{in2, {point(x)}}}, {{intm2, {x}}});
+  auto _fn_5 = func::make(std::move(_replica_fn_6), {{in2, {point(x)}}}, {{intm2, {x}}}, {.allow_in_place = true});
   auto _replica_fn_7 = [=](const buffer<const void>& i0, const buffer<void>& o0) -> index_t {
     const buffer<const void>* input_buffers[] = {&i0};
     const buffer<void>* output_buffers[] = {&o0};
@@ -226,7 +226,7 @@ auto p = []() -> ::slinky::pipeline {
     const std::vector<var> outputs[] = {{x}};
     return ::slinky::internal::replica_pipeline_handler(input_buffers, output_buffers, inputs, outputs);
   };
-  auto _fn_4 = func::make(std::move(_replica_fn_7), {{intm2, {point(x)}}}, {{out2, {x}}});
+  auto _fn_4 = func::make(std::move(_replica_fn_7), {{intm2, {point(x)}}}, {{out2, {x}}}, {.allow_in_place = true});
   auto p = build_pipeline(ctx, {}, {in1, in2}, {out1, out2}, {});
   return p;
 };
@@ -278,7 +278,7 @@ auto p = []() -> ::slinky::pipeline {
     const std::vector<var> outputs[] = {{x, y}};
     return ::slinky::internal::replica_pipeline_handler(input_buffers, output_buffers, inputs, outputs);
   };
-  auto _fn_1 = func::make(std::move(_replica_fn_2), {{in1, {point(x), point(y)}}}, {{intm1, {x, y}}});
+  auto _fn_1 = func::make(std::move(_replica_fn_2), {{in1, {point(x), point(y)}}}, {{intm1, {x, y}}}, {});
   auto _3 = variable::make(in1->sym());
   auto intm2 = buffer_expr::make(ctx, "intm2", /*rank=*/2, /*elem_size=*/2);
   auto _replica_fn_5 = [=](const buffer<const void>& i0, const buffer<void>& o0) -> index_t {
@@ -288,7 +288,7 @@ auto p = []() -> ::slinky::pipeline {
     const std::vector<var> outputs[] = {{x, y}};
     return ::slinky::internal::replica_pipeline_handler(input_buffers, output_buffers, inputs, outputs);
   };
-  auto _fn_4 = func::make(std::move(_replica_fn_5), {{in2, {point(x), point(y)}}}, {{intm2, {x, y}}});
+  auto _fn_4 = func::make(std::move(_replica_fn_5), {{in2, {point(x), point(y)}}}, {{intm2, {x, y}}}, {});
   auto _6 = variable::make(out->sym());
   auto _fn_0 = func::make_copy({{intm1, {point(x), {((y - 0)), ((y - 0))}}, {point(expr()), {0, (((((((buffer_max(_3, 1)) - (buffer_min(_3, 1)))) + 1)) - 1))}}, {}}, {intm2, {point(x), {((y - (((((buffer_max(_3, 1)) - (buffer_min(_3, 1)))) + 1)))), ((y - (((((buffer_max(_3, 1)) - (buffer_min(_3, 1)))) + 1))))}}, {point(expr()), {(((((buffer_max(_3, 1)) - (buffer_min(_3, 1)))) + 1)), (((((((buffer_max(_6, 1)) - (buffer_min(_6, 1)))) + 1)) - 1))}}, {}}}, {out, {x, y}});
   auto p = build_pipeline(ctx, {}, {in1, in2}, {out}, {.no_alias_buffers = true});
@@ -334,7 +334,7 @@ auto p = []() -> ::slinky::pipeline {
     const std::vector<var> outputs[] = {{x, y}};
     return ::slinky::internal::replica_pipeline_handler(input_buffers, output_buffers, inputs, outputs);
   };
-  auto _fn_1 = func::make(std::move(_replica_fn_2), {{in1, {point(x), point(y)}}}, {{intm1, {x, y}}});
+  auto _fn_1 = func::make(std::move(_replica_fn_2), {{in1, {point(x), point(y)}}}, {{intm1, {x, y}}}, {});
   auto intm2 = buffer_expr::make(ctx, "intm2", /*rank=*/2, /*elem_size=*/2);
   auto _replica_fn_4 = [=](const buffer<const void>& i0, const buffer<void>& o0) -> index_t {
     const buffer<const void>* input_buffers[] = {&i0};
@@ -343,7 +343,7 @@ auto p = []() -> ::slinky::pipeline {
     const std::vector<var> outputs[] = {{x, y}};
     return ::slinky::internal::replica_pipeline_handler(input_buffers, output_buffers, inputs, outputs);
   };
-  auto _fn_3 = func::make(std::move(_replica_fn_4), {{in2, {point(x), point(y)}}}, {{intm2, {x, y}}});
+  auto _fn_3 = func::make(std::move(_replica_fn_4), {{in2, {point(x), point(y)}}}, {{intm2, {x, y}}}, {});
   auto _fn_0 = func::make_copy({{intm1, {point(x), point(y)}, {}, {expr(), expr(), 0}}, {intm2, {point(x), point(y)}, {}, {expr(), expr(), 1}}}, {out, {x, y}});
   auto p = build_pipeline(ctx, {}, {in1, in2}, {out}, {});
   return p;
@@ -387,7 +387,7 @@ auto p = []() -> ::slinky::pipeline {
     const std::vector<var> outputs[] = {{x, y}};
     return ::slinky::internal::replica_pipeline_handler(input_buffers, output_buffers, inputs, outputs);
   };
-  auto _fn_2 = func::make(std::move(_replica_fn_3), {{in, {point(x), point(y)}}}, {{intm, {x, y}}});
+  auto _fn_2 = func::make(std::move(_replica_fn_3), {{in, {point(x), point(y)}}}, {{intm, {x, y}}}, {});
   auto _4 = variable::make(in->sym());
   auto _fn_1 = func::make_copy({{intm, {point(x), point(y)}, {{(buffer_min(_4, 0)), (buffer_max(_4, 0))}, {(buffer_min(_4, 1)), (buffer_max(_4, 1))}}, {}}}, {padded_intm, {x, y}});
   _fn_1.compute_root();
@@ -398,7 +398,7 @@ auto p = []() -> ::slinky::pipeline {
     const std::vector<var> outputs[] = {{x, y}};
     return ::slinky::internal::replica_pipeline_handler(input_buffers, output_buffers, inputs, outputs);
   };
-  auto _fn_0 = func::make(std::move(_replica_fn_5), {{padded_intm, {{((x + -1)), ((x + 1))}, {((y + -1)), ((y + 1))}}}}, {{out, {x, y}}});
+  auto _fn_0 = func::make(std::move(_replica_fn_5), {{padded_intm, {{((x + -1)), ((x + 1))}, {((y + -1)), ((y + 1))}}}}, {{out, {x, y}}}, {});
   _fn_0.loops({{y, 1, loop::serial}});
   auto p = build_pipeline(ctx, {}, {in}, {out}, {});
   return p;
@@ -440,7 +440,7 @@ auto p = []() -> ::slinky::pipeline {
     const std::vector<var> outputs[] = {{x, y}};
     return ::slinky::internal::replica_pipeline_handler(input_buffers, output_buffers, inputs, outputs);
   };
-  auto _fn_2 = func::make(std::move(_replica_fn_3), {{in1, {point(x), point(y)}}}, {{intm2, {x, y}}});
+  auto _fn_2 = func::make(std::move(_replica_fn_3), {{in1, {point(x), point(y)}}}, {{intm2, {x, y}}}, {});
   auto _replica_fn_4 = [=](const buffer<const void>& i0, const buffer<void>& o0) -> index_t {
     const buffer<const void>* input_buffers[] = {&i0};
     const buffer<void>* output_buffers[] = {&o0};
@@ -448,7 +448,7 @@ auto p = []() -> ::slinky::pipeline {
     const std::vector<var> outputs[] = {{x, y}};
     return ::slinky::internal::replica_pipeline_handler(input_buffers, output_buffers, inputs, outputs);
   };
-  auto _fn_1 = func::make(std::move(_replica_fn_4), {{intm2, {{((x + -1)), ((x + 1))}, {((y + -1)), ((y + 1))}}}}, {{intm3, {x, y}}});
+  auto _fn_1 = func::make(std::move(_replica_fn_4), {{intm2, {{((x + -1)), ((x + 1))}, {((y + -1)), ((y + 1))}}}}, {{intm3, {x, y}}}, {});
   auto intm4 = buffer_expr::make(ctx, "intm4", /*rank=*/2, /*elem_size=*/2);
   auto _replica_fn_6 = [=](const buffer<const void>& i0, const buffer<void>& o0) -> index_t {
     const buffer<const void>* input_buffers[] = {&i0};
@@ -457,7 +457,7 @@ auto p = []() -> ::slinky::pipeline {
     const std::vector<var> outputs[] = {{x, y}};
     return ::slinky::internal::replica_pipeline_handler(input_buffers, output_buffers, inputs, outputs);
   };
-  auto _fn_5 = func::make(std::move(_replica_fn_6), {{intm2, {{((x + -2)), ((x + 2))}, {((y + -2)), ((y + 2))}}}}, {{intm4, {x, y}}});
+  auto _fn_5 = func::make(std::move(_replica_fn_6), {{intm2, {{((x + -2)), ((x + 2))}, {((y + -2)), ((y + 2))}}}}, {{intm4, {x, y}}}, {});
   auto _replica_fn_7 = [=](const buffer<const void>& i0, const buffer<const void>& i1, const buffer<void>& o0) -> index_t {
     const buffer<const void>* input_buffers[] = {&i0, &i1};
     const buffer<void>* output_buffers[] = {&o0};
@@ -465,7 +465,7 @@ auto p = []() -> ::slinky::pipeline {
     const std::vector<var> outputs[] = {{x, y}};
     return ::slinky::internal::replica_pipeline_handler(input_buffers, output_buffers, inputs, outputs);
   };
-  auto _fn_0 = func::make(std::move(_replica_fn_7), {{intm3, {point(x), point(y)}}, {intm4, {point(x), point(y)}}}, {{out, {x, y}}});
+  auto _fn_0 = func::make(std::move(_replica_fn_7), {{intm3, {point(x), point(y)}}, {intm4, {point(x), point(y)}}}, {{out, {x, y}}}, {});
   _fn_0.loops({{y, 1, loop::serial}});
   auto p = build_pipeline(ctx, {}, {in1}, {out}, {});
   return p;
@@ -507,7 +507,7 @@ auto p = []() -> ::slinky::pipeline {
     const std::vector<var> outputs[] = {{x, y}};
     return ::slinky::internal::replica_pipeline_handler(input_buffers, output_buffers, inputs, outputs);
   };
-  auto _fn_1 = func::make(std::move(_replica_fn_2), {{in1, {point(x), point(y)}}}, {{intm2, {x, y}}});
+  auto _fn_1 = func::make(std::move(_replica_fn_2), {{in1, {point(x), point(y)}}}, {{intm2, {x, y}}}, {});
   auto _replica_fn_3 = [=](const buffer<const void>& i0, const buffer<void>& o0) -> index_t {
     const buffer<const void>* input_buffers[] = {&i0};
     const buffer<void>* output_buffers[] = {&o0};
@@ -515,7 +515,7 @@ auto p = []() -> ::slinky::pipeline {
     const std::vector<var> outputs[] = {{x, y}};
     return ::slinky::internal::replica_pipeline_handler(input_buffers, output_buffers, inputs, outputs);
   };
-  auto _fn_0 = func::make(std::move(_replica_fn_3), {{intm2, {point(x), point(y)}}}, {{intm3, {x, y}}});
+  auto _fn_0 = func::make(std::move(_replica_fn_3), {{intm2, {point(x), point(y)}}}, {{intm3, {x, y}}}, {});
   auto intm4 = buffer_expr::make(ctx, "intm4", /*rank=*/2, /*elem_size=*/2);
   auto _replica_fn_5 = [=](const buffer<const void>& i0, const buffer<void>& o0) -> index_t {
     const buffer<const void>* input_buffers[] = {&i0};
@@ -524,7 +524,7 @@ auto p = []() -> ::slinky::pipeline {
     const std::vector<var> outputs[] = {{x, y}};
     return ::slinky::internal::replica_pipeline_handler(input_buffers, output_buffers, inputs, outputs);
   };
-  auto _fn_4 = func::make(std::move(_replica_fn_5), {{intm2, {point(x), point(y)}}}, {{intm4, {x, y}}});
+  auto _fn_4 = func::make(std::move(_replica_fn_5), {{intm2, {point(x), point(y)}}}, {{intm4, {x, y}}}, {});
   _fn_4.loops({{y, 1, loop::serial}});
   auto p = build_pipeline(ctx, {}, {in1}, {intm3, intm4}, {});
   return p;
@@ -545,6 +545,65 @@ auto p = []() -> ::slinky::pipeline {
   // Not having span(std::initializer_list<T>) is unfortunate.
   const raw_buffer* inputs[] = {&in_buf};
   const raw_buffer* outputs[] = {&intm3_buf, &intm4_buf};
+
+  eval_context eval_ctx;
+  ASSERT_EQ(0, p().evaluate(inputs, outputs, eval_ctx));
+}
+
+TEST(replica, stencil_chain) {
+  // clang-format off
+// BEGIN define_replica_pipeline() output
+auto p = []() -> ::slinky::pipeline {
+  using std::abs, std::min, std::max;
+  node_context ctx;
+  auto in = buffer_expr::make(ctx, "in", /*rank=*/2, /*elem_size=*/2);
+  auto out = buffer_expr::make(ctx, "out", /*rank=*/2, /*elem_size=*/2);
+  auto x = var(ctx, "x");
+  auto y = var(ctx, "y");
+  auto stencil1_result = buffer_expr::make(ctx, "stencil1_result", /*rank=*/2, /*elem_size=*/2);
+  auto add_result = buffer_expr::make(ctx, "add_result", /*rank=*/2, /*elem_size=*/2);
+  auto _replica_fn_3 = [=](const buffer<const void>& i0, const buffer<void>& o0) -> index_t {
+    const buffer<const void>* input_buffers[] = {&i0};
+    const buffer<void>* output_buffers[] = {&o0};
+    const func::input inputs[] = {{in, {point(x), point(y)}}};
+    const std::vector<var> outputs[] = {{x, y}};
+    return ::slinky::internal::replica_pipeline_handler(input_buffers, output_buffers, inputs, outputs);
+  };
+  auto _fn_2 = func::make(std::move(_replica_fn_3), {{in, {point(x), point(y)}}}, {{add_result, {x, y}}}, {.name = "add_1"});
+  auto _replica_fn_4 = [=](const buffer<const void>& i0, const buffer<void>& o0) -> index_t {
+    const buffer<const void>* input_buffers[] = {&i0};
+    const buffer<void>* output_buffers[] = {&o0};
+    const func::input inputs[] = {{add_result, {{((x + -1)), ((x + 1))}, {((y + -1)), ((y + 1))}}}};
+    const std::vector<var> outputs[] = {{x, y}};
+    return ::slinky::internal::replica_pipeline_handler(input_buffers, output_buffers, inputs, outputs);
+  };
+  auto _fn_1 = func::make(std::move(_replica_fn_4), {{add_result, {{((x + -1)), ((x + 1))}, {((y + -1)), ((y + 1))}}}}, {{stencil1_result, {x, y}}}, {.name = "sum3x3"});
+  auto _replica_fn_5 = [=](const buffer<const void>& i0, const buffer<void>& o0) -> index_t {
+    const buffer<const void>* input_buffers[] = {&i0};
+    const buffer<void>* output_buffers[] = {&o0};
+    const func::input inputs[] = {{stencil1_result, {{((x + -1)), ((x + 1))}, {((y + -1)), ((y + 1))}}}};
+    const std::vector<var> outputs[] = {{x, y}};
+    return ::slinky::internal::replica_pipeline_handler(input_buffers, output_buffers, inputs, outputs);
+  };
+  auto _fn_0 = func::make(std::move(_replica_fn_5), {{stencil1_result, {{((x + -1)), ((x + 1))}, {((y + -1)), ((y + 1))}}}}, {{out, {x, y}}}, {.name = "sum3x3"});
+  _fn_0.loops({{y, 1, loop::serial}});
+  auto p = build_pipeline(ctx, {}, {in}, {out}, {});
+  return p;
+};
+// END define_replica_pipeline() output
+  // clang-format on
+
+  const int W = 20;
+  const int H = 30;
+  buffer<short, 2> in_buf({W + 4, H + 4});
+  in_buf.translate(-2, -2);
+  buffer<short, 2> out_buf({W, H});
+
+  init_random(in_buf);
+  out_buf.allocate();
+
+  const raw_buffer* inputs[] = {&in_buf};
+  const raw_buffer* outputs[] = {&out_buf};
 
   eval_context eval_ctx;
   ASSERT_EQ(0, p().evaluate(inputs, outputs, eval_ctx));


### PR DESCRIPTION
Fixes #246 