### PR TITLE
Stop substituting lets unless they are trivial

### DIFF
--- a/builder/simplify.cc
+++ b/builder/simplify.cc
@@ -351,7 +351,7 @@ public:
         // Prune dead lets
         it = std::make_reverse_iterator(lets.erase(std::next(it).base()));
         values_changed = true;
-      } else if ((deps.ref_count == 1 && !deps.used_in_loop) || is_trivial_let_value(it->second)) {
+      } else if (is_trivial_let_value(it->second)) {
         // Inline single-ref lets outside of a loop, along with lets that are trivial
         body = mutate(substitute(body, it->first, it->second), &body_bounds);
         for (auto inner = lets.rbegin(); inner != it; ++inner) {

--- a/builder/test/simplify.cc
+++ b/builder/test/simplify.cc
@@ -139,12 +139,8 @@ TEST(simplify, basic) {
 TEST(simplify, let) {
   // lets that should be removed
   test_simplify(let::make(x, y, z), z);                                // Dead let
-  test_simplify(let::make(x, y * 2, x), y * 2);                        // Single use, substitute
-  test_simplify(let::make(x, y * w, x), y * w);                        // Single use, substitute
   test_simplify(let::make(x, y, (x + 1) / x), (y + 1) / y);            // Trivial value, substitute
   test_simplify(let::make(x, 10, x / x), 1);                           // Trivial value, substitute
-  test_simplify(let::make(x, buffer_max(y, 0), x), buffer_max(y, 0));  // buffer_max, substitute
-  test_simplify(let::make(x, buffer_min(y, 0), x), buffer_min(y, 0));  // buffer_min, substitute
 
   test_simplify(let_stmt::make(x, y, loop::make(z, loop::serial, bounds(0, 3), 1, check::make(x + z))),
       loop::make(z, loop::serial, bounds(0, 3), 1, check::make(y + z)));  // Trivial value, substitute
@@ -162,8 +158,8 @@ TEST(simplify, let) {
 
   // Compound lets with dependencies between let values.
   test_simplify(let::make({{x, y}, {z, x}}, z), y);
-  test_simplify(let::make({{x, y}, {z, x * 2}}, z), y * 2);
-  test_simplify(let::make({{x, y * 2}, {z, x}}, z), y * 2);
+  test_simplify(let::make({{x, y}, {z, x * 2}}, z), let::make(z, y * 2, z));
+  test_simplify(let::make({{x, y * 2}, {z, x}}, z), let::make(x, y * 2, x));
   test_simplify(let::make({{x, y * 2}, {z, y}}, z), y);
   test_simplify(let::make({{x, y}, {z, (x + 1) / x}}, (z + 1) / z), let::make({{z, (y + 1) / y}}, (z + 1) / z));
 }

--- a/builder/test/visualize/padded_stencil_2.html
+++ b/builder/test/visualize/padded_stencil_2.html
@@ -278,21 +278,24 @@ function pipeline(__in, out) {
           {bounds:{min:max((buffer_min(out, 0) + -1), buffer_min(__in, 0)), max:min((buffer_max(out, 0) + 1), buffer_max(__in, 0))}, stride:2, fold_factor:9223372036854775807},
           {bounds:{min:max((buffer_min(out, 1) + -1), buffer_min(__in, 1)), max:min((buffer_max(out, 1) + 1), buffer_max(__in, 1))}, stride:(((min((buffer_max(out, 0) + 1), buffer_max(__in, 0)) - max((buffer_min(out, 0) + -1), buffer_min(__in, 0))) * 2) + 2), fold_factor:9223372036854775807}
         ]);
-        for(let y = (buffer_min(out, 1) + -2); y <= buffer_max(out, 1); y += 1) {
-          { let __intm = crop_dim(intm, 1, {min:(max(y, (max(y, buffer_min(out, 1)) + -2)) + 1), max:(y + 1)});
-            consume(__in);
-            produce(intm);
-            intm = __intm;
-          }
-          { let __padded_intm = crop_dim(padded_intm, 1, {min:(y + 1), max:(y + 1)});
-            consume(intm);
-            produce(padded_intm);
-            padded_intm = __padded_intm;
-          }
-          { let __out = crop_dim(out, 1, {min:y, max:y});
-            consume(padded_intm_uncropped);
-            produce(out);
-            out = __out;
+        {
+          let y_min_orig = buffer_min(out, 1);
+          for(let y = (y_min_orig + -2); y <= buffer_max(out, 1); y += 1) {
+            { let __intm = crop_dim(intm, 1, {min:(max(y, (max(y, buffer_min(out, 1)) + -2)) + 1), max:(y + 1)});
+              consume(__in);
+              produce(intm);
+              intm = __intm;
+            }
+            { let __padded_intm = crop_dim(padded_intm, 1, {min:(y + 1), max:(y + 1)});
+              consume(intm);
+              produce(padded_intm);
+              padded_intm = __padded_intm;
+            }
+            { let __out = crop_dim(out, 1, {min:y, max:y});
+              consume(padded_intm_uncropped);
+              produce(out);
+              out = __out;
+            }
           }
         }
         free(intm);

--- a/builder/test/visualize/parallel_stencils_0.html
+++ b/builder/test/visualize/parallel_stencils_0.html
@@ -302,32 +302,35 @@ function pipeline(in1, in2, out) {
                   {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:(((buffer_max(out, 0) - buffer_min(out, 0)) * 2) + 6), fold_factor:3}
                 ]);
                 { let intm1_uncropped = clone_buffer(intm1);
-                  for(let y = (buffer_min(out, 1) + -6); y <= buffer_max(out, 1); y += 1) {
-                    { let __intm1 = crop_dim(intm1, 1, {min:(y + 1), max:(y + 1)});
-                      consume(in1);
-                      produce(intm1);
-                      intm1 = __intm1;
-                    }
-                    { let __intm3 = crop_dim(intm3, 1, {min:y, max:y});
-                      consume(intm1_uncropped);
-                      produce(intm3);
-                      intm3 = __intm3;
-                    }
-                    { let __intm2 = crop_dim(intm2, 1, {min:(y + 2), max:(y + 2)});
-                      consume(in2);
-                      produce(intm2);
-                      intm2 = __intm2;
-                    }
-                    { let __intm4 = crop_dim(intm4, 1, {min:y, max:y});
-                      consume(intm2_uncropped);
-                      produce(intm4);
-                      intm4 = __intm4;
-                    }
-                    { let __out = crop_dim(out, 1, {min:y, max:y});
-                      consume(intm3_uncropped);
-                      consume(intm4_uncropped);
-                      produce(out);
-                      out = __out;
+                  {
+                    let y_min_orig = buffer_min(out, 1);
+                    for(let y = (y_min_orig + -6); y <= buffer_max(out, 1); y += 1) {
+                      { let __intm1 = crop_dim(intm1, 1, {min:(y + 1), max:(y + 1)});
+                        consume(in1);
+                        produce(intm1);
+                        intm1 = __intm1;
+                      }
+                      { let __intm3 = crop_dim(intm3, 1, {min:y, max:y});
+                        consume(intm1_uncropped);
+                        produce(intm3);
+                        intm3 = __intm3;
+                      }
+                      { let __intm2 = crop_dim(intm2, 1, {min:(y + 2), max:(y + 2)});
+                        consume(in2);
+                        produce(intm2);
+                        intm2 = __intm2;
+                      }
+                      { let __intm4 = crop_dim(intm4, 1, {min:y, max:y});
+                        consume(intm2_uncropped);
+                        produce(intm4);
+                        intm4 = __intm4;
+                      }
+                      { let __out = crop_dim(out, 1, {min:y, max:y});
+                        consume(intm3_uncropped);
+                        consume(intm4_uncropped);
+                        produce(out);
+                        out = __out;
+                      }
                     }
                   }
                 }

--- a/builder/test/visualize/parallel_stencils_1.html
+++ b/builder/test/visualize/parallel_stencils_1.html
@@ -303,27 +303,30 @@ function pipeline(in1, in2, out) {
                 ]);
                 consume(in1);
                 produce(intm1);
-                for(let y = (buffer_min(out, 1) + -4); y <= buffer_max(out, 1); y += 2) {
-                  { let __intm3 = crop_dim(intm3, 1, {min:y, max:min((y + 1), buffer_max(out, 1))});
-                    consume(intm1);
-                    produce(intm3);
-                    intm3 = __intm3;
-                  }
-                  { let __intm2 = crop_dim(intm2, 1, {min:(y + 2), max:(min((y + 1), buffer_max(out, 1)) + 2)});
-                    consume(in2);
-                    produce(intm2);
-                    intm2 = __intm2;
-                  }
-                  { let __intm4 = crop_dim(intm4, 1, {min:y, max:min((y + 1), buffer_max(out, 1))});
-                    consume(intm2_uncropped);
-                    produce(intm4);
-                    intm4 = __intm4;
-                  }
-                  { let __out = crop_dim(out, 1, {min:y, max:(y + 1)});
-                    consume(intm3_uncropped);
-                    consume(intm4_uncropped);
-                    produce(out);
-                    out = __out;
+                {
+                  let y_min_orig = buffer_min(out, 1);
+                  for(let y = (y_min_orig + -4); y <= buffer_max(out, 1); y += 2) {
+                    { let __intm3 = crop_dim(intm3, 1, {min:y, max:min((y + 1), buffer_max(out, 1))});
+                      consume(intm1);
+                      produce(intm3);
+                      intm3 = __intm3;
+                    }
+                    { let __intm2 = crop_dim(intm2, 1, {min:(y + 2), max:(min((y + 1), buffer_max(out, 1)) + 2)});
+                      consume(in2);
+                      produce(intm2);
+                      intm2 = __intm2;
+                    }
+                    { let __intm4 = crop_dim(intm4, 1, {min:y, max:min((y + 1), buffer_max(out, 1))});
+                      consume(intm2_uncropped);
+                      produce(intm4);
+                      intm4 = __intm4;
+                    }
+                    { let __out = crop_dim(out, 1, {min:y, max:(y + 1)});
+                      consume(intm3_uncropped);
+                      consume(intm4_uncropped);
+                      produce(out);
+                      out = __out;
+                    }
                   }
                 }
                 free(intm1);

--- a/builder/test/visualize/parallel_stencils_2.html
+++ b/builder/test/visualize/parallel_stencils_2.html
@@ -302,32 +302,35 @@ function pipeline(in1, in2, out) {
                   {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:(((buffer_max(out, 0) - buffer_min(out, 0)) * 2) + 6), fold_factor:4}
                 ]);
                 { let intm1_uncropped = clone_buffer(intm1);
-                  for(let y = (buffer_min(out, 1) + -6); y <= buffer_max(out, 1); y += 2) {
-                    { let __intm1 = crop_dim(intm1, 1, {min:(y + 1), max:(min((y + 1), buffer_max(out, 1)) + 1)});
-                      consume(in1);
-                      produce(intm1);
-                      intm1 = __intm1;
-                    }
-                    { let __intm3 = crop_dim(intm3, 1, {min:y, max:min((y + 1), buffer_max(out, 1))});
-                      consume(intm1_uncropped);
-                      produce(intm3);
-                      intm3 = __intm3;
-                    }
-                    { let __intm2 = crop_dim(intm2, 1, {min:(y + 2), max:(min((y + 1), buffer_max(out, 1)) + 2)});
-                      consume(in2);
-                      produce(intm2);
-                      intm2 = __intm2;
-                    }
-                    { let __intm4 = crop_dim(intm4, 1, {min:y, max:min((y + 1), buffer_max(out, 1))});
-                      consume(intm2_uncropped);
-                      produce(intm4);
-                      intm4 = __intm4;
-                    }
-                    { let __out = crop_dim(out, 1, {min:y, max:(y + 1)});
-                      consume(intm3_uncropped);
-                      consume(intm4_uncropped);
-                      produce(out);
-                      out = __out;
+                  {
+                    let y_min_orig = buffer_min(out, 1);
+                    for(let y = (y_min_orig + -6); y <= buffer_max(out, 1); y += 2) {
+                      { let __intm1 = crop_dim(intm1, 1, {min:(y + 1), max:(min((y + 1), buffer_max(out, 1)) + 1)});
+                        consume(in1);
+                        produce(intm1);
+                        intm1 = __intm1;
+                      }
+                      { let __intm3 = crop_dim(intm3, 1, {min:y, max:min((y + 1), buffer_max(out, 1))});
+                        consume(intm1_uncropped);
+                        produce(intm3);
+                        intm3 = __intm3;
+                      }
+                      { let __intm2 = crop_dim(intm2, 1, {min:(y + 2), max:(min((y + 1), buffer_max(out, 1)) + 2)});
+                        consume(in2);
+                        produce(intm2);
+                        intm2 = __intm2;
+                      }
+                      { let __intm4 = crop_dim(intm4, 1, {min:y, max:min((y + 1), buffer_max(out, 1))});
+                        consume(intm2_uncropped);
+                        produce(intm4);
+                        intm4 = __intm4;
+                      }
+                      { let __out = crop_dim(out, 1, {min:y, max:(y + 1)});
+                        consume(intm3_uncropped);
+                        consume(intm4_uncropped);
+                        produce(out);
+                        out = __out;
+                      }
                     }
                   }
                 }

--- a/builder/test/visualize/stencil_chain_split_serial_split_1.html
+++ b/builder/test/visualize/stencil_chain_split_serial_split_1.html
@@ -286,8 +286,9 @@ function pipeline(__in, out) {
           ]);
           { let add_result_uncropped = clone_buffer(add_result);
             {
+              let y_min_orig = buffer_min(out, 1);
               let __trace_token = trace_begin(buffer_at(__trace_names, 17));
-              for(let y = (buffer_min(out, 1) + -4); y <= buffer_max(out, 1); y += 1) {
+              for(let y = (y_min_orig + -4); y <= buffer_max(out, 1); y += 1) {
                 {
                   let __trace_token = trace_begin(buffer_at(__trace_names, 0));
                   { let __add_result = crop_dim(add_result, 1, {min:(y + 2), max:(y + 2)});

--- a/builder/test/visualize/stencil_chain_split_serial_split_2.html
+++ b/builder/test/visualize/stencil_chain_split_serial_split_2.html
@@ -286,8 +286,9 @@ function pipeline(__in, out) {
           ]);
           { let add_result_uncropped = clone_buffer(add_result);
             {
+              let y_min_orig = buffer_min(out, 1);
               let __trace_token = trace_begin(buffer_at(__trace_names, 17));
-              for(let y = (buffer_min(out, 1) + -4); y <= buffer_max(out, 1); y += 2) {
+              for(let y = (y_min_orig + -4); y <= buffer_max(out, 1); y += 2) {
                 {
                   let __trace_token = trace_begin(buffer_at(__trace_names, 0));
                   { let __add_result = crop_dim(add_result, 1, {min:(y + 2), max:(min((y + 1), buffer_max(out, 1)) + 2)});

--- a/builder/test/visualize/stencil_split_1.html
+++ b/builder/test/visualize/stencil_split_1.html
@@ -278,16 +278,19 @@ function pipeline(__in, out) {
       {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:(((buffer_max(out, 0) - buffer_min(out, 0)) * 2) + 6), fold_factor:3}
     ]);
     { let intm_uncropped = clone_buffer(intm);
-      for(let y = (buffer_min(out, 1) + -2); y <= buffer_max(out, 1); y += 1) {
-        { let __intm = crop_dim(intm, 1, {min:(y + 1), max:(y + 1)});
-          consume(__in);
-          produce(intm);
-          intm = __intm;
-        }
-        { let __out = crop_dim(out, 1, {min:y, max:y});
-          consume(intm_uncropped);
-          produce(out);
-          out = __out;
+      {
+        let y_min_orig = buffer_min(out, 1);
+        for(let y = (y_min_orig + -2); y <= buffer_max(out, 1); y += 1) {
+          { let __intm = crop_dim(intm, 1, {min:(y + 1), max:(y + 1)});
+            consume(__in);
+            produce(intm);
+            intm = __intm;
+          }
+          { let __out = crop_dim(out, 1, {min:y, max:y});
+            consume(intm_uncropped);
+            produce(out);
+            out = __out;
+          }
         }
       }
     }

--- a/builder/test/visualize/stencil_split_2.html
+++ b/builder/test/visualize/stencil_split_2.html
@@ -278,16 +278,19 @@ function pipeline(__in, out) {
       {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:(((buffer_max(out, 0) - buffer_min(out, 0)) * 2) + 6), fold_factor:4}
     ]);
     { let intm_uncropped = clone_buffer(intm);
-      for(let y = (buffer_min(out, 1) + -2); y <= buffer_max(out, 1); y += 2) {
-        { let __intm = crop_dim(intm, 1, {min:(y + 1), max:(min((y + 1), buffer_max(out, 1)) + 1)});
-          consume(__in);
-          produce(intm);
-          intm = __intm;
-        }
-        { let __out = crop_dim(out, 1, {min:y, max:(y + 1)});
-          consume(intm_uncropped);
-          produce(out);
-          out = __out;
+      {
+        let y_min_orig = buffer_min(out, 1);
+        for(let y = (y_min_orig + -2); y <= buffer_max(out, 1); y += 2) {
+          { let __intm = crop_dim(intm, 1, {min:(y + 1), max:(min((y + 1), buffer_max(out, 1)) + 1)});
+            consume(__in);
+            produce(intm);
+            intm = __intm;
+          }
+          { let __out = crop_dim(out, 1, {min:y, max:(y + 1)});
+            consume(intm_uncropped);
+            produce(out);
+            out = __out;
+          }
         }
       }
     }

--- a/builder/test/visualize/stencil_split_3.html
+++ b/builder/test/visualize/stencil_split_3.html
@@ -278,16 +278,19 @@ function pipeline(__in, out) {
       {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:(((buffer_max(out, 0) - buffer_min(out, 0)) * 2) + 6), fold_factor:6}
     ]);
     { let intm_uncropped = clone_buffer(intm);
-      for(let y = (buffer_min(out, 1) + -2); y <= buffer_max(out, 1); y += 3) {
-        { let __intm = crop_dim(intm, 1, {min:(y + 1), max:(min((y + 2), buffer_max(out, 1)) + 1)});
-          consume(__in);
-          produce(intm);
-          intm = __intm;
-        }
-        { let __out = crop_dim(out, 1, {min:y, max:(y + 2)});
-          consume(intm_uncropped);
-          produce(out);
-          out = __out;
+      {
+        let y_min_orig = buffer_min(out, 1);
+        for(let y = (y_min_orig + -2); y <= buffer_max(out, 1); y += 3) {
+          { let __intm = crop_dim(intm, 1, {min:(y + 1), max:(min((y + 2), buffer_max(out, 1)) + 1)});
+            consume(__in);
+            produce(intm);
+            intm = __intm;
+          }
+          { let __out = crop_dim(out, 1, {min:y, max:(y + 2)});
+            consume(intm_uncropped);
+            produce(out);
+            out = __out;
+          }
         }
       }
     }

--- a/runtime/buffer.h
+++ b/runtime/buffer.h
@@ -68,8 +68,9 @@ public:
 
   void translate(index_t offset) { min_ += offset; }
 
-  bool contains(index_t x) const { return stride() == 0 || (min() <= x && x <= max()); }
-  bool contains(const dim& other) const { return stride() == 0 || (min() <= other.min() && other.max() <= max()); }
+  bool contains(index_t a, index_t b) const { return stride() == 0 || (min() <= a && b <= max()); }
+  bool contains(index_t x) const { return contains(x, x); }
+  bool contains(const dim& other) const { return contains(other.min(), other.max()); }
 
   std::ptrdiff_t flat_offset_bytes(index_t i) const {
     // Conceptually, accesses may be out of bounds, but in practice, if the stride is 0, the accesses will not read

--- a/runtime/depends_on.cc
+++ b/runtime/depends_on.cc
@@ -72,18 +72,7 @@ public:
     op->bounds.max.accept(this);
     if (op->step.defined()) op->step.accept(this);
 
-    std::vector<int> old_ref_count(var_deps.size());
-    for (std::size_t i = 0; i < var_deps.size(); ++i) {
-      old_ref_count[i] = var_deps[i].second.ref_count;
-    }
-
     visit_sym_body(op);
-
-    for (std::size_t i = 0; i < var_deps.size(); ++i) {
-      if (var_deps[i].second.ref_count > old_ref_count[i]) {
-        var_deps[i].second.used_in_loop = true;
-      }
-    }
   }
 
   void visit(const call_stmt* op) override {

--- a/runtime/depends_on.h
+++ b/runtime/depends_on.h
@@ -25,9 +25,6 @@ struct depends_on_result {
   // How many references there are.
   int ref_count = 0;
 
-  // True if any reference is in a loop.
-  bool used_in_loop = false;
-
   bool buffer_data() const { return buffer_input || buffer_output || buffer_src || buffer_dst; }
   bool buffer_meta() const { return buffer_meta_read || buffer_meta_mutated; }
   bool buffer() const { return buffer_data() || buffer_meta(); }

--- a/runtime/test/depends_on.cc
+++ b/runtime/test/depends_on.cc
@@ -25,7 +25,6 @@ bool operator==(const depends_on_result& l, const depends_on_result& r) {
   if (l.buffer_meta_read != r.buffer_meta_read) return false;
   if (l.buffer_meta_mutated != r.buffer_meta_mutated) return false;
   if (l.ref_count != r.ref_count) return false;
-  if (l.used_in_loop != r.used_in_loop) return false;
   return true;
 }
 


### PR DESCRIPTION
There are cases in which substitute can fail if the value uses buffer metadata shadowed by crops/slices that are hard to detect by depends_on. Rather than try to fix this, we should just not try to substitute non-trivial lets.