### PR TITLE
Buffer test cleanup and bug fix

### DIFF
--- a/runtime/buffer.cc
+++ b/runtime/buffer.cc
@@ -28,6 +28,14 @@ std::size_t alloc_size(std::size_t rank, std::size_t elem_size, const dim* dims)
 
 std::size_t raw_buffer::size_bytes() const { return alloc_size(rank, elem_size, dims); }
 
+std::ptrdiff_t raw_buffer::elem_count() const {
+  std::ptrdiff_t result = 1;
+  for (std::size_t d = 0; d < rank; ++d) {
+    result *= dim(d).extent();
+  }
+  return result;
+}
+
 raw_buffer_ptr raw_buffer::make(std::size_t rank, std::size_t elem_size, const class dim* dims) {
   std::size_t size = sizeof(raw_buffer) + sizeof(slinky::dim) * rank;
   if (dims) {

--- a/runtime/buffer.h
+++ b/runtime/buffer.h
@@ -264,6 +264,8 @@ public:
 
   std::size_t size_bytes() const;
 
+  std::ptrdiff_t elem_count() const;
+
   // Allocate and set the base pointer using `malloc`. Returns a pointer to the allocated memory, which should
   // be deallocated with `free`.
   void* allocate();
@@ -340,6 +342,7 @@ public:
   using raw_buffer::dim;
   using raw_buffer::elem_size;
   using raw_buffer::flat_offset_bytes;
+  using raw_buffer::elem_count;
   using raw_buffer::rank;
 
   buffer() {

--- a/runtime/buffer.h
+++ b/runtime/buffer.h
@@ -486,11 +486,11 @@ inline void fuse(fuse_type type, int inner, int outer, raw_buffer& buf) {
   dim& id = buf.dim(inner);
   dim& od = buf.dim(outer);
   assert(can_fuse(id, od));
-  id.set_min_extent(od.min() * id.extent(), od.extent() * id.extent());
   if (od.extent() != 1 && od.fold_factor() != dim::unfolded) {
     assert(id.fold_factor() == dim::unfolded);
     id.set_fold_factor(od.fold_factor() * id.extent());
   }
+  id.set_min_extent(od.min() * id.extent(), od.extent() * id.extent());
   if (type == fuse_type::keep) {
     od.set_min_extent(0, 1);
   } else if (type == fuse_type::remove) {

--- a/runtime/test/BUILD
+++ b/runtime/test/BUILD
@@ -15,7 +15,10 @@ cc_test(
 
 cc_test(
     name = "buffer",
-    srcs = ["buffer.cc"],
+    srcs = [
+        "buffer.cc",
+        "buffer.h"
+    ],
     deps = [
         "//runtime",
         "@googletest//:gtest_main",

--- a/runtime/test/buffer.cc
+++ b/runtime/test/buffer.cc
@@ -828,6 +828,18 @@ TEST(fuse_contiguous_dims, fuse3) {
   ASSERT_EQ(b.dim(0).extent(), 6 * 7 * 8);
 }
 
+TEST(fuse_contiguous_dims, fuse_folded) {
+  buffer<int, 3> a({6, 7, 8}), b({6, 7, 8});
+  a.dim(2).set_fold_factor(3);
+  fuse_contiguous_dims(a, b);
+  ASSERT_EQ(a.rank, 1);
+  ASSERT_EQ(b.rank, 1);
+  ASSERT_EQ(a.dim(0).extent(), 6 * 7 * 8);
+  ASSERT_EQ(a.dim(0).fold_factor(), 6 * 7 * 3);
+  ASSERT_EQ(b.dim(0).extent(), 6 * 7 * 8);
+  ASSERT_EQ(b.dim(0).fold_factor(), dim::unfolded);
+}
+
 TEST(fuse_contiguous_dims, cant_fuse) {
   buffer<int, 4> a({2, 3, 4, 5}), b({2, 3, 4, 5});
   ASSERT_NE(a.dim(0).stride(), 0);

--- a/runtime/test/buffer.cc
+++ b/runtime/test/buffer.cc
@@ -865,7 +865,7 @@ TEST(fuse_contiguous_dims, copy) {
     for (std::size_t d = 0; d < src.rank; ++d) {
       src.dim(d).set_min_extent(0, 5);
     }
-    randomize_strides_and_padding(src, {-1, 1, true, false});
+    randomize_strides_and_padding(src, {-1, 1, true, true});
     init_random(src);
     buffer<void, max_rank> src_opt = src;
 

--- a/runtime/test/buffer.h
+++ b/runtime/test/buffer.h
@@ -1,0 +1,40 @@
+#ifndef SLINKY_RUNTIME_TEST_BUFFER_H
+#define SLINKY_RUNTIME_TEST_BUFFER_H
+
+#include <cassert>
+#include <vector>
+
+#include "runtime/buffer.h"
+
+namespace slinky {
+
+// Flatten a buffer into a vector. Not efficient, but useful for testing.
+template <typename T>
+std::vector<T> flatten(const raw_buffer& buf) {
+  assert(buf.elem_size == sizeof(T));
+  std::vector<T> flat(buf.elem_count());
+  raw_buffer flat_buf;
+  flat_buf.base = flat.data();
+  flat_buf.elem_size = buf.elem_size;
+  flat_buf.rank = buf.rank;
+  flat_buf.dims = SLINKY_ALLOCA(dim, buf.rank);
+  index_t stride = buf.elem_size;
+  for (std::size_t d = 0; d < buf.rank; ++d) {
+    flat_buf.dim(d).set_min_extent(buf.dim(d).min(), buf.dim(d).extent());
+    flat_buf.dim(d).set_stride(stride);
+    flat_buf.dim(d).set_fold_factor(dim::unfolded);
+    stride *= flat_buf.dim(d).extent();
+  }
+  assert(stride == static_cast<index_t>(flat.size() * sizeof(T)));
+  copy(buf, flat_buf);
+  return flat;
+}
+
+template <typename T, std::size_t DimsSize>
+std::vector<T> flatten(const buffer<T, DimsSize>& buf) {
+  return flatten<T>(static_cast<const raw_buffer&>(buf));
+}
+
+}  // namespace slinky
+
+#endif  // SLINKY_RUNTIME_TEST_BUFFER_H


### PR DESCRIPTION
The way we check buffers for correctness now is really annoying:
- ASSERT_* does some crazy hackery where it doesn't end the test if it's called inside a function. So if you use it inside a `for_each_index`-ish lambda callback, one failing test generates thousands of errors. And we run fuzz tests in loops...
- It's hard to see problems without context in the buffers.

One way to fix that would be to use the ASSERT_THAT matchers from gmock.h. This PR tries to do that in a few places, but hasn't eliminated all uses of `for_each_index` yet.

While attempting this PR, discovered a bug when fusing folded buffers.
