### PR TITLE
Minor pipeline cleanups

### DIFF
--- a/builder/pipeline.cc
+++ b/builder/pipeline.cc
@@ -454,9 +454,8 @@ void compute_innermost_locations(const std::vector<const func*>& order,
 
     // Add loops for this function to the loop nest. The loops are defined
     // from innermost to outermost, so iterate in reverse order.
-    for (int i = f->loops().size() - 1; i >= 0; i--) {
-      const auto& l = f->loops()[i];
-      loop_tree.push_back({parent_id, {f, l.var}});
+    for (auto l = f->loops().rbegin(); l != f->loops().rend(); ++l) {
+      loop_tree.push_back({parent_id, {f, l->var}});
       parent_id = loop_tree.size() - 1;
     }
     func_to_loop_tree[f] = parent_id;
@@ -552,8 +551,8 @@ class pipeline_builder {
   lift_buffer_metadata sanitizer_;
 
   void substitute_buffer_dims() {
-    for (int ix = order_.size() - 1; ix >= 0; ix--) {
-      const func* f = order_[ix];
+    for (auto i = order_.rbegin(); i != order_.rend(); ++i) {
+      const func* f = *i;
       for (const func::output& o : f->outputs()) {
         const buffer_expr_ptr& b = o.buffer;
         if (output_syms_.count(b->sym())) continue;
@@ -649,9 +648,8 @@ class pipeline_builder {
 
       // Followed by intermediate buffers in the reverse topological order
       // (i.e. the outermost buffers are closer to the outputs of the pipeline).
-      for (int ix = order_.size() - 1; ix >= 0; ix--) {
-        const func* f = order_[ix];
-
+      for (auto i = order_.rbegin(); i != order_.rend(); ++i) {
+        const func* f = *i;
         for (const func::output& o : f->outputs()) {
           const buffer_expr_ptr& b = o.buffer;
           if (!inferred_bounds_[b->sym()]) continue;
@@ -740,8 +738,8 @@ public:
     stmt result;
 
     // Build the functions computed at this loop level.
-    for (int ix = order_.size() - 1; ix >= 0; ix--) {
-      const func* f = order_[ix];
+    for (auto i = order_.rbegin(); i != order_.rend(); ++i) {
+      const func* f = *i;
       const auto& compute_at = compute_at_levels_.find(f);
       assert(compute_at != compute_at_levels_.end());
       if (compute_at->second == at) {
@@ -753,8 +751,8 @@ public:
 
     symbol_map<var> uncropped_subs;
     // Add all allocations at this loop level.
-    for (int ix = order_.size() - 1; ix >= 0; ix--) {
-      const func* f = order_[ix];
+    for (auto i = order_.rbegin(); i != order_.rend(); ++i) {
+      const func* f = *i;
       for (const func::output& o : f->outputs()) {
         const buffer_expr_ptr& b = o.buffer;
         if (output_syms_.count(b->sym())) continue;
@@ -810,9 +808,8 @@ public:
 
   // Wrap the statement into make_buffer-s to define the bounds of allocations.
   stmt make_buffers(stmt body) {
-    for (int ix = order_.size() - 1; ix >= 0; ix--) {
-      const func* f = order_[ix];
-
+    for (auto i = order_.rbegin(); i != order_.rend(); ++i) {
+      const func* f = *i;
       for (const func::output& o : f->outputs()) {
         const buffer_expr_ptr& b = o.buffer;
         const std::optional<std::vector<dim_expr>>& maybe_dims = inferred_shapes_[b->sym()];

--- a/builder/pipeline.cc
+++ b/builder/pipeline.cc
@@ -391,9 +391,9 @@ int lca(const std::vector<loop_tree_node>& loop_tree, const std::vector<int>& pa
 
   // Compare paths to the root node until the diverge. The last node before
   // the diversion point is the least common ancestor.
-  int max_match = paths_from_root[0].size() - 1;
-  for (std::size_t ix = 1; ix < paths_from_root.size(); ix++) {
-    max_match = compare_paths_up_to(paths_from_root[0], paths_from_root[ix], max_match);
+  int max_match = static_cast<int>(paths_from_root[0].size()) - 1;
+  for (const std::vector<int>& path : paths_from_root) {
+    max_match = compare_paths_up_to(paths_from_root[0], path, max_match);
   }
 
   return paths_from_root[0][max_match];
@@ -458,7 +458,7 @@ void compute_innermost_locations(const std::vector<const func*>& order,
     // from innermost to outermost, so iterate in reverse order.
     for (auto l = f->loops().rbegin(); l != f->loops().rend(); ++l) {
       loop_tree.push_back({parent_id, {f, l->var}});
-      parent_id = loop_tree.size() - 1;
+      parent_id = static_cast<int>(loop_tree.size()) - 1;
     }
     func_to_loop_tree[f] = parent_id;
   }
@@ -769,11 +769,9 @@ public:
           result = allocate::make(b->sym(), b->storage(), b->elem_size(), dims, result);
 
           std::vector<stmt> checks;
-          for (std::size_t d = 0; d < dims.size(); ++d) {
-            if (d < bounds.size()) {
-              checks.push_back(check::make(dims[d].min() <= bounds[d].min));
-              checks.push_back(check::make(dims[d].max() >= bounds[d].max));
-            }
+          for (std::size_t d = 0; d < std::min(dims.size(), bounds.size()); ++d) {
+            checks.push_back(check::make(dims[d].min() <= bounds[d].min));
+            checks.push_back(check::make(dims[d].max() >= bounds[d].max));
           }
 
           result = block::make(std::move(checks), result);

--- a/builder/pipeline.cc
+++ b/builder/pipeline.cc
@@ -354,13 +354,14 @@ struct loop_tree_node {
 };
 
 // Find a path from the node to the root of the tree.
-void find_path_from_root(const std::vector<loop_tree_node>& loop_tree, int node_id, std::vector<int>& path_from_root) {
-  path_from_root.push_back(node_id);
+std::vector<int> find_path_from_root(const std::vector<loop_tree_node>& loop_tree, int node_id) {
+  std::vector<int> path_from_root = {node_id};
   while (node_id > 0) {
     node_id = loop_tree[node_id].parent_index;
     path_from_root.push_back(node_id);
   }
   std::reverse(path_from_root.begin(), path_from_root.end());
+  return path_from_root;
 }
 
 // Compare two paths and return the last point where they match.
@@ -382,9 +383,10 @@ int lca(const std::vector<loop_tree_node>& loop_tree, const std::vector<int>& pa
   // if we see it as a bottleneck later.
 
   // For each of the nodes find the path to the root of the tree.
-  std::vector<std::vector<int>> paths_from_root(parent_ids.size());
-  for (std::size_t ix = 0; ix < parent_ids.size(); ix++) {
-    find_path_from_root(loop_tree, parent_ids[ix], paths_from_root[ix]);
+  std::vector<std::vector<int>> paths_from_root;
+  paths_from_root.reserve(parent_ids.size());
+  for (std::size_t parent_id : parent_ids) {
+    paths_from_root.push_back(find_path_from_root(loop_tree, parent_id));
   }
 
   // Compare paths to the root node until the diverge. The last node before

--- a/builder/pipeline.cc
+++ b/builder/pipeline.cc
@@ -906,9 +906,7 @@ stmt build_pipeline(node_context& ctx, const std::vector<buffer_expr_ptr>& input
     const std::vector<buffer_expr_ptr>& outputs, std::set<buffer_expr_ptr>& constants, const build_options& options) {
   pipeline_builder builder(ctx, inputs, outputs, constants);
 
-  stmt result;
-  result = builder.build(result, nullptr, loop_id());
-  std::cout << std::tie(result, ctx) << std::endl;
+  stmt result = builder.build(result, nullptr, loop_id());
   result = builder.add_input_checks(result);
   result = builder.make_buffers(result);
   result = builder.define_sanitized_replacements(result);

--- a/builder/pipeline.cc
+++ b/builder/pipeline.cc
@@ -242,7 +242,7 @@ public:
     for (const auto& i : replacements) {
       lets.push_back({i.second, i.first});
     }
-    return let_stmt::make(std::move(lets), s);
+    return let_stmt::make(std::move(lets), std::move(s));
   }
 
   void visit(const call* op) override {
@@ -807,7 +807,7 @@ public:
   }
 
   // Wrap the statement into make_buffer-s to define the bounds of allocations.
-  stmt make_buffers(stmt body) {
+  stmt make_buffers(const stmt& body) {
     for (auto i = order_.rbegin(); i != order_.rend(); ++i) {
       const func* f = *i;
       for (const func::output& o : f->outputs()) {

--- a/builder/pipeline.cc
+++ b/builder/pipeline.cc
@@ -807,14 +807,14 @@ public:
   }
 
   // Wrap the statement into make_buffer-s to define the bounds of allocations.
-  stmt make_buffers(const stmt& body) {
+  stmt make_buffers(stmt body) {
     for (auto i = order_.rbegin(); i != order_.rend(); ++i) {
       const func* f = *i;
       for (const func::output& o : f->outputs()) {
         const buffer_expr_ptr& b = o.buffer;
         const std::optional<std::vector<dim_expr>>& maybe_dims = inferred_shapes_[b->sym()];
         if (!maybe_dims) continue;
-        body = make_buffer::make(b->sym(), expr(), expr(), *maybe_dims, body);
+        body = make_buffer::make(b->sym(), expr(), expr(), *maybe_dims, std::move(body));
       }
     }
     return body;
@@ -906,7 +906,8 @@ stmt build_pipeline(node_context& ctx, const std::vector<buffer_expr_ptr>& input
     const std::vector<buffer_expr_ptr>& outputs, std::set<buffer_expr_ptr>& constants, const build_options& options) {
   pipeline_builder builder(ctx, inputs, outputs, constants);
 
-  stmt result = builder.build(result, nullptr, loop_id());
+  stmt result;
+  result = builder.build(result, nullptr, loop_id());
   result = builder.add_input_checks(result);
   result = builder.make_buffers(result);
   result = builder.define_sanitized_replacements(result);


### PR DESCRIPTION
I've been looking at this code as part of another change, peeling of some minor cleanups, mostly avoiding use of `container::size()` as a signed integer where possible