### PR TITLE
Always use symbolic bounds for output bounds

### DIFF
--- a/builder/pipeline.cc
+++ b/builder/pipeline.cc
@@ -261,7 +261,8 @@ public:
   interval_expr mutate(const interval_expr& i) { return {mutate(i.min), mutate(i.max)}; }
 };
 
-void get_output_bounds(const std::vector<func::output>& outputs, bounds_map& output_bounds) {
+bounds_map get_output_bounds(const std::vector<func::output>& outputs) {
+  bounds_map output_bounds;
   for (const func::output& o : outputs) {
     for (index_t d = 0; d < static_cast<index_t>(o.dims.size()); ++d) {
       std::optional<interval_expr>& output_bounds_d = output_bounds[o.dims[d]];
@@ -272,6 +273,7 @@ void get_output_bounds(const std::vector<func::output>& outputs, bounds_map& out
       }
     }
   }
+  return output_bounds;
 }
 
 box_expr compute_input_bounds(
@@ -642,8 +644,7 @@ class pipeline_builder {
 
   void compute_allocation_bounds() {
     for (const func* f : order_) {
-      bounds_map output_bounds;
-      get_output_bounds(f->outputs(), output_bounds);
+      bounds_map output_bounds = get_output_bounds(f->outputs());
 
       for (const auto& i : f->inputs()) {
         box_expr crop = compute_input_bounds(f, i, output_bounds, sanitizer_);

--- a/builder/pipeline.cc
+++ b/builder/pipeline.cc
@@ -263,12 +263,12 @@ public:
 
 void get_output_bounds(const std::vector<func::output>& outputs, bounds_map& output_bounds) {
   for (const func::output& o : outputs) {
-    for (std::size_t d = 0; d < o.dims.size(); ++d) {
+    for (index_t d = 0; d < static_cast<index_t>(o.dims.size()); ++d) {
       std::optional<interval_expr>& output_bounds_d = output_bounds[o.dims[d]];
       if (!output_bounds_d) {
-        output_bounds_d = o.buffer->dim(d).bounds;
+        output_bounds_d = buffer_bounds(o.sym(), d);
       } else {
-        *output_bounds_d |= o.buffer->dim(d).bounds;
+        *output_bounds_d |= buffer_bounds(o.sym(), d);
       }
     }
   }

--- a/builder/test/pipeline.cc
+++ b/builder/test/pipeline.cc
@@ -431,14 +431,15 @@ TEST_P(stencil, pipeline) {
   }
 }
 
-class slide_2d : public testing::TestWithParam<std::tuple<int, int>> {};
+class slide_2d : public testing::TestWithParam<std::tuple<int, int, bool>> {};
 
 INSTANTIATE_TEST_SUITE_P(
-    split_split_mode, slide_2d, testing::Combine(loop_modes, loop_modes), test_params_to_string<slide_2d::ParamType>);
+    split_split_mode, slide_2d, testing::Combine(loop_modes, loop_modes, testing::Values(false, true)), test_params_to_string<slide_2d::ParamType>);
 
 TEST_P(slide_2d, pipeline) {
   int max_workers_x = std::get<0>(GetParam());
   int max_workers_y = std::get<1>(GetParam());
+  bool constrain_min = std::get<2>(GetParam());
 
   // Make the pipeline
   node_context ctx;
@@ -447,6 +448,11 @@ TEST_P(slide_2d, pipeline) {
   auto out = buffer_expr::make(ctx, "out", 2, sizeof(short));
 
   auto intm = buffer_expr::make(ctx, "intm", 2, sizeof(short));
+
+  if (constrain_min) {
+    out->dim(0).bounds.min = 0;
+    out->dim(1).bounds.min = 0;
+  }
 
   var x(ctx, "x");
   var y(ctx, "y");


### PR DESCRIPTION
This fixes an issue where constraints on bounds of inputs or outputs would propagate into intermediate buffers and their crops.