### PR TITLE
Add an option to set node_context for print globally

### DIFF
--- a/builder/pipeline.cc
+++ b/builder/pipeline.cc
@@ -25,6 +25,9 @@
 
 namespace slinky {
 
+// in print.cc, don't want to expose this.
+const node_context* set_default_print_context(const node_context* ctx);
+
 buffer_expr::buffer_expr(var sym, std::size_t rank, expr elem_size)
     : sym_(sym), elem_size_(std::move(elem_size)), producer_(nullptr), constant_(nullptr) {
   dims_.reserve(rank);
@@ -900,6 +903,8 @@ stmt inject_traces(const stmt& s, node_context& ctx, std::set<buffer_expr_ptr>& 
 
 stmt build_pipeline(node_context& ctx, const std::vector<buffer_expr_ptr>& inputs,
     const std::vector<buffer_expr_ptr>& outputs, std::set<buffer_expr_ptr>& constants, const build_options& options) {
+  const node_context* old_context = set_default_print_context(&ctx);
+
   pipeline_builder builder(ctx, inputs, outputs, constants);
 
   stmt result;
@@ -943,8 +948,10 @@ stmt build_pipeline(node_context& ctx, const std::vector<buffer_expr_ptr>& input
   }
 
   if (is_verbose()) {
-    std::cout << std::tie(result, ctx) << std::endl;
+    std::cout << result << std::endl;
   }
+
+  set_default_print_context(old_context);
 
   return result;
 }

--- a/runtime/print.cc
+++ b/runtime/print.cc
@@ -305,33 +305,35 @@ public:
   void visit(const check* n) override { *this << indent() << "check(" << n->condition << ")\n"; }
 };
 
+namespace {
+
+thread_local const node_context* default_context = nullptr;
+
+}  // namespace
+
+const node_context* set_default_print_context(const node_context* ctx) {
+  const node_context* old = default_context;
+  default_context = ctx;
+  return old;
+}
+
 void print(std::ostream& os, const expr& e, const node_context* ctx) {
-  printer p(os, ctx);
+  printer p(os, ctx ? ctx : default_context);
   p << e;
 }
 
 void print(std::ostream& os, const stmt& s, const node_context* ctx) {
-  printer p(os, ctx);
+  printer p(os, ctx ? ctx : default_context);
   p << s;
 }
 
-static const node_context* default_context = nullptr;
-
 std::ostream& operator<<(std::ostream& os, const expr& e) {
-  if (default_context) {
-    print(os, e, default_context);
-  } else {
-    print(os, e);
-  }
+  print(os, e);
   return os;
 }
 
 std::ostream& operator<<(std::ostream& os, const stmt& s) {
-  if (default_context) {
-    print(os, s, default_context);
-  } else {
-    print(os, s);
-  }
+  print(os, s);
   return os;
 }
 
@@ -365,7 +367,5 @@ std::ostream& operator<<(std::ostream& os, const dim& d) {
   os << "}";
   return os;
 }
-
-void set_default_printer_context(const node_context* ctx) { default_context = ctx; }
 
 }  // namespace slinky

--- a/runtime/print.cc
+++ b/runtime/print.cc
@@ -315,13 +315,23 @@ void print(std::ostream& os, const stmt& s, const node_context* ctx) {
   p << s;
 }
 
+static const node_context* default_context = nullptr;
+
 std::ostream& operator<<(std::ostream& os, const expr& e) {
-  print(os, e);
+  if (default_context) {
+    print(os, e, default_context);
+  } else {
+    print(os, e);
+  }
   return os;
 }
 
 std::ostream& operator<<(std::ostream& os, const stmt& s) {
-  print(os, s);
+  if (default_context) {
+    print(os, s, default_context);
+  } else {
+    print(os, s);
+  }
   return os;
 }
 
@@ -354,6 +364,10 @@ std::ostream& operator<<(std::ostream& os, const dim& d) {
   }
   os << "}";
   return os;
+}
+
+void set_default_printer_context(const node_context* ctx) {
+  default_context = ctx;
 }
 
 }  // namespace slinky

--- a/runtime/print.cc
+++ b/runtime/print.cc
@@ -366,8 +366,6 @@ std::ostream& operator<<(std::ostream& os, const dim& d) {
   return os;
 }
 
-void set_default_printer_context(const node_context* ctx) {
-  default_context = ctx;
-}
+void set_default_printer_context(const node_context* ctx) { default_context = ctx; }
 
 }  // namespace slinky

--- a/runtime/print.h
+++ b/runtime/print.h
@@ -34,6 +34,7 @@ std::string to_string(var sym);
 std::string to_string(intrinsic fn);
 std::string to_string(memory_type type);
 
+void set_default_printer_context(const node_context* ctx);
 }  // namespace slinky
 
 #endif  // SLINKY_RUNTIME_PRINT_H

--- a/runtime/print.h
+++ b/runtime/print.h
@@ -34,7 +34,6 @@ std::string to_string(var sym);
 std::string to_string(intrinsic fn);
 std::string to_string(memory_type type);
 
-void set_default_printer_context(const node_context* ctx);
 }  // namespace slinky
 
 #endif  // SLINKY_RUNTIME_PRINT_H

--- a/runtime/test/buffer.cc
+++ b/runtime/test/buffer.cc
@@ -18,21 +18,6 @@ namespace slinky {
 
 bool operator==(const dim& a, const dim& b) { return memcmp(&a, &b, sizeof(dim)) == 0; }
 
-std::ostream& operator<<(std::ostream& os, const dim& d) {
-  return os << "{min: " << d.min() << ", max: " << d.max() << ", stride: " << d.stride()
-            << ", fold_factor: " << d.fold_factor() << "}";
-}
-
-std::ostream& operator<<(std::ostream& os, const raw_buffer& buf) {
-  os << "{base: " << buf.base << ", elem_size: " << buf.elem_size << ", dims = {";
-  for (std::size_t i = 0; i < buf.rank; ++i) {
-    if (i > 0) os << ", ";
-    os << buf.dim(i);
-  }
-  os << "}";
-  return os;
-}
-
 int random(int min, int max) { return rng()() % (max - min + 1) + min; }
 
 template <typename T, std::size_t N>


### PR DESCRIPTION
I found this quite helpful while debugging.