### PR TITLE
Buffer helper improvements

### DIFF
--- a/builder/test/copy.cc
+++ b/builder/test/copy.cc
@@ -29,9 +29,9 @@ public:
 template <typename T, std::size_t N>
 void init_random(buffer<T, N>& x) {
   x.allocate();
-  for_each_contiguous_slice(x, [&](index_t extent, void* base) {
+  for_each_contiguous_slice(x, [&](index_t extent, T* base) {
     for (index_t i = 0; i < extent; ++i) {
-      reinterpret_cast<T*>(base)[i] = (rand() % 20) - 10;
+      base[i] = (rand() % 20) - 10;
     }
   });
 }

--- a/builder/test/elementwise.cc
+++ b/builder/test/elementwise.cc
@@ -16,9 +16,9 @@ namespace slinky {
 template <typename T, std::size_t N>
 void init_random(buffer<T, N>& x) {
   x.allocate();
-  for_each_contiguous_slice(x, [&](index_t extent, void* base) {
+  for_each_contiguous_slice(x, [&](index_t extent, T* base) {
     for (index_t i = 0; i < extent; ++i) {
-      reinterpret_cast<T*>(base)[i] = (rand() % 20) - 10;
+      base[i] = (rand() % 20) - 10;
     }
   });
 }

--- a/runtime/buffer.h
+++ b/runtime/buffer.h
@@ -825,17 +825,17 @@ void for_each_slice(std::size_t slice_rank, const raw_buffer& buf, const F& f, c
 // Call `f` for each element of `buf`, and the same corresponding elements of `bufs`.
 template <typename F, typename Buf, typename... Bufs>
 void for_each_element(const F& f, const Buf& buf, const Bufs&... bufs) {
-  constexpr std::size_t BufsCount = sizeof...(Bufs) + 1;
-  std::array<const raw_buffer*, BufsCount> buf_ptrs = {&buf, &bufs...};
+  constexpr std::size_t BufsSize = sizeof...(Bufs) + 1;
+  std::array<const raw_buffer*, BufsSize> buf_ptrs = {&buf, &bufs...};
 
   // We might need a slice dim for each dimension in the buffer, plus one for the call to f.
-  auto* plan = SLINKY_ALLOCA(char, internal::size_of_plan(buf.rank, BufsCount));
-  std::array<void*, BufsCount> bases;
+  auto* plan = SLINKY_ALLOCA(char, internal::size_of_plan(buf.rank, BufsSize));
+  std::array<void*, BufsSize> bases;
   internal::make_for_each_slice_dims(buf_ptrs, bases.data(), plan);
 
-  internal::for_each_slice_impl(bases, plan, [&](const std::array<void*, BufsCount>& bases) {
+  internal::for_each_slice_impl(bases, plan, [&](const std::array<void*, BufsSize>& bases) {
     std::apply(f, internal::tuple_cast<typename Buf::pointer, typename Bufs::pointer...>(
-                      bases, std::make_index_sequence<BufsCount>()));
+                      bases, std::make_index_sequence<BufsSize>()));
   });
 }
 

--- a/runtime/buffer.h
+++ b/runtime/buffer.h
@@ -822,7 +822,7 @@ void for_each_slice(std::size_t slice_rank, const raw_buffer& buf, const F& f, c
   });
 }
 
-// Call `f` for each element of `buf`, and the same corresponding elements of `bufs`.
+// Call `f` with a pointer to each element of `buf`, and pointers to the same corresponding elements of `bufs`.
 template <typename F, typename Buf, typename... Bufs>
 void for_each_element(const F& f, const Buf& buf, const Bufs&... bufs) {
   constexpr std::size_t BufsSize = sizeof...(Bufs) + 1;

--- a/runtime/test/buffer.cc
+++ b/runtime/test/buffer.cc
@@ -429,6 +429,23 @@ TEST(buffer, for_each_tile_all) {
   ASSERT_EQ(tiles, ceil_div<index_t>(buf.dim(1).extent(), slice[1]));
 }
 
+TEST(buffer, for_each_element) {
+  buffer<int, 2> buf({10, 20});
+  buf.allocate();
+  int elements = 0;
+  for_each_element([&](int* elt) {
+    *elt = 7;
+    elements++;
+  }, buf);
+  int expected_elements = 1;
+  for (std::size_t d = 0; d < buf.rank; ++d) {
+    expected_elements *= buf.dim(d).extent();
+  }
+  ASSERT_EQ(elements, expected_elements);
+
+  for_each_index(buf, [&](auto i) { ASSERT_EQ(buf(i), 7); });
+}
+
 TEST(buffer, for_each_slice) {
   for (std::size_t slice_rank : {0, 1, 2}) {
     buffer<int, 2> buf({10, 20});

--- a/runtime/test/buffer.cc
+++ b/runtime/test/buffer.cc
@@ -178,7 +178,7 @@ TEST(buffer, for_each_contiguous_slice) {
   buffer<char, 3> buf({10, 20, 30});
   buf.allocate();
   int slices = 0;
-  for_each_contiguous_slice(buf, [&](index_t slice_extent, void* slice) {
+  for_each_contiguous_slice(buf, [&](index_t slice_extent, char* slice) {
     memset(slice, 7, slice_extent);
     slices++;
   });
@@ -191,7 +191,7 @@ TEST(buffer, for_each_contiguous_slice_non_zero_min) {
   buf.allocate();
   buf.translate(1, 2, 3);
   int slices = 0;
-  for_each_contiguous_slice(buf, [&](index_t slice_extent, void* slice) {
+  for_each_contiguous_slice(buf, [&](index_t slice_extent, char* slice) {
     memset(slice, 7, slice_extent);
     slices++;
   });
@@ -206,7 +206,7 @@ TEST(buffer, for_each_contiguous_folded) {
   for (int crop_extent : {1, 2, 3, 4}) {
     buf.dim(1).set_min_extent(8, crop_extent);
     int slices = 0;
-    for_each_contiguous_slice(buf, [&](index_t slice_extent, void* slice) {
+    for_each_contiguous_slice(buf, [&](index_t slice_extent, char* slice) {
       memset(slice, 7, slice_extent);
       slices++;
     });
@@ -220,7 +220,7 @@ TEST(buffer, for_each_contiguous_slice_padded) {
     buffer<char, 3> buf({10, 20, 30});
     buf.allocate();
     buf.dim(padded_dim).set_bounds(0, 8);
-    for_each_contiguous_slice(buf, [&](index_t slice_extent, void* slice) { memset(slice, 7, slice_extent); });
+    for_each_contiguous_slice(buf, [&](index_t slice_extent, char* slice) { memset(slice, 7, slice_extent); });
     for_each_index(buf, [&](auto i) { ASSERT_EQ(buf(i), 7); });
   }
 }
@@ -230,7 +230,7 @@ TEST(buffer, for_each_contiguous_slice_non_innermost) {
   buf.allocate();
   std::swap(buf.dim(0), buf.dim(1));
   int slices = 0;
-  for_each_contiguous_slice(buf, [&](index_t slice_extent, void* slice) {
+  for_each_contiguous_slice(buf, [&](index_t slice_extent, int* slice) {
     ASSERT_EQ(slice_extent, 10);
     slices++;
   });
@@ -247,7 +247,7 @@ void test_for_each_contiguous_slice_fill() {
   dst.allocate();
 
   for_each_contiguous_slice(
-      dst, [&](index_t slice_extent, void* dst) { std::fill_n(reinterpret_cast<T*>(dst), slice_extent, 7); });
+      dst, [&](index_t slice_extent, T* dst) { std::fill_n(dst, slice_extent, 7); });
 
   for_each_index(dst, [&](const auto i) { ASSERT_EQ(dst(i), 7); });
 }
@@ -313,10 +313,7 @@ void test_for_each_contiguous_slice_add() {
 
   for_each_contiguous_slice(
       dst,
-      [&](index_t slice_extent, void* dst_v, const void* a_v, const void* b_v) {
-        Dst* dst = reinterpret_cast<int*>(dst_v);
-        const A* a = reinterpret_cast<const A*>(a_v);
-        const B* b = reinterpret_cast<const B*>(b_v);
+      [&](index_t slice_extent, Dst* dst, const A* a, const B* b) {
         for (index_t i = 0; i < slice_extent; ++i) {
           dst[i] = saturate_add<Dst>(a[i], b[i]);
         }
@@ -357,8 +354,8 @@ TEST(buffer, for_each_contiguous_slice_multi_fuse_lots) {
   int slices = 0;
   for_each_contiguous_slice(
       buf1,
-      [&](index_t slice_extent, void* slice1, void* slice2, void* slice3, void* slice4, void* slice5, void* slice6,
-          void* slice7, void* slice8, void* slice9) {
+      [&](index_t slice_extent, char* slice1, char* slice2, char* slice3, char* slice4, char* slice5, char* slice6,
+          char* slice7, char* slice8, char* slice9) {
         memset(slice1, 1, slice_extent);
         memset(slice2, 2, slice_extent);
         memset(slice3, 3, slice_extent);


### PR DESCRIPTION
- `for_each_contiguous_slice` is now type safe (fixes #133)
- Adds `for_each_element`

I think that we should consider removing `for_each_slice` entirely. It's very hard to make it type safe. Existing uses of it can use `for_each_element`, and just explicitly slice the leading dimensions as desired first. The implicit slicing of buffers in `for_each_slice` can be confusing, because there is some accommodation for missing dimensions at both ends of the dimension list. `for_each_element` eliminates the leading dimensions from consideration, and requires the user to explicitly slice those as they see fit.

The downside is that the callback only gets a pointer and not a buffer, so if a buffer object is required, the user needs to construct one inside the callback.