### PR TITLE
Use symbolic bounds for loops in addition to input crops (like #278)

### DIFF
--- a/builder/pipeline.cc
+++ b/builder/pipeline.cc
@@ -605,7 +605,7 @@ class pipeline_builder {
       for (int d = 0; d < static_cast<int>(o.dims.size()); ++d) {
         if (o.dims[d] == loop.sym()) {
           // This output uses this loop. Add it to the bounds.
-          bounds |= o.buffer->dim(d).bounds;
+          bounds |= buffer_bounds(o.sym(), d);
         }
       }
     }


### PR DESCRIPTION
This doesn't fix any actual issue I know of, but it seems right, like #278 for buffers.