### PR TITLE
Implement `copy`/`pad`/`fill` using `for_each_element`

### DIFF
--- a/runtime/buffer.cc
+++ b/runtime/buffer.cc
@@ -5,6 +5,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
+#include <functional>
 
 #include "runtime/util.h"
 

--- a/runtime/buffer.cc
+++ b/runtime/buffer.cc
@@ -257,11 +257,17 @@ SLINKY_NO_STACK_PROTECTOR void copy(const raw_buffer& src, const raw_buffer& dst
       dims[rank].src_stride = src_dim.stride();
       dims[rank].dst_stride = dst_dim.stride();
       dims[rank].total_size = dst_dim.extent();
-      compute_padding(src_dim.begin(), src_dim.end(), dst_dim, dims[rank]);
-      if (src_dim.min() < dst_dim.min() && src_dim.contains(dst_dim.min())) {
-        src_base += src_dim.flat_offset_bytes(dst_dim.min());
-      }
       assert(dst.dims[rank].extent() <= dst.dims[rank].fold_factor());
+      if (src_dim.stride() != 0) {
+        compute_padding(src_dim.begin(), src_dim.end(), dst_dim, dims[rank]);
+        if (src_dim.min() < dst_dim.min() && src_dim.contains(dst_dim.min())) {
+          src_base += src_dim.flat_offset_bytes(dst_dim.min());
+        }
+      } else {
+        dims[rank].size = dims[rank].total_size;
+        dims[rank].pad_before = 0;
+        dims[rank].pad_after = 0;
+      }
       ++rank;
     }
   }
@@ -290,7 +296,13 @@ SLINKY_NO_STACK_PROTECTOR void pad(const dim* in_bounds, const raw_buffer& dst, 
     dims[rank].src_stride = 0;
     dims[rank].dst_stride = dst_dim.stride();
     dims[rank].total_size = dst_dim.extent();
-    compute_padding(in_bounds[i].begin(), in_bounds[i].end(), dst_dim, dims[rank]);
+    if (in_bounds[i].stride() != 0) {
+      compute_padding(in_bounds[i].begin(), in_bounds[i].end(), dst_dim, dims[rank]);
+    } else {
+      dims[rank].size = dims[rank].total_size;
+      dims[rank].pad_before = 0;
+      dims[rank].pad_after = 0;
+    }
     ++rank;
   }
 

--- a/runtime/buffer.h
+++ b/runtime/buffer.h
@@ -16,10 +16,12 @@ using index_t = std::ptrdiff_t;
 // Helper to offset a pointer by a number of bytes.
 template <typename T>
 T* offset_bytes(T* x, std::ptrdiff_t bytes) {
+  assert(x != nullptr || bytes == 0);
   return reinterpret_cast<T*>(reinterpret_cast<char*>(x) + bytes);
 }
 template <typename T>
 const T* offset_bytes(const T* x, std::ptrdiff_t bytes) {
+  assert(x != nullptr || bytes == 0);
   return reinterpret_cast<const T*>(reinterpret_cast<const char*>(x) + bytes);
 }
 
@@ -235,7 +237,9 @@ public:
   // If `d` is 0 or rank - 1, the slice does not mutate the dims array.
   raw_buffer& slice(std::size_t d) { return slice({d}); }
   raw_buffer& slice(std::size_t d, index_t at) {
-    base = offset_bytes(base, dim(d).flat_offset_bytes(at));
+    if (base != nullptr) {
+      base = offset_bytes(base, dim(d).flat_offset_bytes(at));
+    }
     return slice({d});
   }
 
@@ -246,7 +250,7 @@ public:
     max = std::min(max, dim(d).max());
 
     index_t offset = 0;
-    if (max >= min) {
+    if (base != nullptr && max >= min) {
       offset = dim(d).flat_offset_bytes(min);
       base = offset_bytes(base, offset);
     }

--- a/runtime/buffer.h
+++ b/runtime/buffer.h
@@ -68,7 +68,7 @@ public:
 
   void translate(index_t offset) { min_ += offset; }
 
-  bool contains(index_t x) const { return min() <= x && x <= max(); }
+  bool contains(index_t x) const { return stride() == 0 || (min() <= x && x <= max()); }
 
   std::ptrdiff_t flat_offset_bytes(index_t i) const {
     // Conceptually, accesses may be out of bounds, but in practice, if the stride is 0, the accesses will not read

--- a/runtime/buffer.h
+++ b/runtime/buffer.h
@@ -69,6 +69,7 @@ public:
   void translate(index_t offset) { min_ += offset; }
 
   bool contains(index_t x) const { return stride() == 0 || (min() <= x && x <= max()); }
+  bool contains(const dim& other) const { return stride() == 0 || (min() <= other.min() && other.max() <= max()); }
 
   std::ptrdiff_t flat_offset_bytes(index_t i) const {
     // Conceptually, accesses may be out of bounds, but in practice, if the stride is 0, the accesses will not read
@@ -674,15 +675,17 @@ void for_each_slice_impl(const std::array<void*, NumBufs>& bases, const void* pl
       // If the next step is to call f, do that eagerly here to avoid an extra call.
       for (index_t i = 0; i < slice_dim->extent; ++i) {
         f(bases_i);
-        for (std::size_t n = 0; n < NumBufs; n++) {
-          bases_i[n] = offset_bytes(bases_i[n], strides[n]);
+        bases_i[0] = offset_bytes(bases_i[0], strides[0]);
+        for (std::size_t n = 1; n < NumBufs; n++) {
+          bases_i[n] = bases_i[n] ? offset_bytes(bases_i[n], strides[n]) : nullptr;
         }
       }
     } else {
       for (index_t i = 0; i < slice_dim->extent; ++i) {
         for_each_slice_impl(bases_i, plan, f);
-        for (std::size_t n = 0; n < NumBufs; n++) {
-          bases_i[n] = offset_bytes(bases_i[n], strides[n]);
+        bases_i[0] = offset_bytes(bases_i[0], strides[0]);
+        for (std::size_t n = 1; n < NumBufs; n++) {
+          bases_i[n] = bases_i[n] ? offset_bytes(bases_i[n], strides[n]) : nullptr;
         }
       }
     }
@@ -698,8 +701,13 @@ void for_each_slice_impl(const std::array<void*, NumBufs>& bases, const void* pl
     index_t end = begin + slice_dim->extent;
     for (index_t i = begin; i < end; ++i) {
       std::array<void*, NumBufs> bases_i;
-      for (std::size_t n = 0; n < NumBufs; n++) {
-        bases_i[n] = offset_bytes(bases[n], dims[n]->flat_offset_bytes(i));
+      bases_i[0] = offset_bytes(bases[0], dims[0]->flat_offset_bytes(i));
+      for (std::size_t n = 1; n < NumBufs; n++) {
+        if (bases[n] && dims[n]->contains(i)) {
+          bases_i[n] = offset_bytes(bases[n], dims[n]->flat_offset_bytes(i));
+        } else {
+          bases_i[n] = nullptr;
+        }
       }
       for_each_slice_impl(bases_i, plan, f);
     }
@@ -756,6 +764,7 @@ auto tuple_cast(const T& x, std::index_sequence<Is...>) {
 //
 // When additional buffers are passed, they will be sliced in tandem with the 'main' buffer. Additional buffers can be
 // lower rank than the main buffer, these "missing" dimensions are not sliced (i.e. broadcasting in this dimension).
+// If the other buffers are out of bounds for a slice, the corresponding argument to the callback will be `nullptr`.
 template <typename Buf, typename F, typename... Bufs>
 SLINKY_NO_STACK_PROTECTOR void for_each_contiguous_slice(const Buf& buf, const F& f, const Bufs&... bufs) {
   constexpr std::size_t BufsSize = sizeof...(Bufs) + 1;
@@ -774,7 +783,8 @@ SLINKY_NO_STACK_PROTECTOR void for_each_contiguous_slice(const Buf& buf, const F
 }
 
 // Call `f` for each slice of the first `slice_rank` dimensions of `buf`. The trailing dimensions of `bufs` will also be
-// sliced at the same indices as `buf`. Assumes that all of the sliced dimensions of `buf` are in bounds in `bufs...`.
+// sliced at the same indices as `buf`.  If the other buffers are out of bounds for a slice, the corresponding argument
+// to the callback will be `nullptr`.
 template <typename F, typename... Bufs>
 void for_each_slice(std::size_t slice_rank, const raw_buffer& buf, const F& f, const Bufs&... bufs) {
   constexpr std::size_t BufsSize = sizeof...(Bufs) + 1;
@@ -810,7 +820,8 @@ void for_each_slice(std::size_t slice_rank, const raw_buffer& buf, const F& f, c
   });
 }
 
-// Call `f` with a pointer to each element of `buf`, and pointers to the same corresponding elements of `bufs`.
+// Call `f` with a pointer to each element of `buf`, and pointers to the same corresponding elements of `bufs`, or
+// `nullptr` if `buf` is out of bounds of `bufs`.
 template <typename F, typename Buf, typename... Bufs>
 void for_each_element(const F& f, const Buf& buf, const Bufs&... bufs) {
   constexpr std::size_t BufsSize = sizeof...(Bufs) + 1;

--- a/runtime/buffer.h
+++ b/runtime/buffer.h
@@ -574,7 +574,7 @@ void sort_dims(span<const int> dim_sets, raw_buffer& buf, Bufs&... bufs) {
     for (std::size_t j = i + 1; j < buf.rank; ++j) {
       if (j < dim_sets.size() && dim_sets[i] != dim_sets[j]) continue;
       if (buf.dim(i).stride() > buf.dim(j).stride()) {
-        swap_dims(i, j, buf, bufs...);
+      internal::swap_dims(i, j, buf, bufs...);
       }
     }
   }

--- a/runtime/evaluate.cc
+++ b/runtime/evaluate.cc
@@ -193,7 +193,10 @@ public:
     assert(op->args.size() <= buf->rank + 1);
     for (std::size_t d = 0; d < op->args.size() - 1; ++d) {
       if (op->args[d + 1].defined()) {
-        result = offset_bytes(result, buf->dims[d].flat_offset_bytes(eval_expr(op->args[d + 1])));
+        index_t offset = eval_expr(op->args[d + 1]);
+        if (result) {
+          result = offset_bytes(result, buf->dims[d].flat_offset_bytes(offset));
+        }
       }
     }
     return result;
@@ -549,7 +552,9 @@ public:
     }
 
     void* old_base = buffer->base;
-    buffer->base = offset_bytes(buffer->base, offset);
+    if (buffer->base) {
+      buffer->base = offset_bytes(buffer->base, offset);
+    }
     std::swap(buffer->rank, rank);
     std::swap(buffer->dims, dims);
 
@@ -572,7 +577,9 @@ public:
     index_t at = eval_expr(op->at);
     index_t offset = old_dims[op->dim].flat_offset_bytes(at);
     void* old_base = buffer->base;
-    buffer->base = offset_bytes(buffer->base, offset);
+    if (buffer->base) {
+      buffer->base = offset_bytes(buffer->base, offset);
+    }
 
     for (int d = 0; d < op->dim; ++d) {
       buffer->dims[d] = old_dims[d];


### PR DESCRIPTION
This replaces the implementation of copy/fill/pad with `for_each_element`. This fixes a bunch of issues:
- copy/fill/pad's implementation was highly redundant with `for_each_element`
- copy/fill/pad didn't support folded buffers (#41)
- `for_each_element` didn't support padding

