### PR TITLE
Crop both inputs and outputs of concatenates

### DIFF
--- a/base/ref_count.h
+++ b/base/ref_count.h
@@ -1,6 +1,7 @@
 #ifndef SLINKY_BASE_REF_COUNT_H
 #define SLINKY_BASE_REF_COUNT_H
 
+#include <algorithm>
 #include <atomic>
 
 #include "base/util.h"

--- a/builder/pipeline.cc
+++ b/builder/pipeline.cc
@@ -188,7 +188,7 @@ func func::make_concat(std::vector<buffer_expr_ptr> in, output out, std::size_t 
     // We leave the dimensions not concatenated undefined so infer_bounds will require each input to provide the full
     // output in those dimensions.
     input.input_crop.resize(dim + 1);
-    input.input_crop[dim] = range(bounds[i], bounds[i + 1]);
+    input.input_crop[dim] = range(0, bounds[i + 1] - bounds[i]);
     input.output_crop.resize(dim + 1);
     input.output_crop[dim] = range(bounds[i], bounds[i + 1]);
 
@@ -283,23 +283,17 @@ bounds_map get_output_bounds(const std::vector<func::output>& outputs) {
 
 box_expr compute_input_bounds(
     const func* f, const func::input& i, const bounds_map& output_bounds, lift_buffer_metadata& sanitizer) {
-  bounds_map output_bounds_i = output_bounds;
-  if (!i.input_crop.empty()) {
-    assert(f->outputs().size() == 1);
-    const func::output& o = f->outputs()[0];
-    // We have an output crop for this input. Apply it to our bounds.
-    // TODO: It would be nice if this were simply a crop_buffer inserted in the right place. However, that is
-    // difficult to do because it could be used in several places, each with a different output crop to apply.
-    const box_expr& crop = i.input_crop;
-    for (std::size_t d = 0; d < std::min(crop.size(), o.dims.size()); ++d) {
-      *output_bounds_i[o.dims[d]] &= sanitizer.mutate(crop[d]);
-    }
-  }
-
   assert(i.bounds.size() == i.buffer->rank());
   box_expr crop(i.buffer->rank());
   for (std::size_t d = 0; d < crop.size(); ++d) {
-    crop[d] = bounds_of(sanitizer.mutate(i.bounds[d]), output_bounds_i);
+    crop[d] = bounds_of(sanitizer.mutate(i.bounds[d]), output_bounds);
+
+    if (d < i.input_crop.size()) {
+      // We have an output crop for this input, intersect with the crop we have.
+      // TODO: It would be nice if this were simply a crop_buffer inserted in the right place. However, that is
+      // difficult to do because it could be used in several places, each with a different output crop to apply.
+      crop[d] &= sanitizer.mutate(i.input_crop[d]);
+    }
   }
 
   return crop;

--- a/builder/pipeline.cc
+++ b/builder/pipeline.cc
@@ -287,7 +287,7 @@ box_expr compute_input_bounds(
     // TODO: It would be nice if this were simply a crop_buffer inserted in the right place. However, that is
     // difficult to do because it could be used in several places, each with a different output crop to apply.
     for (std::size_t d = 0; d < std::min(crop.size(), o.dims.size()); ++d) {
-      *output_bounds_i[o.dims[d]] &= crop[d];
+      *output_bounds_i[o.dims[d]] &= sanitizer.mutate(crop[d]);
     }
   }
 

--- a/builder/pipeline.h
+++ b/builder/pipeline.h
@@ -105,6 +105,9 @@ public:
     // These intervals should be a function of the expressions found in the output dims.
     box_expr bounds;
 
+    // A region to crop the input to while consuming this input. Only used by copies.
+    box_expr input_crop;
+
     // A region to crop the output to while consuming this input. Only used by copies.
     box_expr output_crop;
 

--- a/builder/replica_pipeline.cc
+++ b/builder/replica_pipeline.cc
@@ -189,11 +189,12 @@ public:
     print(func_input.buffer);
 
     std::string name = ctx_.name(func_input.sym());
-    std::string bounds = print(func_input.bounds, /*inlined*/ true);
-    if (!func_input.output_crop.empty() || !func_input.output_slice.empty()) {
-      std::string output_crop = print(func_input.output_crop, /*inlined*/ true);
+    std::string bounds = print(func_input.bounds, /*inlined=*/true);
+    if (!func_input.input_crop.empty() || !func_input.output_crop.empty() || !func_input.output_slice.empty()) {
+      std::string input_crop = print(func_input.input_crop, /*inlined=*/true);
+      std::string output_crop = print(func_input.output_crop, /*inlined=*/true);
       std::string output_slice = print_vector(func_input.output_slice);
-      return print_string_vector({name, bounds, output_crop, output_slice});
+      return print_string_vector({name, bounds, input_crop, output_crop, output_slice});
     } else {
       return print_string_vector({name, bounds});
     }

--- a/builder/test/BUILD
+++ b/builder/test/BUILD
@@ -63,6 +63,7 @@ cc_test(
     data = ["replica_pipeline.cc"] + glob(["visualize/*.html"]),
     deps = [
         ":util",
+        "//base/test:util",
         "//builder",
         "//builder:replica_pipeline",
         "//runtime",
@@ -79,6 +80,7 @@ cc_test(
     data = ["replica_pipeline.cc"],
     deps = [
         ":util",
+        "//base/test:util",
         "//builder",
         "//builder:replica_pipeline",
         "//runtime",
@@ -94,6 +96,7 @@ cc_test(
     data = ["replica_pipeline.cc"],
     deps = [
         ":util",
+        "//base/test:util",
         "//builder",
         "//builder:replica_pipeline",
         "//runtime",

--- a/builder/test/BUILD
+++ b/builder/test/BUILD
@@ -38,6 +38,7 @@ cc_test(
     name = "copy",
     srcs = ["copy.cc"],
     deps = [
+        ":util",
         "//builder",
         "//runtime",
         "@googletest//:gtest_main",

--- a/builder/test/copy.cc
+++ b/builder/test/copy.cc
@@ -212,12 +212,7 @@ TEST(padded, copy) {
 
   std::vector<char> padding(sizeof(int), 0);
 
-  // Crop the output to the intersection of the input and output buffer.
-  box_expr in_bounds = in->bounds();
-  in_bounds[0] += padding_x;
-  in_bounds[1] += padding_y;
-  box_expr output_crop = in_bounds;
-  func copy = func::make_copy({in, {point(x) - padding_x, point(y) - padding_y}, output_crop}, {out, {x, y}}, padding);
+  func copy = func::make_copy({in, {point(x) - padding_x, point(y) - padding_y}, in->bounds()}, {out, {x, y}}, padding);
 
   pipeline p = build_pipeline(ctx, {in}, {out});
 

--- a/builder/test/replica_pipeline.cc
+++ b/builder/test/replica_pipeline.cc
@@ -280,7 +280,7 @@ auto p = []() -> ::slinky::pipeline {
   };
   auto _fn_4 = func::make(std::move(_replica_fn_5), {{in2, {point(x), point(y)}}}, {{intm2, {x, y}}}, {});
   auto _6 = variable::make(out->sym());
-  auto _fn_0 = func::make_copy({{intm1, {point(x), point(((y - 0)))}, {point(expr()), {0, (((((((buffer_max(_3, 1)) - (buffer_min(_3, 1)))) + 1)) - 1))}}, {}}, {intm2, {point(x), point(((y - (((((buffer_max(_3, 1)) - (buffer_min(_3, 1)))) + 1)))))}, {point(expr()), {(((((buffer_max(_3, 1)) - (buffer_min(_3, 1)))) + 1)), (((((((buffer_max(_6, 1)) - (buffer_min(_6, 1)))) + 1)) - 1))}}, {}}}, {out, {x, y}});
+  auto _fn_0 = func::make_copy({{intm1, {point(x), point(((y - 0)))}, {point(expr()), {0, (((((((buffer_max(_3, 1)) - (buffer_min(_3, 1)))) + 1)) - 1))}}, {point(expr()), {0, (((((((buffer_max(_3, 1)) - (buffer_min(_3, 1)))) + 1)) - 1))}}, {}}, {intm2, {point(x), point(((y - (((((buffer_max(_3, 1)) - (buffer_min(_3, 1)))) + 1)))))}, {point(expr()), {(((((buffer_max(_3, 1)) - (buffer_min(_3, 1)))) + 1)), (((((((buffer_max(_6, 1)) - (buffer_min(_6, 1)))) + 1)) - 1))}}, {point(expr()), {(((((buffer_max(_3, 1)) - (buffer_min(_3, 1)))) + 1)), (((((((buffer_max(_6, 1)) - (buffer_min(_6, 1)))) + 1)) - 1))}}, {}}}, {out, {x, y}});
   auto p = build_pipeline(ctx, {}, {in1, in2}, {out}, {.no_alias_buffers = true});
   return p;
 };
@@ -334,7 +334,7 @@ auto p = []() -> ::slinky::pipeline {
     return ::slinky::internal::replica_pipeline_handler(input_buffers, output_buffers, inputs, outputs);
   };
   auto _fn_3 = func::make(std::move(_replica_fn_4), {{in2, {point(x), point(y)}}}, {{intm2, {x, y}}}, {});
-  auto _fn_0 = func::make_copy({{intm1, {point(x), point(y)}, {}, {expr(), expr(), 0}}, {intm2, {point(x), point(y)}, {}, {expr(), expr(), 1}}}, {out, {x, y}});
+  auto _fn_0 = func::make_copy({{intm1, {point(x), point(y)}, {}, {}, {expr(), expr(), 0}}, {intm2, {point(x), point(y)}, {}, {}, {expr(), expr(), 1}}}, {out, {x, y}});
   auto p = build_pipeline(ctx, {}, {in1, in2}, {out}, {});
   return p;
 };
@@ -379,7 +379,7 @@ auto p = []() -> ::slinky::pipeline {
   };
   auto _fn_2 = func::make(std::move(_replica_fn_3), {{in, {point(x), point(y)}}}, {{intm, {x, y}}}, {});
   auto _4 = variable::make(in->sym());
-  auto _fn_1 = func::make_copy({{intm, {point(x), point(y)}, {{(buffer_min(_4, 0)), (buffer_max(_4, 0))}, {(buffer_min(_4, 1)), (buffer_max(_4, 1))}}, {}}}, {padded_intm, {x, y}});
+  auto _fn_1 = func::make_copy({{intm, {point(x), point(y)}, {{(buffer_min(_4, 0)), (buffer_max(_4, 0))}, {(buffer_min(_4, 1)), (buffer_max(_4, 1))}}, {}, {}}}, {padded_intm, {x, y}});
   _fn_1.compute_root();
   auto _replica_fn_5 = [=](const buffer<const void>& i0, const buffer<void>& o0) -> index_t {
     const buffer<const void>* input_buffers[] = {&i0};

--- a/builder/test/replica_pipeline.cc
+++ b/builder/test/replica_pipeline.cc
@@ -280,7 +280,7 @@ auto p = []() -> ::slinky::pipeline {
   };
   auto _fn_4 = func::make(std::move(_replica_fn_5), {{in2, {point(x), point(y)}}}, {{intm2, {x, y}}}, {});
   auto _6 = variable::make(out->sym());
-  auto _fn_0 = func::make_copy({{intm1, {point(x), point(((y - 0)))}, {point(expr()), {0, (((((((buffer_max(_3, 1)) - (buffer_min(_3, 1)))) + 1)) - 1))}}, {point(expr()), {0, (((((((buffer_max(_3, 1)) - (buffer_min(_3, 1)))) + 1)) - 1))}}, {}}, {intm2, {point(x), point(((y - (((((buffer_max(_3, 1)) - (buffer_min(_3, 1)))) + 1)))))}, {point(expr()), {(((((buffer_max(_3, 1)) - (buffer_min(_3, 1)))) + 1)), (((((((buffer_max(_6, 1)) - (buffer_min(_6, 1)))) + 1)) - 1))}}, {point(expr()), {(((((buffer_max(_3, 1)) - (buffer_min(_3, 1)))) + 1)), (((((((buffer_max(_6, 1)) - (buffer_min(_6, 1)))) + 1)) - 1))}}, {}}}, {out, {x, y}});
+  auto _fn_0 = func::make_copy({{intm1, {point(x), point(((y - 0)))}, {point(expr()), {0, (((((((((buffer_max(_3, 1)) - (buffer_min(_3, 1)))) + 1)) - 0)) - 1))}}, {point(expr()), {0, (((((((buffer_max(_3, 1)) - (buffer_min(_3, 1)))) + 1)) - 1))}}, {}}, {intm2, {point(x), point(((y - (((((buffer_max(_3, 1)) - (buffer_min(_3, 1)))) + 1)))))}, {point(expr()), {0, (((((((((buffer_max(_6, 1)) - (buffer_min(_6, 1)))) + 1)) - (((((buffer_max(_3, 1)) - (buffer_min(_3, 1)))) + 1)))) - 1))}}, {point(expr()), {(((((buffer_max(_3, 1)) - (buffer_min(_3, 1)))) + 1)), (((((((buffer_max(_6, 1)) - (buffer_min(_6, 1)))) + 1)) - 1))}}, {}}}, {out, {x, y}});
   auto p = build_pipeline(ctx, {}, {in1, in2}, {out}, {.no_alias_buffers = true});
   return p;
 };

--- a/builder/test/visualize/padded_stencil_0.html
+++ b/builder/test/visualize/padded_stencil_0.html
@@ -267,37 +267,43 @@ function pipeline(__in, out) {
   check((buffer_elem_size(out) == 2));
   check((((buffer_max(out, 0) - buffer_min(out, 0)) + 1) <= buffer_fold_factor(out, 0)));
   check((((buffer_max(out, 1) - buffer_min(out, 1)) + 1) <= buffer_fold_factor(out, 1)));
-  check((((min((buffer_max(out, 0) + 1), buffer_max(__in, 0)) - max((buffer_min(out, 0) + -1), buffer_min(__in, 0))) + 1) <= buffer_fold_factor(__in, 0)));
-  check((((min((buffer_max(out, 1) + 1), buffer_max(__in, 1)) - max((buffer_min(out, 1) + -1), buffer_min(__in, 1))) + 1) <= buffer_fold_factor(__in, 1)));
-  { let padded_intm = allocate('padded_intm', 2, [
-      {bounds:{min:(buffer_min(out, 0) + -1), max:(buffer_max(out, 0) + 1)}, stride:2, fold_factor:9223372036854775807},
-      {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:(((buffer_max(out, 0) - buffer_min(out, 0)) * 2) + 6), fold_factor:9223372036854775807}
-    ]);
-    {
-      let __base = buffer_at(padded_intm, max((buffer_min(out, 0) + -1), buffer_min(__in, 0)), max((buffer_min(out, 1) + -1), buffer_min(__in, 1)));
-      let __elem_size = 2;
-      let __dims = [
-          {bounds:{min:max((buffer_min(out, 0) + -1), buffer_min(__in, 0)), max:min((buffer_max(out, 0) + 1), buffer_max(__in, 0))}, stride:buffer_stride(padded_intm, 0), fold_factor:buffer_fold_factor(padded_intm, 0)},
-          {bounds:{min:max((buffer_min(out, 1) + -1), buffer_min(__in, 1)), max:min((buffer_max(out, 1) + 1), buffer_max(__in, 1))}, stride:buffer_stride(padded_intm, 1), fold_factor:buffer_fold_factor(padded_intm, 1)}
-      ];
-      { let intm = make_buffer('intm', __base, __elem_size, __dims);        consume(__in);
-        produce(intm);
+  {
+    let g = buffer_min(__in, 0);
+    let g1 = buffer_min(__in, 1);
+    let g0 = buffer_max(__in, 0);
+    let g2 = buffer_max(__in, 1);
+    check((((min(g0, (buffer_max(out, 0) + 1)) - max(g, (buffer_min(out, 0) + -1))) + 1) <= buffer_fold_factor(__in, 0)));
+    check((((min(g2, (buffer_max(out, 1) + 1)) - max(g1, (buffer_min(out, 1) + -1))) + 1) <= buffer_fold_factor(__in, 1)));
+    { let padded_intm = allocate('padded_intm', 2, [
+        {bounds:{min:(buffer_min(out, 0) + -1), max:(buffer_max(out, 0) + 1)}, stride:2, fold_factor:9223372036854775807},
+        {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:(((buffer_max(out, 0) - buffer_min(out, 0)) * 2) + 6), fold_factor:9223372036854775807}
+      ]);
+      {
+        let __base = buffer_at(padded_intm, max(g, (buffer_min(out, 0) + -1)), max(g1, (buffer_min(out, 1) + -1)));
+        let __elem_size = 2;
+        let __dims = [
+            {bounds:{min:max(g, (buffer_min(out, 0) + -1)), max:min(g0, (buffer_max(out, 0) + 1))}, stride:buffer_stride(padded_intm, 0), fold_factor:buffer_fold_factor(padded_intm, 0)},
+            {bounds:{min:max(g1, (buffer_min(out, 1) + -1)), max:min(g2, (buffer_max(out, 1) + 1))}, stride:buffer_stride(padded_intm, 1), fold_factor:buffer_fold_factor(padded_intm, 1)}
+        ];
+        { let intm = make_buffer('intm', __base, __elem_size, __dims);          consume(__in);
+          produce(intm);
+        }
       }
-    }
-    {
-      let __base = buffer_at(padded_intm, max((buffer_min(out, 0) + -1), buffer_min(__in, 0)), max((buffer_min(out, 1) + -1), buffer_min(__in, 1)));
-      let __elem_size = 2;
-      let __dims = [
-          {bounds:{min:max((buffer_min(out, 0) + -1), buffer_min(__in, 0)), max:min((buffer_max(out, 0) + 1), buffer_max(__in, 0))}, stride:buffer_stride(padded_intm, 0), fold_factor:buffer_fold_factor(padded_intm, 0)},
-          {bounds:{min:max((buffer_min(out, 1) + -1), buffer_min(__in, 1)), max:min((buffer_max(out, 1) + 1), buffer_max(__in, 1))}, stride:buffer_stride(padded_intm, 1), fold_factor:buffer_fold_factor(padded_intm, 1)}
-      ];
-      { let intm = make_buffer('intm', __base, __elem_size, __dims);        consume(intm);
-        produce(padded_intm);
+      {
+        let __base = buffer_at(padded_intm, max(g, (buffer_min(out, 0) + -1)), max(g1, (buffer_min(out, 1) + -1)));
+        let __elem_size = 2;
+        let __dims = [
+            {bounds:{min:max(g, (buffer_min(out, 0) + -1)), max:min(g0, (buffer_max(out, 0) + 1))}, stride:buffer_stride(padded_intm, 0), fold_factor:buffer_fold_factor(padded_intm, 0)},
+            {bounds:{min:max(g1, (buffer_min(out, 1) + -1)), max:min(g2, (buffer_max(out, 1) + 1))}, stride:buffer_stride(padded_intm, 1), fold_factor:buffer_fold_factor(padded_intm, 1)}
+        ];
+        { let intm = make_buffer('intm', __base, __elem_size, __dims);          consume(intm);
+          produce(padded_intm);
+        }
       }
+      consume(padded_intm);
+      produce(out);
+      free(padded_intm);
     }
-    consume(padded_intm);
-    produce(out);
-    free(padded_intm);
   }
 }
 let __in = allocate('in', 2, [{bounds: {min:0, max:19}, stride:2, fold_factor:9223372036854775807}, {bounds: {min:0, max:29}, stride:40, fold_factor:9223372036854775807}], true);

--- a/builder/test/visualize/padded_stencil_1.html
+++ b/builder/test/visualize/padded_stencil_1.html
@@ -267,37 +267,43 @@ function pipeline(__in, out) {
   check((buffer_elem_size(out) == 2));
   check((((buffer_max(out, 0) - buffer_min(out, 0)) + 1) <= buffer_fold_factor(out, 0)));
   check((((buffer_max(out, 1) - buffer_min(out, 1)) + 1) <= buffer_fold_factor(out, 1)));
-  check((((min((buffer_max(out, 0) + 1), buffer_max(__in, 0)) - max((buffer_min(out, 0) + -1), buffer_min(__in, 0))) + 1) <= buffer_fold_factor(__in, 0)));
-  check((((min((buffer_max(out, 1) + 1), buffer_max(__in, 1)) - max((buffer_min(out, 1) + -1), buffer_min(__in, 1))) + 1) <= buffer_fold_factor(__in, 1)));
-  { let padded_intm = allocate('padded_intm', 2, [
-      {bounds:{min:(buffer_min(out, 0) + -1), max:(buffer_max(out, 0) + 1)}, stride:2, fold_factor:9223372036854775807},
-      {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:(((buffer_max(out, 0) - buffer_min(out, 0)) * 2) + 6), fold_factor:9223372036854775807}
-    ]);
-    {
-      let __base = buffer_at(padded_intm, max((buffer_min(out, 0) + -1), buffer_min(__in, 0)), max((buffer_min(out, 1) + -1), buffer_min(__in, 1)));
-      let __elem_size = 2;
-      let __dims = [
-          {bounds:{min:max((buffer_min(out, 0) + -1), buffer_min(__in, 0)), max:min((buffer_max(out, 0) + 1), buffer_max(__in, 0))}, stride:buffer_stride(padded_intm, 0), fold_factor:buffer_fold_factor(padded_intm, 0)},
-          {bounds:{min:max((buffer_min(out, 1) + -1), buffer_min(__in, 1)), max:min((buffer_max(out, 1) + 1), buffer_max(__in, 1))}, stride:buffer_stride(padded_intm, 1), fold_factor:buffer_fold_factor(padded_intm, 1)}
-      ];
-      { let intm = make_buffer('intm', __base, __elem_size, __dims);        consume(__in);
-        produce(intm);
+  {
+    let g = buffer_min(__in, 0);
+    let g1 = buffer_min(__in, 1);
+    let g0 = buffer_max(__in, 0);
+    let g2 = buffer_max(__in, 1);
+    check((((min(g0, (buffer_max(out, 0) + 1)) - max(g, (buffer_min(out, 0) + -1))) + 1) <= buffer_fold_factor(__in, 0)));
+    check((((min(g2, (buffer_max(out, 1) + 1)) - max(g1, (buffer_min(out, 1) + -1))) + 1) <= buffer_fold_factor(__in, 1)));
+    { let padded_intm = allocate('padded_intm', 2, [
+        {bounds:{min:(buffer_min(out, 0) + -1), max:(buffer_max(out, 0) + 1)}, stride:2, fold_factor:9223372036854775807},
+        {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:(((buffer_max(out, 0) - buffer_min(out, 0)) * 2) + 6), fold_factor:9223372036854775807}
+      ]);
+      {
+        let __base = buffer_at(padded_intm, max(g, (buffer_min(out, 0) + -1)), max(g1, (buffer_min(out, 1) + -1)));
+        let __elem_size = 2;
+        let __dims = [
+            {bounds:{min:max(g, (buffer_min(out, 0) + -1)), max:min(g0, (buffer_max(out, 0) + 1))}, stride:buffer_stride(padded_intm, 0), fold_factor:buffer_fold_factor(padded_intm, 0)},
+            {bounds:{min:max(g1, (buffer_min(out, 1) + -1)), max:min(g2, (buffer_max(out, 1) + 1))}, stride:buffer_stride(padded_intm, 1), fold_factor:buffer_fold_factor(padded_intm, 1)}
+        ];
+        { let intm = make_buffer('intm', __base, __elem_size, __dims);          consume(__in);
+          produce(intm);
+        }
       }
-    }
-    {
-      let __base = buffer_at(padded_intm, max((buffer_min(out, 0) + -1), buffer_min(__in, 0)), max((buffer_min(out, 1) + -1), buffer_min(__in, 1)));
-      let __elem_size = 2;
-      let __dims = [
-          {bounds:{min:max((buffer_min(out, 0) + -1), buffer_min(__in, 0)), max:min((buffer_max(out, 0) + 1), buffer_max(__in, 0))}, stride:buffer_stride(padded_intm, 0), fold_factor:buffer_fold_factor(padded_intm, 0)},
-          {bounds:{min:max((buffer_min(out, 1) + -1), buffer_min(__in, 1)), max:min((buffer_max(out, 1) + 1), buffer_max(__in, 1))}, stride:buffer_stride(padded_intm, 1), fold_factor:buffer_fold_factor(padded_intm, 1)}
-      ];
-      { let intm = make_buffer('intm', __base, __elem_size, __dims);        consume(intm);
-        produce(padded_intm);
+      {
+        let __base = buffer_at(padded_intm, max(g, (buffer_min(out, 0) + -1)), max(g1, (buffer_min(out, 1) + -1)));
+        let __elem_size = 2;
+        let __dims = [
+            {bounds:{min:max(g, (buffer_min(out, 0) + -1)), max:min(g0, (buffer_max(out, 0) + 1))}, stride:buffer_stride(padded_intm, 0), fold_factor:buffer_fold_factor(padded_intm, 0)},
+            {bounds:{min:max(g1, (buffer_min(out, 1) + -1)), max:min(g2, (buffer_max(out, 1) + 1))}, stride:buffer_stride(padded_intm, 1), fold_factor:buffer_fold_factor(padded_intm, 1)}
+        ];
+        { let intm = make_buffer('intm', __base, __elem_size, __dims);          consume(intm);
+          produce(padded_intm);
+        }
       }
+      consume(padded_intm);
+      produce(out);
+      free(padded_intm);
     }
-    consume(padded_intm);
-    produce(out);
-    free(padded_intm);
   }
 }
 let __in = allocate('in', 2, [{bounds: {min:0, max:19}, stride:2, fold_factor:9223372036854775807}, {bounds: {min:0, max:29}, stride:40, fold_factor:9223372036854775807}], true);

--- a/builder/test/visualize/padded_stencil_2.html
+++ b/builder/test/visualize/padded_stencil_2.html
@@ -267,41 +267,47 @@ function pipeline(__in, out) {
   check((buffer_elem_size(out) == 2));
   check((((buffer_max(out, 0) - buffer_min(out, 0)) + 1) <= buffer_fold_factor(out, 0)));
   check((((buffer_max(out, 1) - buffer_min(out, 1)) + 1) <= buffer_fold_factor(out, 1)));
-  check((((min((buffer_max(out, 0) + 1), buffer_max(__in, 0)) - max((buffer_min(out, 0) + -1), buffer_min(__in, 0))) + 1) <= buffer_fold_factor(__in, 0)));
-  check((((min((buffer_max(out, 1) + 1), buffer_max(__in, 1)) - max((buffer_min(out, 1) + -1), buffer_min(__in, 1))) + 1) <= buffer_fold_factor(__in, 1)));
-  { let padded_intm = allocate('padded_intm', 2, [
-      {bounds:{min:(buffer_min(out, 0) + -1), max:(buffer_max(out, 0) + 1)}, stride:2, fold_factor:9223372036854775807},
-      {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:(((buffer_max(out, 0) - buffer_min(out, 0)) * 2) + 6), fold_factor:3}
-    ]);
-    { let padded_intm_uncropped = clone_buffer(padded_intm);
-      { let intm = allocate('intm', 2, [
-          {bounds:{min:max((buffer_min(out, 0) + -1), buffer_min(__in, 0)), max:min((buffer_max(out, 0) + 1), buffer_max(__in, 0))}, stride:2, fold_factor:9223372036854775807},
-          {bounds:{min:max((buffer_min(out, 1) + -1), buffer_min(__in, 1)), max:min((buffer_max(out, 1) + 1), buffer_max(__in, 1))}, stride:(((min((buffer_max(out, 0) + 1), buffer_max(__in, 0)) - max((buffer_min(out, 0) + -1), buffer_min(__in, 0))) * 2) + 2), fold_factor:9223372036854775807}
-        ]);
-        {
-          let y_min_orig = buffer_min(out, 1);
-          for(let y = (y_min_orig + -2); y <= buffer_max(out, 1); y += 1) {
-            { let __intm = crop_dim(intm, 1, {min:max((y + 1), buffer_min(__in, 1)), max:min((y + 1), buffer_max(__in, 1))});
-              consume(__in);
-              produce(intm);
-              intm = __intm;
-            }
-            { let __padded_intm = crop_dim(padded_intm, 1, {min:(y + 1), max:(y + 1)});
-              consume(intm);
-              produce(padded_intm);
-              padded_intm = __padded_intm;
-            }
-            { let __out = crop_dim(out, 1, {min:y, max:y});
-              consume(padded_intm_uncropped);
-              produce(out);
-              out = __out;
+  {
+    let g = buffer_min(__in, 0);
+    let g1 = buffer_min(__in, 1);
+    let g0 = buffer_max(__in, 0);
+    let g2 = buffer_max(__in, 1);
+    check((((min(g0, (buffer_max(out, 0) + 1)) - max(g, (buffer_min(out, 0) + -1))) + 1) <= buffer_fold_factor(__in, 0)));
+    check((((min(g2, (buffer_max(out, 1) + 1)) - max(g1, (buffer_min(out, 1) + -1))) + 1) <= buffer_fold_factor(__in, 1)));
+    { let padded_intm = allocate('padded_intm', 2, [
+        {bounds:{min:(buffer_min(out, 0) + -1), max:(buffer_max(out, 0) + 1)}, stride:2, fold_factor:9223372036854775807},
+        {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:(((buffer_max(out, 0) - buffer_min(out, 0)) * 2) + 6), fold_factor:3}
+      ]);
+      { let padded_intm_uncropped = clone_buffer(padded_intm);
+        { let intm = allocate('intm', 2, [
+            {bounds:{min:max(g, (buffer_min(out, 0) + -1)), max:min(g0, (buffer_max(out, 0) + 1))}, stride:2, fold_factor:9223372036854775807},
+            {bounds:{min:max(g1, (buffer_min(out, 1) + -1)), max:min(g2, (buffer_max(out, 1) + 1))}, stride:(((min(g0, (buffer_max(out, 0) + 1)) - max(g, (buffer_min(out, 0) + -1))) * 2) + 2), fold_factor:9223372036854775807}
+          ]);
+          {
+            let y_min_orig = buffer_min(out, 1);
+            for(let y = (y_min_orig + -2); y <= buffer_max(out, 1); y += 1) {
+              { let __intm = crop_dim(intm, 1, {min:max(g1, (y + 1)), max:min(g2, (y + 1))});
+                consume(__in);
+                produce(intm);
+                intm = __intm;
+              }
+              { let __padded_intm = crop_dim(padded_intm, 1, {min:(y + 1), max:(y + 1)});
+                consume(intm);
+                produce(padded_intm);
+                padded_intm = __padded_intm;
+              }
+              { let __out = crop_dim(out, 1, {min:y, max:y});
+                consume(padded_intm_uncropped);
+                produce(out);
+                out = __out;
+              }
             }
           }
+          free(intm);
         }
-        free(intm);
       }
+      free(padded_intm);
     }
-    free(padded_intm);
   }
 }
 let __in = allocate('in', 2, [{bounds: {min:0, max:19}, stride:2, fold_factor:9223372036854775807}, {bounds: {min:0, max:29}, stride:40, fold_factor:9223372036854775807}], true);

--- a/runtime/buffer.cc
+++ b/runtime/buffer.cc
@@ -28,6 +28,14 @@ std::size_t alloc_size(std::size_t rank, std::size_t elem_size, const dim* dims)
 
 std::size_t raw_buffer::size_bytes() const { return alloc_size(rank, elem_size, dims); }
 
+std::size_t raw_buffer::elem_count() const {
+  std::size_t result = 1;
+  for (std::size_t i = 0; i < rank; ++i) {
+    result *= std::max<index_t>(0, dims[i].extent());
+  }
+  return result;
+}
+
 raw_buffer_ptr raw_buffer::make(std::size_t rank, std::size_t elem_size, const class dim* dims) {
   std::size_t size = sizeof(raw_buffer) + sizeof(slinky::dim) * rank;
   if (dims) {
@@ -263,7 +271,7 @@ SLINKY_ALWAYS_INLINE inline bool is_contiguous_slice(const raw_buffer* const* bu
     } else if (bufs[n]->dim(d).stride() != static_cast<index_t>(bufs[n]->elem_size)) {
       // This dimension is not contiguous.
       return false;
-    } 
+    }
   }
   return true;
 }

--- a/runtime/buffer.h
+++ b/runtime/buffer.h
@@ -264,6 +264,8 @@ public:
 
   std::size_t size_bytes() const;
 
+  std::size_t elem_count() const;
+
   // Allocate and set the base pointer using `malloc`. Returns a pointer to the allocated memory, which should
   // be deallocated with `free`.
   void* allocate();


### PR DESCRIPTION
Before this PR, we only cropped inputs (and confusingly called it `output_crop`), and relied on `copy` treating out of bounds values as undefined.

This doesn't work well when copying buffers with broadcasting, because nothing is out of bounds in broadcasted dimensions.

This PR fixes these problems by cropping both the input and output of copies in concatenates, and fixes a bug where we forgot to sanitize crops of buffer metadata.