### PR TITLE
Support optional broadcast copies

### DIFF
--- a/builder/simplify.cc
+++ b/builder/simplify.cc
@@ -823,7 +823,7 @@ public:
       if (slice->sym == op->sym && slice->dim == op->dim) {
         // This is a slice of the same dimension of the buffer we just cropped.
         // Don't drop the clamp that crop performs.
-        expr at = clamp(slice->at, bounds.min, bounds.max);
+        expr at = clamp(slice->at, bounds);
         set_result(mutate(slice_dim::make(op->sym, op->src, op->dim, at, slice->body)));
         return;
       }

--- a/builder/simplify_bounds.cc
+++ b/builder/simplify_bounds.cc
@@ -314,8 +314,10 @@ interval_expr bounds_of(const class select* op, interval_expr c, interval_expr t
     return t;
   } else if (is_false(c.max)) {
     return f;
+  } else if (c.is_point()) {
+    return select(c.min, std::move(t), std::move(f));
   } else {
-    return f | t;
+    return t | f;
   }
 }
 

--- a/builder/test/copy.cc
+++ b/builder/test/copy.cc
@@ -447,7 +447,6 @@ TEST_P(broadcast, copy) {
   in_buf.dim(dim).set_extent(1);
   init_random(in_buf);
 
-  // Ask for an output padded in every direction.
   buffer<int, 3> out_buf({W, H, D});
   out_buf.allocate();
 
@@ -497,7 +496,6 @@ TEST_P(broadcast, copy_sliced) {
   buffer<int, 2> in_buf({in_extents[0], in_extents[1]});
   init_random(in_buf);
 
-  // Ask for an output padded in every direction.
   buffer<int, 3> out_buf({W, H, D});
   out_buf.allocate();
 
@@ -548,7 +546,6 @@ TEST_P(broadcast, optional) {
   in_buf.dim(dim).set_extent(1);
   init_random(in_buf);
 
-  // Ask for an output padded in every direction.
   buffer<int, 3> out_buf({W, H, D});
   out_buf.allocate();
 

--- a/builder/test/copy.cc
+++ b/builder/test/copy.cc
@@ -420,7 +420,7 @@ class broadcast : public testing::TestWithParam<int> {};
 INSTANTIATE_TEST_SUITE_P(dim, broadcast, testing::Range(0, 3));
 
 TEST_P(broadcast, copy) {
-  int dim = GetParam();
+  const int dim = GetParam();
 
   // Make the pipeline
   node_context ctx;
@@ -469,7 +469,7 @@ TEST_P(broadcast, copy) {
 }
 
 TEST_P(broadcast, copy_sliced) {
-  int dim = GetParam();
+  const int dim = GetParam();
 
   // Make the pipeline
   node_context ctx;
@@ -512,6 +512,57 @@ TEST_P(broadcast, copy_sliced) {
       for (int x = 0; x < W; ++x) {
         std::vector<index_t> i = {x, y, z};
         i.erase(i.begin() + dim);
+        ASSERT_EQ(out_buf(x, y, z), in_buf(i));
+      }
+    }
+  }
+}
+
+TEST_P(broadcast, optional) {
+  // Make the pipeline
+  node_context ctx;
+
+  auto in = buffer_expr::make(ctx, "in", 3, sizeof(int));
+  auto out = buffer_expr::make(ctx, "out", 3, sizeof(int));
+
+  var x(ctx, "x");
+  var y(ctx, "y");
+  var z(ctx, "z");
+
+  box_expr bounds = {
+      select(in->dim(0).extent() == 1, point(in->dim(0).min()), point(x)),
+      select(in->dim(1).extent() == 1, point(in->dim(1).min()), point(y)),
+      select(in->dim(2).extent() == 1, point(in->dim(2).min()), point(z)),
+  };
+  func crop = func::make_copy({in, bounds}, {out, {x, y, z}});
+
+  pipeline p = build_pipeline(ctx, {in}, {out});
+
+  const int W = 8;
+  const int H = 5;
+  const int D = 3;
+
+  // Run the pipeline.
+  const int dim = GetParam();
+  buffer<int, 3> in_buf({W, H, D});
+  in_buf.dim(dim).set_extent(1);
+  init_random(in_buf);
+
+  // Ask for an output padded in every direction.
+  buffer<int, 3> out_buf({W, H, D});
+  out_buf.allocate();
+
+  const raw_buffer* inputs[] = {&in_buf};
+  const raw_buffer* outputs[] = {&out_buf};
+  test_context eval_ctx;
+  p.evaluate(inputs, outputs, eval_ctx);
+  ASSERT_EQ(eval_ctx.copy_calls, 1);
+
+  for (int z = 0; z < D; ++z) {
+    for (int y = 0; y < H; ++y) {
+      for (int x = 0; x < W; ++x) {
+        index_t i[] = {x, y, z};
+        i[dim] = 0;
         ASSERT_EQ(out_buf(x, y, z), in_buf(i));
       }
     }

--- a/runtime/evaluate.cc
+++ b/runtime/evaluate.cc
@@ -56,6 +56,10 @@ struct allocated_buffer : public raw_buffer {
   void* allocation;
 };
 
+struct interval {
+  index_t min, max;
+};
+
 // TODO(https://github.com/dsharlet/slinky/issues/2): I think the T::accept/T_visitor::visit
 // overhead (two virtual function calls per node) might be significant. This could be implemented
 // as a switch statement instead.
@@ -86,7 +90,7 @@ public:
   }
 
   // Assume `e` is defined, evaluate it and return the result.
-  index_t eval_expr(const expr& e) {
+  index_t eval(const expr& e) {
     visit(e);
     index_t r = result;
     result = 0;
@@ -94,11 +98,32 @@ public:
   }
 
   // If `e` is defined, evaluate it and return the result. Otherwise, return default `def`.
-  index_t eval_expr(const expr& e, index_t def) {
+  index_t eval(const expr& e, index_t def) {
     if (e.defined()) {
-      return eval_expr(e);
+      return eval(e);
     } else {
       return def;
+    }
+  }
+
+  interval eval(const interval_expr& x) {
+    if (x.is_point()) {
+      index_t result = eval(x.min);
+      return {result, result};
+    } else {
+      return {eval(x.min), eval(x.max)};
+    }
+  }
+  interval eval(const interval_expr& x, interval def) {
+    if (x.is_point()) {
+      if (x.min.defined()) {
+        index_t result = eval(x.min);
+        return {result, result};
+      } else {
+        return def;
+      }
+    } else {
+      return {eval(x.min, def.min), eval(x.max, def.max)};
     }
   }
 
@@ -120,7 +145,7 @@ public:
     for (size_t i = 0; i < size; ++i) {
       const auto& let = op->lets[i];
       old_values[i] = context[let.first];
-      context[let.first] = eval_expr(let.second);
+      context[let.first] = eval(let.second);
     }
     visit(op->body);
     for (size_t i = 0; i < size; ++i) {
@@ -134,7 +159,7 @@ public:
 
   template <typename T>
   void visit_binary(const T* op) {
-    result = make_binary<T>(eval_expr(op->a), eval_expr(op->b));
+    result = make_binary<T>(eval(op->a), eval(op->b));
   }
 
   void visit(const add* op) override { visit_binary(op); }
@@ -151,19 +176,19 @@ public:
   void visit(const logical_and* op) override { visit_binary(op); }
   void visit(const logical_or* op) override { visit_binary(op); }
 
-  void visit(const logical_not* op) override { result = eval_expr(op->a) == 0; }
+  void visit(const logical_not* op) override { result = eval(op->a) == 0; }
 
   void visit(const class select* op) override {
-    if (eval_expr(op->condition)) {
-      result = eval_expr(op->true_value);
+    if (eval(op->condition)) {
+      result = eval(op->true_value);
     } else {
-      result = eval_expr(op->false_value);
+      result = eval(op->false_value);
     }
   }
 
   index_t eval_buffer_metadata(const call* op) {
     assert(op->args.size() == 1);
-    raw_buffer* buf = reinterpret_cast<raw_buffer*>(eval_expr(op->args[0]));
+    raw_buffer* buf = reinterpret_cast<raw_buffer*>(eval(op->args[0]));
     assert(buf);
     switch (op->intrinsic) {
     case intrinsic::buffer_rank: return buf->rank;
@@ -175,9 +200,9 @@ public:
 
   index_t eval_dim_metadata(const call* op) {
     assert(op->args.size() == 2);
-    raw_buffer* buffer = reinterpret_cast<raw_buffer*>(eval_expr(op->args[0]));
+    raw_buffer* buffer = reinterpret_cast<raw_buffer*>(eval(op->args[0]));
     assert(buffer);
-    index_t d = eval_expr(op->args[1]);
+    index_t d = eval(op->args[1]);
     assert(d < static_cast<index_t>(buffer->rank));
     const slinky::dim& dim = buffer->dim(d);
     switch (op->intrinsic) {
@@ -191,12 +216,12 @@ public:
 
   void* eval_buffer_at(const call* op) {
     assert(op->args.size() >= 1);
-    raw_buffer* buf = reinterpret_cast<raw_buffer*>(eval_expr(op->args[0]));
+    raw_buffer* buf = reinterpret_cast<raw_buffer*>(eval(op->args[0]));
     void* result = buf->base;
     assert(op->args.size() <= buf->rank + 1);
     for (std::size_t d = 0; d < op->args.size() - 1; ++d) {
       if (op->args[d + 1].defined()) {
-        index_t offset = eval_expr(op->args[d + 1]);
+        index_t offset = eval(op->args[d + 1]);
         if (result) {
           result = offset_bytes(result, buf->dims[d].flat_offset_bytes(offset));
         }
@@ -207,8 +232,8 @@ public:
 
   index_t eval_semaphore_init(const call* op) {
     assert(op->args.size() == 2);
-    index_t* sem = reinterpret_cast<index_t*>(eval_expr(op->args[0]));
-    index_t count = eval_expr(op->args[1], 0);
+    index_t* sem = reinterpret_cast<index_t*>(eval(op->args[0]));
+    index_t count = eval(op->args[1], 0);
     context.atomic_call([=]() { *sem = count; });
     return 1;
   }
@@ -219,8 +244,8 @@ public:
     index_t** sems = SLINKY_ALLOCA(index_t*, sem_count);
     index_t* counts = SLINKY_ALLOCA(index_t, sem_count);
     for (std::size_t i = 0; i < sem_count; ++i) {
-      sems[i] = reinterpret_cast<index_t*>(eval_expr(op->args[i * 2 + 0]));
-      counts[i] = eval_expr(op->args[i * 2 + 1], 1);
+      sems[i] = reinterpret_cast<index_t*>(eval(op->args[i * 2 + 0]));
+      counts[i] = eval(op->args[i * 2 + 1], 1);
     }
     context.atomic_call([=]() {
       for (std::size_t i = 0; i < sem_count; ++i) {
@@ -236,8 +261,8 @@ public:
     index_t** sems = SLINKY_ALLOCA(index_t*, sem_count);
     index_t* counts = SLINKY_ALLOCA(index_t, sem_count);
     for (std::size_t i = 0; i < sem_count; ++i) {
-      sems[i] = reinterpret_cast<index_t*>(eval_expr(op->args[i * 2 + 0]));
-      counts[i] = eval_expr(op->args[i * 2 + 1], 1);
+      sems[i] = reinterpret_cast<index_t*>(eval(op->args[i * 2 + 0]));
+      counts[i] = eval(op->args[i * 2 + 1], 1);
     }
     context.wait_for([=]() {
       // Check we can acquire all of the semaphores before acquiring any of them.
@@ -255,19 +280,19 @@ public:
 
   index_t eval_trace_begin(const call* op) {
     assert(op->args.size() == 1);
-    const char* name = reinterpret_cast<const char*>(eval_expr(op->args[0]));
+    const char* name = reinterpret_cast<const char*>(eval(op->args[0]));
     return context.trace_begin ? context.trace_begin(name) : 0;
   }
 
   index_t eval_trace_end(const call* op) {
     assert(op->args.size() == 1);
     if (context.trace_end) {
-      context.trace_end(eval_expr(op->args[0]));
+      context.trace_end(eval(op->args[0]));
     }
     return 1;
   }
 
-  index_t eval_free(const call* op) { 
+  index_t eval_free(const call* op) {
     assert(op->args.size() == 1);
     var sym = *as_variable(op->args[0]);
     allocated_buffer* buf = reinterpret_cast<allocated_buffer*>(*context.lookup(sym));
@@ -284,7 +309,7 @@ public:
 
     case intrinsic::abs:
       assert(op->args.size() == 1);
-      result = std::abs(eval_expr(op->args[0]));
+      result = std::abs(eval(op->args[0]));
       return;
 
     case intrinsic::buffer_rank:
@@ -319,9 +344,8 @@ public:
   }
 
   void visit(const loop* op) override {
-    index_t min = eval_expr(op->bounds.min);
-    index_t max = eval_expr(op->bounds.max);
-    index_t step = eval_expr(op->step, 1);
+    interval bounds = eval(op->bounds);
+    index_t step = eval(op->step, 1);
     if (op->max_workers > 1) {
       assert(context.enqueue_many);
       assert(context.enqueue);
@@ -335,7 +359,8 @@ public:
 
         // We want copies of these in the shared state so we can allow the worker to run after returning from this
         // scope.
-        index_t min, max, step;
+        interval bounds;
+        index_t step;
 
         // The first non-zero result is stored here.
         std::atomic<index_t> result;
@@ -359,10 +384,9 @@ public:
           working_threads.erase(i);
         }
 
-        shared_state(index_t min, index_t max, index_t step)
-            : i(min), done(min), min(min), max(max), step(step), result(0) {}
+        shared_state(interval bounds, index_t step) : i(bounds.min), done(bounds.min), bounds(bounds), step(step), result(0) {}
       };
-      auto state = std::make_shared<shared_state>(min, max, step);
+      auto state = std::make_shared<shared_state>(bounds, step);
       // It is safe to capture op even though it's a pointer, because we only access it after we know that we're still
       // in this scope.
       // TODO: Can we do this without capturing context by value?
@@ -373,7 +397,7 @@ public:
 
         while (state->result == 0) {
           index_t i = state->i.fetch_add(state->step);
-          if (!(state->min <= i && i <= state->max)) break;
+          if (!(state->bounds.min <= i && i <= state->bounds.max)) break;
 
           context[op->sym] = i;
           // Evaluate the parallel loop body with our copy of the context.
@@ -394,7 +418,8 @@ public:
       }
       worker();
       // While the loop still isn't done, work on other tasks.
-      context.wait_for([&]() { return state->result != 0 || !(min <= state->done && state->done <= max); });
+      context.wait_for(
+          [&]() { return state->result != 0 || !(bounds.min <= state->done && state->done <= bounds.max); });
       result = state->result;
     } else {
       // TODO(https://github.com/dsharlet/slinky/issues/3): We don't get a reference to context[op->sym] here
@@ -402,7 +427,7 @@ public:
       // fully traverse the expression to find the max var, and pre-allocate the context up front. It's
       // not clear this optimization is necessary yet.
       std::optional<index_t> old_value = context[op->sym];
-      for (index_t i = min; result == 0 && min <= i && i <= max; i += step) {
+      for (index_t i = bounds.min; result == 0 && bounds.min <= i && i <= bounds.max; i += step) {
         context[op->sym] = i;
         visit(op->body);
       }
@@ -431,15 +456,16 @@ public:
   void visit(const allocate* op) override {
     std::size_t rank = op->dims.size();
     allocated_buffer buffer;
-    buffer.elem_size = eval_expr(op->elem_size);
+    buffer.elem_size = eval(op->elem_size);
     buffer.rank = rank;
     buffer.dims = SLINKY_ALLOCA(dim, rank);
 
-    for (std::size_t i = 0; i < rank; ++i) {
-      slinky::dim& dim = buffer.dim(i);
-      dim.set_bounds(eval_expr(op->dims[i].min()), eval_expr(op->dims[i].max()));
-      dim.set_stride(eval_expr(op->dims[i].stride));
-      dim.set_fold_factor(eval_expr(op->dims[i].fold_factor, dim::unfolded));
+    for (std::size_t d = 0; d < rank; ++d) {
+      slinky::dim& dim = buffer.dim(d);
+      interval bounds = eval(op->dims[d].bounds);
+      dim.set_bounds(bounds.min, bounds.max);
+      dim.set_stride(eval(op->dims[d].stride));
+      dim.set_fold_factor(eval(op->dims[d].fold_factor, dim::unfolded));
     }
 
     if (op->storage == memory_type::stack) {
@@ -461,16 +487,17 @@ public:
   SLINKY_NO_STACK_PROTECTOR void visit(const make_buffer* op) override {
     std::size_t rank = op->dims.size();
     raw_buffer buffer;
-    buffer.elem_size = eval_expr(op->elem_size, 0);
-    buffer.base = reinterpret_cast<void*>(eval_expr(op->base, 0));
+    buffer.elem_size = eval(op->elem_size, 0);
+    buffer.base = reinterpret_cast<void*>(eval(op->base, 0));
     buffer.rank = rank;
     buffer.dims = SLINKY_ALLOCA(dim, rank);
 
-    for (std::size_t i = 0; i < rank; ++i) {
-      slinky::dim& dim = buffer.dim(i);
-      dim.set_bounds(eval_expr(op->dims[i].min()), eval_expr(op->dims[i].max()));
-      dim.set_stride(eval_expr(op->dims[i].stride, 0));
-      dim.set_fold_factor(eval_expr(op->dims[i].fold_factor, dim::unfolded));
+    for (std::size_t d = 0; d < rank; ++d) {
+      slinky::dim& dim = buffer.dim(d);
+      interval bounds = eval(op->dims[d].bounds);
+      dim.set_bounds(bounds.min, bounds.max);
+      dim.set_stride(eval(op->dims[d].stride, 0));
+      dim.set_fold_factor(eval(op->dims[d].fold_factor, dim::unfolded));
     }
 
     auto set_buffer = set_value_in_scope(context, op->sym, reinterpret_cast<index_t>(&buffer));
@@ -500,11 +527,6 @@ public:
     raw_buffer* buffer = reinterpret_cast<raw_buffer*>(*context.lookup(op->sym));
     assert(buffer);
 
-    struct interval {
-      index_t min;
-      index_t max;
-    };
-
     std::size_t crop_rank = op->bounds.size();
     interval* old_bounds = SLINKY_ALLOCA(interval, crop_rank);
 
@@ -516,7 +538,8 @@ public:
       old_bounds[d].min = old_min;
       old_bounds[d].max = old_max;
 
-      buffer->crop(d, eval_expr(op->bounds[d].min, old_min), eval_expr(op->bounds[d].max, old_max));
+      interval bounds = eval(op->bounds[d], {old_min, old_max});
+      buffer->crop(d, bounds.min, bounds.max);
     }
 
     visit(op->body);
@@ -536,7 +559,8 @@ public:
     index_t old_max = dim.max();
     void* old_base = buffer->base;
 
-    buffer->crop(op->dim, eval_expr(op->bounds.min, old_min), eval_expr(op->bounds.max, old_max));
+    interval bounds = eval(op->bounds, {old_min, old_max});
+    buffer->crop(op->dim, bounds.min, bounds.max);
     visit(op->body);
 
     buffer->base = old_base;
@@ -554,7 +578,7 @@ public:
     index_t offset = 0;
     for (std::size_t d = 0; d < buffer->rank; ++d) {
       if (d < op->at.size() && op->at[d].defined()) {
-        offset += buffer->dims[d].flat_offset_bytes(eval_expr(op->at[d]));
+        offset += buffer->dims[d].flat_offset_bytes(eval(op->at[d]));
       } else {
         dims[rank++] = buffer->dims[d];
       }
@@ -583,7 +607,7 @@ public:
 
     buffer->dims = SLINKY_ALLOCA(dim, buffer->rank - 1);
 
-    index_t at = eval_expr(op->at);
+    index_t at = eval(op->at);
     index_t offset = old_dims[op->dim].flat_offset_bytes(at);
     void* old_base = buffer->base;
     if (buffer->base) {
@@ -637,7 +661,7 @@ public:
   void visit(const truncate_rank* op) override { visit_maybe_shadowed(op); }
 
   void visit(const check* op) override {
-    result = eval_expr(op->condition, 0) != 0 ? 0 : 1;
+    result = eval(op->condition, 0) != 0 ? 0 : 1;
     if (result) {
       if (context.check_failed) {
         context.check_failed(op->condition);
@@ -681,7 +705,7 @@ class constant_evaluator : public expr_visitor {
 public:
   std::optional<index_t> result;
 
-  std::optional<index_t> eval_expr(const expr& e) {
+  std::optional<index_t> eval(const expr& e) {
     if (e.defined()) {
       e.accept(this);
       return result;
@@ -697,8 +721,8 @@ public:
 
   template <typename T>
   void visit_binary(const T* op) {
-    std::optional<index_t> a = eval_expr(op->a);
-    std::optional<index_t> b = eval_expr(op->b);
+    std::optional<index_t> a = eval(op->a);
+    std::optional<index_t> b = eval(op->b);
     if (a && b) {
       result = make_binary<T>(*a, *b);
     } else {
@@ -720,7 +744,7 @@ public:
   void visit(const logical_and* op) override { visit_binary(op); }
   void visit(const logical_or* op) override { visit_binary(op); }
   void visit(const logical_not* op) override {
-    std::optional<index_t> a = eval_expr(op->a);
+    std::optional<index_t> a = eval(op->a);
     if (a) {
       result = *a == 0;
     } else {
@@ -729,9 +753,9 @@ public:
   }
 
   void visit(const class select* op) override {
-    std::optional<index_t> c = eval_expr(op->condition);
-    std::optional<index_t> t = eval_expr(op->true_value);
-    std::optional<index_t> f = eval_expr(op->false_value);
+    std::optional<index_t> c = eval(op->condition);
+    std::optional<index_t> t = eval(op->true_value);
+    std::optional<index_t> f = eval(op->false_value);
     if (c && *c && t) {
       result = *t;
     } else if (c && !*c && f) {
@@ -745,7 +769,7 @@ public:
     switch (op->intrinsic) {
     case intrinsic::abs: {
       assert(op->args.size() == 1);
-      std::optional<index_t> x = eval_expr(op->args[0]);
+      std::optional<index_t> x = eval(op->args[0]);
       if (x) {
         result = std::abs(*x);
       } else {
@@ -761,6 +785,6 @@ public:
 
 }  // namespace
 
-std::optional<index_t> evaluate_constant(const expr& e) { return constant_evaluator().eval_expr(e); }
+std::optional<index_t> evaluate_constant(const expr& e) { return constant_evaluator().eval(e); }
 
 }  // namespace slinky

--- a/runtime/expr.h
+++ b/runtime/expr.h
@@ -306,6 +306,9 @@ inline interval_expr point(const expr& x) { return {x, x}; }
 inline interval_expr operator*(const expr& a, const interval_expr& b) { return b * a; }
 inline interval_expr operator+(const expr& a, const interval_expr& b) { return b + a; }
 
+expr clamp(expr x, interval_expr b);
+interval_expr select(const expr& c, interval_expr t, interval_expr f);
+
 // A box is a multidimensional interval.
 using box_expr = std::vector<interval_expr>;
 box_expr operator|(box_expr a, const box_expr& b);

--- a/runtime/expr_stmt.cc
+++ b/runtime/expr_stmt.cc
@@ -287,6 +287,18 @@ interval_expr interval_expr::operator&(const interval_expr& r) const {
   return result;
 }
 
+expr clamp(expr x, interval_expr bounds) { return clamp(std::move(x), std::move(bounds.min), std::move(bounds.max)); }
+interval_expr select(const expr& c, interval_expr t, interval_expr f) {
+  if (t.is_point() && f.is_point()) {
+    return point(select(std::move(c), std::move(t.min), std::move(f.min)));
+  } else {
+    return {
+        select(c, std::move(t.min), std::move(f.min)),
+        select(c, std::move(t.max), std::move(f.max)),
+    };
+  }
+}
+
 box_expr operator|(box_expr a, const box_expr& b) {
   assert(a.size() == b.size());
   for (std::size_t i = 0; i < a.size(); ++i) {
@@ -501,9 +513,7 @@ const expr& indeterminate() {
 expr abs(expr x) { return call::make(intrinsic::abs, {std::move(x)}); }
 expr align_down(expr x, expr a) { return (x / a) * a; }
 expr align_up(expr x, expr a) { return ((x + a - 1) / a) * a; }
-interval_expr align(interval_expr x, expr a) {
-  return {align_down(x.min, a), align_up(x.max + 1, a) - 1};
-}
+interval_expr align(interval_expr x, expr a) { return {align_down(x.min, a), align_up(x.max + 1, a) - 1}; }
 
 expr buffer_rank(expr buf) { return call::make(intrinsic::buffer_rank, {std::move(buf)}); }
 expr buffer_elem_size(expr buf) { return call::make(intrinsic::buffer_elem_size, {std::move(buf)}); }


### PR DESCRIPTION
This PR allows constructing copies that broadcast or copy in a dimension based on a runtime condition.

This PR also contains some minor refactoring/optimization of `evaluate` related to evaluating intervals that might be points.