### PR TITLE
Fix visualization bugs and add visualization for softmax

### DIFF
--- a/base/test/BUILD
+++ b/base/test/BUILD
@@ -5,6 +5,7 @@ package(
 
 cc_library(
     name = "util",
+    srcs = ["bazel_util.cc"],
     hdrs = ["bazel_util.h"],
     deps = [
         "@bazel_tools//tools/cpp/runfiles",

--- a/base/test/bazel_util.cc
+++ b/base/test/bazel_util.cc
@@ -1,0 +1,30 @@
+#include "base/test/bazel_util.h"
+
+#include <iostream>
+
+#include "tools/cpp/runfiles/runfiles.h"
+
+namespace slinky {
+
+bool is_bazel_test() { return getenv("BAZEL_TEST") != nullptr; }
+
+// Get the path to a file relative to the root of the repo in the current bazel invocation.
+std::string get_bazel_file_path(const std::string& repo_path) {
+  if (is_bazel_test()) {
+    using bazel::tools::cpp::runfiles::Runfiles;
+
+    std::string error;
+    std::unique_ptr<Runfiles> runfiles(Runfiles::CreateForTest(BAZEL_CURRENT_REPOSITORY, &error));
+    if (runfiles == nullptr) {
+      std::cerr << "Can't find runfile directory: " << error;
+      std::abort();
+    }
+
+    return runfiles->Rlocation("_main/" + repo_path);
+  } else {
+    // When running without bazel, just assume we're in the repo root.
+    return repo_path;
+  }
+}
+
+}  // namespace slinky

--- a/base/test/bazel_util.h
+++ b/base/test/bazel_util.h
@@ -7,26 +7,10 @@
 
 namespace slinky {
 
-inline bool is_bazel_test() { return getenv("BAZEL_TEST") != nullptr; }
+bool is_bazel_test();
 
 // Get the path to a file relative to the root of the repo in the current bazel invocation.
-inline std::string get_bazel_file_path(const std::string& repo_path) {
-  if (is_bazel_test()) {
-    using bazel::tools::cpp::runfiles::Runfiles;
-
-    std::string error;
-    std::unique_ptr<Runfiles> runfiles(Runfiles::CreateForTest(BAZEL_CURRENT_REPOSITORY, &error));
-    if (runfiles == nullptr) {
-      std::cerr << "Can't find runfile directory: " << error;
-      std::abort();
-    }
-
-    return runfiles->Rlocation("_main/" + repo_path);
-  } else {
-    // When running without bazel, just assume we're in the repo root.
-    return repo_path;
-  }
-}
+std::string get_bazel_file_path(const std::string& repo_path);
 
 }  // namespace slinky
 

--- a/builder/test/BUILD
+++ b/builder/test/BUILD
@@ -111,8 +111,10 @@ cc_test(
     srcs = ["softmax.cc"],
     deps = [
         ":util",
+        "//base/test:util",
         "//builder",
         "//runtime",
+        "//runtime:visualize",
         "@googletest//:gtest_main",
     ],
     size = "small",

--- a/builder/test/BUILD
+++ b/builder/test/BUILD
@@ -6,7 +6,10 @@ package(
 cc_library(
     name = "util",
     testonly = True,
-    srcs = ["context.cc"],
+    srcs = [
+        "context.cc", 
+        "util.cc",
+    ],
     hdrs = [
         "context.h",
         "funcs.h",
@@ -14,10 +17,11 @@ cc_library(
     ],
     deps = [
         "//runtime",
+        "//runtime:visualize",
         "//base:chrome_trace",
         "//base:thread_pool",
         "//base/test:util",
-        "@bazel_tools//tools/cpp/runfiles",
+        "//builder:replica_pipeline",
         "@googletest//:gtest",
     ],
 )
@@ -65,10 +69,7 @@ cc_test(
         ":util",
         "//base/test:util",
         "//builder",
-        "//builder:replica_pipeline",
         "//runtime",
-        "//runtime:visualize",
-        "@bazel_tools//tools/cpp/runfiles",  # Needed for -DBAZEL_CURRENT_REPOSITORY even though it's used transitively via util
         "@googletest//:gtest_main",
     ],
     size = "small",
@@ -84,7 +85,6 @@ cc_test(
         "//builder",
         "//builder:replica_pipeline",
         "//runtime",
-        "@bazel_tools//tools/cpp/runfiles",  # Needed for -DBAZEL_CURRENT_REPOSITORY even though it's used transitively via util
         "@googletest//:gtest_main",
     ],
     size = "small",
@@ -100,7 +100,6 @@ cc_test(
         "//builder",
         "//builder:replica_pipeline",
         "//runtime",
-        "@bazel_tools//tools/cpp/runfiles",  # Needed for -DBAZEL_CURRENT_REPOSITORY even though it's used transitively via util
         "@googletest//:gtest_main",
     ],
     size = "small",
@@ -109,6 +108,7 @@ cc_test(
 cc_test(
     name = "softmax",
     srcs = ["softmax.cc"],
+    data = glob(["visualize/*.html"]),
     deps = [
         ":util",
         "//base/test:util",

--- a/builder/test/pipeline.cc
+++ b/builder/test/pipeline.cc
@@ -2,7 +2,6 @@
 
 #include <numeric>
 
-#include "base/test/bazel_util.h"
 #include "builder/pipeline.h"
 #include "builder/replica_pipeline.h"
 #include "builder/substitute.h"
@@ -12,38 +11,8 @@
 #include "runtime/expr.h"
 #include "runtime/pipeline.h"
 #include "runtime/print.h"
-#include "runtime/visualize.h"
 
 namespace slinky {
-
-std::string get_replica_golden() {
-  static std::string golden = read_entire_file(get_bazel_file_path("builder/test/replica_pipeline.cc"));
-  return golden;
-}
-
-void check_replica_pipeline(const std::string& replica_text) {
-  size_t pos = get_replica_golden().find(replica_text);
-  ASSERT_NE(pos, std::string::npos) << "Matching replica text not found, expected:\n" << replica_text;
-}
-
-void check_visualize(const std::string& filename, const pipeline& p, pipeline::buffers inputs,
-    pipeline::buffers outputs, const node_context* ctx) {
-  std::stringstream viz_stream;
-  visualize(viz_stream, p, inputs, outputs, ctx);
-  std::string viz = viz_stream.str();
-
-  std::string golden_path = get_bazel_file_path("builder/test/visualize/" + filename);
-  if (is_bazel_test()) {
-    std::string golden = read_entire_file(golden_path);
-    ASSERT_FALSE(golden.empty());
-    // If this check fails, and you believe the changes to the visualization is correct, run this
-    // test outside of bazel from the root of the repo to update the golden files.
-    ASSERT_TRUE(golden == viz);
-  } else {
-    std::ofstream file(golden_path);
-    file << viz;
-  }
-}
 
 // Matrix multiplication (not fast!)
 template <typename T>

--- a/builder/test/softmax.cc
+++ b/builder/test/softmax.cc
@@ -1,7 +1,6 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-#include "base/test/bazel_util.h"
 #include "builder/pipeline.h"
 #include "builder/test/funcs.h"
 #include "builder/test/util.h"
@@ -10,25 +9,6 @@
 #include "runtime/visualize.h"
 
 namespace slinky {
-
-void check_visualize(const std::string& filename, const pipeline& p, pipeline::buffers inputs,
-    pipeline::buffers outputs, const node_context* ctx) {
-  std::stringstream viz_stream;
-  visualize(viz_stream, p, inputs, outputs, ctx);
-  std::string viz = viz_stream.str();
-
-  std::string golden_path = get_bazel_file_path("builder/test/visualize/" + filename);
-  if (is_bazel_test()) {
-    std::string golden = read_entire_file(golden_path);
-    ASSERT_FALSE(golden.empty());
-    // If this check fails, and you believe the changes to the visualization is correct, run this
-    // test outside of bazel from the root of the repo to update the golden files.
-    ASSERT_TRUE(golden == viz);
-  } else {
-    std::ofstream file(golden_path);
-    file << viz;
-  }
-}
 
 // This implementation of softmax is not intended to be fast, it is only intended to model the data dependencies.
 index_t max_dim0(const buffer<const float>& in, const buffer<float>& max_in) {

--- a/builder/test/util.cc
+++ b/builder/test/util.cc
@@ -1,0 +1,51 @@
+#include "builder/test/util.h"
+
+#include <fstream>
+
+#include "base/test/bazel_util.h"
+#include "runtime/visualize.h"
+
+namespace slinky {
+
+std::string remove_windows_newlines(std::string s) {
+  s.erase(std::remove(s.begin(), s.end(), '\r'), s.end());
+  return s;
+}
+
+std::string read_entire_file(const std::string& pathname) {
+  std::ifstream f(pathname);
+  std::stringstream buffer;
+  buffer << f.rdbuf();
+  return remove_windows_newlines(buffer.str());
+}
+
+void check_visualize(const std::string& filename, const pipeline& p, pipeline::buffers inputs,
+    pipeline::buffers outputs, const node_context* ctx) {
+  std::stringstream viz_stream;
+  visualize(viz_stream, p, inputs, outputs, ctx);
+  std::string viz = viz_stream.str();
+
+  std::string golden_path = get_bazel_file_path("builder/test/visualize/" + filename);
+  if (is_bazel_test()) {
+    std::string golden = read_entire_file(golden_path);
+    ASSERT_FALSE(golden.empty());
+    // If this check fails, and you believe the changes to the visualization is correct, run this
+    // test outside of bazel from the root of the repo to update the golden files.
+    ASSERT_TRUE(golden == viz);
+  } else {
+    std::ofstream file(golden_path);
+    file << viz;
+  }
+}
+
+std::string get_replica_golden() {
+  static std::string golden = read_entire_file(get_bazel_file_path("builder/test/replica_pipeline.cc"));
+  return golden;
+}
+
+void check_replica_pipeline(const std::string& replica_text) {
+  size_t pos = get_replica_golden().find(replica_text);
+  ASSERT_NE(pos, std::string::npos) << "Matching replica text not found, expected:\n" << replica_text;
+}
+
+}  // namespace slinky

--- a/builder/test/util.h
+++ b/builder/test/util.h
@@ -1,11 +1,12 @@
 #ifndef SLINKY_BUILDER_TEST_UTIL_H
 #define SLINKY_BUILDER_TEST_UTIL_H
 
-#include <fstream>
 #include <numeric>
 #include <string>
 
 #include <gtest/gtest.h>
+
+#include "runtime/pipeline.h"
 
 namespace slinky {
 
@@ -32,17 +33,9 @@ std::string test_params_to_string(const testing::TestParamInfo<T>& info) {
   return test_params_to_string_impl(info.param, std::make_index_sequence<n>());
 }
 
-inline std::string remove_windows_newlines(std::string s) {
-  s.erase(std::remove(s.begin(), s.end(), '\r'), s.end());
-  return s;
-}
+std::string remove_windows_newlines(std::string s);
 
-inline std::string read_entire_file(const std::string& pathname) {
-  std::ifstream f(pathname);
-  std::stringstream buffer;
-  buffer << f.rdbuf();
-  return remove_windows_newlines(buffer.str());
-}
+std::string read_entire_file(const std::string& pathname);
 
 template <typename T>
 std::vector<T> permute(span<const int> p, const std::vector<T>& x) {
@@ -58,6 +51,13 @@ inline bool is_permutation(span<const int> p) {
   std::iota(unpermuted.begin(), unpermuted.end(), 0);
   return std::is_permutation(p.begin(), p.end(), unpermuted.begin());
 }
+
+void check_visualize(const std::string& filename, const pipeline& p, pipeline::buffers inputs,
+    pipeline::buffers outputs, const node_context* ctx);
+
+std::string get_replica_golden();
+
+void check_replica_pipeline(const std::string& replica_text);
 
 }  // namespace slinky
 

--- a/builder/test/visualize/padded_stencil_0.html
+++ b/builder/test/visualize/padded_stencil_0.html
@@ -108,9 +108,18 @@ function define_mapping(buffer) {
   buf.mem.base = buffer.base;
   closure = function(base, elem_size, dims) {
     let sorted_dims = structuredClone(dims.toSorted(function(a, b) { return a.stride - b.stride; }));
-    return function(at) {
-      at -= base;
-      return [unpack_dim(at, sorted_dims[0]), unpack_dim(at, sorted_dims[1])];
+    if (sorted_dims.length > 1) {
+      return function(at) {
+        at -= base;
+        return [unpack_dim(at, sorted_dims[0]), unpack_dim(at, sorted_dims[1])];
+      }
+    } else if (sorted_dims.length == 1) {
+      return function(at) {
+        at -= base;
+        return [unpack_dim(at, sorted_dims[0]), 0];
+      }
+    } else {
+      return function(at) { return [0, 0]; }
     }
   }
   buf.mem.mapping = closure(buffer.base, buffer.elem_size, buffer.dims);
@@ -251,7 +260,7 @@ function truncate_rank(b, rank) {
 function produce(b) {
   m = find_mapping(b.base);
   if (m) {
-    m.element.mem.productions.push({t: __event_t++, buf: clone_buffer(b)});
+    m.element.mem.productions.push({t: __event_t, buf: clone_buffer(b)});
   }
 }
 function consume(b) {}
@@ -287,6 +296,7 @@ function pipeline(__in, out) {
         ];
         { let intm = make_buffer('intm', __base, __elem_size, __dims);          consume(__in);
           produce(intm);
+          __event_t++;
         }
       }
       {
@@ -298,10 +308,12 @@ function pipeline(__in, out) {
         ];
         { let intm = make_buffer('intm', __base, __elem_size, __dims);          consume(intm);
           produce(padded_intm);
+          __event_t++;
         }
       }
       consume(padded_intm);
       produce(out);
+      __event_t++;
       free(padded_intm);
     }
   }

--- a/builder/test/visualize/padded_stencil_1.html
+++ b/builder/test/visualize/padded_stencil_1.html
@@ -108,9 +108,18 @@ function define_mapping(buffer) {
   buf.mem.base = buffer.base;
   closure = function(base, elem_size, dims) {
     let sorted_dims = structuredClone(dims.toSorted(function(a, b) { return a.stride - b.stride; }));
-    return function(at) {
-      at -= base;
-      return [unpack_dim(at, sorted_dims[0]), unpack_dim(at, sorted_dims[1])];
+    if (sorted_dims.length > 1) {
+      return function(at) {
+        at -= base;
+        return [unpack_dim(at, sorted_dims[0]), unpack_dim(at, sorted_dims[1])];
+      }
+    } else if (sorted_dims.length == 1) {
+      return function(at) {
+        at -= base;
+        return [unpack_dim(at, sorted_dims[0]), 0];
+      }
+    } else {
+      return function(at) { return [0, 0]; }
     }
   }
   buf.mem.mapping = closure(buffer.base, buffer.elem_size, buffer.dims);
@@ -251,7 +260,7 @@ function truncate_rank(b, rank) {
 function produce(b) {
   m = find_mapping(b.base);
   if (m) {
-    m.element.mem.productions.push({t: __event_t++, buf: clone_buffer(b)});
+    m.element.mem.productions.push({t: __event_t, buf: clone_buffer(b)});
   }
 }
 function consume(b) {}
@@ -287,6 +296,7 @@ function pipeline(__in, out) {
         ];
         { let intm = make_buffer('intm', __base, __elem_size, __dims);          consume(__in);
           produce(intm);
+          __event_t++;
         }
       }
       {
@@ -298,10 +308,12 @@ function pipeline(__in, out) {
         ];
         { let intm = make_buffer('intm', __base, __elem_size, __dims);          consume(intm);
           produce(padded_intm);
+          __event_t++;
         }
       }
       consume(padded_intm);
       produce(out);
+      __event_t++;
       free(padded_intm);
     }
   }

--- a/builder/test/visualize/padded_stencil_2.html
+++ b/builder/test/visualize/padded_stencil_2.html
@@ -108,9 +108,18 @@ function define_mapping(buffer) {
   buf.mem.base = buffer.base;
   closure = function(base, elem_size, dims) {
     let sorted_dims = structuredClone(dims.toSorted(function(a, b) { return a.stride - b.stride; }));
-    return function(at) {
-      at -= base;
-      return [unpack_dim(at, sorted_dims[0]), unpack_dim(at, sorted_dims[1])];
+    if (sorted_dims.length > 1) {
+      return function(at) {
+        at -= base;
+        return [unpack_dim(at, sorted_dims[0]), unpack_dim(at, sorted_dims[1])];
+      }
+    } else if (sorted_dims.length == 1) {
+      return function(at) {
+        at -= base;
+        return [unpack_dim(at, sorted_dims[0]), 0];
+      }
+    } else {
+      return function(at) { return [0, 0]; }
     }
   }
   buf.mem.mapping = closure(buffer.base, buffer.elem_size, buffer.dims);
@@ -251,7 +260,7 @@ function truncate_rank(b, rank) {
 function produce(b) {
   m = find_mapping(b.base);
   if (m) {
-    m.element.mem.productions.push({t: __event_t++, buf: clone_buffer(b)});
+    m.element.mem.productions.push({t: __event_t, buf: clone_buffer(b)});
   }
 }
 function consume(b) {}
@@ -292,16 +301,19 @@ function pipeline(__in, out) {
               { let __intm = crop_dim(intm, 1, {min:max(g1, (y + 1)), max:min(g2, (y + 1))});
                 consume(__in);
                 produce(intm);
+                __event_t++;
                 intm = __intm;
               }
               { let __padded_intm = crop_dim(padded_intm, 1, {min:(y + 1), max:(y + 1)});
                 consume(intm);
                 produce(padded_intm);
+                __event_t++;
                 padded_intm = __padded_intm;
               }
               { let __out = crop_dim(out, 1, {min:y, max:y});
                 consume(padded_intm_uncropped);
                 produce(out);
+                __event_t++;
                 out = __out;
               }
             }

--- a/builder/test/visualize/padded_stencil_2.html
+++ b/builder/test/visualize/padded_stencil_2.html
@@ -285,7 +285,10 @@ function pipeline(__in, out) {
           ]);
           {
             let y_min_orig = buffer_min(out, 1);
-            for(let y = (y_min_orig + -2); y <= buffer_max(out, 1); y += 1) {
+            let __loop_min = (y_min_orig + -2);
+            let __loop_max = buffer_max(out, 1);
+            let __loop_step = 1;
+            for(let y = __loop_min; y <= __loop_max; y += __loop_step) {
               { let __intm = crop_dim(intm, 1, {min:max(g1, (y + 1)), max:min(g2, (y + 1))});
                 consume(__in);
                 produce(intm);

--- a/builder/test/visualize/parallel_stencils_0.html
+++ b/builder/test/visualize/parallel_stencils_0.html
@@ -108,9 +108,18 @@ function define_mapping(buffer) {
   buf.mem.base = buffer.base;
   closure = function(base, elem_size, dims) {
     let sorted_dims = structuredClone(dims.toSorted(function(a, b) { return a.stride - b.stride; }));
-    return function(at) {
-      at -= base;
-      return [unpack_dim(at, sorted_dims[0]), unpack_dim(at, sorted_dims[1])];
+    if (sorted_dims.length > 1) {
+      return function(at) {
+        at -= base;
+        return [unpack_dim(at, sorted_dims[0]), unpack_dim(at, sorted_dims[1])];
+      }
+    } else if (sorted_dims.length == 1) {
+      return function(at) {
+        at -= base;
+        return [unpack_dim(at, sorted_dims[0]), 0];
+      }
+    } else {
+      return function(at) { return [0, 0]; }
     }
   }
   buf.mem.mapping = closure(buffer.base, buffer.elem_size, buffer.dims);
@@ -251,7 +260,7 @@ function truncate_rank(b, rank) {
 function produce(b) {
   m = find_mapping(b.base);
   if (m) {
-    m.element.mem.productions.push({t: __event_t++, buf: clone_buffer(b)});
+    m.element.mem.productions.push({t: __event_t, buf: clone_buffer(b)});
   }
 }
 function consume(b) {}
@@ -311,27 +320,32 @@ function pipeline(in1, in2, out) {
                       { let __intm1 = crop_dim(intm1, 1, {min:(y + 1), max:(y + 1)});
                         consume(in1);
                         produce(intm1);
+                        __event_t++;
                         intm1 = __intm1;
                       }
                       { let __intm3 = crop_dim(intm3, 1, {min:y, max:y});
                         consume(intm1_uncropped);
                         produce(intm3);
+                        __event_t++;
                         intm3 = __intm3;
                       }
                       { let __intm2 = crop_dim(intm2, 1, {min:(y + 2), max:(y + 2)});
                         consume(in2);
                         produce(intm2);
+                        __event_t++;
                         intm2 = __intm2;
                       }
                       { let __intm4 = crop_dim(intm4, 1, {min:y, max:y});
                         consume(intm2_uncropped);
                         produce(intm4);
+                        __event_t++;
                         intm4 = __intm4;
                       }
                       { let __out = crop_dim(out, 1, {min:y, max:y});
                         consume(intm3_uncropped);
                         consume(intm4_uncropped);
                         produce(out);
+                        __event_t++;
                         out = __out;
                       }
                     }

--- a/builder/test/visualize/parallel_stencils_0.html
+++ b/builder/test/visualize/parallel_stencils_0.html
@@ -304,7 +304,10 @@ function pipeline(in1, in2, out) {
                 { let intm1_uncropped = clone_buffer(intm1);
                   {
                     let y_min_orig = buffer_min(out, 1);
-                    for(let y = (y_min_orig + -6); y <= buffer_max(out, 1); y += 1) {
+                    let __loop_min = (y_min_orig + -6);
+                    let __loop_max = buffer_max(out, 1);
+                    let __loop_step = 1;
+                    for(let y = __loop_min; y <= __loop_max; y += __loop_step) {
                       { let __intm1 = crop_dim(intm1, 1, {min:(y + 1), max:(y + 1)});
                         consume(in1);
                         produce(intm1);

--- a/builder/test/visualize/parallel_stencils_1.html
+++ b/builder/test/visualize/parallel_stencils_1.html
@@ -305,9 +305,15 @@ function pipeline(in1, in2, out) {
                 produce(intm1);
                 {
                   let y_min_orig = buffer_min(out, 1);
-                  for(let y = (y_min_orig + -4); y <= buffer_max(out, 1); y += 2) {
+                  let __loop_min = (y_min_orig + -4);
+                  let __loop_max = buffer_max(out, 1);
+                  let __loop_step = 2;
+                  for(let y = __loop_min; y <= __loop_max; y += __loop_step) {
                     { let __intm3 = crop_dim(intm3, 1, {min:y, max:min((y + 1), buffer_max(out, 1))});
-                      for(let y = y; y <= min((y + 1), buffer_max(out, 1)); y += 1) {
+                      let __loop_min = y;
+                      let __loop_max = min((y + 1), buffer_max(out, 1));
+                      let __loop_step = 1;
+                      for(let y = __loop_min; y <= __loop_max; y += __loop_step) {
                         { let __intm3 = crop_dim(intm3, 1, {min:NaN, max:y});
                           consume(intm1);
                           produce(intm3);

--- a/builder/test/visualize/parallel_stencils_1.html
+++ b/builder/test/visualize/parallel_stencils_1.html
@@ -108,9 +108,18 @@ function define_mapping(buffer) {
   buf.mem.base = buffer.base;
   closure = function(base, elem_size, dims) {
     let sorted_dims = structuredClone(dims.toSorted(function(a, b) { return a.stride - b.stride; }));
-    return function(at) {
-      at -= base;
-      return [unpack_dim(at, sorted_dims[0]), unpack_dim(at, sorted_dims[1])];
+    if (sorted_dims.length > 1) {
+      return function(at) {
+        at -= base;
+        return [unpack_dim(at, sorted_dims[0]), unpack_dim(at, sorted_dims[1])];
+      }
+    } else if (sorted_dims.length == 1) {
+      return function(at) {
+        at -= base;
+        return [unpack_dim(at, sorted_dims[0]), 0];
+      }
+    } else {
+      return function(at) { return [0, 0]; }
     }
   }
   buf.mem.mapping = closure(buffer.base, buffer.elem_size, buffer.dims);
@@ -251,7 +260,7 @@ function truncate_rank(b, rank) {
 function produce(b) {
   m = find_mapping(b.base);
   if (m) {
-    m.element.mem.productions.push({t: __event_t++, buf: clone_buffer(b)});
+    m.element.mem.productions.push({t: __event_t, buf: clone_buffer(b)});
   }
 }
 function consume(b) {}
@@ -303,6 +312,7 @@ function pipeline(in1, in2, out) {
                 ]);
                 consume(in1);
                 produce(intm1);
+                __event_t++;
                 {
                   let y_min_orig = buffer_min(out, 1);
                   let __loop_min = (y_min_orig + -4);
@@ -317,6 +327,7 @@ function pipeline(in1, in2, out) {
                         { let __intm3 = crop_dim(intm3, 1, {min:NaN, max:y});
                           consume(intm1);
                           produce(intm3);
+                          __event_t++;
                           intm3 = __intm3;
                         }
                       }
@@ -325,17 +336,20 @@ function pipeline(in1, in2, out) {
                     { let __intm2 = crop_dim(intm2, 1, {min:(y + 2), max:(min((y + 1), buffer_max(out, 1)) + 2)});
                       consume(in2);
                       produce(intm2);
+                      __event_t++;
                       intm2 = __intm2;
                     }
                     { let __intm4 = crop_dim(intm4, 1, {min:y, max:min((y + 1), buffer_max(out, 1))});
                       consume(intm2_uncropped);
                       produce(intm4);
+                      __event_t++;
                       intm4 = __intm4;
                     }
                     { let __out = crop_dim(out, 1, {min:y, max:(y + 1)});
                       consume(intm3_uncropped);
                       consume(intm4_uncropped);
                       produce(out);
+                      __event_t++;
                       out = __out;
                     }
                   }

--- a/builder/test/visualize/parallel_stencils_2.html
+++ b/builder/test/visualize/parallel_stencils_2.html
@@ -108,9 +108,18 @@ function define_mapping(buffer) {
   buf.mem.base = buffer.base;
   closure = function(base, elem_size, dims) {
     let sorted_dims = structuredClone(dims.toSorted(function(a, b) { return a.stride - b.stride; }));
-    return function(at) {
-      at -= base;
-      return [unpack_dim(at, sorted_dims[0]), unpack_dim(at, sorted_dims[1])];
+    if (sorted_dims.length > 1) {
+      return function(at) {
+        at -= base;
+        return [unpack_dim(at, sorted_dims[0]), unpack_dim(at, sorted_dims[1])];
+      }
+    } else if (sorted_dims.length == 1) {
+      return function(at) {
+        at -= base;
+        return [unpack_dim(at, sorted_dims[0]), 0];
+      }
+    } else {
+      return function(at) { return [0, 0]; }
     }
   }
   buf.mem.mapping = closure(buffer.base, buffer.elem_size, buffer.dims);
@@ -251,7 +260,7 @@ function truncate_rank(b, rank) {
 function produce(b) {
   m = find_mapping(b.base);
   if (m) {
-    m.element.mem.productions.push({t: __event_t++, buf: clone_buffer(b)});
+    m.element.mem.productions.push({t: __event_t, buf: clone_buffer(b)});
   }
 }
 function consume(b) {}
@@ -311,27 +320,32 @@ function pipeline(in1, in2, out) {
                       { let __intm1 = crop_dim(intm1, 1, {min:(y + 1), max:(min((y + 1), buffer_max(out, 1)) + 1)});
                         consume(in1);
                         produce(intm1);
+                        __event_t++;
                         intm1 = __intm1;
                       }
                       { let __intm3 = crop_dim(intm3, 1, {min:y, max:min((y + 1), buffer_max(out, 1))});
                         consume(intm1_uncropped);
                         produce(intm3);
+                        __event_t++;
                         intm3 = __intm3;
                       }
                       { let __intm2 = crop_dim(intm2, 1, {min:(y + 2), max:(min((y + 1), buffer_max(out, 1)) + 2)});
                         consume(in2);
                         produce(intm2);
+                        __event_t++;
                         intm2 = __intm2;
                       }
                       { let __intm4 = crop_dim(intm4, 1, {min:y, max:min((y + 1), buffer_max(out, 1))});
                         consume(intm2_uncropped);
                         produce(intm4);
+                        __event_t++;
                         intm4 = __intm4;
                       }
                       { let __out = crop_dim(out, 1, {min:y, max:(y + 1)});
                         consume(intm3_uncropped);
                         consume(intm4_uncropped);
                         produce(out);
+                        __event_t++;
                         out = __out;
                       }
                     }

--- a/builder/test/visualize/parallel_stencils_2.html
+++ b/builder/test/visualize/parallel_stencils_2.html
@@ -304,7 +304,10 @@ function pipeline(in1, in2, out) {
                 { let intm1_uncropped = clone_buffer(intm1);
                   {
                     let y_min_orig = buffer_min(out, 1);
-                    for(let y = (y_min_orig + -6); y <= buffer_max(out, 1); y += 2) {
+                    let __loop_min = (y_min_orig + -6);
+                    let __loop_max = buffer_max(out, 1);
+                    let __loop_step = 2;
+                    for(let y = __loop_min; y <= __loop_max; y += __loop_step) {
                       { let __intm1 = crop_dim(intm1, 1, {min:(y + 1), max:(min((y + 1), buffer_max(out, 1)) + 1)});
                         consume(in1);
                         produce(intm1);

--- a/builder/test/visualize/softmax_split_0.html
+++ b/builder/test/visualize/softmax_split_0.html
@@ -1,0 +1,355 @@
+
+<!DOCTYPE html><html><head><title>Visualizer</title>
+<style>
+div.buffer {
+  border:2px solid gray;
+  width:400px;
+  height:400px;
+  display:inline-block;
+  margin:3px;
+  position:relative;
+}
+div.mem_wrapper {
+  width:100%;
+  height:100%;
+  position:absolute;
+  top:0;
+}
+div.overlays {
+  margin:auto;
+  padding:3px;
+  position:absolute;
+  bottom:0;
+  right:0;
+}
+p.label {
+  font-family:monospace;
+  margin:4px;
+  border-radius:5px;
+  background:black;
+  opacity:75%;
+  padding:3px;
+}
+div.controls {
+  position:fixed;
+  bottom:0;
+  left:0;
+  right:0;
+  width: 300px;
+  margin: auto;
+}
+input.slider {
+  width:300px;
+  margin:10px;
+}
+</style>
+</head>
+<script>
+var __current_t = 0;
+</script>
+<body>
+<div width='100%' height='100%' id='buffers' class='buffers'>
+  <div class='buffer' id='template' style='display:none;'>
+    <div class='mem_wrapper'><canvas id='mem' style='width:100%; height:100%'></canvas></div>
+    <div class='overlays'></div>
+  </div>
+</div>
+<div class='controls' width='100%'>
+  <input type='range' min='0' value='0' class='slider' id='event_slider' oninput='__current_t = this.value'>
+</div>
+<script>
+var __buffers = document.getElementById('buffers');
+let __template = document.getElementById('template');
+var __heap_map = [];
+var __event_t = 1;
+function euclidean_div(a, b) { return Math.floor(a / b); }
+function euclidean_mod(a, b) { return Math.round(a - b * euclidean_div(a, b)); }
+function min(a, b) { return Math.min(a, b); }
+function max(a, b) { return Math.max(a, b); }
+function abs(a) { return Math.abs(a); }
+function clamp(x, a, b) { return min(max(x, a), b); }
+function lerp(a, b, t) { return a + (b - a) * t; }
+function lerp_color(a, b, t) {
+  return [lerp(a[0], b[0], t), lerp(a[1], b[1], t), lerp(a[2], b[2], t)];
+}
+function make_color(a) {
+  return 'rgb(' + a[0] + ', ' + a[1] + ', ' + a[2] + ')';
+}
+function buffer_min(b, d) { return b.dims[d].bounds.min; }
+function buffer_max(b, d) { return b.dims[d].bounds.max; }
+function buffer_extent(b, d) { return b.dims[d].bounds.max - b.dims[d].bounds.min + 1; }
+function buffer_stride(b, d) { return b.dims[d].stride; }
+function buffer_fold_factor(b, d) { return b.dims[d].fold_factor; }
+function buffer_rank(b) { return b.dims.length; }
+function buffer_elem_size(b) { return b.elem_size; }
+function flat_offset_dim(d, x) { return ((x - d.bounds.min) % d.fold_factor) * d.stride; }
+function unpack_dim(at, dim) {
+  if (dim.stride == 0) {
+    return 0;
+  } else {
+    return euclidean_mod(euclidean_div(at, dim.stride), dim.bounds.max - dim.bounds.min + 1);
+  }
+}
+function add_label(buf, name, dims, color) {
+  let label = name + ': ' + dims.map(i => '[' + i.bounds.min + ',' + i.bounds.max + ']').toString();
+  let p = document.createElement('p');
+  p.classList.add('label');
+  p.style.color = make_color(color);
+  p.appendChild(document.createTextNode(label));
+  buf.querySelector('.overlays').appendChild(p);
+}
+
+function define_mapping(buffer) {
+  let buf = __template.cloneNode(true);
+  buf.id = name;
+  buf.style = '';
+  buf.mem = buf.querySelector('canvas#mem');
+  add_label(buf, buffer.name, buffer.dims, buffer.color);
+  buf.mem.base = buffer.base;
+  closure = function(base, elem_size, dims) {
+    let sorted_dims = structuredClone(dims.toSorted(function(a, b) { return a.stride - b.stride; }));
+    if (sorted_dims.length > 1) {
+      return function(at) {
+        at -= base;
+        return [unpack_dim(at, sorted_dims[0]), unpack_dim(at, sorted_dims[1])];
+      }
+    } else if (sorted_dims.length == 1) {
+      return function(at) {
+        at -= base;
+        return [unpack_dim(at, sorted_dims[0]), 0];
+      }
+    } else {
+      return function(at) { return [0, 0]; }
+    }
+  }
+  buf.mem.mapping = closure(buffer.base, buffer.elem_size, buffer.dims);
+  buf.mem.elem_size = buffer.elem_size;
+  buf.mem.productions = [];
+  __buffers.appendChild(buf);
+  __heap_map.push({begin: buffer.base, end: buffer.base + buffer.size, element: buf})
+  window.requestAnimationFrame(function(t) { draw(buf.mem, __current_t); });
+}
+function find_mapping(base) {
+  for (let m of __heap_map) {
+    if (m.begin <= base && base < m.end) {
+      return m;
+    }
+  }
+  return 0;
+}
+function add_mapping(buffer) {
+  let m = find_mapping(buffer.base);
+  if (m) {
+    add_label(m.element, buffer.name, buffer.dims, buffer.color);
+  }
+}
+function for_each_offset_dim(buf, at, dim, fn) {
+  for (let i = buf.dims[dim].bounds.min; i <= buf.dims[dim].bounds.max; ++i) {
+    if (dim == 0) {
+      fn(at + flat_offset_dim(buf.dims[dim], i));
+    } else {
+      for_each_offset_dim(buf, at + flat_offset_dim(buf.dims[dim], i), dim - 1, fn);
+    }
+  }
+}
+function for_each_offset(buf, fn) {
+  for_each_offset_dim(buf, buf.base, buf.dims.length - 1, fn);
+}
+function draw(mem, t) {
+  if (!mem.getContext) return;
+  mem.width = mem.offsetWidth;
+  mem.height = mem.offsetHeight;
+  const ctx = mem.getContext('2d');
+  ctx.clearRect(0, 0, mem.width, mem.height);
+  for (let p of mem.productions) {
+    dt = t - p.t;
+    if (dt < 0) continue;
+    color = make_color(lerp_color(p.buf.color, [0, 0, 0], clamp(dt / 8, 0, 0.25)));
+    ctx.fillStyle = color;
+    for_each_offset(p.buf, function(at) {
+      [x, y] = mem.mapping(at);
+      ctx.fillRect(x*10 + 5, y*10 + 5, 8, 8);
+    });
+  }
+  window.requestAnimationFrame(function(t) { draw(mem, __current_t); });
+}
+function check(condition) {}
+function buffer_at(b, ...at) {
+  let result = b.base;
+  for (let d = 0; d < at.length; ++d) {
+    if (isNaN(at[d])) continue;
+    result = result + flat_offset_dim(b.dims[d], at[d]);
+  }
+  return result;
+}
+function select(c, t, f) { return c ? t : f; }
+function flat_allocate(size) {
+  if (typeof flat_allocate.heap == 'undefined') {
+    flat_allocate.heap = 0;
+  }
+  let result = flat_allocate.heap;
+  flat_allocate.heap += size;
+  return result;
+}
+function next_color() {
+  const colors = [[255, 0, 0], [0, 255, 0], [65, 105, 225], [240, 230, 140], [255, 0, 255], [0, 255, 255]];
+  if (typeof next_color.next == 'undefined') {
+    next_color.next = 0;
+  }
+  return colors[(next_color.next++) % colors.length];
+}
+function allocate(name, elem_size, dims, hidden = false) {
+  let flat_min = 0;
+  let flat_max = 0;
+  for (let i = 0; i < dims.length; ++i) {
+    let extent = min(dims[i].bounds.max - dims[i].bounds.min + 1, dims[i].fold_factor);
+    flat_min += (extent - 1) * min(0, dims[i].stride);
+    flat_max += (extent - 1) * max(0, dims[i].stride);
+  }
+  let size = flat_max - flat_min + elem_size;
+  let base = flat_allocate(size);
+  let buffer = {name: name, base: base, size: size, elem_size: elem_size, dims: dims, color: next_color()};
+  if (!hidden) {
+    define_mapping(buffer);
+  }
+  return buffer;
+}
+function free(b) {}
+function make_buffer(name, base, elem_size, dims) { 
+  let buffer = {name: name, base: base, elem_size: elem_size, dims: dims, color: next_color()};
+  add_mapping(buffer);
+  return buffer;  
+}
+function clone_buffer(b) { return structuredClone(b); }
+function crop_dim(b, d, bounds) {
+  let result = clone_buffer(b);
+  let new_min = max(b.dims[d].bounds.min, bounds.min);
+  let new_max = min(b.dims[d].bounds.max, bounds.max);
+  if (new_max >= new_min) {
+    b.base += flat_offset_dim(b.dims[d], new_min);
+  }
+  b.dims[d].bounds.min = new_min;
+  b.dims[d].bounds.max = new_max;
+  return result;
+}
+function crop_buffer(b, bounds) {
+  let result = clone_buffer(b);
+  for (let d = 0; d < bounds.length; ++d) {
+    crop_dim(b, d, bounds[d]);
+  }
+  return result;
+}
+function slice_dim(b, d, at) {
+  let result = clone_buffer(b);
+  b.base += flat_offset_dim(b.dims[d], at);
+  b.dims.splice(d, 1);
+  return result;
+}
+function slice_buffer(b, at) {
+  let result = clone_buffer(b);
+  for (let d = at.length - 1; d >= 0; --d) {
+    slice_dim(b, d, at[d]);
+  }
+  return result;
+}
+function truncate_rank(b, rank) {
+  let result = clone_buffer(b);
+  b.dims.length = rank;
+  return result;
+}
+function produce(b) {
+  m = find_mapping(b.base);
+  if (m) {
+    m.element.mem.productions.push({t: __event_t, buf: clone_buffer(b)});
+  }
+}
+function consume(b) {}
+function trace_begin(x) { return x; }
+function trace_end(x) { return 1; }
+let __trace_names = allocate('__trace_names', 1, [{bounds:{min:0, max:0}, stride:1, fold_factor:1}], true);
+function pipeline(__in, out) {
+  check((__in != 0));
+  check((buffer_rank(__in) == 2));
+  check((buffer_elem_size(__in) == 4));
+  check((out != 0));
+  check((buffer_rank(out) == 2));
+  check((buffer_elem_size(out) == 4));
+  check((((buffer_max(out, 0) - buffer_min(out, 0)) + 1) <= buffer_fold_factor(out, 0)));
+  check((((buffer_max(out, 1) - buffer_min(out, 1)) + 1) <= buffer_fold_factor(out, 1)));
+  {
+    let g = buffer_min(out, 0);
+    let g0 = buffer_max(out, 0);
+    check((buffer_min(__in, 0) <= min(g, g0)));
+    check((max(g, g0) <= buffer_max(__in, 0)));
+    check(((abs((g - g0)) + 1) <= buffer_fold_factor(__in, 0)));
+    check((buffer_min(__in, 1) <= buffer_min(out, 1)));
+    check((buffer_max(out, 1) <= buffer_max(__in, 1)));
+    check((((buffer_max(out, 1) - buffer_min(out, 1)) + 1) <= buffer_fold_factor(__in, 1)));
+    { let softmax_out = allocate('softmax_out', 4, [
+        {bounds:{min:buffer_min(out, 0), max:buffer_max(out, 0)}, stride:4, fold_factor:9223372036854775807},
+        {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:(((buffer_max(out, 0) - buffer_min(out, 0)) * 4) + 4), fold_factor:9223372036854775807}
+      ]);
+      { let sum_exp_in = allocate('sum_exp_in', 4, [
+          {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:4, fold_factor:9223372036854775807}
+        ]);
+        { let sum_exp_in_uncropped = clone_buffer(sum_exp_in);
+          { let exp_in = allocate('exp_in', 4, [
+              {bounds:{min:min(g, g0), max:max(g, g0)}, stride:4, fold_factor:9223372036854775807},
+              {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:((abs((g - g0)) * 4) + 4), fold_factor:9223372036854775807}
+            ]);
+            { let max_in = allocate('max_in', 4, [
+                {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:4, fold_factor:9223372036854775807}
+              ]);
+              { let softmax_in = allocate('softmax_in', 4, [
+                  {bounds:{min:min(g, g0), max:max(g, g0)}, stride:4, fold_factor:9223372036854775807},
+                  {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:((abs((g - g0)) * 4) + 4), fold_factor:9223372036854775807}
+                ]);
+                consume(__in);
+                produce(softmax_in);
+                __event_t++;
+                consume(softmax_in);
+                produce(max_in);
+                __event_t++;
+                free(softmax_in);
+              }
+              consume(__in);
+              consume(max_in);
+              produce(exp_in);
+              produce(sum_exp_in);
+              __event_t++;
+              free(max_in);
+            }
+            consume(exp_in);
+            consume(sum_exp_in_uncropped);
+            produce(softmax_out);
+            __event_t++;
+            free(exp_in);
+          }
+        }
+        free(sum_exp_in);
+      }
+      consume(softmax_out);
+      produce(out);
+      __event_t++;
+      free(softmax_out);
+    }
+  }
+}
+let __in = allocate('in', 4, [{bounds: {min:0, max:29}, stride:4, fold_factor:9223372036854775807}, {bounds: {min:0, max:19}, stride:120, fold_factor:9223372036854775807}], true);
+let out = allocate('out', 4, [{bounds: {min:0, max:29}, stride:4, fold_factor:9223372036854775807}, {bounds: {min:0, max:19}, stride:120, fold_factor:9223372036854775807}]);
+pipeline(__in, out);
+
+let __end_t = __event_t;
+let __event_slider = document.getElementById('event_slider');
+let __autoplay = true;
+__event_slider.max = __end_t - 1;
+document.addEventListener('keyup', event => { if (event.code === 'Space') __autoplay = !__autoplay; });
+let rate = Math.min(1000, 5000 / __end_t);
+setInterval(function() {
+  if (__autoplay) {
+    __current_t = (__current_t + 1) % __end_t;
+    __event_slider.value = __current_t;
+  }
+}, rate);
+</script></body></html>
+

--- a/builder/test/visualize/softmax_split_1.html
+++ b/builder/test/visualize/softmax_split_1.html
@@ -1,0 +1,389 @@
+
+<!DOCTYPE html><html><head><title>Visualizer</title>
+<style>
+div.buffer {
+  border:2px solid gray;
+  width:400px;
+  height:400px;
+  display:inline-block;
+  margin:3px;
+  position:relative;
+}
+div.mem_wrapper {
+  width:100%;
+  height:100%;
+  position:absolute;
+  top:0;
+}
+div.overlays {
+  margin:auto;
+  padding:3px;
+  position:absolute;
+  bottom:0;
+  right:0;
+}
+p.label {
+  font-family:monospace;
+  margin:4px;
+  border-radius:5px;
+  background:black;
+  opacity:75%;
+  padding:3px;
+}
+div.controls {
+  position:fixed;
+  bottom:0;
+  left:0;
+  right:0;
+  width: 300px;
+  margin: auto;
+}
+input.slider {
+  width:300px;
+  margin:10px;
+}
+</style>
+</head>
+<script>
+var __current_t = 0;
+</script>
+<body>
+<div width='100%' height='100%' id='buffers' class='buffers'>
+  <div class='buffer' id='template' style='display:none;'>
+    <div class='mem_wrapper'><canvas id='mem' style='width:100%; height:100%'></canvas></div>
+    <div class='overlays'></div>
+  </div>
+</div>
+<div class='controls' width='100%'>
+  <input type='range' min='0' value='0' class='slider' id='event_slider' oninput='__current_t = this.value'>
+</div>
+<script>
+var __buffers = document.getElementById('buffers');
+let __template = document.getElementById('template');
+var __heap_map = [];
+var __event_t = 1;
+function euclidean_div(a, b) { return Math.floor(a / b); }
+function euclidean_mod(a, b) { return Math.round(a - b * euclidean_div(a, b)); }
+function min(a, b) { return Math.min(a, b); }
+function max(a, b) { return Math.max(a, b); }
+function abs(a) { return Math.abs(a); }
+function clamp(x, a, b) { return min(max(x, a), b); }
+function lerp(a, b, t) { return a + (b - a) * t; }
+function lerp_color(a, b, t) {
+  return [lerp(a[0], b[0], t), lerp(a[1], b[1], t), lerp(a[2], b[2], t)];
+}
+function make_color(a) {
+  return 'rgb(' + a[0] + ', ' + a[1] + ', ' + a[2] + ')';
+}
+function buffer_min(b, d) { return b.dims[d].bounds.min; }
+function buffer_max(b, d) { return b.dims[d].bounds.max; }
+function buffer_extent(b, d) { return b.dims[d].bounds.max - b.dims[d].bounds.min + 1; }
+function buffer_stride(b, d) { return b.dims[d].stride; }
+function buffer_fold_factor(b, d) { return b.dims[d].fold_factor; }
+function buffer_rank(b) { return b.dims.length; }
+function buffer_elem_size(b) { return b.elem_size; }
+function flat_offset_dim(d, x) { return ((x - d.bounds.min) % d.fold_factor) * d.stride; }
+function unpack_dim(at, dim) {
+  if (dim.stride == 0) {
+    return 0;
+  } else {
+    return euclidean_mod(euclidean_div(at, dim.stride), dim.bounds.max - dim.bounds.min + 1);
+  }
+}
+function add_label(buf, name, dims, color) {
+  let label = name + ': ' + dims.map(i => '[' + i.bounds.min + ',' + i.bounds.max + ']').toString();
+  let p = document.createElement('p');
+  p.classList.add('label');
+  p.style.color = make_color(color);
+  p.appendChild(document.createTextNode(label));
+  buf.querySelector('.overlays').appendChild(p);
+}
+
+function define_mapping(buffer) {
+  let buf = __template.cloneNode(true);
+  buf.id = name;
+  buf.style = '';
+  buf.mem = buf.querySelector('canvas#mem');
+  add_label(buf, buffer.name, buffer.dims, buffer.color);
+  buf.mem.base = buffer.base;
+  closure = function(base, elem_size, dims) {
+    let sorted_dims = structuredClone(dims.toSorted(function(a, b) { return a.stride - b.stride; }));
+    if (sorted_dims.length > 1) {
+      return function(at) {
+        at -= base;
+        return [unpack_dim(at, sorted_dims[0]), unpack_dim(at, sorted_dims[1])];
+      }
+    } else if (sorted_dims.length == 1) {
+      return function(at) {
+        at -= base;
+        return [unpack_dim(at, sorted_dims[0]), 0];
+      }
+    } else {
+      return function(at) { return [0, 0]; }
+    }
+  }
+  buf.mem.mapping = closure(buffer.base, buffer.elem_size, buffer.dims);
+  buf.mem.elem_size = buffer.elem_size;
+  buf.mem.productions = [];
+  __buffers.appendChild(buf);
+  __heap_map.push({begin: buffer.base, end: buffer.base + buffer.size, element: buf})
+  window.requestAnimationFrame(function(t) { draw(buf.mem, __current_t); });
+}
+function find_mapping(base) {
+  for (let m of __heap_map) {
+    if (m.begin <= base && base < m.end) {
+      return m;
+    }
+  }
+  return 0;
+}
+function add_mapping(buffer) {
+  let m = find_mapping(buffer.base);
+  if (m) {
+    add_label(m.element, buffer.name, buffer.dims, buffer.color);
+  }
+}
+function for_each_offset_dim(buf, at, dim, fn) {
+  for (let i = buf.dims[dim].bounds.min; i <= buf.dims[dim].bounds.max; ++i) {
+    if (dim == 0) {
+      fn(at + flat_offset_dim(buf.dims[dim], i));
+    } else {
+      for_each_offset_dim(buf, at + flat_offset_dim(buf.dims[dim], i), dim - 1, fn);
+    }
+  }
+}
+function for_each_offset(buf, fn) {
+  for_each_offset_dim(buf, buf.base, buf.dims.length - 1, fn);
+}
+function draw(mem, t) {
+  if (!mem.getContext) return;
+  mem.width = mem.offsetWidth;
+  mem.height = mem.offsetHeight;
+  const ctx = mem.getContext('2d');
+  ctx.clearRect(0, 0, mem.width, mem.height);
+  for (let p of mem.productions) {
+    dt = t - p.t;
+    if (dt < 0) continue;
+    color = make_color(lerp_color(p.buf.color, [0, 0, 0], clamp(dt / 8, 0, 0.25)));
+    ctx.fillStyle = color;
+    for_each_offset(p.buf, function(at) {
+      [x, y] = mem.mapping(at);
+      ctx.fillRect(x*10 + 5, y*10 + 5, 8, 8);
+    });
+  }
+  window.requestAnimationFrame(function(t) { draw(mem, __current_t); });
+}
+function check(condition) {}
+function buffer_at(b, ...at) {
+  let result = b.base;
+  for (let d = 0; d < at.length; ++d) {
+    if (isNaN(at[d])) continue;
+    result = result + flat_offset_dim(b.dims[d], at[d]);
+  }
+  return result;
+}
+function select(c, t, f) { return c ? t : f; }
+function flat_allocate(size) {
+  if (typeof flat_allocate.heap == 'undefined') {
+    flat_allocate.heap = 0;
+  }
+  let result = flat_allocate.heap;
+  flat_allocate.heap += size;
+  return result;
+}
+function next_color() {
+  const colors = [[255, 0, 0], [0, 255, 0], [65, 105, 225], [240, 230, 140], [255, 0, 255], [0, 255, 255]];
+  if (typeof next_color.next == 'undefined') {
+    next_color.next = 0;
+  }
+  return colors[(next_color.next++) % colors.length];
+}
+function allocate(name, elem_size, dims, hidden = false) {
+  let flat_min = 0;
+  let flat_max = 0;
+  for (let i = 0; i < dims.length; ++i) {
+    let extent = min(dims[i].bounds.max - dims[i].bounds.min + 1, dims[i].fold_factor);
+    flat_min += (extent - 1) * min(0, dims[i].stride);
+    flat_max += (extent - 1) * max(0, dims[i].stride);
+  }
+  let size = flat_max - flat_min + elem_size;
+  let base = flat_allocate(size);
+  let buffer = {name: name, base: base, size: size, elem_size: elem_size, dims: dims, color: next_color()};
+  if (!hidden) {
+    define_mapping(buffer);
+  }
+  return buffer;
+}
+function free(b) {}
+function make_buffer(name, base, elem_size, dims) { 
+  let buffer = {name: name, base: base, elem_size: elem_size, dims: dims, color: next_color()};
+  add_mapping(buffer);
+  return buffer;  
+}
+function clone_buffer(b) { return structuredClone(b); }
+function crop_dim(b, d, bounds) {
+  let result = clone_buffer(b);
+  let new_min = max(b.dims[d].bounds.min, bounds.min);
+  let new_max = min(b.dims[d].bounds.max, bounds.max);
+  if (new_max >= new_min) {
+    b.base += flat_offset_dim(b.dims[d], new_min);
+  }
+  b.dims[d].bounds.min = new_min;
+  b.dims[d].bounds.max = new_max;
+  return result;
+}
+function crop_buffer(b, bounds) {
+  let result = clone_buffer(b);
+  for (let d = 0; d < bounds.length; ++d) {
+    crop_dim(b, d, bounds[d]);
+  }
+  return result;
+}
+function slice_dim(b, d, at) {
+  let result = clone_buffer(b);
+  b.base += flat_offset_dim(b.dims[d], at);
+  b.dims.splice(d, 1);
+  return result;
+}
+function slice_buffer(b, at) {
+  let result = clone_buffer(b);
+  for (let d = at.length - 1; d >= 0; --d) {
+    slice_dim(b, d, at[d]);
+  }
+  return result;
+}
+function truncate_rank(b, rank) {
+  let result = clone_buffer(b);
+  b.dims.length = rank;
+  return result;
+}
+function produce(b) {
+  m = find_mapping(b.base);
+  if (m) {
+    m.element.mem.productions.push({t: __event_t, buf: clone_buffer(b)});
+  }
+}
+function consume(b) {}
+function trace_begin(x) { return x; }
+function trace_end(x) { return 1; }
+let __trace_names = allocate('__trace_names', 1, [{bounds:{min:0, max:0}, stride:1, fold_factor:1}], true);
+function pipeline(__in, out) {
+  check((__in != 0));
+  check((buffer_rank(__in) == 2));
+  check((buffer_elem_size(__in) == 4));
+  check((out != 0));
+  check((buffer_rank(out) == 2));
+  check((buffer_elem_size(out) == 4));
+  check((((buffer_max(out, 0) - buffer_min(out, 0)) + 1) <= buffer_fold_factor(out, 0)));
+  check((((buffer_max(out, 1) - buffer_min(out, 1)) + 1) <= buffer_fold_factor(out, 1)));
+  {
+    let g = buffer_min(out, 0);
+    let g0 = buffer_max(out, 0);
+    check((buffer_min(__in, 0) <= min(g, g0)));
+    check((max(g, g0) <= buffer_max(__in, 0)));
+    check(((abs((g - g0)) + 1) <= buffer_fold_factor(__in, 0)));
+    check((buffer_min(__in, 1) <= buffer_min(out, 1)));
+    check((buffer_max(out, 1) <= buffer_max(__in, 1)));
+    check((((buffer_max(out, 1) - buffer_min(out, 1)) + 1) <= buffer_fold_factor(__in, 1)));
+    { let softmax_out = allocate('softmax_out', 4, [
+        {bounds:{min:buffer_min(out, 0), max:buffer_max(out, 0)}, stride:4, fold_factor:9223372036854775807},
+        {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:(((buffer_max(out, 0) - buffer_min(out, 0)) * 4) + 4), fold_factor:1}
+      ]);
+      { let softmax_out_uncropped = clone_buffer(softmax_out);
+        { let sum_exp_in = allocate('sum_exp_in', 4, [
+            {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:4, fold_factor:1}
+          ]);
+          { let sum_exp_in_uncropped = clone_buffer(sum_exp_in);
+            { let exp_in = allocate('exp_in', 4, [
+                {bounds:{min:min(g, g0), max:max(g, g0)}, stride:4, fold_factor:9223372036854775807},
+                {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:((abs((g - g0)) * 4) + 4), fold_factor:1}
+              ]);
+              { let exp_in_uncropped = clone_buffer(exp_in);
+                { let max_in = allocate('max_in', 4, [
+                    {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:4, fold_factor:1}
+                  ]);
+                  { let max_in_uncropped = clone_buffer(max_in);
+                    { let softmax_in = allocate('softmax_in', 4, [
+                        {bounds:{min:min(g, g0), max:max(g, g0)}, stride:4, fold_factor:9223372036854775807},
+                        {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:((abs((g - g0)) * 4) + 4), fold_factor:1}
+                      ]);
+                      { let softmax_in_uncropped = clone_buffer(softmax_in);
+                        {
+                          let b_min_orig = buffer_min(out, 1);
+                          let __loop_min = b_min_orig;
+                          let __loop_max = buffer_max(out, 1);
+                          let __loop_step = 1;
+                          for(let b = __loop_min; b <= __loop_max; b += __loop_step) {
+                            { let __softmax_in = crop_dim(softmax_in, 1, {min:b, max:b});
+                              consume(__in);
+                              produce(softmax_in);
+                              __event_t++;
+                              softmax_in = __softmax_in;
+                            }
+                            { let __max_in = crop_dim(max_in, 0, {min:b, max:b});
+                              consume(softmax_in_uncropped);
+                              produce(max_in);
+                              __event_t++;
+                              max_in = __max_in;
+                            }
+                            { let __sum_exp_in = crop_dim(sum_exp_in, 0, {min:b, max:b});
+                              { let __exp_in = crop_dim(exp_in, 1, {min:b, max:b});
+                                consume(__in);
+                                consume(max_in_uncropped);
+                                produce(exp_in);
+                                produce(sum_exp_in);
+                                __event_t++;
+                                exp_in = __exp_in;
+                              }
+                              sum_exp_in = __sum_exp_in;
+                            }
+                            { let __softmax_out = crop_dim(softmax_out, 1, {min:b, max:b});
+                              consume(exp_in_uncropped);
+                              consume(sum_exp_in_uncropped);
+                              produce(softmax_out);
+                              __event_t++;
+                              softmax_out = __softmax_out;
+                            }
+                            { let __out = crop_dim(out, 1, {min:b, max:b});
+                              consume(softmax_out_uncropped);
+                              produce(out);
+                              __event_t++;
+                              out = __out;
+                            }
+                          }
+                        }
+                      }
+                      free(softmax_in);
+                    }
+                  }
+                  free(max_in);
+                }
+              }
+              free(exp_in);
+            }
+          }
+          free(sum_exp_in);
+        }
+      }
+      free(softmax_out);
+    }
+  }
+}
+let __in = allocate('in', 4, [{bounds: {min:0, max:29}, stride:4, fold_factor:9223372036854775807}, {bounds: {min:0, max:19}, stride:120, fold_factor:9223372036854775807}], true);
+let out = allocate('out', 4, [{bounds: {min:0, max:29}, stride:4, fold_factor:9223372036854775807}, {bounds: {min:0, max:19}, stride:120, fold_factor:9223372036854775807}]);
+pipeline(__in, out);
+
+let __end_t = __event_t;
+let __event_slider = document.getElementById('event_slider');
+let __autoplay = true;
+__event_slider.max = __end_t - 1;
+document.addEventListener('keyup', event => { if (event.code === 'Space') __autoplay = !__autoplay; });
+let rate = Math.min(1000, 5000 / __end_t);
+setInterval(function() {
+  if (__autoplay) {
+    __current_t = (__current_t + 1) % __end_t;
+    __event_slider.value = __current_t;
+  }
+}, rate);
+</script></body></html>
+

--- a/builder/test/visualize/softmax_split_4.html
+++ b/builder/test/visualize/softmax_split_4.html
@@ -1,0 +1,389 @@
+
+<!DOCTYPE html><html><head><title>Visualizer</title>
+<style>
+div.buffer {
+  border:2px solid gray;
+  width:400px;
+  height:400px;
+  display:inline-block;
+  margin:3px;
+  position:relative;
+}
+div.mem_wrapper {
+  width:100%;
+  height:100%;
+  position:absolute;
+  top:0;
+}
+div.overlays {
+  margin:auto;
+  padding:3px;
+  position:absolute;
+  bottom:0;
+  right:0;
+}
+p.label {
+  font-family:monospace;
+  margin:4px;
+  border-radius:5px;
+  background:black;
+  opacity:75%;
+  padding:3px;
+}
+div.controls {
+  position:fixed;
+  bottom:0;
+  left:0;
+  right:0;
+  width: 300px;
+  margin: auto;
+}
+input.slider {
+  width:300px;
+  margin:10px;
+}
+</style>
+</head>
+<script>
+var __current_t = 0;
+</script>
+<body>
+<div width='100%' height='100%' id='buffers' class='buffers'>
+  <div class='buffer' id='template' style='display:none;'>
+    <div class='mem_wrapper'><canvas id='mem' style='width:100%; height:100%'></canvas></div>
+    <div class='overlays'></div>
+  </div>
+</div>
+<div class='controls' width='100%'>
+  <input type='range' min='0' value='0' class='slider' id='event_slider' oninput='__current_t = this.value'>
+</div>
+<script>
+var __buffers = document.getElementById('buffers');
+let __template = document.getElementById('template');
+var __heap_map = [];
+var __event_t = 1;
+function euclidean_div(a, b) { return Math.floor(a / b); }
+function euclidean_mod(a, b) { return Math.round(a - b * euclidean_div(a, b)); }
+function min(a, b) { return Math.min(a, b); }
+function max(a, b) { return Math.max(a, b); }
+function abs(a) { return Math.abs(a); }
+function clamp(x, a, b) { return min(max(x, a), b); }
+function lerp(a, b, t) { return a + (b - a) * t; }
+function lerp_color(a, b, t) {
+  return [lerp(a[0], b[0], t), lerp(a[1], b[1], t), lerp(a[2], b[2], t)];
+}
+function make_color(a) {
+  return 'rgb(' + a[0] + ', ' + a[1] + ', ' + a[2] + ')';
+}
+function buffer_min(b, d) { return b.dims[d].bounds.min; }
+function buffer_max(b, d) { return b.dims[d].bounds.max; }
+function buffer_extent(b, d) { return b.dims[d].bounds.max - b.dims[d].bounds.min + 1; }
+function buffer_stride(b, d) { return b.dims[d].stride; }
+function buffer_fold_factor(b, d) { return b.dims[d].fold_factor; }
+function buffer_rank(b) { return b.dims.length; }
+function buffer_elem_size(b) { return b.elem_size; }
+function flat_offset_dim(d, x) { return ((x - d.bounds.min) % d.fold_factor) * d.stride; }
+function unpack_dim(at, dim) {
+  if (dim.stride == 0) {
+    return 0;
+  } else {
+    return euclidean_mod(euclidean_div(at, dim.stride), dim.bounds.max - dim.bounds.min + 1);
+  }
+}
+function add_label(buf, name, dims, color) {
+  let label = name + ': ' + dims.map(i => '[' + i.bounds.min + ',' + i.bounds.max + ']').toString();
+  let p = document.createElement('p');
+  p.classList.add('label');
+  p.style.color = make_color(color);
+  p.appendChild(document.createTextNode(label));
+  buf.querySelector('.overlays').appendChild(p);
+}
+
+function define_mapping(buffer) {
+  let buf = __template.cloneNode(true);
+  buf.id = name;
+  buf.style = '';
+  buf.mem = buf.querySelector('canvas#mem');
+  add_label(buf, buffer.name, buffer.dims, buffer.color);
+  buf.mem.base = buffer.base;
+  closure = function(base, elem_size, dims) {
+    let sorted_dims = structuredClone(dims.toSorted(function(a, b) { return a.stride - b.stride; }));
+    if (sorted_dims.length > 1) {
+      return function(at) {
+        at -= base;
+        return [unpack_dim(at, sorted_dims[0]), unpack_dim(at, sorted_dims[1])];
+      }
+    } else if (sorted_dims.length == 1) {
+      return function(at) {
+        at -= base;
+        return [unpack_dim(at, sorted_dims[0]), 0];
+      }
+    } else {
+      return function(at) { return [0, 0]; }
+    }
+  }
+  buf.mem.mapping = closure(buffer.base, buffer.elem_size, buffer.dims);
+  buf.mem.elem_size = buffer.elem_size;
+  buf.mem.productions = [];
+  __buffers.appendChild(buf);
+  __heap_map.push({begin: buffer.base, end: buffer.base + buffer.size, element: buf})
+  window.requestAnimationFrame(function(t) { draw(buf.mem, __current_t); });
+}
+function find_mapping(base) {
+  for (let m of __heap_map) {
+    if (m.begin <= base && base < m.end) {
+      return m;
+    }
+  }
+  return 0;
+}
+function add_mapping(buffer) {
+  let m = find_mapping(buffer.base);
+  if (m) {
+    add_label(m.element, buffer.name, buffer.dims, buffer.color);
+  }
+}
+function for_each_offset_dim(buf, at, dim, fn) {
+  for (let i = buf.dims[dim].bounds.min; i <= buf.dims[dim].bounds.max; ++i) {
+    if (dim == 0) {
+      fn(at + flat_offset_dim(buf.dims[dim], i));
+    } else {
+      for_each_offset_dim(buf, at + flat_offset_dim(buf.dims[dim], i), dim - 1, fn);
+    }
+  }
+}
+function for_each_offset(buf, fn) {
+  for_each_offset_dim(buf, buf.base, buf.dims.length - 1, fn);
+}
+function draw(mem, t) {
+  if (!mem.getContext) return;
+  mem.width = mem.offsetWidth;
+  mem.height = mem.offsetHeight;
+  const ctx = mem.getContext('2d');
+  ctx.clearRect(0, 0, mem.width, mem.height);
+  for (let p of mem.productions) {
+    dt = t - p.t;
+    if (dt < 0) continue;
+    color = make_color(lerp_color(p.buf.color, [0, 0, 0], clamp(dt / 8, 0, 0.25)));
+    ctx.fillStyle = color;
+    for_each_offset(p.buf, function(at) {
+      [x, y] = mem.mapping(at);
+      ctx.fillRect(x*10 + 5, y*10 + 5, 8, 8);
+    });
+  }
+  window.requestAnimationFrame(function(t) { draw(mem, __current_t); });
+}
+function check(condition) {}
+function buffer_at(b, ...at) {
+  let result = b.base;
+  for (let d = 0; d < at.length; ++d) {
+    if (isNaN(at[d])) continue;
+    result = result + flat_offset_dim(b.dims[d], at[d]);
+  }
+  return result;
+}
+function select(c, t, f) { return c ? t : f; }
+function flat_allocate(size) {
+  if (typeof flat_allocate.heap == 'undefined') {
+    flat_allocate.heap = 0;
+  }
+  let result = flat_allocate.heap;
+  flat_allocate.heap += size;
+  return result;
+}
+function next_color() {
+  const colors = [[255, 0, 0], [0, 255, 0], [65, 105, 225], [240, 230, 140], [255, 0, 255], [0, 255, 255]];
+  if (typeof next_color.next == 'undefined') {
+    next_color.next = 0;
+  }
+  return colors[(next_color.next++) % colors.length];
+}
+function allocate(name, elem_size, dims, hidden = false) {
+  let flat_min = 0;
+  let flat_max = 0;
+  for (let i = 0; i < dims.length; ++i) {
+    let extent = min(dims[i].bounds.max - dims[i].bounds.min + 1, dims[i].fold_factor);
+    flat_min += (extent - 1) * min(0, dims[i].stride);
+    flat_max += (extent - 1) * max(0, dims[i].stride);
+  }
+  let size = flat_max - flat_min + elem_size;
+  let base = flat_allocate(size);
+  let buffer = {name: name, base: base, size: size, elem_size: elem_size, dims: dims, color: next_color()};
+  if (!hidden) {
+    define_mapping(buffer);
+  }
+  return buffer;
+}
+function free(b) {}
+function make_buffer(name, base, elem_size, dims) { 
+  let buffer = {name: name, base: base, elem_size: elem_size, dims: dims, color: next_color()};
+  add_mapping(buffer);
+  return buffer;  
+}
+function clone_buffer(b) { return structuredClone(b); }
+function crop_dim(b, d, bounds) {
+  let result = clone_buffer(b);
+  let new_min = max(b.dims[d].bounds.min, bounds.min);
+  let new_max = min(b.dims[d].bounds.max, bounds.max);
+  if (new_max >= new_min) {
+    b.base += flat_offset_dim(b.dims[d], new_min);
+  }
+  b.dims[d].bounds.min = new_min;
+  b.dims[d].bounds.max = new_max;
+  return result;
+}
+function crop_buffer(b, bounds) {
+  let result = clone_buffer(b);
+  for (let d = 0; d < bounds.length; ++d) {
+    crop_dim(b, d, bounds[d]);
+  }
+  return result;
+}
+function slice_dim(b, d, at) {
+  let result = clone_buffer(b);
+  b.base += flat_offset_dim(b.dims[d], at);
+  b.dims.splice(d, 1);
+  return result;
+}
+function slice_buffer(b, at) {
+  let result = clone_buffer(b);
+  for (let d = at.length - 1; d >= 0; --d) {
+    slice_dim(b, d, at[d]);
+  }
+  return result;
+}
+function truncate_rank(b, rank) {
+  let result = clone_buffer(b);
+  b.dims.length = rank;
+  return result;
+}
+function produce(b) {
+  m = find_mapping(b.base);
+  if (m) {
+    m.element.mem.productions.push({t: __event_t, buf: clone_buffer(b)});
+  }
+}
+function consume(b) {}
+function trace_begin(x) { return x; }
+function trace_end(x) { return 1; }
+let __trace_names = allocate('__trace_names', 1, [{bounds:{min:0, max:0}, stride:1, fold_factor:1}], true);
+function pipeline(__in, out) {
+  check((__in != 0));
+  check((buffer_rank(__in) == 2));
+  check((buffer_elem_size(__in) == 4));
+  check((out != 0));
+  check((buffer_rank(out) == 2));
+  check((buffer_elem_size(out) == 4));
+  check((((buffer_max(out, 0) - buffer_min(out, 0)) + 1) <= buffer_fold_factor(out, 0)));
+  check((((buffer_max(out, 1) - buffer_min(out, 1)) + 1) <= buffer_fold_factor(out, 1)));
+  {
+    let g = buffer_min(out, 0);
+    let g0 = buffer_max(out, 0);
+    check((buffer_min(__in, 0) <= min(g, g0)));
+    check((max(g, g0) <= buffer_max(__in, 0)));
+    check(((abs((g - g0)) + 1) <= buffer_fold_factor(__in, 0)));
+    check((buffer_min(__in, 1) <= buffer_min(out, 1)));
+    check((buffer_max(out, 1) <= buffer_max(__in, 1)));
+    check((((buffer_max(out, 1) - buffer_min(out, 1)) + 1) <= buffer_fold_factor(__in, 1)));
+    { let softmax_out = allocate('softmax_out', 4, [
+        {bounds:{min:buffer_min(out, 0), max:buffer_max(out, 0)}, stride:4, fold_factor:9223372036854775807},
+        {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:(((buffer_max(out, 0) - buffer_min(out, 0)) * 4) + 4), fold_factor:4}
+      ]);
+      { let softmax_out_uncropped = clone_buffer(softmax_out);
+        { let sum_exp_in = allocate('sum_exp_in', 4, [
+            {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:4, fold_factor:4}
+          ]);
+          { let sum_exp_in_uncropped = clone_buffer(sum_exp_in);
+            { let exp_in = allocate('exp_in', 4, [
+                {bounds:{min:min(g, g0), max:max(g, g0)}, stride:4, fold_factor:9223372036854775807},
+                {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:((abs((g - g0)) * 4) + 4), fold_factor:4}
+              ]);
+              { let exp_in_uncropped = clone_buffer(exp_in);
+                { let max_in = allocate('max_in', 4, [
+                    {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:4, fold_factor:4}
+                  ]);
+                  { let max_in_uncropped = clone_buffer(max_in);
+                    { let softmax_in = allocate('softmax_in', 4, [
+                        {bounds:{min:min(g, g0), max:max(g, g0)}, stride:4, fold_factor:9223372036854775807},
+                        {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:((abs((g - g0)) * 4) + 4), fold_factor:4}
+                      ]);
+                      { let softmax_in_uncropped = clone_buffer(softmax_in);
+                        {
+                          let b_min_orig = buffer_min(out, 1);
+                          let __loop_min = b_min_orig;
+                          let __loop_max = buffer_max(out, 1);
+                          let __loop_step = 4;
+                          for(let b = __loop_min; b <= __loop_max; b += __loop_step) {
+                            { let __softmax_in = crop_dim(softmax_in, 1, {min:b, max:min((b + 3), buffer_max(out, 1))});
+                              consume(__in);
+                              produce(softmax_in);
+                              __event_t++;
+                              softmax_in = __softmax_in;
+                            }
+                            { let __max_in = crop_dim(max_in, 0, {min:b, max:min((b + 3), buffer_max(out, 1))});
+                              consume(softmax_in_uncropped);
+                              produce(max_in);
+                              __event_t++;
+                              max_in = __max_in;
+                            }
+                            { let __sum_exp_in = crop_dim(sum_exp_in, 0, {min:b, max:min((b + 3), buffer_max(out, 1))});
+                              { let __exp_in = crop_dim(exp_in, 1, {min:b, max:min((b + 3), buffer_max(out, 1))});
+                                consume(__in);
+                                consume(max_in_uncropped);
+                                produce(exp_in);
+                                produce(sum_exp_in);
+                                __event_t++;
+                                exp_in = __exp_in;
+                              }
+                              sum_exp_in = __sum_exp_in;
+                            }
+                            { let __softmax_out = crop_dim(softmax_out, 1, {min:b, max:min((b + 3), buffer_max(out, 1))});
+                              consume(exp_in_uncropped);
+                              consume(sum_exp_in_uncropped);
+                              produce(softmax_out);
+                              __event_t++;
+                              softmax_out = __softmax_out;
+                            }
+                            { let __out = crop_dim(out, 1, {min:b, max:(b + 3)});
+                              consume(softmax_out_uncropped);
+                              produce(out);
+                              __event_t++;
+                              out = __out;
+                            }
+                          }
+                        }
+                      }
+                      free(softmax_in);
+                    }
+                  }
+                  free(max_in);
+                }
+              }
+              free(exp_in);
+            }
+          }
+          free(sum_exp_in);
+        }
+      }
+      free(softmax_out);
+    }
+  }
+}
+let __in = allocate('in', 4, [{bounds: {min:0, max:29}, stride:4, fold_factor:9223372036854775807}, {bounds: {min:0, max:19}, stride:120, fold_factor:9223372036854775807}], true);
+let out = allocate('out', 4, [{bounds: {min:0, max:29}, stride:4, fold_factor:9223372036854775807}, {bounds: {min:0, max:19}, stride:120, fold_factor:9223372036854775807}]);
+pipeline(__in, out);
+
+let __end_t = __event_t;
+let __event_slider = document.getElementById('event_slider');
+let __autoplay = true;
+__event_slider.max = __end_t - 1;
+document.addEventListener('keyup', event => { if (event.code === 'Space') __autoplay = !__autoplay; });
+let rate = Math.min(1000, 5000 / __end_t);
+setInterval(function() {
+  if (__autoplay) {
+    __current_t = (__current_t + 1) % __end_t;
+    __event_slider.value = __current_t;
+  }
+}, rate);
+</script></body></html>
+

--- a/builder/test/visualize/stencil_chain_split_serial_split_0.html
+++ b/builder/test/visualize/stencil_chain_split_serial_split_0.html
@@ -108,9 +108,18 @@ function define_mapping(buffer) {
   buf.mem.base = buffer.base;
   closure = function(base, elem_size, dims) {
     let sorted_dims = structuredClone(dims.toSorted(function(a, b) { return a.stride - b.stride; }));
-    return function(at) {
-      at -= base;
-      return [unpack_dim(at, sorted_dims[0]), unpack_dim(at, sorted_dims[1])];
+    if (sorted_dims.length > 1) {
+      return function(at) {
+        at -= base;
+        return [unpack_dim(at, sorted_dims[0]), unpack_dim(at, sorted_dims[1])];
+      }
+    } else if (sorted_dims.length == 1) {
+      return function(at) {
+        at -= base;
+        return [unpack_dim(at, sorted_dims[0]), 0];
+      }
+    } else {
+      return function(at) { return [0, 0]; }
     }
   }
   buf.mem.mapping = closure(buffer.base, buffer.elem_size, buffer.dims);
@@ -251,7 +260,7 @@ function truncate_rank(b, rank) {
 function produce(b) {
   m = find_mapping(b.base);
   if (m) {
-    m.element.mem.productions.push({t: __event_t++, buf: clone_buffer(b)});
+    m.element.mem.productions.push({t: __event_t, buf: clone_buffer(b)});
   }
 }
 function consume(b) {}
@@ -287,12 +296,14 @@ function pipeline(__in, out) {
           let __trace_token = trace_begin(buffer_at(__trace_names, 0));
           consume(__in);
           produce(add_result);
+          __event_t++;
           check(trace_end(__trace_token));
         }
         {
           let __trace_token = trace_begin(buffer_at(__trace_names, 6));
           consume(add_result);
           produce(stencil1_result);
+          __event_t++;
           check(trace_end(__trace_token));
         }
         free(add_result);
@@ -301,6 +312,7 @@ function pipeline(__in, out) {
         let __trace_token = trace_begin(buffer_at(__trace_names, 6));
         consume(stencil1_result);
         produce(out);
+        __event_t++;
         check(trace_end(__trace_token));
       }
       free(stencil1_result);

--- a/builder/test/visualize/stencil_chain_split_serial_split_1.html
+++ b/builder/test/visualize/stencil_chain_split_serial_split_1.html
@@ -288,7 +288,10 @@ function pipeline(__in, out) {
             {
               let y_min_orig = buffer_min(out, 1);
               let __trace_token = trace_begin(buffer_at(__trace_names, 17));
-              for(let y = (y_min_orig + -4); y <= buffer_max(out, 1); y += 1) {
+              let __loop_min = (y_min_orig + -4);
+              let __loop_max = buffer_max(out, 1);
+              let __loop_step = 1;
+              for(let y = __loop_min; y <= __loop_max; y += __loop_step) {
                 {
                   let __trace_token = trace_begin(buffer_at(__trace_names, 0));
                   { let __add_result = crop_dim(add_result, 1, {min:(y + 2), max:(y + 2)});

--- a/builder/test/visualize/stencil_chain_split_serial_split_1.html
+++ b/builder/test/visualize/stencil_chain_split_serial_split_1.html
@@ -108,9 +108,18 @@ function define_mapping(buffer) {
   buf.mem.base = buffer.base;
   closure = function(base, elem_size, dims) {
     let sorted_dims = structuredClone(dims.toSorted(function(a, b) { return a.stride - b.stride; }));
-    return function(at) {
-      at -= base;
-      return [unpack_dim(at, sorted_dims[0]), unpack_dim(at, sorted_dims[1])];
+    if (sorted_dims.length > 1) {
+      return function(at) {
+        at -= base;
+        return [unpack_dim(at, sorted_dims[0]), unpack_dim(at, sorted_dims[1])];
+      }
+    } else if (sorted_dims.length == 1) {
+      return function(at) {
+        at -= base;
+        return [unpack_dim(at, sorted_dims[0]), 0];
+      }
+    } else {
+      return function(at) { return [0, 0]; }
     }
   }
   buf.mem.mapping = closure(buffer.base, buffer.elem_size, buffer.dims);
@@ -251,7 +260,7 @@ function truncate_rank(b, rank) {
 function produce(b) {
   m = find_mapping(b.base);
   if (m) {
-    m.element.mem.productions.push({t: __event_t++, buf: clone_buffer(b)});
+    m.element.mem.productions.push({t: __event_t, buf: clone_buffer(b)});
   }
 }
 function consume(b) {}
@@ -299,6 +308,7 @@ function pipeline(__in, out) {
                       let __trace_token = trace_begin(buffer_at(__trace_names, 24));
                       consume(__in);
                       produce(add_result);
+                      __event_t++;
                       check(trace_end(__trace_token));
                     }
                     add_result = __add_result;
@@ -308,6 +318,7 @@ function pipeline(__in, out) {
                       let __trace_token = trace_begin(buffer_at(__trace_names, 30));
                       consume(add_result_uncropped);
                       produce(stencil1_result);
+                      __event_t++;
                       check(trace_end(__trace_token));
                     }
                     stencil1_result = __stencil1_result;
@@ -317,6 +328,7 @@ function pipeline(__in, out) {
                       let __trace_token = trace_begin(buffer_at(__trace_names, 30));
                       consume(stencil1_result_uncropped);
                       produce(out);
+                      __event_t++;
                       check(trace_end(__trace_token));
                     }
                     out = __out;

--- a/builder/test/visualize/stencil_chain_split_serial_split_2.html
+++ b/builder/test/visualize/stencil_chain_split_serial_split_2.html
@@ -108,9 +108,18 @@ function define_mapping(buffer) {
   buf.mem.base = buffer.base;
   closure = function(base, elem_size, dims) {
     let sorted_dims = structuredClone(dims.toSorted(function(a, b) { return a.stride - b.stride; }));
-    return function(at) {
-      at -= base;
-      return [unpack_dim(at, sorted_dims[0]), unpack_dim(at, sorted_dims[1])];
+    if (sorted_dims.length > 1) {
+      return function(at) {
+        at -= base;
+        return [unpack_dim(at, sorted_dims[0]), unpack_dim(at, sorted_dims[1])];
+      }
+    } else if (sorted_dims.length == 1) {
+      return function(at) {
+        at -= base;
+        return [unpack_dim(at, sorted_dims[0]), 0];
+      }
+    } else {
+      return function(at) { return [0, 0]; }
     }
   }
   buf.mem.mapping = closure(buffer.base, buffer.elem_size, buffer.dims);
@@ -251,7 +260,7 @@ function truncate_rank(b, rank) {
 function produce(b) {
   m = find_mapping(b.base);
   if (m) {
-    m.element.mem.productions.push({t: __event_t++, buf: clone_buffer(b)});
+    m.element.mem.productions.push({t: __event_t, buf: clone_buffer(b)});
   }
 }
 function consume(b) {}
@@ -299,6 +308,7 @@ function pipeline(__in, out) {
                       let __trace_token = trace_begin(buffer_at(__trace_names, 24));
                       consume(__in);
                       produce(add_result);
+                      __event_t++;
                       check(trace_end(__trace_token));
                     }
                     add_result = __add_result;
@@ -308,6 +318,7 @@ function pipeline(__in, out) {
                       let __trace_token = trace_begin(buffer_at(__trace_names, 30));
                       consume(add_result_uncropped);
                       produce(stencil1_result);
+                      __event_t++;
                       check(trace_end(__trace_token));
                     }
                     stencil1_result = __stencil1_result;
@@ -317,6 +328,7 @@ function pipeline(__in, out) {
                       let __trace_token = trace_begin(buffer_at(__trace_names, 30));
                       consume(stencil1_result_uncropped);
                       produce(out);
+                      __event_t++;
                       check(trace_end(__trace_token));
                     }
                     out = __out;

--- a/builder/test/visualize/stencil_chain_split_serial_split_2.html
+++ b/builder/test/visualize/stencil_chain_split_serial_split_2.html
@@ -288,7 +288,10 @@ function pipeline(__in, out) {
             {
               let y_min_orig = buffer_min(out, 1);
               let __trace_token = trace_begin(buffer_at(__trace_names, 17));
-              for(let y = (y_min_orig + -4); y <= buffer_max(out, 1); y += 2) {
+              let __loop_min = (y_min_orig + -4);
+              let __loop_max = buffer_max(out, 1);
+              let __loop_step = 2;
+              for(let y = __loop_min; y <= __loop_max; y += __loop_step) {
                 {
                   let __trace_token = trace_begin(buffer_at(__trace_names, 0));
                   { let __add_result = crop_dim(add_result, 1, {min:(y + 2), max:(min((y + 1), buffer_max(out, 1)) + 2)});

--- a/builder/test/visualize/stencil_split_0.html
+++ b/builder/test/visualize/stencil_split_0.html
@@ -108,9 +108,18 @@ function define_mapping(buffer) {
   buf.mem.base = buffer.base;
   closure = function(base, elem_size, dims) {
     let sorted_dims = structuredClone(dims.toSorted(function(a, b) { return a.stride - b.stride; }));
-    return function(at) {
-      at -= base;
-      return [unpack_dim(at, sorted_dims[0]), unpack_dim(at, sorted_dims[1])];
+    if (sorted_dims.length > 1) {
+      return function(at) {
+        at -= base;
+        return [unpack_dim(at, sorted_dims[0]), unpack_dim(at, sorted_dims[1])];
+      }
+    } else if (sorted_dims.length == 1) {
+      return function(at) {
+        at -= base;
+        return [unpack_dim(at, sorted_dims[0]), 0];
+      }
+    } else {
+      return function(at) { return [0, 0]; }
     }
   }
   buf.mem.mapping = closure(buffer.base, buffer.elem_size, buffer.dims);
@@ -251,7 +260,7 @@ function truncate_rank(b, rank) {
 function produce(b) {
   m = find_mapping(b.base);
   if (m) {
-    m.element.mem.productions.push({t: __event_t++, buf: clone_buffer(b)});
+    m.element.mem.productions.push({t: __event_t, buf: clone_buffer(b)});
   }
 }
 function consume(b) {}
@@ -279,8 +288,10 @@ function pipeline(__in, out) {
     ]);
     consume(__in);
     produce(intm);
+    __event_t++;
     consume(intm);
     produce(out);
+    __event_t++;
     free(intm);
   }
 }

--- a/builder/test/visualize/stencil_split_1.html
+++ b/builder/test/visualize/stencil_split_1.html
@@ -108,9 +108,18 @@ function define_mapping(buffer) {
   buf.mem.base = buffer.base;
   closure = function(base, elem_size, dims) {
     let sorted_dims = structuredClone(dims.toSorted(function(a, b) { return a.stride - b.stride; }));
-    return function(at) {
-      at -= base;
-      return [unpack_dim(at, sorted_dims[0]), unpack_dim(at, sorted_dims[1])];
+    if (sorted_dims.length > 1) {
+      return function(at) {
+        at -= base;
+        return [unpack_dim(at, sorted_dims[0]), unpack_dim(at, sorted_dims[1])];
+      }
+    } else if (sorted_dims.length == 1) {
+      return function(at) {
+        at -= base;
+        return [unpack_dim(at, sorted_dims[0]), 0];
+      }
+    } else {
+      return function(at) { return [0, 0]; }
     }
   }
   buf.mem.mapping = closure(buffer.base, buffer.elem_size, buffer.dims);
@@ -251,7 +260,7 @@ function truncate_rank(b, rank) {
 function produce(b) {
   m = find_mapping(b.base);
   if (m) {
-    m.element.mem.productions.push({t: __event_t++, buf: clone_buffer(b)});
+    m.element.mem.productions.push({t: __event_t, buf: clone_buffer(b)});
   }
 }
 function consume(b) {}
@@ -287,11 +296,13 @@ function pipeline(__in, out) {
           { let __intm = crop_dim(intm, 1, {min:(y + 1), max:(y + 1)});
             consume(__in);
             produce(intm);
+            __event_t++;
             intm = __intm;
           }
           { let __out = crop_dim(out, 1, {min:y, max:y});
             consume(intm_uncropped);
             produce(out);
+            __event_t++;
             out = __out;
           }
         }

--- a/builder/test/visualize/stencil_split_1.html
+++ b/builder/test/visualize/stencil_split_1.html
@@ -280,7 +280,10 @@ function pipeline(__in, out) {
     { let intm_uncropped = clone_buffer(intm);
       {
         let y_min_orig = buffer_min(out, 1);
-        for(let y = (y_min_orig + -2); y <= buffer_max(out, 1); y += 1) {
+        let __loop_min = (y_min_orig + -2);
+        let __loop_max = buffer_max(out, 1);
+        let __loop_step = 1;
+        for(let y = __loop_min; y <= __loop_max; y += __loop_step) {
           { let __intm = crop_dim(intm, 1, {min:(y + 1), max:(y + 1)});
             consume(__in);
             produce(intm);

--- a/builder/test/visualize/stencil_split_2.html
+++ b/builder/test/visualize/stencil_split_2.html
@@ -280,7 +280,10 @@ function pipeline(__in, out) {
     { let intm_uncropped = clone_buffer(intm);
       {
         let y_min_orig = buffer_min(out, 1);
-        for(let y = (y_min_orig + -2); y <= buffer_max(out, 1); y += 2) {
+        let __loop_min = (y_min_orig + -2);
+        let __loop_max = buffer_max(out, 1);
+        let __loop_step = 2;
+        for(let y = __loop_min; y <= __loop_max; y += __loop_step) {
           { let __intm = crop_dim(intm, 1, {min:(y + 1), max:(min((y + 1), buffer_max(out, 1)) + 1)});
             consume(__in);
             produce(intm);

--- a/builder/test/visualize/stencil_split_2.html
+++ b/builder/test/visualize/stencil_split_2.html
@@ -108,9 +108,18 @@ function define_mapping(buffer) {
   buf.mem.base = buffer.base;
   closure = function(base, elem_size, dims) {
     let sorted_dims = structuredClone(dims.toSorted(function(a, b) { return a.stride - b.stride; }));
-    return function(at) {
-      at -= base;
-      return [unpack_dim(at, sorted_dims[0]), unpack_dim(at, sorted_dims[1])];
+    if (sorted_dims.length > 1) {
+      return function(at) {
+        at -= base;
+        return [unpack_dim(at, sorted_dims[0]), unpack_dim(at, sorted_dims[1])];
+      }
+    } else if (sorted_dims.length == 1) {
+      return function(at) {
+        at -= base;
+        return [unpack_dim(at, sorted_dims[0]), 0];
+      }
+    } else {
+      return function(at) { return [0, 0]; }
     }
   }
   buf.mem.mapping = closure(buffer.base, buffer.elem_size, buffer.dims);
@@ -251,7 +260,7 @@ function truncate_rank(b, rank) {
 function produce(b) {
   m = find_mapping(b.base);
   if (m) {
-    m.element.mem.productions.push({t: __event_t++, buf: clone_buffer(b)});
+    m.element.mem.productions.push({t: __event_t, buf: clone_buffer(b)});
   }
 }
 function consume(b) {}
@@ -287,11 +296,13 @@ function pipeline(__in, out) {
           { let __intm = crop_dim(intm, 1, {min:(y + 1), max:(min((y + 1), buffer_max(out, 1)) + 1)});
             consume(__in);
             produce(intm);
+            __event_t++;
             intm = __intm;
           }
           { let __out = crop_dim(out, 1, {min:y, max:(y + 1)});
             consume(intm_uncropped);
             produce(out);
+            __event_t++;
             out = __out;
           }
         }

--- a/builder/test/visualize/stencil_split_3.html
+++ b/builder/test/visualize/stencil_split_3.html
@@ -280,7 +280,10 @@ function pipeline(__in, out) {
     { let intm_uncropped = clone_buffer(intm);
       {
         let y_min_orig = buffer_min(out, 1);
-        for(let y = (y_min_orig + -2); y <= buffer_max(out, 1); y += 3) {
+        let __loop_min = (y_min_orig + -2);
+        let __loop_max = buffer_max(out, 1);
+        let __loop_step = 3;
+        for(let y = __loop_min; y <= __loop_max; y += __loop_step) {
           { let __intm = crop_dim(intm, 1, {min:(y + 1), max:(min((y + 2), buffer_max(out, 1)) + 1)});
             consume(__in);
             produce(intm);

--- a/builder/test/visualize/stencil_split_3.html
+++ b/builder/test/visualize/stencil_split_3.html
@@ -108,9 +108,18 @@ function define_mapping(buffer) {
   buf.mem.base = buffer.base;
   closure = function(base, elem_size, dims) {
     let sorted_dims = structuredClone(dims.toSorted(function(a, b) { return a.stride - b.stride; }));
-    return function(at) {
-      at -= base;
-      return [unpack_dim(at, sorted_dims[0]), unpack_dim(at, sorted_dims[1])];
+    if (sorted_dims.length > 1) {
+      return function(at) {
+        at -= base;
+        return [unpack_dim(at, sorted_dims[0]), unpack_dim(at, sorted_dims[1])];
+      }
+    } else if (sorted_dims.length == 1) {
+      return function(at) {
+        at -= base;
+        return [unpack_dim(at, sorted_dims[0]), 0];
+      }
+    } else {
+      return function(at) { return [0, 0]; }
     }
   }
   buf.mem.mapping = closure(buffer.base, buffer.elem_size, buffer.dims);
@@ -251,7 +260,7 @@ function truncate_rank(b, rank) {
 function produce(b) {
   m = find_mapping(b.base);
   if (m) {
-    m.element.mem.productions.push({t: __event_t++, buf: clone_buffer(b)});
+    m.element.mem.productions.push({t: __event_t, buf: clone_buffer(b)});
   }
 }
 function consume(b) {}
@@ -287,11 +296,13 @@ function pipeline(__in, out) {
           { let __intm = crop_dim(intm, 1, {min:(y + 1), max:(min((y + 2), buffer_max(out, 1)) + 1)});
             consume(__in);
             produce(intm);
+            __event_t++;
             intm = __intm;
           }
           { let __out = crop_dim(out, 1, {min:y, max:(y + 2)});
             consume(intm_uncropped);
             produce(out);
+            __event_t++;
             out = __out;
           }
         }

--- a/runtime/visualize.cc
+++ b/runtime/visualize.cc
@@ -206,11 +206,13 @@ public:
     for (var i : n->outputs) {
       *this << indent() << "produce(" << i << ");\n";
     }
+    *this << indent() << "__event_t++;\n";
   }
 
   void visit(const copy_stmt* n) override {
     *this << indent() << "consume(" << n->src << ");\n";
     *this << indent() << "produce(" << n->dst << ");\n";
+    *this << indent() << "__event_t++;\n";
   }
 
   void visit(const allocate* n) override {
@@ -407,9 +409,18 @@ function define_mapping(buffer) {
   buf.mem.base = buffer.base;
   closure = function(base, elem_size, dims) {
     let sorted_dims = structuredClone(dims.toSorted(function(a, b) { return a.stride - b.stride; }));
-    return function(at) {
-      at -= base;
-      return [unpack_dim(at, sorted_dims[0]), unpack_dim(at, sorted_dims[1])];
+    if (sorted_dims.length > 1) {
+      return function(at) {
+        at -= base;
+        return [unpack_dim(at, sorted_dims[0]), unpack_dim(at, sorted_dims[1])];
+      }
+    } else if (sorted_dims.length == 1) {
+      return function(at) {
+        at -= base;
+        return [unpack_dim(at, sorted_dims[0]), 0];
+      }
+    } else {
+      return function(at) { return [0, 0]; }
     }
   }
   buf.mem.mapping = closure(buffer.base, buffer.elem_size, buffer.dims);
@@ -550,7 +561,7 @@ function truncate_rank(b, rank) {
 function produce(b) {
   m = find_mapping(b.base);
   if (m) {
-    m.element.mem.productions.push({t: __event_t++, buf: clone_buffer(b)});
+    m.element.mem.productions.push({t: __event_t, buf: clone_buffer(b)});
   }
 }
 function consume(b) {}

--- a/runtime/visualize.cc
+++ b/runtime/visualize.cc
@@ -185,14 +185,16 @@ public:
   }
 
   void visit(const loop* l) override {
-    *this << indent() << "for(let " << l->sym << " = " << l->bounds.min << "; " << l->sym << " <= " << l->bounds.max
-          << "; ";
+    *this << indent() << "let __loop_min = " << l->bounds.min << ";\n";
+    *this << indent() << "let __loop_max = " << l->bounds.max << ";\n";
+    *this << indent() << "let __loop_step = ";
     if (l->step.defined()) {
-      *this << l->sym << " += " << l->step;
+      *this << l->step << ";\n";
     } else {
-      *this << l->sym << "++";
+      *this << "1;\n";
     }
-    *this << ") {\n";
+    *this << indent() << "for(let " << l->sym << " = __loop_min; " << l->sym << " <= __loop_max; " << l->sym
+          << " += __loop_step) {\n";
     *this << l->body;
     *this << indent() << "}\n";
   }


### PR DESCRIPTION
- Fix visualization bug when loops variables were shadowed
- Change visualization timing to show all produces from a given call/copy at the same timestep
- Add visualization to the softmax pipeline
- Some minor cleanup of deps/headers for visualization in tests