### PR TITLE
Refactor buffer mutators to take an `src` buffer instead of always working in place

### DIFF
--- a/builder/node_mutator.cc
+++ b/builder/node_mutator.cc
@@ -54,19 +54,19 @@ stmt clone_with_new_body(const clone_buffer* op, stmt new_body) {
   return clone_buffer::make(op->sym, op->src, std::move(new_body));
 }
 stmt clone_with_new_body(const crop_buffer* op, stmt new_body) {
-  return crop_buffer::make(op->sym, op->bounds, std::move(new_body));
+  return crop_buffer::make(op->sym, op->src, op->bounds, std::move(new_body));
 }
 stmt clone_with_new_body(const crop_dim* op, stmt new_body) {
-  return crop_dim::make(op->sym, op->dim, op->bounds, std::move(new_body));
+  return crop_dim::make(op->sym, op->src, op->dim, op->bounds, std::move(new_body));
 }
 stmt clone_with_new_body(const slice_buffer* op, stmt new_body) {
-  return slice_buffer::make(op->sym, op->at, std::move(new_body));
+  return slice_buffer::make(op->sym, op->src, op->at, std::move(new_body));
 }
 stmt clone_with_new_body(const slice_dim* op, stmt new_body) {
-  return slice_dim::make(op->sym, op->dim, op->at, std::move(new_body));
+  return slice_dim::make(op->sym, op->src, op->dim, op->at, std::move(new_body));
 }
 stmt clone_with_new_body(const truncate_rank* op, stmt new_body) {
-  return truncate_rank::make(op->sym, op->rank, std::move(new_body));
+  return truncate_rank::make(op->sym, op->src, op->rank, std::move(new_body));
 }
 
 void node_mutator::visit(const let* op) { set_result(mutate_let(this, op)); }
@@ -213,7 +213,7 @@ void node_mutator::visit(const crop_buffer* op) {
   if (!changed && body.same_as(op->body)) {
     set_result(op);
   } else {
-    set_result(crop_buffer::make(op->sym, std::move(bounds), std::move(body)));
+    set_result(crop_buffer::make(op->sym, op->src, std::move(bounds), std::move(body)));
   }
 }
 void node_mutator::visit(const crop_dim* op) {
@@ -222,7 +222,7 @@ void node_mutator::visit(const crop_dim* op) {
   if (bounds.same_as(op->bounds) && body.same_as(op->body)) {
     set_result(op);
   } else {
-    set_result(crop_dim::make(op->sym, op->dim, std::move(bounds), std::move(body)));
+    set_result(crop_dim::make(op->sym, op->src, op->dim, std::move(bounds), std::move(body)));
   }
 }
 void node_mutator::visit(const slice_buffer* op) {
@@ -237,7 +237,7 @@ void node_mutator::visit(const slice_buffer* op) {
   if (!changed && body.same_as(op->body)) {
     set_result(op);
   } else {
-    set_result(slice_buffer::make(op->sym, std::move(at), std::move(body)));
+    set_result(slice_buffer::make(op->sym, op->src, std::move(at), std::move(body)));
   }
 }
 void node_mutator::visit(const slice_dim* op) {
@@ -246,7 +246,7 @@ void node_mutator::visit(const slice_dim* op) {
   if (at.same_as(op->at) && body.same_as(op->body)) {
     set_result(op);
   } else {
-    set_result(slice_dim::make(op->sym, op->dim, std::move(at), std::move(body)));
+    set_result(slice_dim::make(op->sym, op->src, op->dim, std::move(at), std::move(body)));
   }
 }
 void node_mutator::visit(const truncate_rank* op) {
@@ -254,7 +254,7 @@ void node_mutator::visit(const truncate_rank* op) {
   if (body.same_as(op->body)) {
     set_result(op);
   } else {
-    set_result(truncate_rank::make(op->sym, op->rank, std::move(body)));
+    set_result(truncate_rank::make(op->sym, op->src, op->rank, std::move(body)));
   }
 }
 

--- a/builder/optimizations.cc
+++ b/builder/optimizations.cc
@@ -236,6 +236,7 @@ public:
       }
     }
 
+    auto set_info_sym = set_value_in_scope(alias_info, op->sym, alias_info[op->src]);
     node_mutator::visit(op);
 
     // If we chose to alias this buffer, we need to insert offsets for where we sliced it.
@@ -265,6 +266,7 @@ public:
       }
     }
 
+    auto set_info_sym = set_value_in_scope(alias_info, op->sym, alias_info[op->src]);
     node_mutator::visit(op);
 
     // If we chose to alias this buffer, we need to insert offsets for where we sliced it.
@@ -388,7 +390,7 @@ stmt implement_copy(const copy_stmt* op, node_context& ctx) {
   }
 
   for (const std::pair<var, int>& d : dst_x) {
-    result = slice_dim::make(op->dst, d.second, d.first, result);
+    result = slice_dim::make(op->dst, op->dst, d.second, d.first, result);
     result = loop::make(d.first, loop::serial, buffer_bounds(op->dst, d.second), 1, result);
   }
   return let_stmt::make(std::move(lets), result);

--- a/builder/pipeline.cc
+++ b/builder/pipeline.cc
@@ -154,7 +154,7 @@ stmt func::make_call() const {
       }
       stmt copy = copy_stmt::make(input.sym(), src_x, outputs_[0].sym(), dst_x, padding_);
       if (!input.output_slice.empty()) {
-        copy = slice_buffer::make(outputs_[0].sym(), input.output_slice, copy);
+        copy = slice_buffer::make(outputs_[0].sym(), outputs_[0].sym(), input.output_slice, copy);
       }
       copies.push_back(copy);
     }
@@ -580,7 +580,7 @@ class pipeline_builder {
   stmt add_input_crops(stmt result, const func* f) {
     for (const func::input& i : f->inputs()) {
       assert(inferred_bounds_[i.sym()]);
-      result = crop_buffer::make(i.sym(), *inferred_bounds_[i.sym()], result);
+      result = crop_buffer::make(i.sym(), i.sym(), *inferred_bounds_[i.sym()], result);
     }
     return result;
   }
@@ -592,7 +592,7 @@ class pipeline_builder {
         if (o.dims[d] == loop.sym()) {
           expr loop_max = buffer_max(o.sym(), d);
           interval_expr bounds = slinky::bounds(loop.var, min(simplify(loop.var + loop.step - 1), loop_max));
-          body = crop_dim::make(o.sym(), d, bounds, body);
+          body = crop_dim::make(o.sym(), o.sym(), d, bounds, body);
         }
       }
     }
@@ -626,7 +626,7 @@ class pipeline_builder {
       // Wrap loop into crops.
       for (var i : input_syms_) {
         if (!allocation_bounds_[i]) continue;
-        body = crop_buffer::make(i, *allocation_bounds_[i], body);
+        body = crop_buffer::make(i, i, *allocation_bounds_[i], body);
       }
 
       for (int ix = order_.size() - 1; ix >= 0; ix--) {
@@ -635,7 +635,7 @@ class pipeline_builder {
         for (const func::output& o : f->outputs()) {
           const buffer_expr_ptr& b = o.buffer;
           if (!inferred_bounds_[b->sym()]) continue;
-          body = crop_buffer::make(b->sym(), *inferred_bounds_[b->sym()], body);
+          body = crop_buffer::make(b->sym(), b->sym(), *inferred_bounds_[b->sym()], body);
         }
       }
     }

--- a/builder/simplify.cc
+++ b/builder/simplify.cc
@@ -346,7 +346,7 @@ public:
         depends_on(inner->second, it->first, deps);
       }
 
-      if (deps.ref_count == 0) {
+      if (!deps.any()) {
         // Prune dead lets
         it = std::make_reverse_iterator(lets.erase(std::next(it).base()));
         values_changed = true;

--- a/builder/simplify.cc
+++ b/builder/simplify.cc
@@ -379,8 +379,8 @@ public:
   // Assuming that we've entered the body of a declaration of `sym`, remove any references to `sym` from the bounds (as
   // if they came from outside the body).
   static void clear_shadowed_bounds(var sym, interval_expr& bounds) {
-    if (depends_on(bounds.min, sym).buffer_meta_read) bounds.min = expr();
-    if (depends_on(bounds.max, sym).buffer_meta_read) bounds.max = expr();
+    if (depends_on(bounds.min, sym).buffer_meta) bounds.min = expr();
+    if (depends_on(bounds.max, sym).buffer_meta) bounds.max = expr();
   }
   static void clear_shadowed_bounds(var sym, box_expr& bounds) {
     for (interval_expr& i : bounds) {
@@ -465,7 +465,7 @@ public:
       // contiguous crops of a buffer. In these cases, we can drop the loop in favor of just calling the body on the
       // union of the bounds covered by the loop.
       stmt result = body;
-      std::vector<std::tuple<var, int, interval_expr>> new_crops;
+      std::vector<std::tuple<var, var, int, interval_expr>> new_crops;
       bool drop_loop = true;
       while (true) {
         // For now, we only handle crop_dim. I don't think crop_buffer can ever yield this simplification?
@@ -475,7 +475,7 @@ public:
           if (prove_true(crop->bounds.max + 1 >= next_iter.min || next_iter.max + 1 >= crop->bounds.min)) {
             result = crop->body;
             interval_expr new_crop = bounds_of(crop->bounds, {{op->sym, bounds}});
-            new_crops.emplace_back(crop->sym, crop->dim, new_crop);
+            new_crops.emplace_back(crop->sym, crop->src, crop->dim, new_crop);
           } else {
             // This crop was not contiguous, we can't drop the loop.
             drop_loop = false;
@@ -494,7 +494,7 @@ public:
       if (drop_loop) {
         // Rewrite the crops to cover the whole loop, and drop the loop.
         for (auto i = new_crops.rbegin(); i != new_crops.rend(); ++i) {
-          result = crop_dim::make(std::get<0>(*i), std::get<1>(*i), std::get<2>(*i), result);
+          result = crop_dim::make(std::get<0>(*i), std::get<1>(*i), std::get<2>(*i), std::get<3>(*i), result);
         }
         set_result(mutate(result));
         return;
@@ -596,31 +596,31 @@ public:
       if (bc->intrinsic == intrinsic::buffer_at && bc->args.size() == 1) {
         // Check if this make_buffer is truncate_rank, or a clone.
         const var* src_buf = as_variable(bc->args[0]);
-        if (src_buf) {
-          if (match(elem_size, buffer_elem_size(*src_buf))) {
-            bool is_clone = true;
-            for (index_t d = 0; d < static_cast<index_t>(dims.size()); ++d) {
-              is_clone = is_clone && match(dims[d], buffer_dim(*src_buf, d));
+        assert(src_buf);
+        if (match(elem_size, buffer_elem_size(*src_buf))) {
+          bool is_clone = true;
+          for (index_t d = 0; d < static_cast<index_t>(dims.size()); ++d) {
+            is_clone = is_clone && match(dims[d], buffer_dim(*src_buf, d));
+          }
+          if (is_clone) {
+            if (*src_buf == op->sym) {
+              set_result(mutate(truncate_rank::make(op->sym, *src_buf, dims.size(), std::move(body))));
+              return;
             }
-            if (is_clone) {
-              if (*src_buf == op->sym) {
-                set_result(mutate(truncate_rank::make(op->sym, dims.size(), std::move(body))));
-                return;
-              }
-              const std::optional<box_expr>& src_bounds = buffer_bounds[*src_buf];
-              if (src_bounds && src_bounds->size() == dims.size()) {
-                // This is a clone of src_buf.
-                set_result(mutate(clone_buffer::make(op->sym, *src_buf, std::move(body))));
-                return;
-              }
+            const std::optional<box_expr>& src_bounds = buffer_bounds[*src_buf];
+            if (src_bounds && src_bounds->size() == dims.size()) {
+              // This is a clone of src_buf.
+              set_result(mutate(clone_buffer::make(op->sym, *src_buf, std::move(body))));
+              return;
             }
           }
         }
       }
 
       // Check if this make_buffer is equivalent to slice_buffer or crop_buffer
-      if (bc->intrinsic == intrinsic::buffer_at && match(bc->args[0], op->sym) &&
-          match(elem_size, buffer_elem_size(op->sym))) {
+      if (bc->intrinsic == intrinsic::buffer_at && match(elem_size, buffer_elem_size(op->sym))) {
+        const var* src_buf = as_variable(bc->args[0]);
+        assert(src_buf);
         // To be a slice, we need every dimension that is present in the buffer_at call to be skipped, and the rest of
         // the dimensions to be identity.
         std::size_t dim = 0;
@@ -633,12 +633,12 @@ public:
           } else {
             // This arg is undefined. We need to find the next dimension here to be a slice.
             ++slice_rank;
-            is_slice = is_slice && match(dims[dim], buffer_dim(op->sym, d));
+            is_slice = is_slice && match(dims[dim], buffer_dim(*src_buf, d));
           }
         }
         if (is_slice && slice_rank == dims.size()) {
           std::vector<expr> at(bc->args.begin() + 1, bc->args.end());
-          set_result(mutate(slice_buffer::make(op->sym, std::move(at), std::move(body))));
+          set_result(mutate(slice_buffer::make(op->sym, *src_buf, std::move(at), std::move(body))));
           return;
         }
 
@@ -646,8 +646,8 @@ public:
         bool is_crop = bc->args.size() <= dims.size() + 1;
         box_expr crop_bounds(dims.size());
         for (index_t d = 0; d < static_cast<index_t>(dims.size()); ++d) {
-          if (!match(dims[d].stride, buffer_stride(op->sym, d)) ||
-              !match(dims[d].fold_factor, buffer_fold_factor(op->sym, d))) {
+          if (!match(dims[d].stride, buffer_stride(*src_buf, d)) ||
+              !match(dims[d].fold_factor, buffer_fold_factor(*src_buf, d))) {
             is_crop = false;
             break;
           }
@@ -655,7 +655,7 @@ public:
           // If the argument is defined, we need the min to be the same as the argument.
           // If it is not defined, it must be buffer_min(buf, d).
           bool has_at_d = d + 1 < static_cast<index_t>(bc->args.size()) && bc->args[d + 1].defined();
-          expr crop_min = has_at_d ? bc->args[d + 1] : buffer_min(op->sym, d);
+          expr crop_min = has_at_d ? bc->args[d + 1] : buffer_min(*src_buf, d);
           if (match(dims[d].bounds.min, crop_min)) {
             crop_bounds[d] = dims[d].bounds;
           } else {
@@ -664,7 +664,7 @@ public:
           }
         }
         if (is_crop) {
-          set_result(mutate(crop_buffer::make(op->sym, std::move(crop_bounds), std::move(body))));
+          set_result(mutate(crop_buffer::make(op->sym, *src_buf, std::move(crop_bounds), std::move(body))));
           return;
         }
       }
@@ -729,8 +729,8 @@ public:
     index_t dims_count = 0;
     bool changed = false;
     for (index_t i = 0; i < static_cast<index_t>(op->bounds.size()); ++i) {
-      interval_expr bounds_i = simplify_crop_bounds(mutate(op->bounds[i]), op->sym, i);
-      bounds_i = simplify_redundant_bounds(bounds_i, slinky::buffer_bounds(sym_var, i));
+      interval_expr bounds_i = simplify_crop_bounds(mutate(op->bounds[i]), op->src, i);
+      bounds_i = simplify_redundant_bounds(bounds_i, slinky::buffer_bounds(op->src, i));
       changed = changed || !bounds_i.same_as(op->bounds[i]);
 
       bounds[i] = bounds_i;
@@ -770,16 +770,16 @@ public:
       std::vector<stmt> stmts;
       stmts.reserve(b->stmts.size());
       for (const stmt& s : b->stmts) {
-        stmts.push_back(mutate(crop_buffer::make(op->sym, new_bounds, s)));
+        stmts.push_back(mutate(crop_buffer::make(op->sym, op->src, new_bounds, s)));
       }
       set_result(block::make(std::move(stmts)));
     } else if (dims_count == 1) {
       // This crop is of one dimension, replace it with crop_dim.
       // We removed undefined trailing bounds, so this must be the dim we want.
       int d = static_cast<int>(new_bounds.size()) - 1;
-      set_result(mutate(crop_dim::make(op->sym, d, std::move(new_bounds[d]), std::move(body))));
+      set_result(mutate(crop_dim::make(op->sym, op->src, d, std::move(new_bounds[d]), std::move(body))));
     } else if (changed || !body.same_as(op->body)) {
-      set_result(crop_buffer::make(op->sym, std::move(new_bounds), std::move(body)));
+      set_result(crop_buffer::make(op->sym, op->src, std::move(new_bounds), std::move(body)));
     } else {
       set_result(op);
     }
@@ -787,8 +787,8 @@ public:
 
   void visit(const crop_dim* op) override {
     expr sym_var = variable::make(op->sym);
-    interval_expr bounds = simplify_crop_bounds(mutate(op->bounds), op->sym, op->dim);
-    bounds = simplify_redundant_bounds(bounds, slinky::buffer_bounds(sym_var, op->dim));
+    interval_expr bounds = simplify_crop_bounds(mutate(op->bounds), op->src, op->dim);
+    bounds = simplify_redundant_bounds(bounds, slinky::buffer_bounds(op->src, op->dim));
     if (!bounds.min.defined() && !bounds.max.defined()) {
       set_result(mutate(op->body));
       return;
@@ -824,14 +824,14 @@ public:
         // This is a slice of the same dimension of the buffer we just cropped.
         // Don't drop the clamp that crop performs.
         expr at = clamp(slice->at, bounds.min, bounds.max);
-        set_result(mutate(slice_dim::make(op->sym, op->dim, at, slice->body)));
+        set_result(mutate(slice_dim::make(op->sym, op->src, op->dim, at, slice->body)));
         return;
       }
     } else if (const crop_dim* crop = body.as<crop_dim>()) {
       if (crop->sym == op->sym) {
         if (crop->dim == op->dim) {
           // Two nested crops of the same dimension, do one crop of the intersection instead.
-          set_result(mutate(crop_dim::make(op->sym, op->dim, bounds & crop->bounds, crop->body)));
+          set_result(mutate(crop_dim::make(op->sym, op->src, op->dim, bounds & crop->bounds, crop->body)));
           return;
         } else {
           // TODO: This is a nested crop of the same buffer, use crop_buffer instead.
@@ -843,13 +843,13 @@ public:
       std::vector<stmt> stmts;
       stmts.reserve(b->stmts.size());
       for (const stmt& s : b->stmts) {
-        stmts.push_back(mutate(crop_dim::make(op->sym, op->dim, bounds, s)));
+        stmts.push_back(mutate(crop_dim::make(op->sym, op->src, op->dim, bounds, s)));
       }
       set_result(block::make(std::move(stmts)));
     } else if (bounds.same_as(op->bounds) && body.same_as(op->body)) {
       set_result(op);
     } else {
-      set_result(crop_dim::make(op->sym, op->dim, std::move(bounds), std::move(body)));
+      set_result(crop_dim::make(op->sym, op->src, op->dim, std::move(bounds), std::move(body)));
     }
   }
 
@@ -906,16 +906,16 @@ public:
       std::vector<stmt> stmts;
       stmts.reserve(b->stmts.size());
       for (const stmt& s : b->stmts) {
-        stmts.push_back(mutate(slice_buffer::make(op->sym, at, s)));
+        stmts.push_back(mutate(slice_buffer::make(op->sym, op->src, at, s)));
       }
       set_result(block::make(std::move(stmts)));
     } else if (sliced_dims.size() == 1) {
       // This slice is of one dimension, replace it with slice_dim.
       // We removed undefined trailing bounds, so this must be the dim we want.
       int d = static_cast<int>(at.size()) - 1;
-      set_result(slice_dim::make(op->sym, d, std::move(at[d]), std::move(body)));
+      set_result(slice_dim::make(op->sym, op->src, d, std::move(at[d]), std::move(body)));
     } else if (changed || !body.same_as(op->body)) {
-      set_result(slice_buffer::make(op->sym, std::move(at), std::move(body)));
+      set_result(slice_buffer::make(op->sym, op->src, std::move(at), std::move(body)));
     } else {
       set_result(op);
     }
@@ -940,13 +940,13 @@ public:
       std::vector<stmt> stmts;
       stmts.reserve(b->stmts.size());
       for (const stmt& s : b->stmts) {
-        stmts.push_back(mutate(slice_dim::make(op->sym, op->dim, at, s)));
+        stmts.push_back(mutate(slice_dim::make(op->sym, op->src, op->dim, at, s)));
       }
       set_result(block::make(std::move(stmts)));
     } else if (at.same_as(op->at) && body.same_as(op->body)) {
       set_result(op);
     } else {
-      set_result(slice_dim::make(op->sym, op->dim, std::move(at), std::move(body)));
+      set_result(slice_dim::make(op->sym, op->src, op->dim, std::move(at), std::move(body)));
     }
   }
 
@@ -972,13 +972,13 @@ public:
       std::vector<stmt> stmts;
       stmts.reserve(b->stmts.size());
       for (const stmt& s : b->stmts) {
-        stmts.push_back(mutate(truncate_rank::make(op->sym, op->rank, s)));
+        stmts.push_back(mutate(truncate_rank::make(op->sym, op->src, op->rank, s)));
       }
       set_result(block::make(std::move(stmts)));
     } else if (body.same_as(op->body)) {
       set_result(op);
     } else {
-      set_result(truncate_rank::make(op->sym, op->rank, std::move(body)));
+      set_result(truncate_rank::make(op->sym, op->src, op->rank, std::move(body)));
     }
   }
 
@@ -987,9 +987,9 @@ public:
 
     if (!depends_on(body, op->sym).any()) {
       set_result(std::move(body));
-    } else if (!depends_on(body, op->src).buffer_meta_mutated) {
-      // We didn't mutate the original buffer. We can just use that instead.
-      set_result(substitute(body, op->sym, variable::make(op->src)));
+    } else if (!depends_on(body, op->src).any()) {
+      // We didn't use the original buffer. We can just use that instead.
+      set_result(mutate(substitute(body, op->sym, variable::make(op->src))));
     } else if (const block* b = body.as<block>()) {
       std::vector<stmt> stmts;
       stmts.reserve(b->stmts.size());

--- a/builder/slide_and_fold_storage.cc
+++ b/builder/slide_and_fold_storage.cc
@@ -350,7 +350,7 @@ public:
   void visit(const copy_stmt* op) override { visit_call_or_copy(op, {&op->dst, 1}); }
 
   void visit(const crop_buffer* op) override {
-    std::optional<box_expr> bounds = current_buffer_bounds()[op->sym];
+    std::optional<box_expr> bounds = current_buffer_bounds()[op->src];
     merge_crop(bounds, op->bounds);
     if (bounds) {
       substitute_bounds(*bounds, current_buffer_bounds());
@@ -365,14 +365,14 @@ public:
     if (current_buffer_bounds()[op->sym]) {
       // If we folded something, the bounds required may have shrank, update the crop.
       box_expr new_bounds = *current_buffer_bounds()[op->sym];
-      set_result(crop_buffer::make(op->sym, std::move(new_bounds), std::move(body)));
+      set_result(crop_buffer::make(op->sym, op->src, std::move(new_bounds), std::move(body)));
     } else {
-      set_result(crop_buffer::make(op->sym, op->bounds, std::move(body)));
+      set_result(crop_buffer::make(op->sym, op->src, op->bounds, std::move(body)));
     }
   }
 
   void visit(const crop_dim* op) override {
-    std::optional<box_expr> bounds = current_buffer_bounds()[op->sym];
+    std::optional<box_expr> bounds = current_buffer_bounds()[op->src];
     merge_crop(bounds, op->dim, op->bounds);
     substitute_bounds(*bounds, current_buffer_bounds());
     // This simplify can be heavy, but is really useful in reducing the size of the
@@ -388,12 +388,12 @@ public:
     if (body.same_as(op->body) && new_bounds.same_as(op->bounds)) {
       set_result(op);
     } else {
-      set_result(crop_dim::make(op->sym, op->dim, std::move(new_bounds), std::move(body)));
+      set_result(crop_dim::make(op->sym, op->src, op->dim, std::move(new_bounds), std::move(body)));
     }
   }
 
   void visit(const slice_buffer* op) override {
-    std::optional<box_expr> bounds = current_buffer_bounds()[op->sym];
+    std::optional<box_expr> bounds = current_buffer_bounds()[op->src];
     if (bounds) {
       for (int d = std::min(op->at.size(), bounds->size()) - 1; d >= 0; --d) {
         if (!op->at[d].defined()) continue;
@@ -411,7 +411,7 @@ public:
     }
   }
   void visit(const slice_dim* op) override {
-    std::optional<box_expr> bounds = current_buffer_bounds()[op->sym];
+    std::optional<box_expr> bounds = current_buffer_bounds()[op->src];
     if (bounds && op->dim < static_cast<int>(bounds->size())) {
       bounds->erase(bounds->begin() + op->dim);
     }

--- a/builder/substitute.cc
+++ b/builder/substitute.cc
@@ -250,6 +250,7 @@ public:
     assert(cbs);
 
     if (!try_match(cbs->sym, op->sym)) return;
+    if (!try_match(cbs->src, op->src)) return;
     if (!try_match(cbs->bounds, op->bounds)) return;
     if (!try_match(cbs->body, op->body)) return;
   }
@@ -259,6 +260,7 @@ public:
     assert(cds);
 
     if (!try_match(cds->sym, op->sym)) return;
+    if (!try_match(cds->src, op->src)) return;
     if (!try_match(cds->dim, op->dim)) return;
     if (!try_match(cds->bounds, op->bounds)) return;
     if (!try_match(cds->body, op->body)) return;
@@ -269,6 +271,7 @@ public:
     assert(cbs);
 
     if (!try_match(cbs->sym, op->sym)) return;
+    if (!try_match(cbs->src, op->src)) return;
     if (!try_match(cbs->at, op->at)) return;
     if (!try_match(cbs->body, op->body)) return;
   }
@@ -278,6 +281,7 @@ public:
     assert(cds);
 
     if (!try_match(cds->sym, op->sym)) return;
+    if (!try_match(cds->src, op->src)) return;
     if (!try_match(cds->dim, op->dim)) return;
     if (!try_match(cds->at, op->at)) return;
     if (!try_match(cds->body, op->body)) return;
@@ -288,6 +292,7 @@ public:
     assert(trs);
 
     if (!try_match(trs->sym, op->sym)) return;
+    if (!try_match(trs->src, op->src)) return;
     if (!try_match(trs->rank, op->rank)) return;
     if (!try_match(trs->body, op->body)) return;
   }
@@ -508,6 +513,7 @@ public:
     return body;
   }
   void visit(const slice_buffer* op) override {
+    var src = visit_symbol(op->src);
     std::vector<expr> at(op->at.size());
     at.reserve(op->at.size());
     bool changed = false;
@@ -520,30 +526,33 @@ public:
       }
     }
     stmt body = mutate_slice_body(op->sym, dims, op->body);
-    if (!changed && body.same_as(op->body)) {
+    if (!changed && src == op->src && body.same_as(op->body)) {
       set_result(op);
     } else {
-      set_result(slice_buffer::make(op->sym, std::move(at), std::move(body)));
+      set_result(slice_buffer::make(op->sym, src, std::move(at), std::move(body)));
     }
   }
   void visit(const slice_dim* op) override {
+    var src = visit_symbol(op->src);
     expr at = mutate(op->at);
     int slices[] = {op->dim};
     stmt body = mutate_slice_body(op->sym, slices, op->body);
-    if (at.same_as(op->at) && body.same_as(op->body)) {
+    if (src == op->src && at.same_as(op->at) && body.same_as(op->body)) {
       set_result(op);
     } else {
-      set_result(slice_dim::make(op->sym, op->dim, std::move(at), std::move(body)));
+      set_result(slice_dim::make(op->sym, src, op->dim, std::move(at), std::move(body)));
     }
   }
 
-  interval_expr substitute_crop_bounds(var sym, int dim, const interval_expr& bounds) {
+  interval_expr substitute_crop_bounds(var src, int dim, const interval_expr& bounds) {
     // When substituting crop bounds, we need to apply the implicit clamp, which uses buffer_min(sym, dim) and
-    // buffer_max(sym, dim).
-    expr buf_var = variable::make(sym);
-    interval_expr old_bounds = {buffer_min(buf_var, dim), buffer_max(buf_var, dim)};
+    // buffer_max(src, dim).
+    interval_expr old_bounds = buffer_bounds(src, dim);
     interval_expr new_bounds = {mutate(old_bounds.min), mutate(old_bounds.max)};
     interval_expr result = {mutate(bounds.min), mutate(bounds.max)};
+    // TODO: When substituting the crop src, this algorithm results in adding clamps that are unnecessary. The
+    // simplifier should remove them, but we should avoid generating them in the first place if possible.
+    // We could just not do this if src != op->src, but that seems like a hack.
     if (!old_bounds.min.same_as(new_bounds.min)) {
       // The substitution changed the implicit clamp, include it.
       result.min = max(result.min, new_bounds.min);
@@ -556,27 +565,29 @@ public:
   }
 
   void visit(const crop_buffer* op) override {
+    var src = visit_symbol(op->src);
     box_expr bounds(op->bounds.size());
     bool changed = false;
     for (std::size_t i = 0; i < op->bounds.size(); ++i) {
-      bounds[i] = substitute_crop_bounds(op->sym, i, op->bounds[i]);
+      bounds[i] = substitute_crop_bounds(op->src, i, op->bounds[i]);
       changed = changed || !bounds[i].same_as(op->bounds[i]);
     }
     stmt body = mutate_decl_body(op->sym, op->body);
-    if (changed || !body.same_as(op->body)) {
-      set_result(crop_buffer::make(op->sym, std::move(bounds), std::move(body)));
+    if (changed || src != op->src || !body.same_as(op->body)) {
+      set_result(crop_buffer::make(op->sym, src, std::move(bounds), std::move(body)));
     } else {
       set_result(op);
     }
   }
 
   void visit(const crop_dim* op) override {
-    interval_expr bounds = substitute_crop_bounds(op->sym, op->dim, op->bounds);
+    var src = visit_symbol(op->src);
+    interval_expr bounds = substitute_crop_bounds(op->src, op->dim, op->bounds);
     stmt body = mutate_decl_body(op->sym, op->body);
-    if (bounds.same_as(op->bounds) && body.same_as(op->body)) {
+    if (src == op->src && bounds.same_as(op->bounds) && body.same_as(op->body)) {
       set_result(op);
     } else {
-      set_result(crop_dim::make(op->sym, op->dim, std::move(bounds), std::move(body)));
+      set_result(crop_dim::make(op->sym, src, op->dim, std::move(bounds), std::move(body)));
     }
   }
 
@@ -613,10 +624,18 @@ public:
     }
     node_mutator::visit(op);
   }
-  // truncate_rank, clone_buffer, not treated here because references to dimensions of these
-  // operations are still valid.
-  // TODO: truncate_rank is a bit tricky, the replacements for expressions might be invalid if they access truncated
-  // dims.
+
+  void visit(const truncate_rank* op) override {
+    // TODO: truncate_rank is a bit tricky, the replacements for expressions might be invalid if they access truncated
+    // dims.
+    var src = visit_symbol(op->src);
+    stmt body = mutate_decl_body(op->sym, op->body);
+    if (src != op->src || !body.same_as(op->body)) {
+      set_result(truncate_rank::make(op->sym, src, op->rank, std::move(body)));
+    } else {
+      set_result(op);
+    }
+  }
 
   void visit(const call_stmt* op) override {
     call_stmt::symbol_list inputs(op->inputs.size());

--- a/builder/test/simplify.cc
+++ b/builder/test/simplify.cc
@@ -30,6 +30,8 @@ var b1(symbols, "b1");
 var b2(symbols, "b2");
 var b3(symbols, "b3");
 
+MATCHER_P(matches, x, "") { return match(arg, x); }
+
 }  // namespace
 
 template <typename T>
@@ -41,8 +43,6 @@ void dump_symbol_map(std::ostream& s, const symbol_map<T>& m) {
     }
   }
 }
-
-MATCHER_P(matches, x, "") { return match(arg, x); }
 
 TEST(simplify, basic) {
   ASSERT_THAT(simplify(expr() == 1), matches(expr() == 1));

--- a/builder/test/substitute.cc
+++ b/builder/test/substitute.cc
@@ -1,3 +1,4 @@
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include <cassert>
@@ -19,68 +20,59 @@ var z(symbols, "z");
 var w(symbols, "w");
 var u(symbols, "u");
 
+MATCHER_P(IsNode, expected, "") { return match(arg, expected); }
+
 }  // namespace
 
-template <typename T>
-void test_substitute(const expr& test, T target, const expr& replacement, const expr& expected) {
-  expr result = substitute(test, target, replacement);
-  if (!match(result, expected)) {
-    std::cout << "substitute failed" << std::endl;
-    std::cout << test << std::endl;
-    std::cout << "got: " << std::endl;
-    std::cout << result << std::endl;
-    std::cout << "expected: " << std::endl;
-    std::cout << expected << std::endl;
-    ASSERT_TRUE(false);
-  }
-}
-
-template <typename T>
-void test_substitute(const stmt& test, T target, const expr& replacement, const stmt& expected) {
-  stmt result = substitute(test, target, replacement);
-  if (!match(result, expected)) {
-    std::cout << "substitute failed" << std::endl;
-    std::cout << test << std::endl;
-    std::cout << "got: " << std::endl;
-    std::cout << result << std::endl;
-    std::cout << "expected: " << std::endl;
-    std::cout << expected << std::endl;
-    ASSERT_TRUE(false);
-  }
-}
-
 TEST(substitute, basic) {
-  test_substitute(x + y, x, z, z + y);
-  test_substitute(check::make(y == buffer_min(x, 3)), buffer_min(x, 3), z, check::make(expr(y) == expr(z)));
+  ASSERT_THAT(substitute(x + y, x, z), IsNode(z + y));
+  ASSERT_THAT(
+      substitute(check::make(y == buffer_min(x, 3)), buffer_min(x, 3), z), IsNode(check::make(expr(y) == expr(z))));
+  ASSERT_THAT(substitute(crop_dim::make(x, y, 0, {0, 0}, call_stmt::make(nullptr, {}, {x}, {})), y, z),
+      IsNode(
+          crop_dim::make(x, z, 0, buffer_bounds(z, 0) & interval_expr{0, 0}, call_stmt::make(nullptr, {}, {x}, {}))));
+  ASSERT_THAT(substitute(crop_dim::make(y, z, 0, {0, 0}, call_stmt::make(nullptr, {x}, {y}, {})), x, w),
+      IsNode(crop_dim::make(y, z, 0, {0, 0}, call_stmt::make(nullptr, {w}, {y}, {}))));
+  ASSERT_THAT(substitute(crop_dim::make(
+                             y, y, 0, {0, 0}, crop_dim::make(y, y, 0, {0, 0}, call_stmt::make(nullptr, {x}, {y}, {}))),
+                  x, w),
+      IsNode(crop_dim::make(y, y, 0, {0, 0}, crop_dim::make(y, y, 0, {0, 0}, call_stmt::make(nullptr, {w}, {y}, {})))));
 }
 
 TEST(substitute, shadowed) {
-  test_substitute(let::make(x, y, x + z), x, w, let::make(x, y, x + z));
-  test_substitute(let::make({{x, 1}, {y, 2}}, z + 1), z, z + w, let::make({{x, 1}, {y, 2}}, z + w + 1));
+  ASSERT_THAT(substitute(let::make(x, y, x + z), x, w), IsNode(let::make(x, y, x + z)));
 
-  test_substitute(crop_dim::make(x, 1, {y, z}, check::make(0 < buffer_min(x, 1))), buffer_min(x, 1), w,
-      crop_dim::make(x, 1, {max(y, w), z}, check::make(0 < buffer_min(x, 1))));
+  ASSERT_THAT(substitute(let::make({{x, 1}, {y, 2}}, z + 1), z, z + w), IsNode(let::make({{x, 1}, {y, 2}}, z + w + 1)));
 
-  test_substitute(slice_dim::make(x, 2, 0, check::make(buffer_min(x, 3) == 0)), buffer_min(x, 3), 1,
-      slice_dim::make(x, 2, 0, check::make(buffer_min(x, 3) == 0)));
-  test_substitute(slice_dim::make(x, 2, 0, check::make(y == buffer_min(x, 3))), y, buffer_max(x, 3),
-      slice_dim::make(x, 2, 0, check::make(buffer_max(x, 2) == buffer_min(x, 3))));
-  test_substitute(slice_dim::make(x, 2, 0, check::make(y == buffer_min(x, 3))), y, buffer_max(x, 2),
-      slice_dim::make(x, 2, 0, check::make(expr() == buffer_min(x, 3))));
-  test_substitute(slice_dim::make(x, 2, 0, check::make(y == buffer_min(x, 3))), y, buffer_max(x, 1),
-      slice_dim::make(x, 2, 0, check::make(buffer_max(x, 1) == buffer_min(x, 3))));
+  ASSERT_THAT(substitute(crop_dim::make(x, x, 1, {y, z}, check::make(0 < buffer_min(x, 1))), buffer_min(x, 1), w),
+      IsNode(crop_dim::make(x, x, 1, {max(y, w), z}, check::make(0 < buffer_min(x, 1)))));
+  ASSERT_THAT(substitute(crop_dim::make(x, u, 1, {y, z}, check::make(0 < buffer_min(u, 1))), buffer_min(u, 1), w),
+      IsNode(crop_dim::make(x, u, 1, {max(y, w), z}, check::make(0 < w))));
+  ASSERT_THAT(substitute(crop_dim::make(x, u, 1, {y, z}, check::make(0 < buffer_min(x, 1))), buffer_min(x, 1), w),
+      IsNode(crop_dim::make(x, u, 1, {y, z}, check::make(0 < buffer_min(x, 1)))));
 
-  test_substitute(copy_stmt::make(x, {y, z}, w, {y, z}, {}), y, z, copy_stmt::make(x, {y, z}, w, {y, z}, {}));
-  test_substitute(copy_stmt::make(x, {y}, w, {y}, {}), y, z, copy_stmt::make(x, {y}, w, {y}, {}));
-  test_substitute(copy_stmt::make(x, {y}, w, {z}, {}), y, u, copy_stmt::make(x, {u}, w, {z}, {}));
+  ASSERT_THAT(substitute(slice_dim::make(x, x, 2, 0, check::make(buffer_min(x, 3) == 0)), buffer_min(x, 3), 1),
+      IsNode(slice_dim::make(x, x, 2, 0, check::make(buffer_min(x, 3) == 0))));
+  ASSERT_THAT(substitute(slice_dim::make(x, x, 2, 0, check::make(y == buffer_min(x, 3))), y, buffer_max(x, 3)),
+      IsNode(slice_dim::make(x, x, 2, 0, check::make(buffer_max(x, 2) == buffer_min(x, 3)))));
+  ASSERT_THAT(substitute(slice_dim::make(x, x, 2, 0, check::make(y == buffer_min(x, 3))), y, buffer_max(x, 2)),
+      IsNode(slice_dim::make(x, x, 2, 0, check::make(expr() == buffer_min(x, 3)))));
+  ASSERT_THAT(substitute(slice_dim::make(x, x, 2, 0, check::make(y == buffer_min(x, 3))), y, buffer_max(x, 1)),
+      IsNode(slice_dim::make(x, x, 2, 0, check::make(buffer_max(x, 1) == buffer_min(x, 3)))));
+
+  ASSERT_THAT(
+      substitute(copy_stmt::make(x, {y, z}, w, {y, z}, {}), y, z), IsNode(copy_stmt::make(x, {y, z}, w, {y, z}, {})));
+  ASSERT_THAT(substitute(copy_stmt::make(x, {y}, w, {y}, {}), y, z), IsNode(copy_stmt::make(x, {y}, w, {y}, {})));
+  ASSERT_THAT(substitute(copy_stmt::make(x, {y}, w, {z}, {}), y, u), IsNode(copy_stmt::make(x, {u}, w, {z}, {})));
 }
 
 TEST(substitute, implicit_bounds) {
-  test_substitute(crop_dim::make(x, 0, bounds(y, z), check::make(x)), buffer_min(x, 0), w,
-      crop_dim::make(x, 0, bounds(max(y, w), z), check::make(x)));
-  test_substitute(crop_dim::make(x, 0, bounds(y, z), check::make(x)), buffer_max(x, 0), w,
-      crop_dim::make(x, 0, bounds(y, min(z, w)), check::make(x)));
-  test_substitute(buffer_at(x), buffer_min(x, 2), y, buffer_at(x, std::vector<expr>{expr(), expr(), expr(y)}));
+  ASSERT_THAT(substitute(crop_dim::make(x, u, 0, bounds(y, z), check::make(x)), buffer_min(u, 0), w),
+      IsNode(crop_dim::make(x, u, 0, bounds(max(y, w), z), check::make(x))));
+  ASSERT_THAT(substitute(crop_dim::make(x, u, 0, bounds(y, z), check::make(x)), buffer_max(u, 0), w),
+      IsNode(crop_dim::make(x, u, 0, bounds(y, min(z, w)), check::make(x))));
+  ASSERT_THAT(
+      substitute(buffer_at(x), buffer_min(x, 2), y), IsNode(buffer_at(x, std::vector<expr>{expr(), expr(), expr(y)})));
 }
 
 TEST(match, basic) {

--- a/runtime/depends_on.cc
+++ b/runtime/depends_on.cc
@@ -78,7 +78,6 @@ public:
     for (var i : op->inputs) {
       update_deps(i, [](depends_on_result& deps) {
         deps.buffer_input = true;
-        deps.buffer_meta_read = true;
       });
     }
     for (var i : op->outputs) {

--- a/runtime/depends_on.cc
+++ b/runtime/depends_on.cc
@@ -10,18 +10,38 @@ namespace {
 
 class dependencies : public recursive_node_visitor {
 public:
-  span<const std::pair<var, depends_on_result&>> var_deps;
-  std::vector<var> shadowed;
+  std::vector<std::pair<var, depends_on_result*>> var_deps;
 
-  dependencies(span<const std::pair<var, depends_on_result&>> var_deps) : var_deps(var_deps) {}
+  dependencies(std::vector<std::pair<var, depends_on_result*>> var_deps) : var_deps(var_deps) {}
+  dependencies(span<const std::pair<var, depends_on_result&>> deps) {
+    var_deps.reserve(deps.size());
+    for (const auto& i : deps) {
+      var_deps.push_back({i.first, &i.second});
+    }
+  }
 
   template <typename Fn>
-  void update_deps(var i, Fn fn) {
-    if (std::find(shadowed.begin(), shadowed.end(), i) != shadowed.end()) return;
-    for (const auto& v : var_deps) {
-      if (v.first == i) {
-        fn(v.second);
-        v.second.ref_count++;
+  void update_deps(var s, Fn fn) {
+    // Go in reverse order to handle shadowed declarations properly.
+    for (auto i = var_deps.rbegin(); i != var_deps.rend(); ++i) {
+      if (i->first == s) {
+        fn(*i->second);
+        i->second->ref_count++;
+        return;
+      }
+    }
+  }
+
+  // If a symbol is used as a buffer input or output, that should propagate through aliases of the symbol.
+  void propagate_deps(const depends_on_result& deps, var to) {
+    // Go in reverse order to handle shadowed declarations properly.
+    for (auto i = var_deps.rbegin(); i != var_deps.rend(); ++i) {
+      if (i->first == to) {
+        i->second->buffer_input = i->second->buffer_input || deps.buffer_input;
+        i->second->buffer_output = i->second->buffer_output || deps.buffer_output;
+        i->second->buffer_src = i->second->buffer_src || deps.buffer_src;
+        i->second->buffer_dst = i->second->buffer_dst || deps.buffer_dst;
+        return;
       }
     }
   }
@@ -35,7 +55,7 @@ public:
       if (op->args[0].defined()) {
         const var* buf = as_variable(op->args[0]);
         assert(buf);
-        update_deps(*buf, [](depends_on_result& deps) { deps.buffer_meta_read = true; });
+        update_deps(*buf, [](depends_on_result& deps) { deps.buffer_meta = true; });
 
         for (std::size_t i = 1; i < op->args.size(); ++i) {
           if (op->args[i].defined()) op->args[i].accept(this);
@@ -48,22 +68,27 @@ public:
 
   template <typename T>
   void visit_let(const T* op) {
+    std::vector<depends_on_result> let_deps;
+    let_deps.reserve(op->lets.size());
     for (const auto& p : op->lets) {
       p.second.accept(this);
-      shadowed.push_back(p.first);
+      let_deps.push_back({});
+      var_deps.push_back({p.first, &let_deps.back()});
     }
     op->body.accept(this);
     for (const auto& p : op->lets) {
-      shadowed.pop_back();
+      var_deps.pop_back();
     }
   }
 
   template <typename T>
-  void visit_sym_body(const T* op, bool shadow = true) {
-    if (!op->body.defined()) return;
-    if (shadow) shadowed.push_back(op->sym);
+  depends_on_result visit_sym_body(const T* op) {
+    if (!op->body.defined()) return depends_on_result{};
+    depends_on_result sym_deps;
+    var_deps.push_back({op->sym, &sym_deps});
     op->body.accept(this);
-    if (shadow) shadowed.pop_back();
+    var_deps.pop_back();
+    return sym_deps;
   }
 
   void visit(const loop* op) override {
@@ -76,14 +101,12 @@ public:
 
   void visit(const call_stmt* op) override {
     for (var i : op->inputs) {
-      update_deps(i, [](depends_on_result& deps) {
-        deps.buffer_input = true;
-      });
+      update_deps(i, [](depends_on_result& deps) { deps.buffer_input = true; });
     }
     for (var i : op->outputs) {
       update_deps(i, [](depends_on_result& deps) {
         deps.buffer_output = true;
-        deps.buffer_meta_read = true;
+        deps.buffer_meta = true;
       });
     }
   }
@@ -91,11 +114,11 @@ public:
   void visit(const copy_stmt* op) override {
     update_deps(op->src, [](depends_on_result& deps) {
       deps.buffer_src = true;
-      deps.buffer_meta_read = true;
+      deps.buffer_meta = true;
     });
     update_deps(op->dst, [](depends_on_result& deps) {
       deps.buffer_dst = true;
-      deps.buffer_meta_read = true;
+      deps.buffer_meta = true;
     });
     for (const expr& i : op->src_x) {
       i.accept(this);
@@ -103,8 +126,9 @@ public:
   }
 
   void visit(const clone_buffer* op) override {
-    update_deps(op->src, [](depends_on_result& deps) { deps.buffer_meta_read = true; });
-    visit_sym_body(op);
+    update_deps(op->src, [](depends_on_result& deps) { deps.buffer_meta = true; });
+    depends_on_result sym_deps = visit_sym_body(op);
+    propagate_deps(sym_deps, op->src);
   }
 
   void visit(const allocate* op) override {
@@ -133,36 +157,35 @@ public:
       if (i.min.defined()) i.min.accept(this);
       if (i.max.defined()) i.max.accept(this);
     }
-    update_deps(op->sym, [](depends_on_result& deps) {
-      deps.buffer_meta_read = true;
-      deps.buffer_meta_mutated = true;
-    });
-    visit_sym_body(op, /*shadow=*/false);
+    update_deps(op->src, [](depends_on_result& deps) { deps.buffer_meta = true; });
+    depends_on_result sym_deps = visit_sym_body(op);
+    propagate_deps(sym_deps, op->src);
   }
   void visit(const crop_dim* op) override {
     if (op->bounds.min.defined()) op->bounds.min.accept(this);
     if (op->bounds.max.defined()) op->bounds.max.accept(this);
-    update_deps(op->sym, [](depends_on_result& deps) {
-      deps.buffer_meta_read = true;
-      deps.buffer_meta_mutated = true;
-    });
-    visit_sym_body(op, /*shadow=*/false);
+    update_deps(op->src, [](depends_on_result& deps) { deps.buffer_meta = true; });
+    depends_on_result sym_deps = visit_sym_body(op);
+    propagate_deps(sym_deps, op->src);
   }
   void visit(const slice_buffer* op) override {
     for (const expr& i : op->at) {
       if (i.defined()) i.accept(this);
     }
-    update_deps(op->sym, [](depends_on_result& deps) { deps.buffer_meta_mutated = true; });
-    visit_sym_body(op, /*shadow=*/false);
+    update_deps(op->src, [](depends_on_result& deps) { deps.buffer_meta = true; });
+    depends_on_result sym_deps = visit_sym_body(op);
+    propagate_deps(sym_deps, op->src);
   }
   void visit(const slice_dim* op) override {
     op->at.accept(this);
-    update_deps(op->sym, [](depends_on_result& deps) { deps.buffer_meta_mutated = true; });
-    visit_sym_body(op, /*shadow=*/false);
+    update_deps(op->src, [](depends_on_result& deps) { deps.buffer_meta = true; });
+    depends_on_result sym_deps = visit_sym_body(op);
+    propagate_deps(sym_deps, op->src);
   }
   void visit(const truncate_rank* op) override {
-    update_deps(op->sym, [](depends_on_result& deps) { deps.buffer_meta_mutated = true; });
-    visit_sym_body(op, /*shadow=*/false);
+    update_deps(op->src, [](depends_on_result& deps) { deps.buffer_meta = true; });
+    depends_on_result sym_deps = visit_sym_body(op);
+    propagate_deps(sym_deps, op->src);
   }
 };
 

--- a/runtime/depends_on.h
+++ b/runtime/depends_on.h
@@ -21,9 +21,6 @@ struct depends_on_result {
   // True if the buffer metadata is read.
   bool buffer_meta = false;
 
-  // How many references there are.
-  int ref_count = 0;
-
   bool buffer_data() const { return buffer_input || buffer_output || buffer_src || buffer_dst; }
   bool buffer() const { return buffer_data() || buffer_meta; }
 

--- a/runtime/depends_on.h
+++ b/runtime/depends_on.h
@@ -18,16 +18,14 @@ struct depends_on_result {
   bool buffer_src = false;
   bool buffer_dst = false;
 
-  // True if the buffer metadata is read or written.
-  bool buffer_meta_read = false;
-  bool buffer_meta_mutated = false;
+  // True if the buffer metadata is read.
+  bool buffer_meta = false;
 
   // How many references there are.
   int ref_count = 0;
 
   bool buffer_data() const { return buffer_input || buffer_output || buffer_src || buffer_dst; }
-  bool buffer_meta() const { return buffer_meta_read || buffer_meta_mutated; }
-  bool buffer() const { return buffer_data() || buffer_meta(); }
+  bool buffer() const { return buffer_data() || buffer_meta; }
 
   bool any() const { return var || buffer(); }
 };

--- a/runtime/evaluate.cc
+++ b/runtime/evaluate.cc
@@ -41,7 +41,7 @@ void dump_context_for_expr(
       } else {
         s << "  " << sym << " = <>" << std::endl;
       }
-    } else if (!deps_of.defined() || deps.buffer_meta_read) {
+    } else if (!deps_of.defined() || deps.buffer_meta) {
       if (ctx[i]) {
         const raw_buffer* buf = reinterpret_cast<const raw_buffer*>(*ctx[i]);
         s << "  " << sym << " = " << *buf << std::endl;
@@ -235,7 +235,7 @@ public:
       sems[i] = reinterpret_cast<index_t*>(eval_expr(op->args[i * 2 + 0]));
       counts[i] = eval_expr(op->args[i * 2 + 1], 1);
     }
-    context.wait_for([=]() {  
+    context.wait_for([=]() {
       // Check we can acquire all of the semaphores before acquiring any of them.
       for (std::size_t i = 0; i < sem_count; ++i) {
         if (*sems[i] < counts[i]) return false;
@@ -472,21 +472,26 @@ public:
     visit(op->body);
   }
 
-  SLINKY_NO_STACK_PROTECTOR void visit(const clone_buffer* op) override {
-    raw_buffer* src = reinterpret_cast<raw_buffer*>(*context.lookup(op->src));
+  // Call `fn` while a clone of `src` (`sym`) is in scope.
+  template <typename Fn>
+  SLINKY_NO_STACK_PROTECTOR void eval_in_clone(var sym, var src, Fn fn) {
+    raw_buffer* src_buf = reinterpret_cast<raw_buffer*>(*context.lookup(src));
 
-    raw_buffer* buffer = SLINKY_ALLOCA(raw_buffer, 1);
-    buffer->dims = SLINKY_ALLOCA(dim, src->rank);
-    buffer->elem_size = src->elem_size;
-    buffer->base = src->base;
-    buffer->rank = src->rank;
-    memcpy(buffer->dims, src->dims, sizeof(dim) * src->rank);
-
-    auto set_buffer = set_value_in_scope(context, op->sym, reinterpret_cast<index_t>(buffer));
-    visit(op->body);
+    raw_buffer clone;
+    clone.base = src_buf->base;
+    clone.elem_size = src_buf->elem_size;
+    clone.rank = src_buf->rank;
+    clone.dims = SLINKY_ALLOCA(dim, src_buf->rank);
+    memcpy(clone.dims, src_buf->dims, sizeof(dim) * src_buf->rank);
+    auto set_buffer = set_value_in_scope(context, sym, reinterpret_cast<index_t>(&clone));
+    fn();
   }
 
-  SLINKY_NO_STACK_PROTECTOR void visit(const crop_buffer* op) override {
+  void visit(const clone_buffer* op) override {
+    eval_in_clone(op->sym, op->src, [=]() { visit(op->body); });
+  }
+
+  SLINKY_NO_STACK_PROTECTOR void eval_shadowed(const crop_buffer* op) {
     raw_buffer* buffer = reinterpret_cast<raw_buffer*>(*context.lookup(op->sym));
     assert(buffer);
 
@@ -518,7 +523,7 @@ public:
     }
   }
 
-  void visit(const crop_dim* op) override {
+  void eval_shadowed(const crop_dim* op) {
     raw_buffer* buffer = reinterpret_cast<raw_buffer*>(*context.lookup(op->sym));
     assert(buffer);
     slinky::dim& dim = buffer->dims[op->dim];
@@ -533,7 +538,7 @@ public:
     dim.set_bounds(old_min, old_max);
   }
 
-  SLINKY_NO_STACK_PROTECTOR void visit(const slice_buffer* op) override {
+  SLINKY_NO_STACK_PROTECTOR void eval_shadowed(const slice_buffer* op) {
     raw_buffer* buffer = reinterpret_cast<raw_buffer*>(*context.lookup(op->sym));
     assert(buffer);
 
@@ -564,10 +569,10 @@ public:
     buffer->dims = dims;
   }
 
-  SLINKY_NO_STACK_PROTECTOR void visit(const slice_dim* op) override {
+  SLINKY_NO_STACK_PROTECTOR void eval_shadowed(const slice_dim* op) {
     raw_buffer* buffer = reinterpret_cast<raw_buffer*>(*context.lookup(op->sym));
     assert(buffer);
-    
+
     // The rank of the result is equal to the current rank, less any sliced dimensions.
     dim* old_dims = buffer->dims;
 
@@ -595,7 +600,7 @@ public:
     buffer->dims = old_dims;
   }
 
-  void visit(const truncate_rank* op) override {
+  void eval_shadowed(const truncate_rank* op) {
     raw_buffer* buffer = reinterpret_cast<raw_buffer*>(*context.lookup(op->sym));
     assert(buffer);
 
@@ -606,6 +611,25 @@ public:
 
     buffer->rank = old_rank;
   }
+
+  template <typename T>
+  void visit_maybe_shadowed(const T* op) {
+    if (op->sym == op->src) {
+      // The operation is shadowed, we can use eval_shadowed.
+      eval_shadowed(op);
+    } else {
+      // The operation is not shadowed. Make a clone and use eval_shadowed on the clone. This is not as efficient as it
+      // could be, but the shadowed case should be faster, so we'll optimize for that case, and prefer that case when
+      // constructing programs.
+      eval_in_clone(op->sym, op->src, [=]() { eval_shadowed(op); });
+    }
+  }
+
+  void visit(const crop_buffer* op) override { visit_maybe_shadowed(op); }
+  void visit(const crop_dim* op) override { visit_maybe_shadowed(op); }
+  void visit(const slice_buffer* op) override { visit_maybe_shadowed(op); }
+  void visit(const slice_dim* op) override { visit_maybe_shadowed(op); }
+  void visit(const truncate_rank* op) override { visit_maybe_shadowed(op); }
 
   void visit(const check* op) override {
     result = eval_expr(op->condition, 0) != 0 ? 0 : 1;

--- a/runtime/expr_stmt.cc
+++ b/runtime/expr_stmt.cc
@@ -428,43 +428,48 @@ stmt clone_buffer::make(var sym, var src, stmt body) {
   return n;
 }
 
-stmt crop_buffer::make(var sym, std::vector<interval_expr> bounds, stmt body) {
+stmt crop_buffer::make(var sym, var src, std::vector<interval_expr> bounds, stmt body) {
   auto n = new crop_buffer();
   n->sym = sym;
+  n->src = src;
   n->bounds = std::move(bounds);
   n->body = std::move(body);
   return n;
 }
 
-stmt crop_dim::make(var sym, int dim, interval_expr bounds, stmt body) {
+stmt crop_dim::make(var sym, var src, int dim, interval_expr bounds, stmt body) {
   auto n = new crop_dim();
   n->sym = sym;
+  n->src = src;
   n->dim = dim;
   n->bounds = std::move(bounds);
   n->body = std::move(body);
   return n;
 }
 
-stmt slice_buffer::make(var sym, std::vector<expr> at, stmt body) {
+stmt slice_buffer::make(var sym, var src, std::vector<expr> at, stmt body) {
   auto n = new slice_buffer();
   n->sym = sym;
+  n->src = src;
   n->at = std::move(at);
   n->body = std::move(body);
   return n;
 }
 
-stmt slice_dim::make(var sym, int dim, expr at, stmt body) {
+stmt slice_dim::make(var sym, var src, int dim, expr at, stmt body) {
   auto n = new slice_dim();
   n->sym = sym;
+  n->src = src;
   n->dim = dim;
   n->at = std::move(at);
   n->body = std::move(body);
   return n;
 }
 
-stmt truncate_rank::make(var sym, int rank, stmt body) {
+stmt truncate_rank::make(var sym, var src, int rank, stmt body) {
   auto n = new truncate_rank();
   n->sym = sym;
+  n->src = src;
   n->rank = rank;
   n->body = std::move(body);
   return n;

--- a/runtime/print.cc
+++ b/runtime/print.cc
@@ -198,7 +198,7 @@ public:
   }
 
   void visit(const loop* l) override {
-    *this << indent() << "loop(" << l->sym << ", ";
+    *this << indent() << l->sym << " = loop(";
     switch (l->max_workers) {
     case loop::serial: *this << "serial"; break;
     case loop::parallel: *this << "parallel"; break;
@@ -264,7 +264,7 @@ public:
   }
 
   void visit(const crop_buffer* n) override {
-    *this << indent() << "crop_buffer(" << n->sym << ", {";
+    *this << indent() << n->sym << " = crop_buffer(" << n->src << ", {";
     if (!n->bounds.empty()) {
       *this << "\n";
       *this << indent(2);
@@ -278,25 +278,25 @@ public:
   }
 
   void visit(const crop_dim* n) override {
-    *this << indent() << "crop_dim(" << n->sym << ", " << n->dim << ", " << n->bounds << ") {\n";
+    *this << indent() << n->sym << " = crop_dim(" << n->src << ", " << n->dim << ", " << n->bounds << ") {\n";
     *this << n->body;
     *this << indent() << "}\n";
   }
 
   void visit(const slice_buffer* n) override {
-    *this << indent() << "slice_buffer(" << n->sym << ", {" << n->at << "}) {\n";
+    *this << indent() << n->sym << " = slice_buffer(" << n->src << ", {" << n->at << "}) {\n";
     *this << n->body;
     *this << indent() << "}\n";
   }
 
   void visit(const slice_dim* n) override {
-    *this << indent() << "slice_dim(" << n->sym << ", " << n->dim << ", " << n->at << ") {\n";
+    *this << indent() << n->sym << " = slice_dim(" << n->src << ", " << n->dim << ", " << n->at << ") {\n";
     *this << n->body;
     *this << indent() << "}\n";
   }
 
   void visit(const truncate_rank* n) override {
-    *this << indent() << "truncate_rank(" << n->sym << ", " << n->rank << ") {\n";
+    *this << indent() << n->sym << " = truncate_rank(" << n->src << ", " << n->rank << ") {\n";
     *this << n->body;
     *this << indent() << "}\n";
   }

--- a/runtime/stmt.h
+++ b/runtime/stmt.h
@@ -193,8 +193,8 @@ public:
 // this node (`rank` is the size of `dims`).
 class allocate : public stmt_node<allocate> {
 public:
-  memory_type storage;
   var sym;
+  memory_type storage;
   expr elem_size;
   std::vector<dim_expr> dims;
   stmt body;
@@ -245,12 +245,13 @@ public:
 class crop_buffer : public stmt_node<crop_buffer> {
 public:
   var sym;
+  var src;
   std::vector<interval_expr> bounds;
   stmt body;
 
   void accept(stmt_visitor* v) const override;
 
-  static stmt make(var sym, std::vector<interval_expr> bounds, stmt body);
+  static stmt make(var sym, var src, std::vector<interval_expr> bounds, stmt body);
 
   static constexpr stmt_node_type static_type = stmt_node_type::crop_buffer;
 };
@@ -259,13 +260,14 @@ public:
 class crop_dim : public stmt_node<crop_dim> {
 public:
   var sym;
+  var src;
   int dim;
   interval_expr bounds;
   stmt body;
 
   void accept(stmt_visitor* v) const override;
 
-  static stmt make(var sym, int dim, interval_expr bounds, stmt body);
+  static stmt make(var sym, var src, int dim, interval_expr bounds, stmt body);
 
   static constexpr stmt_node_type static_type = stmt_node_type::crop_dim;
 };
@@ -277,12 +279,13 @@ public:
 class slice_buffer : public stmt_node<slice_buffer> {
 public:
   var sym;
+  var src;
   std::vector<expr> at;
   stmt body;
 
   void accept(stmt_visitor* v) const override;
 
-  static stmt make(var sym, std::vector<expr> at, stmt body);
+  static stmt make(var sym, var src, std::vector<expr> at, stmt body);
 
   static constexpr stmt_node_type static_type = stmt_node_type::slice_buffer;
 };
@@ -292,13 +295,14 @@ public:
 class slice_dim : public stmt_node<slice_dim> {
 public:
   var sym;
+  var src;
   int dim;
   expr at;
   stmt body;
 
   void accept(stmt_visitor* v) const override;
 
-  static stmt make(var sym, int dim, expr at, stmt body);
+  static stmt make(var sym, var src, int dim, expr at, stmt body);
 
   static constexpr stmt_node_type static_type = stmt_node_type::slice_dim;
 };
@@ -307,12 +311,13 @@ public:
 class truncate_rank : public stmt_node<truncate_rank> {
 public:
   var sym;
+  var src;
   int rank;
   stmt body;
 
   void accept(stmt_visitor* v) const override;
 
-  static stmt make(var sym, int rank, stmt body);
+  static stmt make(var sym, var src, int rank, stmt body);
 
   static constexpr stmt_node_type static_type = stmt_node_type::truncate_rank;
 };

--- a/runtime/stmt.h
+++ b/runtime/stmt.h
@@ -224,8 +224,6 @@ public:
 };
 
 // Makes a clone of an existing buffer.
-// TODO: This basically only exists because we cannot use `make_buffer` to clone a buffer of unknown rank. Maybe there's
-// a better way to do this.
 class clone_buffer : public stmt_node<clone_buffer> {
 public:
   var sym;
@@ -239,9 +237,9 @@ public:
   static constexpr stmt_node_type static_type = stmt_node_type::clone_buffer;
 };
 
-// For the `body` scope, crops the buffer `sym` to `bounds`. If the expressions in `bounds` are undefined, they default
-// to their original values in the existing buffer. The rank of the buffer is unchanged. If the size of `bounds` is less
-// than the rank, the missing values are considered undefined.
+// Makes a new buffer `sym` that is a cropped view of the buffer `src` to `bounds`. If the expressions in `bounds` are
+// undefined, they default to their original values in the existing buffer. The rank of the buffer is unchanged. If the
+// size of `bounds` is less than the rank, the missing values are considered undefined.
 class crop_buffer : public stmt_node<crop_buffer> {
 public:
   var sym;
@@ -272,10 +270,10 @@ public:
   static constexpr stmt_node_type static_type = stmt_node_type::crop_dim;
 };
 
-// For the `body` scope, slices the buffer `sym` at the coordinate `at`. The `at` expressions can be undefined,
-// indicating that the corresponding dimension is preserved in the sliced buffer. The sliced buffer will have `rank`
-// equal to the rank of the existing buffer, less the number of sliced dimensions. If `at` is smaller than the rank
-// of the buffer, the missing values are considered undefined.
+// Makes a new buffer `sym` that is a sliced view of the buffer `src` at the coordinate `at`. The `at` expressions can
+// be undefined, indicating that the corresponding dimension is preserved in the sliced buffer. The sliced buffer will
+// have `rank` equal to the rank of the existing buffer, less the number of sliced dimensions. If `at` is smaller than
+// the rank of the buffer, the missing values are considered undefined.
 class slice_buffer : public stmt_node<slice_buffer> {
 public:
   var sym;
@@ -307,7 +305,7 @@ public:
   static constexpr stmt_node_type static_type = stmt_node_type::slice_dim;
 };
 
-// Within `body`, remove the dimensions of the buffer `sym` above `rank`.
+// Make a new buffer `sym` that is a copy of the first `rank` dimensions of `src`.
 class truncate_rank : public stmt_node<truncate_rank> {
 public:
   var sym;

--- a/runtime/test/depends_on.cc
+++ b/runtime/test/depends_on.cc
@@ -37,7 +37,7 @@ TEST(depends_on, basic) {
   ASSERT_EQ(depends_on(loop_x, y), (depends_on_result{.var = true, .ref_count = 1}));
 
   stmt call = call_stmt::make(nullptr, {x}, {y}, {});
-  ASSERT_EQ(depends_on(call, x), (depends_on_result{.buffer_input = true, .buffer_meta_read = true, .ref_count = 1}));
+  ASSERT_EQ(depends_on(call, x), (depends_on_result{.buffer_input = true, .ref_count = 1}));
   ASSERT_EQ(depends_on(call, y), (depends_on_result{.buffer_output = true, .buffer_meta_read = true, .ref_count = 1}));
 
   stmt crop = crop_dim::make(x, 1, {y, z}, check::make(y));

--- a/runtime/test/depends_on.cc
+++ b/runtime/test/depends_on.cc
@@ -23,47 +23,48 @@ bool operator==(const depends_on_result& l, const depends_on_result& r) {
   if (l.buffer_src != r.buffer_src) return false;
   if (l.buffer_dst != r.buffer_dst) return false;
   if (l.buffer_meta != r.buffer_meta) return false;
-  if (l.ref_count != r.ref_count) return false;
   return true;
 }
 
 std::ostream& operator<<(std::ostream& os, const depends_on_result& r) {
-  os << "{.var = " << r.var << ", .buffer_input = " << r.buffer_input << ", .buffer_output = " << r.buffer_output
-     << ", .buffer_src = " << r.buffer_src << ", .buffer_dst = " << r.buffer_dst << ", .buffer_meta = " << r.buffer_meta
-     << ", .ref_count = " << r.ref_count << "}";
+  os << "{.var = " << r.var;
+  os << ", .buffer_input = " << r.buffer_input;
+  os << ", .buffer_output = " << r.buffer_output;
+  os << ", .buffer_src = " << r.buffer_src;
+  os << ", .buffer_dst = " << r.buffer_dst;
+  os << ", .buffer_meta = " << r.buffer_meta;
+  os << "}";
   return os;
 }
 
 TEST(depends_on, basic) {
-  ASSERT_EQ(depends_on(x + y, x), (depends_on_result{.var = true, .ref_count = 1}));
-  ASSERT_EQ(depends_on(x + x, x), (depends_on_result{.var = true, .ref_count = 2}));
+  ASSERT_EQ(depends_on(x + y, x), (depends_on_result{.var = true}));
+  ASSERT_EQ(depends_on(x + x, x), (depends_on_result{.var = true}));
 
   stmt loop_x = loop::make(x, loop::serial, {y, z}, 1, check::make(x && z));
   ASSERT_EQ(depends_on(loop_x, x), depends_on_result{});
-  ASSERT_EQ(depends_on(loop_x, y), (depends_on_result{.var = true, .ref_count = 1}));
+  ASSERT_EQ(depends_on(loop_x, y), (depends_on_result{.var = true}));
 
   stmt call = call_stmt::make(nullptr, {x}, {y}, {});
-  ASSERT_EQ(depends_on(call, x), (depends_on_result{.buffer_input = true, .ref_count = 1}));
-  ASSERT_EQ(depends_on(call, y), (depends_on_result{.buffer_output = true, .buffer_meta = true, .ref_count = 1}));
+  ASSERT_EQ(depends_on(call, x), (depends_on_result{.buffer_input = true}));
+  ASSERT_EQ(depends_on(call, y), (depends_on_result{.buffer_output = true, .buffer_meta = true}));
 
   stmt crop = crop_dim::make(x, w, 1, {y, z}, check::make(y));
   ASSERT_EQ(depends_on(crop, x), (depends_on_result{}));
 
   stmt crop_shadowed = crop_dim::make(x, x, 1, {y, z}, check::make(y));
-  ASSERT_EQ(depends_on(crop_shadowed, x), (depends_on_result{.buffer_meta = true, .ref_count = 1}));
+  ASSERT_EQ(depends_on(crop_shadowed, x), (depends_on_result{.buffer_meta = true}));
 
   stmt make_buffer = make_buffer::make(x, 0, 1, {{{y, z}, w}}, check::make(x && z));
   ASSERT_EQ(depends_on(make_buffer, x), (depends_on_result{}));
-  ASSERT_EQ(depends_on(make_buffer, y), (depends_on_result{.var = true, .ref_count = 1}));
-  ASSERT_EQ(depends_on(make_buffer, z), (depends_on_result{.var = true, .ref_count = 2}));
+  ASSERT_EQ(depends_on(make_buffer, y), (depends_on_result{.var = true}));
+  ASSERT_EQ(depends_on(make_buffer, z), (depends_on_result{.var = true}));
 
   stmt cropped_output = crop_dim::make(y, z, 0, {w, w}, call);
-  ASSERT_EQ(
-      depends_on(cropped_output, z), (depends_on_result{.buffer_output = true, .buffer_meta = true, .ref_count = 1}));
+  ASSERT_EQ(depends_on(cropped_output, z), (depends_on_result{.buffer_output = true, .buffer_meta = true}));
 
   stmt cropped_input = crop_dim::make(x, z, 0, {w, w}, call);
-  ASSERT_EQ(
-      depends_on(cropped_input, z), (depends_on_result{.buffer_input = true, .buffer_meta = true, .ref_count = 1}));
+  ASSERT_EQ(depends_on(cropped_input, z), (depends_on_result{.buffer_input = true, .buffer_meta = true}));
 }
 
 }  // namespace slinky

--- a/runtime/test/evaluate.cc
+++ b/runtime/test/evaluate.cc
@@ -106,7 +106,8 @@ TEST(evaluate, crop_dim) {
   buffer<void, 2> buf({10, 20});
   ctx[x] = reinterpret_cast<index_t>(&buf);
 
-  evaluate(crop_dim::make(x, 0, {1, 3}, make_check(x, {3, 20})), ctx);
+  evaluate(crop_dim::make(x, x, 0, {1, 3}, make_check(x, {3, 20})), ctx);
+  evaluate(crop_dim::make(y, x, 0, {1, 3}, block::make({make_check(x, {10, 20}), make_check(y, {3, 20})})), ctx);
   assert_buffer_extents_are(buf, {10, 20});
 }
 
@@ -115,7 +116,10 @@ TEST(evaluate, crop_buffer) {
   buffer<void, 4> buf({10, 20, 30, 40});
   ctx[x] = reinterpret_cast<index_t>(&buf);
 
-  evaluate(crop_buffer::make(x, {{1, 3}, {}, {2, 5}}, make_check(x, {3, 20, 4, 40})), ctx);
+  evaluate(crop_buffer::make(x, x, {{1, 3}, {}, {2, 5}}, make_check(x, {3, 20, 4, 40})), ctx);
+  evaluate(crop_buffer::make(y, x, {{1, 3}, {}, {2, 5}},
+               block::make({make_check(x, {10, 20, 30, 40}), make_check(y, {3, 20, 4, 40})})),
+      ctx);
   assert_buffer_extents_are(buf, {10, 20, 30, 40});
 }
 
@@ -124,7 +128,8 @@ TEST(evaluate, slice_dim) {
   buffer<void, 3> buf({10, 20, 30});
   ctx[x] = reinterpret_cast<index_t>(&buf);
 
-  evaluate(slice_dim::make(x, 1, 2, make_check(x, {10, 30})), ctx);
+  evaluate(slice_dim::make(x, x, 1, 2, make_check(x, {10, 30})), ctx);
+  evaluate(slice_dim::make(y, x, 1, 2, block::make({make_check(x, {10, 20, 30}), make_check(y, {10, 30})})), ctx);
   assert_buffer_extents_are(buf, {10, 20, 30});
 }
 
@@ -133,7 +138,10 @@ TEST(evaluate, slice_buffer) {
   buffer<void, 4> buf({10, 20, 30, 40});
   ctx[x] = reinterpret_cast<index_t>(&buf);
 
-  evaluate(slice_buffer::make(x, {{}, 4, {}, 2}, make_check(x, {10, 30})), ctx);
+  evaluate(slice_buffer::make(x, x, {{}, 4, {}, 2}, make_check(x, {10, 30})), ctx);
+  evaluate(
+      slice_buffer::make(y, x, {{}, 4, {}, 2}, block::make({make_check(x, {10, 20, 30, 40}), make_check(y, {10, 30})})),
+      ctx);
   assert_buffer_extents_are(buf, {10, 20, 30, 40});
 }
 
@@ -142,7 +150,8 @@ TEST(evaluate, truncate_rank) {
   buffer<void, 4> buf({10, 20, 30, 40});
   ctx[x] = reinterpret_cast<index_t>(&buf);
 
-  evaluate(truncate_rank::make(x, 2, make_check(x, {10, 20})), ctx);
+  evaluate(truncate_rank::make(x, x, 2, make_check(x, {10, 20})), ctx);
+  evaluate(truncate_rank::make(y, x, 2, block::make({make_check(x, {10, 20, 30, 40}), make_check(y, {10, 20})})), ctx);
   assert_buffer_extents_are(buf, {10, 20, 30, 40});
 }
 

--- a/runtime/test/evaluate_benchmark.cc
+++ b/runtime/test/evaluate_benchmark.cc
@@ -12,6 +12,8 @@ namespace slinky {
 
 node_context ctx;
 var buf(ctx, "buf");
+var src(ctx, "src");
+var dst(ctx, "dst");
 var buf2(ctx, "buf2");
 var x(ctx, "x");
 var y(ctx, "y");
@@ -33,7 +35,7 @@ stmt make_call_counter(std::atomic<int>& calls) {
 stmt make_loop(stmt body) { return loop::make(x, loop::serial, range(0, iterations), 1, body); }
 
 // For nodes that need a buffer, we can add a buffer outside that loop, the cost of constructing it will be negligible.
-stmt make_buf(int rank, stmt body) {
+stmt make_buf(var buf, int rank, stmt body) {
   std::vector<dim_expr> dims;
   for (int i = 0; i < rank; ++i) {
     dims.push_back({{0, 100}, i, dim::unfolded});
@@ -85,9 +87,9 @@ BENCHMARK(BM_block)->RangeMultiplier(2)->Range(2, 16);
 
 void BM_crop_dim(benchmark::State& state) {
   std::atomic<int> calls = 0;
-  stmt c = crop_dim::make(buf, 0, {1, 10}, make_call_counter(calls));
+  stmt c = crop_dim::make(dst, state.range(0) ? src : dst, 0, {1, 10}, make_call_counter(calls));
   stmt l = make_loop(c);
-  stmt body = make_buf(3, l);
+  stmt body = make_buf(src, 3, make_buf(dst, 3, l));
 
   for (auto _ : state) {
     evaluate(body);
@@ -96,13 +98,13 @@ void BM_crop_dim(benchmark::State& state) {
   state.SetItemsProcessed(calls);
 }
 
-BENCHMARK(BM_crop_dim);
+BENCHMARK(BM_crop_dim)->DenseRange(0, 1);
 
 void BM_crop_buffer(benchmark::State& state) {
   std::atomic<int> calls = 0;
-  stmt c = crop_buffer::make(buf, {{1, 10}, {}, {2, 20}}, make_call_counter(calls));
+  stmt c = crop_buffer::make(dst, state.range(0) ? src : dst, {{1, 10}, {}, {2, 20}}, make_call_counter(calls));
   stmt l = make_loop(c);
-  stmt body = make_buf(3, l);
+  stmt body = make_buf(src, 3, make_buf(dst, 3, l));
 
   for (auto _ : state) {
     evaluate(body);
@@ -111,13 +113,13 @@ void BM_crop_buffer(benchmark::State& state) {
   state.SetItemsProcessed(calls);
 }
 
-BENCHMARK(BM_crop_buffer);
+BENCHMARK(BM_crop_buffer)->DenseRange(0, 1);
 
 void BM_slice_dim(benchmark::State& state) {
   std::atomic<int> calls = 0;
-  stmt c = slice_dim::make(buf, 1, 10, make_call_counter(calls));
+  stmt c = slice_dim::make(dst, state.range(0) ? src : dst, 1, 10, make_call_counter(calls));
   stmt l = make_loop(c);
-  stmt body = make_buf(3, l);
+  stmt body = make_buf(src, 3, make_buf(dst, 3, l));
 
   for (auto _ : state) {
     evaluate(body);
@@ -126,13 +128,13 @@ void BM_slice_dim(benchmark::State& state) {
   state.SetItemsProcessed(calls);
 }
 
-BENCHMARK(BM_slice_dim);
+BENCHMARK(BM_slice_dim)->DenseRange(0, 1);
 
 void BM_slice_buffer(benchmark::State& state) {
   std::atomic<int> calls = 0;
-  stmt c = slice_buffer::make(buf, {10, {}, 20}, make_call_counter(calls));
+  stmt c = slice_buffer::make(dst, state.range(0) ? src : dst, {10, {}, 20}, make_call_counter(calls));
   stmt l = make_loop(c);
-  stmt body = make_buf(3, l);
+  stmt body = make_buf(src, 3, make_buf(dst, 3, l));
 
   for (auto _ : state) {
     evaluate(body);
@@ -141,7 +143,7 @@ void BM_slice_buffer(benchmark::State& state) {
   state.SetItemsProcessed(calls);
 }
 
-BENCHMARK(BM_slice_buffer);
+BENCHMARK(BM_slice_buffer)->DenseRange(0, 1);
 
 void BM_allocate(benchmark::State& state) {
   std::atomic<int> calls = 0;
@@ -159,7 +161,7 @@ BENCHMARK(BM_allocate);
 
 void BM_make_buffer(benchmark::State& state) {
   std::atomic<int> calls = 0;
-  stmt body = make_loop(make_buf(3, make_call_counter(calls)));
+  stmt body = make_loop(make_buf(buf, 3, make_call_counter(calls)));
 
   for (auto _ : state) {
     evaluate(body);
@@ -174,7 +176,7 @@ void BM_buffer_metadata(benchmark::State& state) {
   std::atomic<int> calls = 0;
   std::vector<dim_expr> dims = {buffer_dim(buf, 0), buffer_dim(buf, 1), buffer_dim(buf, 2)};
   stmt clone = make_buffer::make(buf2, buffer_at(buf), buffer_elem_size(buf), dims, make_call_counter(calls));
-  stmt body = make_buf(3, make_loop(clone));
+  stmt body = make_buf(buf, 3, make_loop(clone));
 
   for (auto _ : state) {
     evaluate(body);

--- a/runtime/visualize.cc
+++ b/runtime/visualize.cc
@@ -249,7 +249,7 @@ public:
   }
 
   void visit(const crop_buffer* n) override {
-    *this << indent() << "{ let __" << n->sym << " = crop_buffer(" << n->sym << ", [";
+    *this << indent() << "{ let __" << n->sym << " = crop_buffer(" << n->src << ", [";
     if (!n->bounds.empty()) {
       *this << "\n";
       *this << indent(2);
@@ -264,7 +264,7 @@ public:
   }
 
   void visit(const crop_dim* n) override {
-    *this << indent() << "{ let __" << n->sym << " = crop_dim(" << n->sym << ", " << n->dim << ", " << n->bounds
+    *this << indent() << "{ let __" << n->sym << " = crop_dim(" << n->src << ", " << n->dim << ", " << n->bounds
           << ");\n";
     *this << n->body;
     *this << indent(1) << n->sym << " = __" << n->sym << ";\n";
@@ -272,21 +272,21 @@ public:
   }
 
   void visit(const slice_buffer* n) override {
-    *this << indent() << "{ let __" << n->sym << " = slice_buffer(" << n->sym << ", {" << n->at << "});\n";
+    *this << indent() << "{ let __" << n->sym << " = slice_buffer(" << n->src << ", {" << n->at << "});\n";
     *this << n->body;
     *this << indent(1) << n->sym << " = __" << n->sym << ";\n";
     *this << indent() << "}\n";
   }
 
   void visit(const slice_dim* n) override {
-    *this << indent() << "{ let __" << n->sym << " = slice_dim(" << n->sym << ", " << n->dim << ", " << n->at << ");\n";
+    *this << indent() << "{ let __" << n->sym << " = slice_dim(" << n->src << ", " << n->dim << ", " << n->at << ");\n";
     *this << n->body;
     *this << indent(1) << n->sym << " = __" << n->sym << ";\n";
     *this << indent() << "}\n";
   }
 
   void visit(const truncate_rank* n) override {
-    *this << indent() << "{ let __" << n->sym << " = truncate_rank(" << n->sym << ", " << n->rank << ");\n";
+    *this << indent() << "{ let __" << n->sym << " = truncate_rank(" << n->src << ", " << n->rank << ");\n";
     *this << n->body;
     *this << indent(1) << n->sym << " = __" << n->sym << ";\n";
     *this << indent() << "}\n";


### PR DESCRIPTION
I discovered yet another challenging bug to fix with shadowing in the simplifier, so I've decided to give up on supporting shadowing there.

In order to do this, we need to be able to rewrite programs to never shadow, and to do that, we need to allow buffer mutators to take an src buffer. This PR does that, but does not actually stop shadowing yet.  This PR reproduces existing behavior exactly (surprisingly), but with the extra optional parameter to buffer mutators. 

The next step will be to generate programs that do not have shadowing, and remove the ability for the simplifier to understand shadowing, which should be a big reduction in complexity and avoid probably many undiscovered bugs. We will also want to rewrite programs to shadow before evaluation, which is faster if buffer mutators work in place.