### PR TITLE
Clean up alias_buffers and remove broadcasting hacks

### DIFF
--- a/builder/optimizations.cc
+++ b/builder/optimizations.cc
@@ -22,31 +22,61 @@ namespace slinky {
 
 namespace {
 
+dim_expr select(const expr& c, dim_expr t, dim_expr f) {
+  // dim_expr allows fold_factor to be undefined to indicate `unfolded`, but we can't rely on that here.
+  if (!t.fold_factor.defined()) t.fold_factor = dim::unfolded;
+  if (!f.fold_factor.defined()) f.fold_factor = dim::unfolded;
+  return {
+      select(c, std::move(t.bounds), std::move(f.bounds)),
+      select(c, std::move(t.stride), std::move(f.stride)),
+      select(c, std::move(t.fold_factor), std::move(f.fold_factor)),
+  };
+}
+
 // Checks if the copy operands `src_x` and `dst_x` represent a simple copy that can be handled by slinky::copy.
-bool is_copy(expr src_x, var dst_x, expr& offset, expr& stride) {
+bool is_copy(var src, expr src_x, int src_d, var dst, var dst_x, int dst_d, expr& at, dim_expr& src_dim) {
   if (const class select* s = src_x.as<class select>()) {
     // The src is a select of two things that might both be copies.
-    expr offset_t = offset;
-    expr offset_f = offset;
-    expr stride_t = stride;
-    expr stride_f = stride;
-    if (is_copy(s->true_value, dst_x, offset_t, stride_t) && is_copy(s->false_value, dst_x, offset_f, stride_f)) {
-      offset = select(s->condition, offset_t, offset_f);
-      stride = select(s->condition, stride_t, stride_f);
+    expr at_t = at;
+    expr at_f = at;
+    dim_expr src_dim_t = src_dim;
+    dim_expr src_dim_f = src_dim;
+    if (is_copy(src, s->true_value, src_d, dst, dst_x, dst_d, at_t, src_dim_t) &&
+        is_copy(src, s->false_value, src_d, dst, dst_x, dst_d, at_f, src_dim_f)) {
+      at = select(s->condition, at_t, at_f);
+      src_dim = select(s->condition, src_dim_t, src_dim_f);
       return true;
     } else {
       return false;
     }
+  } else if (src_d < 0) {
+    // This is a broadcast because the dst dim is unused in any src dim.
+    src_dim.stride = 0;
+    src_dim.fold_factor = dim::unfolded;
+    return true;
   } else if (!depends_on(src_x, dst_x).any()) {
-    // This is a broadcast.
-    stride = 0;
-    offset = 0;
+    // This is a broadcast because the src_x is constant w.r.t. dst_x.
+    at = src_x;
+    src_dim.stride = 0;
+    src_dim.fold_factor = dim::unfolded;
     return true;
   } else {
-    // If the difference of src_x and dst_x does not depend on dst_x, it's a simple copy.
-    offset = simplify(src_x - dst_x);
-    return !depends_on(offset, dst_x).any();
+    expr offset = simplify(src_x - dst_x);
+    if (!depends_on(offset, dst_x).any()) {
+      // The difference of src_x and dst_x does not depend on dst_x, it's a simple copy.
+      src_dim.bounds &= (buffer_bounds(src, src_d) - offset);
+      at = src_dim.bounds.min + offset;
+      return true;
+    } else {
+      return false;
+    }
   }
+}
+
+bool is_copy(const copy_stmt* op, int src_d, int dst_d, expr& at, dim_expr& src_dim) {
+  // We might not have an src dim if we're trying to broadcast.
+  expr src_x = src_d >= 0 ? op->src_x[src_d] : expr();
+  return is_copy(op->src, src_x, src_d, op->dst, op->dst_x[dst_d], dst_d, at, src_dim);
 }
 
 // `dst_d` may be a copy dim of `op` if it is used by exactly one src dim, where it might be a copy, or zero src dims,
@@ -66,10 +96,10 @@ bool is_copy_dst_dim(const copy_stmt* op, int dst_d, int& src_d) {
   return true;
 }
 
-std::vector<expr> buffer_strides(var buf, int rank) {
+std::vector<expr> buffer_mins(var buf, std::size_t rank) {
   std::vector<expr> result(rank);
-  for (int d = 0; d < rank; ++d) {
-    result[d] = buffer_stride(buf, d);
+  for (int i = 0; i < static_cast<int>(rank); ++i) {
+    result[i] = buffer_min(buf, i);
   }
   return result;
 }
@@ -137,6 +167,8 @@ public:
       // Replace the allocation with a buffer using the dims the alias wants.
       stmt result =
           make_buffer::make(op->sym, buffer_at(target_var, alias.at), op->elem_size, alias.dims, std::move(body));
+      // The alias might have used buffer metadata from the original, add a buffer for it.
+      result = make_buffer::make(op->sym, {}, op->elem_size, op->dims, std::move(result));
       // If we aliased the source and destination of a copy, replace the copy with a pad.
       stmt pad_result = recursive_mutate<copy_stmt>(result, [a = op->sym, b = target_var](const copy_stmt* op) {
         if (!((op->src == a && op->dst == b) || (op->src == b && op->dst == a))) {
@@ -167,8 +199,12 @@ public:
         // region. That will likely be very difficult to do symbolically.
         for (std::optional<buffer_info>& i : alias_info) {
           if (!i) continue;
-          i->do_not_alias(target.first);
+          i->do_not_alias(target_var);
         }
+      }
+      // We might have thought we could alias this both ways (src -> dst and dst -> src), we only want to do one of them.
+      if (alias_info[target_var]) {
+        alias_info[target_var]->do_not_alias(op->sym);
       }
       set_result(pad_result);
     } else if (!body.same_as(op->body)) {
@@ -176,31 +212,34 @@ public:
     } else {
       set_result(op);
     }
+
+    // When an allocation goes out of scope, we should remove it as an aliasing candidate.
+    for (std::optional<buffer_info>& i : alias_info) {
+      if (i) i->do_not_alias(op->sym);
+    }
+  }
+
+  bool can_alias(var x) {
+    std::optional<bool> no_alias = do_not_alias[x];
+    return !no_alias || !*no_alias;
   }
 
   void visit(const call_stmt* op) override {
     set_result(op);
+    if (!op->attrs.allow_in_place) {
+      // This call does not allow aliasing an input to an output.
+      return;
+    }
     for (var o : op->outputs) {
-      std::optional<bool> no_alias = do_not_alias[o];
-      if (no_alias && *no_alias) {
-        continue;
-      }
-
+      if (!can_alias(o)) continue;
       for (var i : op->inputs) {
-        std::optional<buffer_info>& info = alias_info[i];
-        if (!info) continue;
-
-        if (!op->attrs.allow_in_place) {
-          info->do_not_alias(o);
-          return;
+        std::optional<buffer_info>& input_info = alias_info[i];
+        if (input_info) {
+          buffer_alias a;
+          a.dims = buffer_dims(o, input_info->dims.size());
+          a.at = buffer_mins(o, input_info->dims.size());
+          input_info->maybe_alias(o, std::move(a));
         }
-        buffer_alias a;
-        for (index_t d = 0; d < static_cast<index_t>(info->dims.size()); ++d) {
-          a.dims.push_back(buffer_dim(o, d));
-          a.at.push_back(buffer_min(o, d));
-        }
-
-        info->maybe_alias(o, std::move(a));
       }
     }
   }
@@ -208,80 +247,79 @@ public:
   void visit(const copy_stmt* op) override {
     set_result(op);
 
-    std::optional<bool> no_alias = do_not_alias[op->dst];
-    if (no_alias && *no_alias) {
-      return;
-    }
-
-    var source, target;
-    if (alias_info[op->src]) {
-      // We allocated the src. We might be able to replace the allocation with an alias of the dst.
-      source = op->src;
-      target = op->dst;
-    } else if (alias_info[op->dst]) {
+    if (alias_info[op->dst] && can_alias(op->src)) {
       // We allocated the dst. We might be able to replace the allocation with an alias of the src.
-      source = op->dst;
-      target = op->src;
-    } else {
-      return;
-    }
+      // This case is a straightforward use of is_copy, which produces the dims that should be the src of a copy, which
+      // are the same dimensions we want the dst to be.
+      std::optional<buffer_info>& info = alias_info[op->dst];
 
-    // TODO: This visitor is a nightmare and I'm pretty sure it has many bugs. It needs a rewrite.
-    // It does work for many tests though.
+      buffer_alias a;
+      a.at.resize(op->src_x.size());
+      a.dims = info->dims;
+      bool alias_valid = true;
+      for (int dst_d = 0; dst_d < static_cast<int>(op->dst_x.size()); ++dst_d) {
+        int src_d;
+        if (!is_copy_dst_dim(op, dst_d, src_d)) {
+          alias_valid = false;
+          break;
+        }
 
-    std::optional<buffer_info>& info = alias_info[source];
-
-    std::vector<std::optional<std::size_t>> permutation;
-    std::vector<expr> offset;
-    std::vector<expr> stride = buffer_strides(target, info->dims.size());
-
-    offset.resize(op->dst_x.size());
-    stride.resize(op->dst_x.size());
-    assert(permutation.empty());
-    permutation.resize(op->dst_x.size());
-    for (std::size_t dst_d = 0; dst_d < op->dst_x.size(); ++dst_d) {
-      int src_d;
-      if (!is_copy_dst_dim(op, dst_d, src_d)) {
-        return;
-      }
-
-      if (src_d < 0) {
-        // This is a broadcast.
-        offset[dst_d] = 0;
-        stride[dst_d] = 0;
-      } else if (is_copy(op->src_x[src_d], op->dst_x[dst_d], offset[dst_d], stride[dst_d])) {
-        permutation[src_d] = dst_d;
-      } else {
-        return;
-      }
-    }
-
-    buffer_alias a;
-    a.dims.resize(info->dims.size());
-    for (std::size_t d = 0; d < a.dims.size(); ++d) {
-      if (d < permutation.size() && permutation[d]) {
-        // This dimension is a copy of the input dimension.
-        a.dims[d] = buffer_dim(target, static_cast<int>(*permutation[d]));
-        a.dims[d].bounds &= info->dims[d].bounds;
-        a.dims[d].stride = stride[*permutation[d]];
-      } else {
-        // This dimension is a broadcast.
-        a.dims[d].bounds = info->dims[d].bounds;
-        a.dims[d].stride = 0;
-      }
-    }
-    a.at = std::move(offset);
-    a.at.resize(std::max(a.at.size(), a.dims.size()));
-    for (int d = 0; d < static_cast<int>(a.at.size()); ++d) {
-      if (d < static_cast<int>(info->dims.size())) {
-        if (!a.at[d].defined()) {
-          a.at[d] = max(buffer_min(target, d), info->dims[d].bounds.min);
-        } else {
-          a.at[d] = max(buffer_min(target, d) - a.at[d], info->dims[d].bounds.min);
+        expr at_unused;
+        expr& at = src_d >= 0 ? a.at[src_d] : at_unused;
+        if (!is_copy(op, src_d, dst_d, at, a.dims[dst_d])) {
+          alias_valid = false;
+          break;
         }
       }
+      if (alias_valid) {
+        info->maybe_alias(op->src, std::move(a));
+      }
     }
-    info->maybe_alias(target, std::move(a));
+    if (alias_info[op->src] && can_alias(op->dst)) {
+      // We allocated the src. We might be able to replace the allocation with an alias of the dst.
+      // In this case, we're going to make the src an alias of another buffer. We're more limited in what we can do here
+      // vs. the above case, because we can't expect producers to handle everything the copy is doing (such as
+      // broadcasting).
+      std::optional<buffer_info>& info = alias_info[op->src];
+
+      buffer_alias a;
+      a.at.resize(op->dst_x.size());
+      a.dims.resize(op->src_x.size());
+      assert(op->src_x.size() == info->dims.size());
+      for (int dst_d = 0; dst_d < static_cast<int>(op->dst_x.size()); ++dst_d) {
+        int src_d;
+        if (!is_copy_dst_dim(op, dst_d, src_d)) {
+          return;
+        }
+
+        if (src_d < 0) {
+          // We can't handle a broadcast here, because we can't ask the producer of our src to produce more dimensions.
+          return;
+        }
+
+        expr offset = simplify(op->src_x[src_d] - op->dst_x[dst_d]);
+        if (depends_on(offset, op->dst_x[dst_d]).any()) {
+          // This is not a simple copy, we can't handle it here.
+          return;
+        }
+
+        a.dims[src_d] = {
+            buffer_bounds(op->dst, dst_d) & info->dims[src_d].bounds,
+            buffer_stride(op->dst, dst_d),
+            buffer_fold_factor(op->dst, dst_d),
+        };
+        a.at[dst_d] = max(buffer_min(op->dst, dst_d) - offset, info->dims[dst_d].bounds.min);
+      }
+
+      for (const dim_expr& d : a.dims) {
+        if (!d.stride.defined()) {
+          // We didn't define all the dimensions of the buffer we want to replace.
+          return;
+        }
+      }
+
+      info->maybe_alias(op->dst, std::move(a));
+    }
   }
 
   void merge_alias_info(symbol_map<buffer_info> add) {
@@ -401,23 +439,24 @@ stmt implement_copy(const copy_stmt* op, node_context& ctx) {
 
   // If we just leave these two arrays alone, the copy will be correct, but slow.
   // We can speed it up by finding dimensions we can let pass through to the copy.
-  for (int d = 0; d < static_cast<int>(dst_x.size()); ++d) {
+  for (int dst_d = 0; dst_d < static_cast<int>(dst_x.size()); ++dst_d) {
     int src_d;
-    if (!is_copy_dst_dim(op, d, src_d)) {
+    if (!is_copy_dst_dim(op, dst_d, src_d)) {
       continue;
     }
 
-    expr offset = 0;
-    expr stride = buffer_stride(op->src, src_d);
-    if (src_d < 0) {
-      // This is a broadcast.
-      src_dims.push_back({buffer_bounds(op->dst, d), 0});
-      dst_x[d] = var();
-    } else if (is_copy(op->src_x[src_d], op->dst_x[d], offset, stride)) {
-      interval_expr src_bounds = buffer_bounds(op->dst, d) & (buffer_bounds(op->src, src_d) - offset);
-      src_dims.push_back({src_bounds, stride, buffer_fold_factor(op->src, src_d)});
-      src_x[src_d] = src_bounds.min + offset;
-      dst_x[d] = var();
+    dim_expr src_dim = {buffer_bounds(op->dst, dst_d), 0, dim::unfolded};
+    if (src_d >= 0) {
+      src_dim.stride = buffer_stride(op->src, src_d);
+      src_dim.fold_factor = buffer_fold_factor(op->src, src_d);
+    }
+    expr at;
+    if (is_copy(op, src_d, dst_d, at, src_dim)) {
+      src_dims.push_back(src_dim);
+      if (at.defined()) {
+        src_x[src_d] = at;
+      }
+      dst_x[dst_d] = var();
     }
   }
 

--- a/builder/optimizations.cc
+++ b/builder/optimizations.cc
@@ -59,8 +59,13 @@ bool is_copy(var src, expr src_x, int src_d, var dst, var dst_x, int dst_d, expr
     expr offset = simplify(src_x - dst_x);
     if (!depends_on(offset, dst_x).any()) {
       // The difference of src_x and dst_x does not depend on dst_x, it's a simple copy.
-      src_dim.bounds &= (buffer_bounds(src, src_d) - offset);
-      at = src_dim.bounds.min + offset;
+      if (is_zero(offset)) {
+        src_dim.bounds = buffer_bounds(src, src_d);
+        at = src_dim.bounds.min;
+      } else {
+        src_dim.bounds &= (buffer_bounds(src, src_d) - offset);
+        at = src_dim.bounds.min + offset;
+      }
       return true;
     } else {
       return false;
@@ -195,7 +200,7 @@ public:
           i->do_not_alias(target_var);
         }
       }
-      // We might have thought we could alias this both ways (src -> dst and dst -> src), we only want to do one of them.
+      // We may attempt to alias this both ways (src -> dst and dst -> src), we only want to do one of them.
       if (alias_info[target_var]) {
         alias_info[target_var]->do_not_alias(op->sym);
       }

--- a/builder/optimizations.cc
+++ b/builder/optimizations.cc
@@ -49,11 +49,6 @@ bool is_copy(var src, expr src_x, int src_d, var dst, var dst_x, int dst_d, expr
     } else {
       return false;
     }
-  } else if (src_d < 0) {
-    // This is a broadcast because the dst dim is unused in any src dim.
-    src_dim.stride = 0;
-    src_dim.fold_factor = dim::unfolded;
-    return true;
   } else if (!depends_on(src_x, dst_x).any()) {
     // This is a broadcast because the src_x is constant w.r.t. dst_x.
     at = src_x;

--- a/builder/optimizations.cc
+++ b/builder/optimizations.cc
@@ -162,8 +162,6 @@ public:
       // Replace the allocation with a buffer using the dims the alias wants.
       stmt result =
           make_buffer::make(op->sym, buffer_at(target_var, alias.at), op->elem_size, alias.dims, std::move(body));
-      // The alias might have used buffer metadata from the original, add a buffer for it.
-      result = make_buffer::make(op->sym, {}, op->elem_size, op->dims, std::move(result));
       // If we aliased the source and destination of a copy, replace the copy with a pad.
       stmt pad_result = recursive_mutate<copy_stmt>(result, [a = op->sym, b = target_var](const copy_stmt* op) {
         if (!((op->src == a && op->dst == b) || (op->src == b && op->dst == a))) {

--- a/builder/optimizations.cc
+++ b/builder/optimizations.cc
@@ -60,9 +60,13 @@ bool is_copy(var src, expr src_x, int src_d, var dst, var dst_x, int dst_d, expr
     if (!depends_on(offset, dst_x).any()) {
       // The difference of src_x and dst_x does not depend on dst_x, it's a simple copy.
       if (is_zero(offset)) {
+        // If the offset is zero, the index we want for the buffer_at call is buffer_min(src, src_d), which is
+        // definitely in bounds, so we don't need to clamp it.
         src_dim.bounds = buffer_bounds(src, src_d);
         at = src_dim.bounds.min;
       } else {
+        // The offset is non-zero, we might go out of bounds with our buffer_at call. To avoid this, we need to
+        // clamp to the intersection of the src and dst buffers, like copy would have done.
         src_dim.bounds &= (buffer_bounds(src, src_d) - offset);
         at = src_dim.bounds.min + offset;
       }

--- a/builder/test/copy_pipeline.cc
+++ b/builder/test/copy_pipeline.cc
@@ -185,7 +185,7 @@ TEST_P(copied_result, pipeline) {
 
 class concatenated_result : public testing::TestWithParam<bool> {};
 
-INSTANTIATE_TEST_SUITE_P(schedule, concatenated_result, testing::Values(false, true));
+INSTANTIATE_TEST_SUITE_P(schedule, concatenated_result, testing::Values(true, false));
 
 TEST_P(concatenated_result, pipeline) {
   bool no_alias_buffers = GetParam();
@@ -249,7 +249,7 @@ class transposed_result : public testing::TestWithParam<std::tuple<bool, int, in
 auto iota3 = testing::Values(0, 1, 2);
 
 INSTANTIATE_TEST_SUITE_P(schedule, transposed_result,
-    testing::Combine(testing::Values(false, true), iota3, iota3, iota3),
+    testing::Combine(testing::Values(true, false), iota3, iota3, iota3),
     test_params_to_string<transposed_result::ParamType>);
 
 TEST_P(transposed_result, pipeline) {
@@ -360,7 +360,7 @@ TEST(stacked_result, pipeline) {
 class broadcasted_elementwise : public testing::TestWithParam<std::tuple<bool, int>> {};
 
 INSTANTIATE_TEST_SUITE_P(dim, broadcasted_elementwise,
-    testing::Combine(testing::Values(false, true), testing::Range(0, 2)),
+    testing::Combine(testing::Values(true, false), testing::Range(0, 2)),
     test_params_to_string<broadcasted_elementwise::ParamType>);
 
 TEST_P(broadcasted_elementwise, pipeline) {

--- a/builder/test/elementwise.cc
+++ b/builder/test/elementwise.cc
@@ -64,7 +64,7 @@ public:
     slinky::dim dims[Rank];
     for (std::size_t d = 0; d < Rank; ++d) {
       // TODO: Find a better way to not care about bounds of broadcasted dimensions.
-      dims[d].set_bounds(std::numeric_limits<index_t>::min() / 2 + 1, std::numeric_limits<index_t>::max() / 2);
+      dims[d].set_bounds(std::numeric_limits<index_t>::min(), std::numeric_limits<index_t>::max());
     }
 
     auto value = raw_buffer::make(Rank, sizeof(T), dims);

--- a/builder/test/visualize/padded_stencil_0.html
+++ b/builder/test/visualize/padded_stencil_0.html
@@ -77,7 +77,6 @@ function make_color(a) {
 }
 function buffer_min(b, d) { return b.dims[d].bounds.min; }
 function buffer_max(b, d) { return b.dims[d].bounds.max; }
-function buffer_extent(b, d) { return b.dims[d].bounds.max - b.dims[d].bounds.min + 1; }
 function buffer_stride(b, d) { return b.dims[d].stride; }
 function buffer_fold_factor(b, d) { return b.dims[d].fold_factor; }
 function buffer_rank(b) { return b.dims.length; }

--- a/builder/test/visualize/padded_stencil_1.html
+++ b/builder/test/visualize/padded_stencil_1.html
@@ -77,7 +77,6 @@ function make_color(a) {
 }
 function buffer_min(b, d) { return b.dims[d].bounds.min; }
 function buffer_max(b, d) { return b.dims[d].bounds.max; }
-function buffer_extent(b, d) { return b.dims[d].bounds.max - b.dims[d].bounds.min + 1; }
 function buffer_stride(b, d) { return b.dims[d].stride; }
 function buffer_fold_factor(b, d) { return b.dims[d].fold_factor; }
 function buffer_rank(b) { return b.dims.length; }

--- a/builder/test/visualize/padded_stencil_2.html
+++ b/builder/test/visualize/padded_stencil_2.html
@@ -77,7 +77,6 @@ function make_color(a) {
 }
 function buffer_min(b, d) { return b.dims[d].bounds.min; }
 function buffer_max(b, d) { return b.dims[d].bounds.max; }
-function buffer_extent(b, d) { return b.dims[d].bounds.max - b.dims[d].bounds.min + 1; }
 function buffer_stride(b, d) { return b.dims[d].stride; }
 function buffer_fold_factor(b, d) { return b.dims[d].fold_factor; }
 function buffer_rank(b) { return b.dims.length; }

--- a/builder/test/visualize/parallel_stencils_0.html
+++ b/builder/test/visualize/parallel_stencils_0.html
@@ -77,7 +77,6 @@ function make_color(a) {
 }
 function buffer_min(b, d) { return b.dims[d].bounds.min; }
 function buffer_max(b, d) { return b.dims[d].bounds.max; }
-function buffer_extent(b, d) { return b.dims[d].bounds.max - b.dims[d].bounds.min + 1; }
 function buffer_stride(b, d) { return b.dims[d].stride; }
 function buffer_fold_factor(b, d) { return b.dims[d].fold_factor; }
 function buffer_rank(b) { return b.dims.length; }

--- a/builder/test/visualize/parallel_stencils_1.html
+++ b/builder/test/visualize/parallel_stencils_1.html
@@ -77,7 +77,6 @@ function make_color(a) {
 }
 function buffer_min(b, d) { return b.dims[d].bounds.min; }
 function buffer_max(b, d) { return b.dims[d].bounds.max; }
-function buffer_extent(b, d) { return b.dims[d].bounds.max - b.dims[d].bounds.min + 1; }
 function buffer_stride(b, d) { return b.dims[d].stride; }
 function buffer_fold_factor(b, d) { return b.dims[d].fold_factor; }
 function buffer_rank(b) { return b.dims.length; }

--- a/builder/test/visualize/parallel_stencils_2.html
+++ b/builder/test/visualize/parallel_stencils_2.html
@@ -77,7 +77,6 @@ function make_color(a) {
 }
 function buffer_min(b, d) { return b.dims[d].bounds.min; }
 function buffer_max(b, d) { return b.dims[d].bounds.max; }
-function buffer_extent(b, d) { return b.dims[d].bounds.max - b.dims[d].bounds.min + 1; }
 function buffer_stride(b, d) { return b.dims[d].stride; }
 function buffer_fold_factor(b, d) { return b.dims[d].fold_factor; }
 function buffer_rank(b) { return b.dims.length; }

--- a/builder/test/visualize/softmax_split_0.html
+++ b/builder/test/visualize/softmax_split_0.html
@@ -77,7 +77,6 @@ function make_color(a) {
 }
 function buffer_min(b, d) { return b.dims[d].bounds.min; }
 function buffer_max(b, d) { return b.dims[d].bounds.max; }
-function buffer_extent(b, d) { return b.dims[d].bounds.max - b.dims[d].bounds.min + 1; }
 function buffer_stride(b, d) { return b.dims[d].stride; }
 function buffer_fold_factor(b, d) { return b.dims[d].fold_factor; }
 function buffer_rank(b) { return b.dims.length; }

--- a/builder/test/visualize/softmax_split_1.html
+++ b/builder/test/visualize/softmax_split_1.html
@@ -77,7 +77,6 @@ function make_color(a) {
 }
 function buffer_min(b, d) { return b.dims[d].bounds.min; }
 function buffer_max(b, d) { return b.dims[d].bounds.max; }
-function buffer_extent(b, d) { return b.dims[d].bounds.max - b.dims[d].bounds.min + 1; }
 function buffer_stride(b, d) { return b.dims[d].stride; }
 function buffer_fold_factor(b, d) { return b.dims[d].fold_factor; }
 function buffer_rank(b) { return b.dims.length; }

--- a/builder/test/visualize/softmax_split_4.html
+++ b/builder/test/visualize/softmax_split_4.html
@@ -77,7 +77,6 @@ function make_color(a) {
 }
 function buffer_min(b, d) { return b.dims[d].bounds.min; }
 function buffer_max(b, d) { return b.dims[d].bounds.max; }
-function buffer_extent(b, d) { return b.dims[d].bounds.max - b.dims[d].bounds.min + 1; }
 function buffer_stride(b, d) { return b.dims[d].stride; }
 function buffer_fold_factor(b, d) { return b.dims[d].fold_factor; }
 function buffer_rank(b) { return b.dims.length; }

--- a/builder/test/visualize/stencil_chain_split_serial_split_0.html
+++ b/builder/test/visualize/stencil_chain_split_serial_split_0.html
@@ -77,7 +77,6 @@ function make_color(a) {
 }
 function buffer_min(b, d) { return b.dims[d].bounds.min; }
 function buffer_max(b, d) { return b.dims[d].bounds.max; }
-function buffer_extent(b, d) { return b.dims[d].bounds.max - b.dims[d].bounds.min + 1; }
 function buffer_stride(b, d) { return b.dims[d].stride; }
 function buffer_fold_factor(b, d) { return b.dims[d].fold_factor; }
 function buffer_rank(b) { return b.dims.length; }

--- a/builder/test/visualize/stencil_chain_split_serial_split_1.html
+++ b/builder/test/visualize/stencil_chain_split_serial_split_1.html
@@ -77,7 +77,6 @@ function make_color(a) {
 }
 function buffer_min(b, d) { return b.dims[d].bounds.min; }
 function buffer_max(b, d) { return b.dims[d].bounds.max; }
-function buffer_extent(b, d) { return b.dims[d].bounds.max - b.dims[d].bounds.min + 1; }
 function buffer_stride(b, d) { return b.dims[d].stride; }
 function buffer_fold_factor(b, d) { return b.dims[d].fold_factor; }
 function buffer_rank(b) { return b.dims.length; }

--- a/builder/test/visualize/stencil_chain_split_serial_split_2.html
+++ b/builder/test/visualize/stencil_chain_split_serial_split_2.html
@@ -77,7 +77,6 @@ function make_color(a) {
 }
 function buffer_min(b, d) { return b.dims[d].bounds.min; }
 function buffer_max(b, d) { return b.dims[d].bounds.max; }
-function buffer_extent(b, d) { return b.dims[d].bounds.max - b.dims[d].bounds.min + 1; }
 function buffer_stride(b, d) { return b.dims[d].stride; }
 function buffer_fold_factor(b, d) { return b.dims[d].fold_factor; }
 function buffer_rank(b) { return b.dims.length; }

--- a/builder/test/visualize/stencil_split_0.html
+++ b/builder/test/visualize/stencil_split_0.html
@@ -77,7 +77,6 @@ function make_color(a) {
 }
 function buffer_min(b, d) { return b.dims[d].bounds.min; }
 function buffer_max(b, d) { return b.dims[d].bounds.max; }
-function buffer_extent(b, d) { return b.dims[d].bounds.max - b.dims[d].bounds.min + 1; }
 function buffer_stride(b, d) { return b.dims[d].stride; }
 function buffer_fold_factor(b, d) { return b.dims[d].fold_factor; }
 function buffer_rank(b) { return b.dims.length; }

--- a/builder/test/visualize/stencil_split_1.html
+++ b/builder/test/visualize/stencil_split_1.html
@@ -77,7 +77,6 @@ function make_color(a) {
 }
 function buffer_min(b, d) { return b.dims[d].bounds.min; }
 function buffer_max(b, d) { return b.dims[d].bounds.max; }
-function buffer_extent(b, d) { return b.dims[d].bounds.max - b.dims[d].bounds.min + 1; }
 function buffer_stride(b, d) { return b.dims[d].stride; }
 function buffer_fold_factor(b, d) { return b.dims[d].fold_factor; }
 function buffer_rank(b) { return b.dims.length; }

--- a/builder/test/visualize/stencil_split_2.html
+++ b/builder/test/visualize/stencil_split_2.html
@@ -77,7 +77,6 @@ function make_color(a) {
 }
 function buffer_min(b, d) { return b.dims[d].bounds.min; }
 function buffer_max(b, d) { return b.dims[d].bounds.max; }
-function buffer_extent(b, d) { return b.dims[d].bounds.max - b.dims[d].bounds.min + 1; }
 function buffer_stride(b, d) { return b.dims[d].stride; }
 function buffer_fold_factor(b, d) { return b.dims[d].fold_factor; }
 function buffer_rank(b) { return b.dims.length; }

--- a/builder/test/visualize/stencil_split_3.html
+++ b/builder/test/visualize/stencil_split_3.html
@@ -77,7 +77,6 @@ function make_color(a) {
 }
 function buffer_min(b, d) { return b.dims[d].bounds.min; }
 function buffer_max(b, d) { return b.dims[d].bounds.max; }
-function buffer_extent(b, d) { return b.dims[d].bounds.max - b.dims[d].bounds.min + 1; }
 function buffer_stride(b, d) { return b.dims[d].stride; }
 function buffer_fold_factor(b, d) { return b.dims[d].fold_factor; }
 function buffer_rank(b) { return b.dims.length; }

--- a/runtime/buffer.h
+++ b/runtime/buffer.h
@@ -80,7 +80,7 @@ public:
   bool contains(index_t a, index_t b) const {
     // Conceptually, accesses may be out of bounds, but in practice, if the stride is 0, the accesses will not read
     // invalid memory. It's a bit messy to allow this, but it feels really overzealous to disallow it when attempting to
-    // implement broadcasting in callbacks.
+    // implement broadcasting.
     return stride() == 0 || (min() <= a && b <= max());
   }
   bool contains(index_t x) const { return contains(x, x); }
@@ -93,6 +93,11 @@ public:
     } else {
       return euclidean_mod(i - min(), fold_factor()) * stride();
     }
+  }
+
+  bool is_folded() const {
+    if (fold_factor() == unfolded) return false;
+    return min() / fold_factor() != max() / fold_factor();
   }
 };
 
@@ -268,7 +273,7 @@ public:
 
     dim(d).set_bounds(min, max);
     // Crops can't span a folding boundary if they move the base pointer.
-    assert(offset == 0 || dim(d).min() / dim(d).fold_factor() == dim(d).max() / dim(d).fold_factor());
+    assert(offset == 0 || !dim(d).is_folded());
     return *this;
   }
 

--- a/runtime/buffer.h
+++ b/runtime/buffer.h
@@ -77,12 +77,7 @@ public:
   }
 
   // Returns true if the interval [a, b] is in bounds of this dimension.
-  bool contains(index_t a, index_t b) const {
-    // Conceptually, accesses may be out of bounds, but in practice, if the stride is 0, the accesses will not read
-    // invalid memory. It's a bit messy to allow this, but it feels really overzealous to disallow it when attempting to
-    // implement broadcasting.
-    return stride() == 0 || (min() <= a && b <= max());
-  }
+  bool contains(index_t a, index_t b) const { return min() <= a && b <= max(); }
   bool contains(index_t x) const { return contains(x, x); }
   bool contains(const dim& other) const { return contains(other.min(), other.max()); }
 

--- a/runtime/test/buffer.cc
+++ b/runtime/test/buffer.cc
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
+#include <iostream>
 #include <numeric>
 #include <random>
 
@@ -16,6 +17,21 @@ std::mt19937& rng() {
 namespace slinky {
 
 bool operator==(const dim& a, const dim& b) { return memcmp(&a, &b, sizeof(dim)) == 0; }
+
+std::ostream& operator<<(std::ostream& os, const dim& d) {
+  return os << "{min: " << d.min() << ", max: " << d.max() << ", stride: " << d.stride()
+            << ", fold_factor: " << d.fold_factor() << "}";
+}
+
+std::ostream& operator<<(std::ostream& os, const raw_buffer& buf) {
+  os << "{base: " << buf.base << ", elem_size: " << buf.elem_size << ", dims = {";
+  for (std::size_t i = 0; i < buf.rank; ++i) {
+    if (i > 0) os << ", ";
+    os << buf.dim(i);
+  }
+  os << "}";
+  return os;
+}
 
 int random(int min, int max) { return rng()() % (max - min + 1) + min; }
 
@@ -93,6 +109,7 @@ void randomize_strides_and_padding(buffer<T, N>& buf, const randomize_options& o
     if (options.allow_broadcast && random(0, 9) == 0) {
       // Make this a broadcast.
       dim.set_stride(0);
+      dim.set_bounds(std::numeric_limits<index_t>::min(), std::numeric_limits<index_t>::max());
     } else {
       dim.set_stride(stride);
       // Add some extra random padding.
@@ -733,17 +750,14 @@ TEST(buffer, copy) {
     std::fill(padding.begin(), padding.end(), 7);
 
     buffer<void, max_rank> src(rank, elem_size);
-    for (std::size_t d = 0; d < src.rank; ++d) {
-      src.dim(d).set_min_extent(0, 5);
-    }
-    randomize_strides_and_padding(src, {-1, 1, true, false});
-    init_random(src);
-
     buffer<void, max_rank> dst(rank, elem_size);
     for (std::size_t d = 0; d < src.rank; ++d) {
-      dst.dim(d) = src.dim(d);
+      src.dim(d).set_min_extent(0, 5);
+      dst.dim(d).set_min_extent(0, 5);
     }
+    randomize_strides_and_padding(src, {-1, 1, true, false});
     randomize_strides_and_padding(dst, {-1, 1, false, false});
+    init_random(src);
     dst.allocate();
 
     slinky::copy(src, dst, padding.data());

--- a/runtime/test/buffer.cc
+++ b/runtime/test/buffer.cc
@@ -916,18 +916,15 @@ TEST(fuse_contiguous_dims, copy) {
     std::fill(padding.begin(), padding.end(), 7);
 
     buffer<void, max_rank> src(rank, elem_size);
-    for (std::size_t d = 0; d < src.rank; ++d) {
-      src.dim(d).set_min_extent(0, 5);
-    }
-    randomize_strides_and_padding(src, {-1, 1, true, true});
-    init_random(src);
-    buffer<void, max_rank> src_opt = src;
-
     buffer<void, max_rank> dst(rank, elem_size);
     for (std::size_t d = 0; d < src.rank; ++d) {
-      dst.dim(d) = src.dim(d);
+      src.dim(d).set_min_extent(0, 5);
+      dst.dim(d).set_min_extent(0, 5);
     }
+    randomize_strides_and_padding(src, {-1, 1, true, true});
     randomize_strides_and_padding(dst, {-1, 1, false, false});
+    init_random(src);
+    buffer<void, max_rank> src_opt = src;
     buffer<void, max_rank> dst_opt = dst;
     dst.allocate();
     dst_opt.allocate();

--- a/runtime/visualize.cc
+++ b/runtime/visualize.cc
@@ -374,7 +374,6 @@ function make_color(a) {
 }
 function buffer_min(b, d) { return b.dims[d].bounds.min; }
 function buffer_max(b, d) { return b.dims[d].bounds.max; }
-function buffer_extent(b, d) { return b.dims[d].bounds.max - b.dims[d].bounds.min + 1; }
 function buffer_stride(b, d) { return b.dims[d].stride; }
 function buffer_fold_factor(b, d) { return b.dims[d].fold_factor; }
 function buffer_rank(b) { return b.dims.length; }


### PR DESCRIPTION
`alias_buffers` was the last thing I'm aware of that relied on broadcasting hacks. This PR cleans up `alias_buffers` to hopefully make it easier to understand (mainly by breaking the `copy_stmt` visitor into separate cases for aliasing the src and dst, which are different), and stops relying on the broadcasting hacks by correctly setting the bounds of dimensions that we read broadcasts from. This PR then removes the broadcasting hacks!