### PR TITLE
Simplify some loop invariant code

### DIFF
--- a/builder/simplify.cc
+++ b/builder/simplify.cc
@@ -413,6 +413,7 @@ public:
       std::deque<stmt> in_loop(b->stmts.begin(), b->stmts.end());
       std::deque<stmt> before_loop;
       while (!in_loop.empty() && !depends_on(in_loop.front(), op->sym).any()) {
+        // The first stmt in the loop does not depend on the loop. We can lift it out of the loop.
         before_loop.push_back(std::move(in_loop.front()));
         in_loop.pop_front();
       }

--- a/builder/simplify.cc
+++ b/builder/simplify.cc
@@ -418,8 +418,8 @@ public:
         in_loop.pop_front();
       }
       // TODO: We could also try to move trailing independent stmts out of the end of the loop, and reorder independent
-      // stmts from in the middle of the loop. However, I'm not if this is something that can really happen in practice,
-      // we might as well wait and see if we need this.
+      // stmts from in the middle of the loop. However, I'm not sure if this is something that can really happen in
+      // practice, we might as well wait and see if we need this.
       assert(!in_loop.empty());  // We should have handled this above.
       if (!before_loop.empty()) {
         // Some of the loop did not depend on the loop, we can move it out.

--- a/builder/test/softmax.cc
+++ b/builder/test/softmax.cc
@@ -134,7 +134,7 @@ TEST_P(softmax, pipeline) {
   std::vector<func::loop_info> loops;
   if (split_c > 0) loops.push_back({c, split_c});
   if (split_b > 0) loops.push_back({b, split_b});
-  pass3.loops(std::move(loops));
+  pass4.loops(std::move(loops));
 
   pipeline p = build_pipeline(ctx, {in}, {out});
 

--- a/runtime/print.cc
+++ b/runtime/print.cc
@@ -217,8 +217,10 @@ public:
     *this << indent() << "call(";
     if (!n->attrs.name.empty()) {
       *this << n->attrs.name;
+    } else if (n->target) {
+      *this << "<anonymous target>";
     } else {
-      *this << "<anonymous function>";
+      *this << "<null target>";
     }
     *this << ", {" << n->inputs << "}, {" << n->outputs << "})\n";
   }


### PR DESCRIPTION
This moves loop invariant stmts from the beginning of loops only out of the loop. This does part of what is discussed in #270. 

I decided to just add a TODO for more complicated forms of LICM, which may not really be possible to have in the first place. I can't think of a realistic way to have a loop invariant stmt consume a buffer that is produced by a loop-variant stmt. Everything I can think of would do weird things like read uninitialized memory.