### PR TITLE
A bunch of minor fixes from other WIP branches

### DIFF
--- a/builder/optimizations.cc
+++ b/builder/optimizations.cc
@@ -3,7 +3,6 @@
 #include <cassert>
 #include <cstddef>
 #include <cstdlib>
-#include <iostream>
 #include <map>
 #include <optional>
 #include <set>

--- a/builder/optimizations.cc
+++ b/builder/optimizations.cc
@@ -347,11 +347,9 @@ stmt implement_copy(const copy_stmt* op, node_context& ctx) {
     } else if (dep_count == 1) {
       expr offset;
       if (is_copy(src_x[src_d], op->dst_x[d], offset)) {
-        interval_expr dst_bounds = buffer_bounds(op->dst, d);
-        interval_expr src_bounds = buffer_bounds(op->src, src_d) - offset;
-        src_dims.push_back(
-            {dst_bounds & src_bounds, buffer_stride(op->src, src_d), buffer_fold_factor(op->src, src_d)});
-        src_x[src_d] = max(buffer_min(op->dst, d) + offset, buffer_min(op->src, src_d));
+        interval_expr src_bounds = (buffer_bounds(op->src, src_d) - offset) & buffer_bounds(op->dst, d);
+        src_dims.push_back({src_bounds, buffer_stride(op->src, src_d), buffer_fold_factor(op->src, src_d)});
+        src_x[src_d] = src_bounds.min + offset;
         handled = true;
       }
     }

--- a/builder/test/simplify.cc
+++ b/builder/test/simplify.cc
@@ -2,7 +2,6 @@
 #include <gtest/gtest.h>
 
 #include <cassert>
-#include <iostream>
 
 #include "builder/simplify.h"
 #include "builder/substitute.h"

--- a/builder/test/substitute.cc
+++ b/builder/test/substitute.cc
@@ -2,7 +2,6 @@
 #include <gtest/gtest.h>
 
 #include <cassert>
-#include <iostream>
 
 #include "builder/substitute.h"
 #include "runtime/expr.h"

--- a/runtime/evaluate.cc
+++ b/runtime/evaluate.cc
@@ -271,10 +271,8 @@ public:
     assert(op->args.size() == 1);
     var sym = *as_variable(op->args[0]);
     allocated_buffer* buf = reinterpret_cast<allocated_buffer*>(*context.lookup(sym));
-    if (context.free) {
-      context.free(sym, buf, buf->allocation);
-      buf->allocation = nullptr;
-    }
+    context.free(sym, buf, buf->allocation);
+    buf->allocation = nullptr;
     return 1;
   }
 
@@ -449,24 +447,14 @@ public:
       buffer.allocation = nullptr;
     } else {
       assert(op->storage == memory_type::heap);
-      if (context.allocate) {
-        assert(context.free);
-        buffer.allocation = context.allocate(op->sym, &buffer);
-      } else {
-        buffer.allocation = buffer.allocate();
-      }
+      buffer.allocation = context.allocate(op->sym, &buffer);
     }
 
     auto set_buffer = set_value_in_scope(context, op->sym, reinterpret_cast<index_t>(&buffer));
     visit(op->body);
 
     if (op->storage == memory_type::heap) {
-      if (context.free) {
-        assert(context.allocate);
-        context.free(op->sym, &buffer, buffer.allocation);
-      } else {
-        free(buffer.allocation);
-      }
+      context.free(op->sym, &buffer, buffer.allocation);
     }
   }
 

--- a/runtime/evaluate.h
+++ b/runtime/evaluate.h
@@ -15,8 +15,8 @@ public:
   // passing the result of `allocate` in addition to the buffer.
   // If these functions are not defined, the default handler will call
   // `raw_buffer::allocate` and `::free`.
-  std::function<void*(var, raw_buffer*)> allocate;
-  std::function<void(var, raw_buffer*, void*)> free;
+  std::function<void*(var, raw_buffer*)> allocate = [](var, raw_buffer* buf) { return buf->allocate(); };
+  std::function<void(var, raw_buffer*, void*)> free = [](var, raw_buffer*, void* allocation) { ::free(allocation); };
 
   // Functions called when there is a failure in the pipeline.
   // If these functions are not defined, the default handler will write a
@@ -31,7 +31,7 @@ public:
   // - `wait_for` should wait until the given condition becomes true, executing tasks previously enqueued until it does.
   // - `atomic_call` runs a task on the calling thread, but atomically w.r.t. other `atomic_call` and `wait_for`
   //    conditions.
-  // 
+  //
   // These functions must be implemented if the statement being evaluated includes asynchronous nodes (parallel loops).
   using task = std::function<void()>;
   std::function<void(const task&)> enqueue_many;


### PR DESCRIPTION
These commits keep floating around my WIP branches:
- Remove unused includes
- Use `dim` helper functions where appropriate
- Clean up `allocate`/`free` callback usage
- Clean up `make_buffer` usage for copies that was confusing/tricky, it basically a product of trial and error without thinking.