### PR TITLE
Enable optionally broadcasted copies to alias

### DIFF
--- a/builder/optimizations.cc
+++ b/builder/optimizations.cc
@@ -160,38 +160,31 @@ public:
       var target_var = target.first;
       const buffer_alias& alias = target.second;
 
-      // Here, we're essentially constructing make_buffer(op->sym, ...) { crop_buffer(op->sym, dims_bounds(op->dims) {
-      // ... } }, but we can't do that (and just rely on the simplifier) because translated crops might require a
-      // buffer_at call that is out of bounds.
+      // Replace the allocation with a buffer using the dims the alias wants.
       stmt result =
           make_buffer::make(op->sym, buffer_at(target_var, alias.at), op->elem_size, alias.dims, std::move(body));
       // If we aliased the source and destination of a copy, replace the copy with a pad.
-      stmt pad_result = result;
-      for (const auto& i : {std::make_tuple(op->sym, target_var), std::make_tuple(target_var, op->sym)}) {
-        var src = std::get<0>(i);
-        var dst = std::get<1>(i);
-        pad_result = recursive_mutate<copy_stmt>(pad_result, [src, dst](const copy_stmt* op) {
-          if (op->src != src || op->dst != dst) {
-            // Not this copy.
-            return stmt(op);
-          }
-          if (!op->padding || op->padding->empty()) {
-            // No padding, this copy is now a no-op.
-            return stmt();
-          }
-          // Make a call to `pad`.
-          call_stmt::attributes pad_attrs;
-          pad_attrs.name = "pad";
-          return call_stmt::make(
-              [padding = *op->padding](const call_stmt* op, const eval_context& ctx) -> index_t {
-                const raw_buffer* src_buf = ctx.lookup_buffer(op->inputs[0]);
-                const raw_buffer* dst_buf = ctx.lookup_buffer(op->outputs[0]);
-                ctx.pad(src_buf->dims, *dst_buf, padding.data());
-                return 0;
-              },
-              {src}, {dst}, std::move(pad_attrs));
-        });
-      }
+      stmt pad_result = recursive_mutate<copy_stmt>(result, [a = op->sym, b = target_var](const copy_stmt* op) {
+        if (!((op->src == a && op->dst == b) || (op->src == b && op->dst == a))) {
+          // Not this copy.
+          return stmt(op);
+        }
+        if (!op->padding || op->padding->empty()) {
+          // No padding, this copy is now a no-op.
+          return stmt();
+        }
+        // Make a call to `pad`.
+        call_stmt::attributes pad_attrs;
+        pad_attrs.name = "pad";
+        return call_stmt::make(
+            [padding = *op->padding](const call_stmt* op, const eval_context& ctx) -> index_t {
+              const raw_buffer* src_buf = ctx.lookup_buffer(op->inputs[0]);
+              const raw_buffer* dst_buf = ctx.lookup_buffer(op->outputs[0]);
+              ctx.pad(src_buf->dims, *dst_buf, padding.data());
+              return 0;
+            },
+            {op->src}, {op->dst}, std::move(pad_attrs));
+      });
       if (pad_result.same_as(result)) {
         // This wasn't a copy, we actually did some computation in place. We can't alias another buffer to this target
         // without understanding the lifetimes more carefully.

--- a/builder/optimizations.cc
+++ b/builder/optimizations.cc
@@ -43,6 +43,7 @@ bool is_copy(expr src_x, var dst_x, expr& offset, expr& stride) {
     offset = 0;
     return true;
   } else {
+    // If the difference of src_x and dst_x does not depend on dst_x, it's a simple copy.
     offset = simplify(src_x - dst_x);
     return !depends_on(offset, dst_x).any();
   }
@@ -79,7 +80,7 @@ bool is_copy(
       return false;
     }
 
-    if (src_d == -1) {
+    if (src_d < 0) {
       // This is a broadcast.
       offset[dst_d] = 0;
       stride[dst_d] = 0;

--- a/builder/optimizations.cc
+++ b/builder/optimizations.cc
@@ -223,10 +223,8 @@ public:
         }
         buffer_alias a;
         for (index_t d = 0; d < static_cast<index_t>(info->dims.size()); ++d) {
-          dim_expr a_dim = buffer_dim(o, d);
-          a_dim.bounds = a_dim.bounds & info->dims[d].bounds;
-          a.dims.push_back(a_dim);
-          a.at.push_back(a_dim.bounds.min);
+          a.dims.push_back(buffer_dim(o, d));
+          a.at.push_back(buffer_min(o, d));
         }
 
         info->maybe_alias(o, std::move(a));

--- a/builder/optimizations.h
+++ b/builder/optimizations.h
@@ -5,7 +5,9 @@
 
 namespace slinky {
 
-// Where possible, rewrite copies as buffer metadata rewrites.
+// Where possible, replace `allocate` with `make_buffer` referring to another buffer with appropriate metadata:
+// - `copy_stmt`s that only do simple copies or broadcasts in each dimension.
+// - `call_stmt`s that can be in-place may be able to replace an allocation for the output with an alias of an input.
 stmt alias_buffers(const stmt& s);
 
 // Given a copy_stmt, produce an implementation that calls `slinky::copy`, possibly inside loops that implement copy

--- a/builder/simplify.cc
+++ b/builder/simplify.cc
@@ -533,6 +533,7 @@ public:
     for (std::size_t d = 0; d < op->dims.size(); ++d) {
       interval_expr bounds_d = mutate(op->dims[d].bounds);
       dim_expr new_dim = {bounds_d, mutate(op->dims[d].stride), mutate(op->dims[d].fold_factor)};
+      if (is_constant(new_dim.fold_factor, dim::unfolded)) new_dim.fold_factor = expr();
       changed = changed || !new_dim.same_as(op->dims[d]);
       dims.push_back(std::move(new_dim));
       bounds.push_back(std::move(bounds_d));
@@ -580,6 +581,7 @@ public:
     for (std::size_t d = 0; d < op->dims.size(); ++d) {
       interval_expr new_bounds = mutate(op->dims[d].bounds);
       dim_expr new_dim = {new_bounds, mutate(op->dims[d].stride), mutate(op->dims[d].fold_factor)};
+      if (is_constant(new_dim.fold_factor, dim::unfolded)) new_dim.fold_factor = expr();
       changed = changed || !new_dim.same_as(op->dims[d]);
       dims.push_back(std::move(new_dim));
       bounds.push_back(std::move(new_bounds));

--- a/builder/simplify_exprs.cc
+++ b/builder/simplify_exprs.cc
@@ -655,6 +655,7 @@ expr simplify(const equal* op, expr a, expr b) {
   auto r = make_rewriter(pattern_expr{a} == pattern_expr{b});
   // clang-format off
   if (r.rewrite(x == x, true) ||
+      r.rewrite(x - y == 0, x == y) ||
       r.rewrite(x * y == x * z, y == z || x == 0) ||
       r.rewrite(x == x * y, y == 1 || x == 0) ||
       r.rewrite(x + y == z + y, x == z) ||

--- a/builder/slide_and_fold_storage.cc
+++ b/builder/slide_and_fold_storage.cc
@@ -120,6 +120,7 @@ public:
 };
 
 bool is_produced_by(var v, const stmt& body) {
+  if (!body.defined()) return false;
   check_if_produced f(v);
   body.accept(&f);
   return f.found;

--- a/builder/test/copy.cc
+++ b/builder/test/copy.cc
@@ -1,7 +1,6 @@
 #include <gtest/gtest.h>
 
 #include <cassert>
-#include <numeric>
 #include <vector>
 
 #include "builder/pipeline.h"
@@ -391,21 +390,6 @@ INSTANTIATE_TEST_SUITE_P(schedule, transpose,
         std::vector<int>{1, 2}, std::vector<int>{2, 1}, std::vector<int>{0, 1, 2}, std::vector<int>{2, 1, 0},
         std::vector<int>{1, 0, 2}, std::vector<int>{0, 0, 0}, std::vector<int>{1, 1, 1}, std::vector<int>{2, 2, 2},
         std::vector<int>{1, 0, 2}, std::vector<int>{0, 0, 0}, std::vector<int>{0, 0, 1}));
-
-template <typename T>
-std::vector<T> permute(span<const int> p, const std::vector<T>& x) {
-  std::vector<T> result(p.size());
-  for (std::size_t i = 0; i < p.size(); ++i) {
-    result[i] = x[p[i]];
-  }
-  return result;
-}
-
-bool is_permutation(span<const int> p) {
-  std::vector<int> unpermuted(p.size());
-  std::iota(unpermuted.begin(), unpermuted.end(), 0);
-  return std::is_permutation(p.begin(), p.end(), unpermuted.begin());
-}
 
 TEST_P(transpose, copy) {
   std::vector<int> permutation = GetParam();

--- a/builder/test/copy.cc
+++ b/builder/test/copy.cc
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 
 #include <cassert>
+#include <numeric>
 #include <vector>
 
 #include "builder/pipeline.h"
@@ -398,6 +399,12 @@ std::vector<T> permute(span<const int> p, const std::vector<T>& x) {
   return result;
 }
 
+bool is_permutation(span<const int> p) {
+  std::vector<int> unpermuted(p.size());
+  std::iota(unpermuted.begin(), unpermuted.end(), 0);
+  return std::is_permutation(p.begin(), p.end(), unpermuted.begin());
+}
+
 TEST_P(transpose, copy) {
   std::vector<int> permutation = {std::get<0>(GetParam()), std::get<1>(GetParam()), std::get<2>(GetParam())};
 
@@ -437,7 +444,9 @@ TEST_P(transpose, copy) {
     }
   }
 
-  ASSERT_EQ(eval_ctx.copy_calls, 1);
+  if (is_permutation(permutation)) {
+    ASSERT_EQ(eval_ctx.copy_calls, 1);
+  }
 }
 
 class broadcast : public testing::TestWithParam<int> {};

--- a/builder/test/copy.cc
+++ b/builder/test/copy.cc
@@ -272,12 +272,14 @@ TEST(flip_x, copy) {
   const raw_buffer* outputs[] = {&out_buf};
   test_context eval_ctx;
   p.evaluate(inputs, outputs, eval_ctx);
-  ASSERT_EQ(eval_ctx.copy_calls, W);
-  ASSERT_EQ(eval_ctx.copy_elements, W);
 
   for (int x = 0; x < W; ++x) {
     ASSERT_EQ(out_buf(-x), in_buf(x));
   }
+
+  // TODO: This could be expressed with a single copy with a negative stride.
+  ASSERT_EQ(eval_ctx.copy_calls, W);
+  ASSERT_EQ(eval_ctx.copy_elements, W);
 }
 
 class flip_y : public testing::TestWithParam<int> {};

--- a/builder/test/copy_pipeline.cc
+++ b/builder/test/copy_pipeline.cc
@@ -242,11 +242,13 @@ TEST_P(concatenated_result, pipeline) {
   }
 }
 
-class transposed_result : public testing::TestWithParam<std::tuple<bool, std::vector<int>>> {};
+class transposed_result : public testing::TestWithParam<std::tuple<bool, int, int, int>> {};
+
+auto iota3 = testing::Values(0, 1, 2);
 
 INSTANTIATE_TEST_SUITE_P(schedule, transposed_result,
-    testing::Combine(testing::Values(false, true), testing::Values(std::vector<int>{0, 1, 2}, std::vector<int>{0, 2, 1},
-                                                       std::vector<int>{1, 2, 0}, std::vector<int>{0, 0, 0})));
+    testing::Combine(testing::Values(false, true), iota3, iota3, iota3),
+    test_params_to_string<transposed_result::ParamType>);
 
 template <typename T>
 std::vector<T> permute(span<const int> p, const std::vector<T>& x) {
@@ -265,7 +267,7 @@ bool is_permutation(span<const int> p) {
 
 TEST_P(transposed_result, pipeline) {
   bool no_alias_buffers = std::get<0>(GetParam());
-  const std::vector<int>& permutation = std::get<1>(GetParam());
+  std::vector<int> permutation = {std::get<1>(GetParam()), std::get<2>(GetParam()), std::get<3>(GetParam())};
 
   // Make the pipeline
   node_context ctx;

--- a/builder/test/copy_pipeline.cc
+++ b/builder/test/copy_pipeline.cc
@@ -1,7 +1,5 @@
 #include <gtest/gtest.h>
 
-#include <numeric>
-
 #include "base/test/bazel_util.h"
 #include "builder/pipeline.h"
 #include "builder/replica_pipeline.h"
@@ -253,21 +251,6 @@ auto iota3 = testing::Values(0, 1, 2);
 INSTANTIATE_TEST_SUITE_P(schedule, transposed_result,
     testing::Combine(testing::Values(false, true), iota3, iota3, iota3),
     test_params_to_string<transposed_result::ParamType>);
-
-template <typename T>
-std::vector<T> permute(span<const int> p, const std::vector<T>& x) {
-  std::vector<T> result(x.size());
-  for (std::size_t i = 0; i < x.size(); ++i) {
-    result[i] = x[p[i]];
-  }
-  return result;
-}
-
-bool is_permutation(span<const int> p) {
-  std::vector<int> unpermuted(p.size());
-  std::iota(unpermuted.begin(), unpermuted.end(), 0);
-  return std::is_permutation(p.begin(), p.end(), unpermuted.begin());
-}
 
 TEST_P(transposed_result, pipeline) {
   bool no_alias_buffers = std::get<0>(GetParam());

--- a/builder/test/pipeline.cc
+++ b/builder/test/pipeline.cc
@@ -112,11 +112,12 @@ TEST_P(trivial, pipeline) {
   const raw_buffer* outputs[] = {&out_buf};
   test_context eval_ctx;
   p.evaluate(inputs, outputs, eval_ctx);
-  ASSERT_EQ(eval_ctx.heap.total_size, 0);
 
   for (int i = 0; i < N; ++i) {
     ASSERT_EQ(out_buf(i), 2 * i);
   }
+
+  ASSERT_EQ(eval_ctx.heap.total_size, 0);
 }
 
 class elementwise : public testing::TestWithParam<std::tuple<int, int, bool>> {};
@@ -178,12 +179,13 @@ TEST_P(elementwise, pipeline_1d) {
   const raw_buffer* outputs[] = {&out_buf};
   test_context eval_ctx;
   p.evaluate(inputs, outputs, eval_ctx);
-  if (schedule_storage) {
-    ASSERT_EQ(eval_ctx.heap.total_count, 0);  // The intermediate only needs stack.
-  }
 
   for (int i = 0; i < N; ++i) {
     ASSERT_EQ(out_buf(i), 2 * i + 1);
+  }
+
+  if (schedule_storage) {
+    ASSERT_EQ(eval_ctx.heap.total_count, 0);  // The intermediate only needs stack.
   }
 }
 
@@ -243,16 +245,17 @@ TEST_P(elementwise, pipeline_2d) {
   const raw_buffer* outputs[] = {&out_buf};
   test_context eval_ctx;
   p.evaluate(inputs, outputs, eval_ctx);
-  if (schedule_storage) {
-    ASSERT_EQ(eval_ctx.heap.total_count, 0);  // The intermediate only needs stack.
-  } else {
-    ASSERT_EQ(eval_ctx.heap.total_count, 0);  // The buffers should alias.
-  }
 
   for (int y = 0; y < H; ++y) {
     for (int x = 0; x < W; ++x) {
       ASSERT_EQ(out_buf(x, y), 2 * (y * W + x) + 1);
     }
+  }
+
+  if (schedule_storage) {
+    ASSERT_EQ(eval_ctx.heap.total_count, 0);  // The intermediate only needs stack.
+  } else {
+    ASSERT_EQ(eval_ctx.heap.total_count, 0);  // The buffers should alias.
   }
 }
 
@@ -331,9 +334,6 @@ TEST_P(matmuls, pipeline) {
   const raw_buffer* outputs[] = {&abc_buf};
   test_context eval_ctx;
   p.evaluate(inputs, outputs, eval_ctx);
-  if (split > 0 && max_workers == loop::serial) {
-    ASSERT_EQ(eval_ctx.heap.total_size, N * sizeof(int) * split);
-  }
 
   buffer<int, 2> ref_ab({N, M});
   buffer<int, 2> ref_abc({N, M});
@@ -347,6 +347,10 @@ TEST_P(matmuls, pipeline) {
     for (int j = 0; j < N; ++j) {
       ASSERT_EQ(ref_abc(j, i), abc_buf(j, i));
     }
+  }
+
+  if (split > 0 && max_workers == loop::serial) {
+    ASSERT_EQ(eval_ctx.heap.total_size, N * sizeof(int) * split);
   }
 
   if (split == 1 && max_workers == loop::serial) {
@@ -407,11 +411,6 @@ TEST_P(stencil, pipeline) {
   const raw_buffer* outputs[] = {&out_buf};
   test_context eval_ctx;
   p.evaluate(inputs, outputs, eval_ctx);
-  if (split > 0) {
-    const int parallel_extra = max_workers != loop::serial ? split : 0;
-    ASSERT_EQ(eval_ctx.heap.total_size, (W + 2) * align_up(split + parallel_extra + 2, split) * sizeof(short));
-  }
-  ASSERT_EQ(eval_ctx.heap.total_count, 1);
 
   for (int y = 0; y < H; ++y) {
     for (int x = 0; x < W; ++x) {
@@ -425,6 +424,12 @@ TEST_P(stencil, pipeline) {
     }
   }
 
+  if (split > 0) {
+    const int parallel_extra = max_workers != loop::serial ? split : 0;
+    ASSERT_EQ(eval_ctx.heap.total_size, (W + 2) * align_up(split + parallel_extra + 2, split) * sizeof(short));
+  }
+  ASSERT_EQ(eval_ctx.heap.total_count, 1);
+
   // Also visualize this pipeline.
   if (max_workers == loop::serial && split_intermediate == 0) {
     check_visualize("stencil_split_" + std::to_string(split) + ".html", p, inputs, outputs, &ctx);
@@ -433,8 +438,8 @@ TEST_P(stencil, pipeline) {
 
 class slide_2d : public testing::TestWithParam<std::tuple<int, int, bool>> {};
 
-INSTANTIATE_TEST_SUITE_P(
-    split_split_mode, slide_2d, testing::Combine(loop_modes, loop_modes, testing::Values(false, true)), test_params_to_string<slide_2d::ParamType>);
+INSTANTIATE_TEST_SUITE_P(split_split_mode, slide_2d,
+    testing::Combine(loop_modes, loop_modes, testing::Values(false, true)), test_params_to_string<slide_2d::ParamType>);
 
 TEST_P(slide_2d, pipeline) {
   int max_workers_x = std::get<0>(GetParam());
@@ -485,9 +490,6 @@ TEST_P(slide_2d, pipeline) {
   const raw_buffer* outputs[] = {&out_buf};
   test_context eval_ctx;
   p.evaluate(inputs, outputs, eval_ctx);
-  ASSERT_EQ(eval_ctx.heap.total_size, (W + 2) * 3 * sizeof(short));
-  ASSERT_EQ(eval_ctx.heap.total_count, 1);
-  ASSERT_EQ(add_count, (W + 2) * (H + 2));
 
   for (int y = 0; y < H; ++y) {
     for (int x = 0; x < W; ++x) {
@@ -500,6 +502,10 @@ TEST_P(slide_2d, pipeline) {
       ASSERT_EQ(correct, out_buf(x, y)) << x << " " << y;
     }
   }
+
+  ASSERT_EQ(eval_ctx.heap.total_size, (W + 2) * 3 * sizeof(short));
+  ASSERT_EQ(eval_ctx.heap.total_count, 1);
+  ASSERT_EQ(add_count, (W + 2) * (H + 2));
 }
 
 class stencil_chain : public testing::TestWithParam<std::tuple<int, int>> {};
@@ -557,13 +563,6 @@ TEST_P(stencil_chain, pipeline) {
 
   p.evaluate(inputs, outputs, eval_ctx);
 
-  if (split > 0) {
-    const int parallel_extra = max_workers != loop::serial ? split * 2 : 0;
-    ASSERT_EQ(eval_ctx.heap.total_size, (W + 2) * align_up(split + parallel_extra + 2, split) * sizeof(short) +
-                                            (W + 4) * align_up(split + parallel_extra + 2, split) * sizeof(short));
-  }
-  ASSERT_EQ(eval_ctx.heap.total_count, 2);
-
   // Run the pipeline stages manually to get the reference result.
   buffer<short, 2> ref_intm({W + 4, H + 4});
   buffer<short, 2> ref_intm2({W + 2, H + 2});
@@ -583,6 +582,13 @@ TEST_P(stencil_chain, pipeline) {
       ASSERT_EQ(ref_out(x, y), out_buf(x, y));
     }
   }
+
+  if (split > 0) {
+    const int parallel_extra = max_workers != loop::serial ? split * 2 : 0;
+    ASSERT_EQ(eval_ctx.heap.total_size, (W + 2) * align_up(split + parallel_extra + 2, split) * sizeof(short) +
+                                            (W + 4) * align_up(split + parallel_extra + 2, split) * sizeof(short));
+  }
+  ASSERT_EQ(eval_ctx.heap.total_count, 2);
 
   // Also visualize this pipeline.
   if (max_workers == loop::serial) {
@@ -793,9 +799,6 @@ TEST(unrelated, pipeline) {
   test_context eval_ctx;
   p.evaluate(inputs, outputs, eval_ctx);
 
-  ASSERT_EQ(eval_ctx.heap.total_size, (W1 + 2) * 4 * sizeof(short));
-  ASSERT_EQ(eval_ctx.heap.total_count, 1);  // intm2 aliased to out2.
-
   for (int y = 0; y < H1; ++y) {
     for (int x = 0; x < W1; ++x) {
       int correct = 0;
@@ -811,6 +814,9 @@ TEST(unrelated, pipeline) {
   for (int i = 0; i < N2; ++i) {
     ASSERT_EQ(out2_buf(i), 2 * i + 1);
   }
+
+  ASSERT_EQ(eval_ctx.heap.total_size, (W1 + 2) * 4 * sizeof(short));
+  ASSERT_EQ(eval_ctx.heap.total_count, 1);  // intm2 aliased to out2.
 }
 
 class padded_stencil : public testing::TestWithParam<int> {};
@@ -861,12 +867,6 @@ TEST_P(padded_stencil, pipeline) {
   const raw_buffer* outputs[] = {&out_buf};
   test_context eval_ctx;
   p.evaluate(inputs, outputs, eval_ctx);
-  if (schedule == 2) {
-    // TODO: We need to be able to find the upper bound of
-    // max((x + 1), buffer_min(a, b)) - min((x + 1), buffer_max(a, b)) to fold this.
-    // ASSERT_EQ(eval_ctx.heap.total_size, W * 2 * sizeof(short) + (W + 2) * 3 * sizeof(short));
-    ASSERT_EQ(eval_ctx.heap.total_count, 2);
-  }
 
   for (int y = 0; y < H; ++y) {
     for (int x = 0; x < W; ++x) {
@@ -882,6 +882,13 @@ TEST_P(padded_stencil, pipeline) {
       }
       ASSERT_EQ(correct, out_buf(x, y)) << x << " " << y;
     }
+  }
+
+  if (schedule == 2) {
+    // TODO: We need to be able to find the upper bound of
+    // max((x + 1), buffer_min(a, b)) - min((x + 1), buffer_max(a, b)) to fold this.
+    // ASSERT_EQ(eval_ctx.heap.total_size, W * 2 * sizeof(short) + (W + 2) * 3 * sizeof(short));
+    ASSERT_EQ(eval_ctx.heap.total_count, 2);
   }
 
   // Also visualize this pipeline.

--- a/builder/test/util.h
+++ b/builder/test/util.h
@@ -2,6 +2,7 @@
 #define SLINKY_BUILDER_TEST_UTIL_H
 
 #include <fstream>
+#include <numeric>
 #include <string>
 
 #include <gtest/gtest.h>
@@ -41,6 +42,21 @@ inline std::string read_entire_file(const std::string& pathname) {
   std::stringstream buffer;
   buffer << f.rdbuf();
   return remove_windows_newlines(buffer.str());
+}
+
+template <typename T>
+std::vector<T> permute(span<const int> p, const std::vector<T>& x) {
+  std::vector<T> result(p.size());
+  for (std::size_t i = 0; i < p.size(); ++i) {
+    result[i] = x[p[i]];
+  }
+  return result;
+}
+
+inline bool is_permutation(span<const int> p) {
+  std::vector<int> unpermuted(p.size());
+  std::iota(unpermuted.begin(), unpermuted.end(), 0);
+  return std::is_permutation(p.begin(), p.end(), unpermuted.begin());
 }
 
 }  // namespace slinky

--- a/runtime/buffer.cc
+++ b/runtime/buffer.cc
@@ -124,7 +124,11 @@ void copy_impl(raw_buffer& src, raw_buffer& dst, const void* padding) {
   index_t elem_size = dst.elem_size;
 
   if (rank == 0) {
-    memcpy(dst.base, src.base, elem_size);
+    if (src.base) {
+      memcpy(dst.base, src.base, elem_size);
+    } else if (padding) {
+      memcpy(dst.base, padding, elem_size);
+    }
     return;
   }
 

--- a/runtime/buffer.h
+++ b/runtime/buffer.h
@@ -472,7 +472,7 @@ void fill(const raw_buffer& dst, const void* value);
 
 // Returns true if the two dimensions can be fused.
 inline bool can_fuse(const dim& inner, const dim& outer) {
-  if (outer.extent() == 1) return true;
+  if (outer.extent() == 1 && outer.stride() != 0) return true;
   if (inner.fold_factor() != dim::unfolded) return false;
   if (inner.stride() * inner.extent() != outer.stride()) return false;
   return true;

--- a/runtime/buffer.h
+++ b/runtime/buffer.h
@@ -239,7 +239,11 @@ public:
   raw_buffer& slice(std::size_t d) { return slice({d}); }
   raw_buffer& slice(std::size_t d, index_t at) {
     if (base != nullptr) {
-      base = offset_bytes(base, dim(d).flat_offset_bytes(at));
+      if (dim(d).contains(at)) {
+        base = offset_bytes(base, dim(d).flat_offset_bytes(at));
+      } else {
+        base = nullptr;
+      }
     }
     return slice({d});
   }


### PR DESCRIPTION
This PR is a bunch of changes that enable optionally broadcasted copies from #294 to alias when possible:
- `slice_buffer` and `slice_dim` can now slice out of bounds, which makes the buffer base null. This makes it consistent with `for_each_element` and related helpers, which is necessary to make `copy_stmt` implementations correct when not doing any of the optimizations for copies.
- Attempt to alias copies for the case that either the `src` or `dst` is an allocation.
- Expand `is_copy`'s ability to understand these dynamic broadcast or copy copies.
- A whole lot of refactoring of aliases/copy implementation passes. I think there were a few bug fixes in here. I hope to clean this up further still, this code is too hard to understand currently. I think it can be improved a lot once I better understand what it's doing.

Now that we can do broadcasts properly and cheaply, I intend to go back and clean out all the stride 0 hacks in the code in a follow-up change.