### PR TITLE
Change default strides to be determined by buffers/allocation callbacks instead of pipeline construction

### DIFF
--- a/builder/optimizations.cc
+++ b/builder/optimizations.cc
@@ -22,31 +22,61 @@ namespace slinky {
 
 namespace {
 
+dim_expr select(const expr& c, dim_expr t, dim_expr f) {
+  // dim_expr allows fold_factor to be undefined to indicate `unfolded`, but we can't rely on that here.
+  if (!t.fold_factor.defined()) t.fold_factor = dim::unfolded;
+  if (!f.fold_factor.defined()) f.fold_factor = dim::unfolded;
+  return {
+      select(c, std::move(t.bounds), std::move(f.bounds)),
+      select(c, std::move(t.stride), std::move(f.stride)),
+      select(c, std::move(t.fold_factor), std::move(f.fold_factor)),
+  };
+}
+
 // Checks if the copy operands `src_x` and `dst_x` represent a simple copy that can be handled by slinky::copy.
-bool is_copy(expr src_x, var dst_x, expr& offset, expr& stride) {
+bool is_copy(var src, expr src_x, int src_d, var dst, var dst_x, int dst_d, expr& at, dim_expr& src_dim) {
   if (const class select* s = src_x.as<class select>()) {
     // The src is a select of two things that might both be copies.
-    expr offset_t = offset;
-    expr offset_f = offset;
-    expr stride_t = stride;
-    expr stride_f = stride;
-    if (is_copy(s->true_value, dst_x, offset_t, stride_t) && is_copy(s->false_value, dst_x, offset_f, stride_f)) {
-      offset = select(s->condition, offset_t, offset_f);
-      stride = select(s->condition, stride_t, stride_f);
+    expr at_t = at;
+    expr at_f = at;
+    dim_expr src_dim_t = src_dim;
+    dim_expr src_dim_f = src_dim;
+    if (is_copy(src, s->true_value, src_d, dst, dst_x, dst_d, at_t, src_dim_t) &&
+        is_copy(src, s->false_value, src_d, dst, dst_x, dst_d, at_f, src_dim_f)) {
+      at = select(s->condition, at_t, at_f);
+      src_dim = select(s->condition, src_dim_t, src_dim_f);
       return true;
     } else {
       return false;
     }
+  } else if (src_d < 0) {
+    // This is a broadcast because the dst dim is unused in any src dim.
+    src_dim.stride = 0;
+    src_dim.fold_factor = dim::unfolded;
+    return true;
   } else if (!depends_on(src_x, dst_x).any()) {
-    // This is a broadcast.
-    stride = 0;
-    offset = 0;
+    // This is a broadcast because the src_x is constant w.r.t. dst_x.
+    at = src_x;
+    src_dim.stride = 0;
+    src_dim.fold_factor = dim::unfolded;
     return true;
   } else {
-    // If the difference of src_x and dst_x does not depend on dst_x, it's a simple copy.
-    offset = simplify(src_x - dst_x);
-    return !depends_on(offset, dst_x).any();
+    expr offset = simplify(src_x - dst_x);
+    if (!depends_on(offset, dst_x).any()) {
+      // The difference of src_x and dst_x does not depend on dst_x, it's a simple copy.
+      src_dim.bounds &= (buffer_bounds(src, src_d) - offset);
+      at = src_dim.bounds.min + offset;
+      return true;
+    } else {
+      return false;
+    }
   }
+}
+
+bool is_copy(const copy_stmt* op, int src_d, int dst_d, expr& at, dim_expr& src_dim) {
+  // We might not have an src dim if we're trying to broadcast.
+  expr src_x = src_d >= 0 ? op->src_x[src_d] : expr();
+  return is_copy(op->src, src_x, src_d, op->dst, op->dst_x[dst_d], dst_d, at, src_dim);
 }
 
 // `dst_d` may be a copy dim of `op` if it is used by exactly one src dim, where it might be a copy, or zero src dims,
@@ -66,10 +96,10 @@ bool is_copy_dst_dim(const copy_stmt* op, int dst_d, int& src_d) {
   return true;
 }
 
-std::vector<expr> buffer_strides(var buf, int rank) {
+std::vector<expr> buffer_mins(var buf, std::size_t rank) {
   std::vector<expr> result(rank);
-  for (int d = 0; d < rank; ++d) {
-    result[d] = buffer_stride(buf, d);
+  for (int i = 0; i < static_cast<int>(rank); ++i) {
+    result[i] = buffer_min(buf, i);
   }
   return result;
 }
@@ -137,6 +167,8 @@ public:
       // Replace the allocation with a buffer using the dims the alias wants.
       stmt result =
           make_buffer::make(op->sym, buffer_at(target_var, alias.at), op->elem_size, alias.dims, std::move(body));
+      // The alias might have used buffer metadata from the original, add a buffer for it.
+      result = make_buffer::make(op->sym, {}, op->elem_size, op->dims, std::move(result));
       // If we aliased the source and destination of a copy, replace the copy with a pad.
       stmt pad_result = recursive_mutate<copy_stmt>(result, [a = op->sym, b = target_var](const copy_stmt* op) {
         if (!((op->src == a && op->dst == b) || (op->src == b && op->dst == a))) {
@@ -167,8 +199,12 @@ public:
         // region. That will likely be very difficult to do symbolically.
         for (std::optional<buffer_info>& i : alias_info) {
           if (!i) continue;
-          i->do_not_alias(target.first);
+          i->do_not_alias(target_var);
         }
+      }
+      // We might have thought we could alias this both ways (src -> dst and dst -> src), we only want to do one of them.
+      if (alias_info[target_var]) {
+        alias_info[target_var]->do_not_alias(op->sym);
       }
       set_result(pad_result);
     } else if (!body.same_as(op->body)) {
@@ -176,31 +212,34 @@ public:
     } else {
       set_result(op);
     }
+
+    // When an allocation goes out of scope, we should remove it as an aliasing candidate.
+    for (std::optional<buffer_info>& i : alias_info) {
+      if (i) i->do_not_alias(op->sym);
+    }
+  }
+
+  bool can_alias(var x) {
+    std::optional<bool> no_alias = do_not_alias[x];
+    return !no_alias || !*no_alias;
   }
 
   void visit(const call_stmt* op) override {
     set_result(op);
+    if (!op->attrs.allow_in_place) {
+      // This call does not allow aliasing an input to an output.
+      return;
+    }
     for (var o : op->outputs) {
-      std::optional<bool> no_alias = do_not_alias[o];
-      if (no_alias && *no_alias) {
-        continue;
-      }
-
+      if (!can_alias(o)) continue;
       for (var i : op->inputs) {
-        std::optional<buffer_info>& info = alias_info[i];
-        if (!info) continue;
-
-        if (!op->attrs.allow_in_place) {
-          info->do_not_alias(o);
-          return;
+        std::optional<buffer_info>& input_info = alias_info[i];
+        if (input_info) {
+          buffer_alias a;
+          a.dims = buffer_dims(o, input_info->dims.size());
+          a.at = buffer_mins(o, input_info->dims.size());
+          input_info->maybe_alias(o, std::move(a));
         }
-        buffer_alias a;
-        for (index_t d = 0; d < static_cast<index_t>(info->dims.size()); ++d) {
-          a.dims.push_back(buffer_dim(o, d));
-          a.at.push_back(buffer_min(o, d));
-        }
-
-        info->maybe_alias(o, std::move(a));
       }
     }
   }
@@ -208,80 +247,79 @@ public:
   void visit(const copy_stmt* op) override {
     set_result(op);
 
-    std::optional<bool> no_alias = do_not_alias[op->dst];
-    if (no_alias && *no_alias) {
-      return;
-    }
-
-    var source, target;
-    if (alias_info[op->src]) {
-      // We allocated the src. We might be able to replace the allocation with an alias of the dst.
-      source = op->src;
-      target = op->dst;
-    } else if (alias_info[op->dst]) {
+    if (alias_info[op->dst] && can_alias(op->src)) {
       // We allocated the dst. We might be able to replace the allocation with an alias of the src.
-      source = op->dst;
-      target = op->src;
-    } else {
-      return;
-    }
+      // This case is a straightforward use of is_copy, which produces the dims that should be the src of a copy, which
+      // are the same dimensions we want the dst to be.
+      std::optional<buffer_info>& info = alias_info[op->dst];
 
-    // TODO: This visitor is a nightmare and I'm pretty sure it has many bugs. It needs a rewrite.
-    // It does work for many tests though.
+      buffer_alias a;
+      a.at.resize(op->src_x.size());
+      a.dims = info->dims;
+      bool alias_valid = true;
+      for (int dst_d = 0; dst_d < static_cast<int>(op->dst_x.size()); ++dst_d) {
+        int src_d;
+        if (!is_copy_dst_dim(op, dst_d, src_d)) {
+          alias_valid = false;
+          break;
+        }
 
-    std::optional<buffer_info>& info = alias_info[source];
-
-    std::vector<std::optional<std::size_t>> permutation;
-    std::vector<expr> offset;
-    std::vector<expr> stride = buffer_strides(target, info->dims.size());
-
-    offset.resize(op->dst_x.size());
-    stride.resize(op->dst_x.size());
-    assert(permutation.empty());
-    permutation.resize(op->dst_x.size());
-    for (std::size_t dst_d = 0; dst_d < op->dst_x.size(); ++dst_d) {
-      int src_d;
-      if (!is_copy_dst_dim(op, dst_d, src_d)) {
-        return;
-      }
-
-      if (src_d < 0) {
-        // This is a broadcast.
-        offset[dst_d] = 0;
-        stride[dst_d] = 0;
-      } else if (is_copy(op->src_x[src_d], op->dst_x[dst_d], offset[dst_d], stride[dst_d])) {
-        permutation[src_d] = dst_d;
-      } else {
-        return;
-      }
-    }
-
-    buffer_alias a;
-    a.dims.resize(info->dims.size());
-    for (std::size_t d = 0; d < a.dims.size(); ++d) {
-      if (d < permutation.size() && permutation[d]) {
-        // This dimension is a copy of the input dimension.
-        a.dims[d] = buffer_dim(target, static_cast<int>(*permutation[d]));
-        a.dims[d].bounds &= info->dims[d].bounds;
-        a.dims[d].stride = stride[*permutation[d]];
-      } else {
-        // This dimension is a broadcast.
-        a.dims[d].bounds = info->dims[d].bounds;
-        a.dims[d].stride = 0;
-      }
-    }
-    a.at = std::move(offset);
-    a.at.resize(std::max(a.at.size(), a.dims.size()));
-    for (int d = 0; d < static_cast<int>(a.at.size()); ++d) {
-      if (d < static_cast<int>(info->dims.size())) {
-        if (!a.at[d].defined()) {
-          a.at[d] = max(buffer_min(target, d), info->dims[d].bounds.min);
-        } else {
-          a.at[d] = max(buffer_min(target, d) - a.at[d], info->dims[d].bounds.min);
+        expr at_unused;
+        expr& at = src_d >= 0 ? a.at[src_d] : at_unused;
+        if (!is_copy(op, src_d, dst_d, at, a.dims[dst_d])) {
+          alias_valid = false;
+          break;
         }
       }
+      if (alias_valid) {
+        info->maybe_alias(op->src, std::move(a));
+      }
     }
-    info->maybe_alias(target, std::move(a));
+    if (alias_info[op->src] && can_alias(op->dst)) {
+      // We allocated the src. We might be able to replace the allocation with an alias of the dst.
+      // In this case, we're going to make the src an alias of another buffer. We're more limited in what we can do here
+      // vs. the above case, because we can't expect producers to handle everything the copy is doing (such as
+      // broadcasting).
+      std::optional<buffer_info>& info = alias_info[op->src];
+
+      buffer_alias a;
+      a.at.resize(op->dst_x.size());
+      a.dims.resize(op->src_x.size());
+      assert(op->src_x.size() == info->dims.size());
+      for (int dst_d = 0; dst_d < static_cast<int>(op->dst_x.size()); ++dst_d) {
+        int src_d;
+        if (!is_copy_dst_dim(op, dst_d, src_d)) {
+          return;
+        }
+
+        if (src_d < 0) {
+          // We can't handle a broadcast here, because we can't ask the producer of our src to produce more dimensions.
+          return;
+        }
+
+        expr offset = simplify(op->src_x[src_d] - op->dst_x[dst_d]);
+        if (depends_on(offset, op->dst_x[dst_d]).any()) {
+          // This is not a simple copy, we can't handle it here.
+          return;
+        }
+
+        a.dims[src_d] = {
+            buffer_bounds(op->dst, dst_d) & info->dims[src_d].bounds,
+            buffer_stride(op->dst, dst_d),
+            buffer_fold_factor(op->dst, dst_d),
+        };
+        a.at[dst_d] = max(buffer_min(op->dst, dst_d) - offset, info->dims[dst_d].bounds.min);
+      }
+
+      for (const dim_expr& d : a.dims) {
+        if (!d.stride.defined()) {
+          // We didn't define all the dimensions of the buffer we want to replace.
+          return;
+        }
+      }
+
+      info->maybe_alias(op->dst, std::move(a));
+    }
   }
 
   void merge_alias_info(symbol_map<buffer_info> add) {
@@ -401,23 +439,24 @@ stmt implement_copy(const copy_stmt* op, node_context& ctx) {
 
   // If we just leave these two arrays alone, the copy will be correct, but slow.
   // We can speed it up by finding dimensions we can let pass through to the copy.
-  for (int d = 0; d < static_cast<int>(dst_x.size()); ++d) {
+  for (int dst_d = 0; dst_d < static_cast<int>(dst_x.size()); ++dst_d) {
     int src_d;
-    if (!is_copy_dst_dim(op, d, src_d)) {
+    if (!is_copy_dst_dim(op, dst_d, src_d)) {
       continue;
     }
 
-    expr offset = 0;
-    expr stride = buffer_stride(op->src, src_d);
-    if (src_d < 0) {
-      // This is a broadcast.
-      src_dims.push_back({buffer_bounds(op->dst, d), 0});
-      dst_x[d] = var();
-    } else if (is_copy(op->src_x[src_d], op->dst_x[d], offset, stride)) {
-      interval_expr src_bounds = buffer_bounds(op->dst, d) & (buffer_bounds(op->src, src_d) - offset);
-      src_dims.push_back({src_bounds, stride, buffer_fold_factor(op->src, src_d)});
-      src_x[src_d] = src_bounds.min + offset;
-      dst_x[d] = var();
+    dim_expr src_dim = {buffer_bounds(op->dst, dst_d), 0, dim::unfolded};
+    if (src_d >= 0) {
+      src_dim.stride = buffer_stride(op->src, src_d);
+      src_dim.fold_factor = buffer_fold_factor(op->src, src_d);
+    }
+    expr at;
+    if (is_copy(op, src_d, dst_d, at, src_dim)) {
+      src_dims.push_back(src_dim);
+      if (at.defined()) {
+        src_x[src_d] = at;
+      }
+      dst_x[dst_d] = var();
     }
   }
 

--- a/builder/optimizations.cc
+++ b/builder/optimizations.cc
@@ -49,11 +49,6 @@ bool is_copy(var src, expr src_x, int src_d, var dst, var dst_x, int dst_d, expr
     } else {
       return false;
     }
-  } else if (src_d < 0) {
-    // This is a broadcast because the dst dim is unused in any src dim.
-    src_dim.stride = 0;
-    src_dim.fold_factor = dim::unfolded;
-    return true;
   } else if (!depends_on(src_x, dst_x).any()) {
     // This is a broadcast because the src_x is constant w.r.t. dst_x.
     at = src_x;

--- a/builder/optimizations.cc
+++ b/builder/optimizations.cc
@@ -23,9 +23,6 @@ namespace slinky {
 namespace {
 
 dim_expr select(const expr& c, dim_expr t, dim_expr f) {
-  // dim_expr allows fold_factor to be undefined to indicate `unfolded`, but we can't rely on that here.
-  if (!t.fold_factor.defined()) t.fold_factor = dim::unfolded;
-  if (!f.fold_factor.defined()) f.fold_factor = dim::unfolded;
   return {
       select(c, std::move(t.bounds), std::move(f.bounds)),
       select(c, std::move(t.stride), std::move(f.stride)),
@@ -259,6 +256,8 @@ public:
 
         expr at_unused;
         expr& at = src_d >= 0 ? a.at[src_d] : at_unused;
+        a.dims[dst_d].stride = buffer_stride(op->src, src_d);
+        a.dims[dst_d].fold_factor = buffer_fold_factor(op->src, src_d);
         if (!is_copy(op, src_d, dst_d, at, a.dims[dst_d])) {
           alias_valid = false;
           break;

--- a/builder/optimizations.cc
+++ b/builder/optimizations.cc
@@ -162,8 +162,6 @@ public:
       // Replace the allocation with a buffer using the dims the alias wants.
       stmt result =
           make_buffer::make(op->sym, buffer_at(target_var, alias.at), op->elem_size, alias.dims, std::move(body));
-      // The alias might have used buffer metadata from the original, add a buffer for it.
-      result = make_buffer::make(op->sym, {}, op->elem_size, op->dims, std::move(result));
       // If we aliased the source and destination of a copy, replace the copy with a pad.
       stmt pad_result = recursive_mutate<copy_stmt>(result, [a = op->sym, b = target_var](const copy_stmt* op) {
         if (!((op->src == a && op->dst == b) || (op->src == b && op->dst == a))) {

--- a/builder/pipeline.cc
+++ b/builder/pipeline.cc
@@ -570,14 +570,9 @@ class pipeline_builder {
         }
         std::vector<dim_expr> dims = substitute_from_map(b->dims(), substitutions);
 
-        // After substituting the bounds, compute the default strides, and substitute those.
-        // TODO: I think this is bad, if the user sets a stride, we won't see it. I think
-        // maybe allowing users to set strides is just a bad idea.
         substitutions.clear();
-        expr stride = b->elem_size();
         for (index_t d = 0; d < static_cast<index_t>(bounds.size()); ++d) {
-          substitutions.emplace_back(buffer_stride(alloc_var, d), stride);
-          stride *= min(dims[d].bounds.extent(), buffer_fold_factor(alloc_var, d));
+          substitutions.emplace_back(buffer_stride(alloc_var, d), expr());
         }
         dims = substitute_from_map(dims, substitutions);
 

--- a/builder/test/copy_pipeline.cc
+++ b/builder/test/copy_pipeline.cc
@@ -185,7 +185,7 @@ TEST_P(copied_result, pipeline) {
 
 class concatenated_result : public testing::TestWithParam<bool> {};
 
-INSTANTIATE_TEST_SUITE_P(schedule, concatenated_result, testing::Values(false, true));
+INSTANTIATE_TEST_SUITE_P(schedule, concatenated_result, testing::Values(true, false));
 
 TEST_P(concatenated_result, pipeline) {
   bool no_alias_buffers = GetParam();
@@ -249,7 +249,7 @@ class transposed_result : public testing::TestWithParam<std::tuple<bool, int, in
 auto iota3 = testing::Values(0, 1, 2);
 
 INSTANTIATE_TEST_SUITE_P(schedule, transposed_result,
-    testing::Combine(testing::Values(false, true), iota3, iota3, iota3),
+    testing::Combine(testing::Values(true, false), iota3, iota3, iota3),
     test_params_to_string<transposed_result::ParamType>);
 
 TEST_P(transposed_result, pipeline) {
@@ -360,7 +360,7 @@ TEST(stacked_result, pipeline) {
 class broadcasted_elementwise : public testing::TestWithParam<std::tuple<bool, int>> {};
 
 INSTANTIATE_TEST_SUITE_P(dim, broadcasted_elementwise,
-    testing::Combine(testing::Values(false, true), testing::Range(0, 2)),
+    testing::Combine(testing::Values(true, false), testing::Range(0, 2)),
     test_params_to_string<broadcasted_elementwise::ParamType>);
 
 TEST_P(broadcasted_elementwise, pipeline) {

--- a/builder/test/elementwise.cc
+++ b/builder/test/elementwise.cc
@@ -65,6 +65,7 @@ public:
     for (std::size_t d = 0; d < Rank; ++d) {
       // TODO: Find a better way to not care about bounds of broadcasted dimensions.
       dims[d].set_bounds(std::numeric_limits<index_t>::min(), std::numeric_limits<index_t>::max());
+      dims[d].set_stride(0);
     }
 
     auto value = raw_buffer::make(Rank, sizeof(T), dims);
@@ -144,37 +145,24 @@ public:
 
   void init_buffer(buffer<T, Rank>& b) {
     b.free();
-    index_t stride = sizeof(T);
     for (std::size_t d = 0; d < Rank; ++d) {
       b.dims[d].set_min_extent(0, extents[d]);
-      b.dims[d].set_stride(stride);
-      stride *= extents[d];
     }
     b.allocate();
-  }
-
-  std::size_t prepare_result() {
-    result.free();
-    index_t stride = 1;
-    for (std::size_t d = 0; d < Rank; ++d) {
-      result.dims[d].set_min_extent(0, extents[d]);
-      result.dims[d].set_stride(stride * sizeof(T));
-      stride *= extents[d];
-    }
-    result.allocate();
-    return stride;
   }
 
   void visit(const variable* v) override {
     const std::optional<buffer<T, Rank>*>& i = vars[v->sym];
     assert(i);
-    prepare_result();
+    result.free();
+    init_buffer(result);
     copy(**i, result);
   }
 
   void visit(const constant* c) override {
-    std::size_t flat_size = prepare_result();
-    std::fill_n(result.base(), flat_size, c->value);
+    result.free();
+    init_buffer(result);
+    std::fill_n(result.base(), result.elem_count(), c->value);
   }
 
   void visit_expr(const expr& e, buffer<T, Rank>& r) {
@@ -238,14 +226,9 @@ void test_expr_pipeline(node_context& ctx, const expr& e) {
   std::vector<buffer<T, Rank>> input_bufs(p.inputs.size());
 
   for (std::size_t i = 0; i < p.inputs.size(); ++i) {
-    index_t stride = sizeof(T);
     for (std::size_t d = 0; d < Rank; ++d) {
       input_bufs[i].dims[d].set_min_extent(0, extents[d]);
-      input_bufs[i].dims[d].set_stride(stride);
-      stride *= extents[d];
     }
-  }
-  for (std::size_t i = 0; i < p.inputs.size(); ++i) {
     init_random(input_bufs[i]);
     inputs.push_back(&input_bufs[i]);
   }

--- a/builder/test/elementwise.cc
+++ b/builder/test/elementwise.cc
@@ -64,7 +64,7 @@ public:
     slinky::dim dims[Rank];
     for (std::size_t d = 0; d < Rank; ++d) {
       // TODO: Find a better way to not care about bounds of broadcasted dimensions.
-      dims[d].set_bounds(std::numeric_limits<index_t>::min() / 2 + 1, std::numeric_limits<index_t>::max() / 2);
+      dims[d].set_bounds(std::numeric_limits<index_t>::min(), std::numeric_limits<index_t>::max());
     }
 
     auto value = raw_buffer::make(Rank, sizeof(T), dims);

--- a/builder/test/pipeline.cc
+++ b/builder/test/pipeline.cc
@@ -298,7 +298,6 @@ TEST_P(matmuls, pipeline) {
 
   // TODO: There should be a more user friendly way to control the strides.
   ab->dim(1).stride = static_cast<index_t>(sizeof(int));
-  ab->dim(0).stride = ab->dim(1).extent() * ab->dim(1).stride;
 
   if (split > 0) {
     matmul_abc.loops({{i, split, max_workers}});

--- a/builder/test/pipeline.cc
+++ b/builder/test/pipeline.cc
@@ -297,7 +297,7 @@ TEST_P(matmuls, pipeline) {
   abc->dim(1).stride = abc->elem_size();
 
   // TODO: There should be a more user friendly way to control the strides.
-  ab->dim(1).stride = static_cast<index_t>(sizeof(int));
+  ab->dim(1).stride = ab->elem_size();
 
   if (split > 0) {
     matmul_abc.loops({{i, split, max_workers}});

--- a/builder/test/replica_pipeline.cc
+++ b/builder/test/replica_pipeline.cc
@@ -26,27 +26,25 @@ auto p = []() -> ::slinky::pipeline {
   auto i = var(ctx, "i");
   auto j = var(ctx, "j");
   auto ab = buffer_expr::make(ctx, "ab", /*rank=*/2, /*elem_size=*/4);
-  auto _1 = variable::make(ab->sym());
-  ab->dim(0).stride = (((((((buffer_max(_1, 1)) - (buffer_min(_1, 1)))) + 1)) * 4));
   ab->dim(1).stride = 4;
-  auto _3 = variable::make(a->sym());
-  auto _replica_fn_4 = [=](const buffer<const void>& i0, const buffer<const void>& i1, const buffer<void>& o0) -> index_t {
+  auto _2 = variable::make(a->sym());
+  auto _replica_fn_3 = [=](const buffer<const void>& i0, const buffer<const void>& i1, const buffer<void>& o0) -> index_t {
     const buffer<const void>* input_buffers[] = {&i0, &i1};
     const buffer<void>* output_buffers[] = {&o0};
-    const func::input inputs[] = {{a, {point(i), {(buffer_min(_3, 1)), (buffer_max(_3, 1))}}}, {b, {{(buffer_min(_3, 1)), (buffer_max(_3, 1))}, point(j)}}};
+    const func::input inputs[] = {{a, {point(i), {(buffer_min(_2, 1)), (buffer_max(_2, 1))}}}, {b, {{(buffer_min(_2, 1)), (buffer_max(_2, 1))}, point(j)}}};
     const std::vector<var> outputs[] = {{i, j}};
     return ::slinky::internal::replica_pipeline_handler(input_buffers, output_buffers, inputs, outputs);
   };
-  auto _fn_2 = func::make(std::move(_replica_fn_4), {{a, {point(i), {(buffer_min(_3, 1)), (buffer_max(_3, 1))}}}, {b, {{(buffer_min(_3, 1)), (buffer_max(_3, 1))}, point(j)}}}, {{ab, {i, j}}}, {});
-  auto _5 = variable::make(c->sym());
-  auto _replica_fn_6 = [=](const buffer<const void>& i0, const buffer<const void>& i1, const buffer<void>& o0) -> index_t {
+  auto _fn_1 = func::make(std::move(_replica_fn_3), {{a, {point(i), {(buffer_min(_2, 1)), (buffer_max(_2, 1))}}}, {b, {{(buffer_min(_2, 1)), (buffer_max(_2, 1))}, point(j)}}}, {{ab, {i, j}}}, {});
+  auto _4 = variable::make(c->sym());
+  auto _replica_fn_5 = [=](const buffer<const void>& i0, const buffer<const void>& i1, const buffer<void>& o0) -> index_t {
     const buffer<const void>* input_buffers[] = {&i0, &i1};
     const buffer<void>* output_buffers[] = {&o0};
-    const func::input inputs[] = {{ab, {point(i), {(buffer_min(_5, 0)), (buffer_max(_5, 0))}}}, {c, {{(buffer_min(_5, 0)), (buffer_max(_5, 0))}, point(j)}}};
+    const func::input inputs[] = {{ab, {point(i), {(buffer_min(_4, 0)), (buffer_max(_4, 0))}}}, {c, {{(buffer_min(_4, 0)), (buffer_max(_4, 0))}, point(j)}}};
     const std::vector<var> outputs[] = {{i, j}};
     return ::slinky::internal::replica_pipeline_handler(input_buffers, output_buffers, inputs, outputs);
   };
-  auto _fn_0 = func::make(std::move(_replica_fn_6), {{ab, {point(i), {(buffer_min(_5, 0)), (buffer_max(_5, 0))}}}, {c, {{(buffer_min(_5, 0)), (buffer_max(_5, 0))}, point(j)}}}, {{abc, {i, j}}}, {});
+  auto _fn_0 = func::make(std::move(_replica_fn_5), {{ab, {point(i), {(buffer_min(_4, 0)), (buffer_max(_4, 0))}}}, {c, {{(buffer_min(_4, 0)), (buffer_max(_4, 0))}, point(j)}}}, {{abc, {i, j}}}, {});
   _fn_0.loops({{i, 1, loop::serial}});
   auto p = build_pipeline(ctx, {}, {a, b, c}, {abc}, {});
   return p;

--- a/builder/test/visualize/padded_stencil_0.html
+++ b/builder/test/visualize/padded_stencil_0.html
@@ -77,7 +77,6 @@ function make_color(a) {
 }
 function buffer_min(b, d) { return b.dims[d].bounds.min; }
 function buffer_max(b, d) { return b.dims[d].bounds.max; }
-function buffer_extent(b, d) { return b.dims[d].bounds.max - b.dims[d].bounds.min + 1; }
 function buffer_stride(b, d) { return b.dims[d].stride; }
 function buffer_fold_factor(b, d) { return b.dims[d].fold_factor; }
 function buffer_rank(b) { return b.dims.length; }

--- a/builder/test/visualize/padded_stencil_0.html
+++ b/builder/test/visualize/padded_stencil_0.html
@@ -188,7 +188,61 @@ function next_color() {
   }
   return colors[(next_color.next++) % colors.length];
 }
+function alloc_extent(dim) {
+  let extent = dim.bounds.max - dim.bounds.min + 1;
+  return isNaN(dim.fold_factor) ? extent : Math.min(extent, dim.fold_factor);
+}
+function is_stride_ok_dim(stride, extent, dim) {
+  if (isNaN(dim.stride)) {
+    return true;
+  } else if (extent == 1 && Math.abs(stride) == Math.abs(dim.stride) && alloc_extent(dim) > 1) {
+    return false;
+  } else if (alloc_extent(dim) * Math.abs(dim.stride) <= stride) {
+    return true;
+  }
+  return Math.abs(dim.stride) >= extent * stride;
+}
+function is_stride_ok(stride, extent, dims) {
+  for (let i of dims) {
+    if (!is_stride_ok_dim(stride, extent, i)) {
+      return false;
+    }
+  }
+  return true;
+}
+function init_strides(elem_size, dims) {
+  for (let i of dims) {
+    if (!isNaN(i.stride)) continue;
+
+    let alloc_extent_i = alloc_extent(i);
+
+    if (is_stride_ok(elem_size, alloc_extent_i, dims)) {
+      i.stride = elem_size;
+      continue;
+    }
+
+    let min = Infinity;
+    for (let j of dims) {
+      if (isNaN(j.stride)) {
+        continue;
+      } else if (j.bounds.max < j.bounds.min) {
+        min = 0;
+        break;
+      }
+
+      let candidate = Math.abs(j.stride) * alloc_extent(j);
+      if (candidate >= min) {
+        continue;
+      } else if (!is_stride_ok(candidate, alloc_extent_i, dims)) {
+        continue;
+      }
+      min = candidate;
+    }
+    i.stride = min;
+  }
+}
 function allocate(name, elem_size, dims, hidden = false) {
+  init_strides(elem_size, dims);
   let flat_min = 0;
   let flat_max = 0;
   for (let i = 0; i < dims.length; ++i) {
@@ -274,8 +328,8 @@ function pipeline(__in, out) {
     check((((min(g0, (buffer_max(out, 0) + 1)) - max(g, (buffer_min(out, 0) + -1))) + 1) <= buffer_fold_factor(__in, 0)));
     check((((min(g2, (buffer_max(out, 1) + 1)) - max(g1, (buffer_min(out, 1) + -1))) + 1) <= buffer_fold_factor(__in, 1)));
     { let padded_intm = allocate('padded_intm', 2, [
-        {bounds:{min:(buffer_min(out, 0) + -1), max:(buffer_max(out, 0) + 1)}, stride:2, fold_factor:9223372036854775807},
-        {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:(((buffer_max(out, 0) - buffer_min(out, 0)) * 2) + 6), fold_factor:9223372036854775807}
+        {bounds:{min:(buffer_min(out, 0) + -1), max:(buffer_max(out, 0) + 1)}, stride:NaN, fold_factor:9223372036854775807},
+        {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:NaN, fold_factor:9223372036854775807}
       ]);
       {
         let __base = buffer_at(padded_intm, max(g, (buffer_min(out, 0) + -1)), max(g1, (buffer_min(out, 1) + -1)));

--- a/builder/test/visualize/padded_stencil_1.html
+++ b/builder/test/visualize/padded_stencil_1.html
@@ -77,7 +77,6 @@ function make_color(a) {
 }
 function buffer_min(b, d) { return b.dims[d].bounds.min; }
 function buffer_max(b, d) { return b.dims[d].bounds.max; }
-function buffer_extent(b, d) { return b.dims[d].bounds.max - b.dims[d].bounds.min + 1; }
 function buffer_stride(b, d) { return b.dims[d].stride; }
 function buffer_fold_factor(b, d) { return b.dims[d].fold_factor; }
 function buffer_rank(b) { return b.dims.length; }

--- a/builder/test/visualize/padded_stencil_1.html
+++ b/builder/test/visualize/padded_stencil_1.html
@@ -188,7 +188,61 @@ function next_color() {
   }
   return colors[(next_color.next++) % colors.length];
 }
+function alloc_extent(dim) {
+  let extent = dim.bounds.max - dim.bounds.min + 1;
+  return isNaN(dim.fold_factor) ? extent : Math.min(extent, dim.fold_factor);
+}
+function is_stride_ok_dim(stride, extent, dim) {
+  if (isNaN(dim.stride)) {
+    return true;
+  } else if (extent == 1 && Math.abs(stride) == Math.abs(dim.stride) && alloc_extent(dim) > 1) {
+    return false;
+  } else if (alloc_extent(dim) * Math.abs(dim.stride) <= stride) {
+    return true;
+  }
+  return Math.abs(dim.stride) >= extent * stride;
+}
+function is_stride_ok(stride, extent, dims) {
+  for (let i of dims) {
+    if (!is_stride_ok_dim(stride, extent, i)) {
+      return false;
+    }
+  }
+  return true;
+}
+function init_strides(elem_size, dims) {
+  for (let i of dims) {
+    if (!isNaN(i.stride)) continue;
+
+    let alloc_extent_i = alloc_extent(i);
+
+    if (is_stride_ok(elem_size, alloc_extent_i, dims)) {
+      i.stride = elem_size;
+      continue;
+    }
+
+    let min = Infinity;
+    for (let j of dims) {
+      if (isNaN(j.stride)) {
+        continue;
+      } else if (j.bounds.max < j.bounds.min) {
+        min = 0;
+        break;
+      }
+
+      let candidate = Math.abs(j.stride) * alloc_extent(j);
+      if (candidate >= min) {
+        continue;
+      } else if (!is_stride_ok(candidate, alloc_extent_i, dims)) {
+        continue;
+      }
+      min = candidate;
+    }
+    i.stride = min;
+  }
+}
 function allocate(name, elem_size, dims, hidden = false) {
+  init_strides(elem_size, dims);
   let flat_min = 0;
   let flat_max = 0;
   for (let i = 0; i < dims.length; ++i) {
@@ -274,8 +328,8 @@ function pipeline(__in, out) {
     check((((min(g0, (buffer_max(out, 0) + 1)) - max(g, (buffer_min(out, 0) + -1))) + 1) <= buffer_fold_factor(__in, 0)));
     check((((min(g2, (buffer_max(out, 1) + 1)) - max(g1, (buffer_min(out, 1) + -1))) + 1) <= buffer_fold_factor(__in, 1)));
     { let padded_intm = allocate('padded_intm', 2, [
-        {bounds:{min:(buffer_min(out, 0) + -1), max:(buffer_max(out, 0) + 1)}, stride:2, fold_factor:9223372036854775807},
-        {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:(((buffer_max(out, 0) - buffer_min(out, 0)) * 2) + 6), fold_factor:9223372036854775807}
+        {bounds:{min:(buffer_min(out, 0) + -1), max:(buffer_max(out, 0) + 1)}, stride:NaN, fold_factor:9223372036854775807},
+        {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:NaN, fold_factor:9223372036854775807}
       ]);
       {
         let __base = buffer_at(padded_intm, max(g, (buffer_min(out, 0) + -1)), max(g1, (buffer_min(out, 1) + -1)));

--- a/builder/test/visualize/padded_stencil_2.html
+++ b/builder/test/visualize/padded_stencil_2.html
@@ -77,7 +77,6 @@ function make_color(a) {
 }
 function buffer_min(b, d) { return b.dims[d].bounds.min; }
 function buffer_max(b, d) { return b.dims[d].bounds.max; }
-function buffer_extent(b, d) { return b.dims[d].bounds.max - b.dims[d].bounds.min + 1; }
 function buffer_stride(b, d) { return b.dims[d].stride; }
 function buffer_fold_factor(b, d) { return b.dims[d].fold_factor; }
 function buffer_rank(b) { return b.dims.length; }

--- a/builder/test/visualize/padded_stencil_2.html
+++ b/builder/test/visualize/padded_stencil_2.html
@@ -188,7 +188,61 @@ function next_color() {
   }
   return colors[(next_color.next++) % colors.length];
 }
+function alloc_extent(dim) {
+  let extent = dim.bounds.max - dim.bounds.min + 1;
+  return isNaN(dim.fold_factor) ? extent : Math.min(extent, dim.fold_factor);
+}
+function is_stride_ok_dim(stride, extent, dim) {
+  if (isNaN(dim.stride)) {
+    return true;
+  } else if (extent == 1 && Math.abs(stride) == Math.abs(dim.stride) && alloc_extent(dim) > 1) {
+    return false;
+  } else if (alloc_extent(dim) * Math.abs(dim.stride) <= stride) {
+    return true;
+  }
+  return Math.abs(dim.stride) >= extent * stride;
+}
+function is_stride_ok(stride, extent, dims) {
+  for (let i of dims) {
+    if (!is_stride_ok_dim(stride, extent, i)) {
+      return false;
+    }
+  }
+  return true;
+}
+function init_strides(elem_size, dims) {
+  for (let i of dims) {
+    if (!isNaN(i.stride)) continue;
+
+    let alloc_extent_i = alloc_extent(i);
+
+    if (is_stride_ok(elem_size, alloc_extent_i, dims)) {
+      i.stride = elem_size;
+      continue;
+    }
+
+    let min = Infinity;
+    for (let j of dims) {
+      if (isNaN(j.stride)) {
+        continue;
+      } else if (j.bounds.max < j.bounds.min) {
+        min = 0;
+        break;
+      }
+
+      let candidate = Math.abs(j.stride) * alloc_extent(j);
+      if (candidate >= min) {
+        continue;
+      } else if (!is_stride_ok(candidate, alloc_extent_i, dims)) {
+        continue;
+      }
+      min = candidate;
+    }
+    i.stride = min;
+  }
+}
 function allocate(name, elem_size, dims, hidden = false) {
+  init_strides(elem_size, dims);
   let flat_min = 0;
   let flat_max = 0;
   for (let i = 0; i < dims.length; ++i) {
@@ -274,13 +328,13 @@ function pipeline(__in, out) {
     check((((min(g0, (buffer_max(out, 0) + 1)) - max(g, (buffer_min(out, 0) + -1))) + 1) <= buffer_fold_factor(__in, 0)));
     check((((min(g2, (buffer_max(out, 1) + 1)) - max(g1, (buffer_min(out, 1) + -1))) + 1) <= buffer_fold_factor(__in, 1)));
     { let padded_intm = allocate('padded_intm', 2, [
-        {bounds:{min:(buffer_min(out, 0) + -1), max:(buffer_max(out, 0) + 1)}, stride:2, fold_factor:9223372036854775807},
-        {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:(((buffer_max(out, 0) - buffer_min(out, 0)) * 2) + 6), fold_factor:3}
+        {bounds:{min:(buffer_min(out, 0) + -1), max:(buffer_max(out, 0) + 1)}, stride:NaN, fold_factor:9223372036854775807},
+        {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:NaN, fold_factor:3}
       ]);
       { let padded_intm_uncropped = clone_buffer(padded_intm);
         { let intm = allocate('intm', 2, [
-            {bounds:{min:max(g, (buffer_min(out, 0) + -1)), max:min(g0, (buffer_max(out, 0) + 1))}, stride:2, fold_factor:9223372036854775807},
-            {bounds:{min:max(g1, (buffer_min(out, 1) + -1)), max:min(g2, (buffer_max(out, 1) + 1))}, stride:(((min(g0, (buffer_max(out, 0) + 1)) - max(g, (buffer_min(out, 0) + -1))) * 2) + 2), fold_factor:9223372036854775807}
+            {bounds:{min:max(g, (buffer_min(out, 0) + -1)), max:min(g0, (buffer_max(out, 0) + 1))}, stride:NaN, fold_factor:9223372036854775807},
+            {bounds:{min:max(g1, (buffer_min(out, 1) + -1)), max:min(g2, (buffer_max(out, 1) + 1))}, stride:NaN, fold_factor:9223372036854775807}
           ]);
           {
             let y_min_orig = buffer_min(out, 1);

--- a/builder/test/visualize/parallel_stencils_0.html
+++ b/builder/test/visualize/parallel_stencils_0.html
@@ -188,7 +188,61 @@ function next_color() {
   }
   return colors[(next_color.next++) % colors.length];
 }
+function alloc_extent(dim) {
+  let extent = dim.bounds.max - dim.bounds.min + 1;
+  return isNaN(dim.fold_factor) ? extent : Math.min(extent, dim.fold_factor);
+}
+function is_stride_ok_dim(stride, extent, dim) {
+  if (isNaN(dim.stride)) {
+    return true;
+  } else if (extent == 1 && Math.abs(stride) == Math.abs(dim.stride) && alloc_extent(dim) > 1) {
+    return false;
+  } else if (alloc_extent(dim) * Math.abs(dim.stride) <= stride) {
+    return true;
+  }
+  return Math.abs(dim.stride) >= extent * stride;
+}
+function is_stride_ok(stride, extent, dims) {
+  for (let i of dims) {
+    if (!is_stride_ok_dim(stride, extent, i)) {
+      return false;
+    }
+  }
+  return true;
+}
+function init_strides(elem_size, dims) {
+  for (let i of dims) {
+    if (!isNaN(i.stride)) continue;
+
+    let alloc_extent_i = alloc_extent(i);
+
+    if (is_stride_ok(elem_size, alloc_extent_i, dims)) {
+      i.stride = elem_size;
+      continue;
+    }
+
+    let min = Infinity;
+    for (let j of dims) {
+      if (isNaN(j.stride)) {
+        continue;
+      } else if (j.bounds.max < j.bounds.min) {
+        min = 0;
+        break;
+      }
+
+      let candidate = Math.abs(j.stride) * alloc_extent(j);
+      if (candidate >= min) {
+        continue;
+      } else if (!is_stride_ok(candidate, alloc_extent_i, dims)) {
+        continue;
+      }
+      min = candidate;
+    }
+    i.stride = min;
+  }
+}
 function allocate(name, elem_size, dims, hidden = false) {
+  init_strides(elem_size, dims);
   let flat_min = 0;
   let flat_max = 0;
   for (let i = 0; i < dims.length; ++i) {
@@ -282,23 +336,23 @@ function pipeline(in1, in2, out) {
   check(((buffer_max(out, 1) + 2) <= buffer_max(in2, 1)));
   check((((buffer_max(out, 1) - buffer_min(out, 1)) + 5) <= buffer_fold_factor(in2, 1)));
   { let intm4 = allocate('intm4', 2, [
-      {bounds:{min:buffer_min(out, 0), max:buffer_max(out, 0)}, stride:2, fold_factor:9223372036854775807},
-      {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:(((buffer_max(out, 0) - buffer_min(out, 0)) * 2) + 2), fold_factor:1}
+      {bounds:{min:buffer_min(out, 0), max:buffer_max(out, 0)}, stride:NaN, fold_factor:9223372036854775807},
+      {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:NaN, fold_factor:1}
     ]);
     { let intm4_uncropped = clone_buffer(intm4);
       { let intm2 = allocate('intm2', 2, [
-          {bounds:{min:(buffer_min(out, 0) + -2), max:(buffer_max(out, 0) + 2)}, stride:2, fold_factor:9223372036854775807},
-          {bounds:{min:(buffer_min(out, 1) + -2), max:(buffer_max(out, 1) + 2)}, stride:(((buffer_max(out, 0) - buffer_min(out, 0)) * 2) + 10), fold_factor:5}
+          {bounds:{min:(buffer_min(out, 0) + -2), max:(buffer_max(out, 0) + 2)}, stride:NaN, fold_factor:9223372036854775807},
+          {bounds:{min:(buffer_min(out, 1) + -2), max:(buffer_max(out, 1) + 2)}, stride:NaN, fold_factor:5}
         ]);
         { let intm2_uncropped = clone_buffer(intm2);
           { let intm3 = allocate('intm3', 2, [
-              {bounds:{min:buffer_min(out, 0), max:buffer_max(out, 0)}, stride:2, fold_factor:9223372036854775807},
-              {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:(((buffer_max(out, 0) - buffer_min(out, 0)) * 2) + 2), fold_factor:1}
+              {bounds:{min:buffer_min(out, 0), max:buffer_max(out, 0)}, stride:NaN, fold_factor:9223372036854775807},
+              {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:NaN, fold_factor:1}
             ]);
             { let intm3_uncropped = clone_buffer(intm3);
               { let intm1 = allocate('intm1', 2, [
-                  {bounds:{min:(buffer_min(out, 0) + -1), max:(buffer_max(out, 0) + 1)}, stride:2, fold_factor:9223372036854775807},
-                  {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:(((buffer_max(out, 0) - buffer_min(out, 0)) * 2) + 6), fold_factor:3}
+                  {bounds:{min:(buffer_min(out, 0) + -1), max:(buffer_max(out, 0) + 1)}, stride:NaN, fold_factor:9223372036854775807},
+                  {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:NaN, fold_factor:3}
                 ]);
                 { let intm1_uncropped = clone_buffer(intm1);
                   {

--- a/builder/test/visualize/parallel_stencils_0.html
+++ b/builder/test/visualize/parallel_stencils_0.html
@@ -77,7 +77,6 @@ function make_color(a) {
 }
 function buffer_min(b, d) { return b.dims[d].bounds.min; }
 function buffer_max(b, d) { return b.dims[d].bounds.max; }
-function buffer_extent(b, d) { return b.dims[d].bounds.max - b.dims[d].bounds.min + 1; }
 function buffer_stride(b, d) { return b.dims[d].stride; }
 function buffer_fold_factor(b, d) { return b.dims[d].fold_factor; }
 function buffer_rank(b) { return b.dims.length; }

--- a/builder/test/visualize/parallel_stencils_1.html
+++ b/builder/test/visualize/parallel_stencils_1.html
@@ -77,7 +77,6 @@ function make_color(a) {
 }
 function buffer_min(b, d) { return b.dims[d].bounds.min; }
 function buffer_max(b, d) { return b.dims[d].bounds.max; }
-function buffer_extent(b, d) { return b.dims[d].bounds.max - b.dims[d].bounds.min + 1; }
 function buffer_stride(b, d) { return b.dims[d].stride; }
 function buffer_fold_factor(b, d) { return b.dims[d].fold_factor; }
 function buffer_rank(b) { return b.dims.length; }

--- a/builder/test/visualize/parallel_stencils_1.html
+++ b/builder/test/visualize/parallel_stencils_1.html
@@ -188,7 +188,61 @@ function next_color() {
   }
   return colors[(next_color.next++) % colors.length];
 }
+function alloc_extent(dim) {
+  let extent = dim.bounds.max - dim.bounds.min + 1;
+  return isNaN(dim.fold_factor) ? extent : Math.min(extent, dim.fold_factor);
+}
+function is_stride_ok_dim(stride, extent, dim) {
+  if (isNaN(dim.stride)) {
+    return true;
+  } else if (extent == 1 && Math.abs(stride) == Math.abs(dim.stride) && alloc_extent(dim) > 1) {
+    return false;
+  } else if (alloc_extent(dim) * Math.abs(dim.stride) <= stride) {
+    return true;
+  }
+  return Math.abs(dim.stride) >= extent * stride;
+}
+function is_stride_ok(stride, extent, dims) {
+  for (let i of dims) {
+    if (!is_stride_ok_dim(stride, extent, i)) {
+      return false;
+    }
+  }
+  return true;
+}
+function init_strides(elem_size, dims) {
+  for (let i of dims) {
+    if (!isNaN(i.stride)) continue;
+
+    let alloc_extent_i = alloc_extent(i);
+
+    if (is_stride_ok(elem_size, alloc_extent_i, dims)) {
+      i.stride = elem_size;
+      continue;
+    }
+
+    let min = Infinity;
+    for (let j of dims) {
+      if (isNaN(j.stride)) {
+        continue;
+      } else if (j.bounds.max < j.bounds.min) {
+        min = 0;
+        break;
+      }
+
+      let candidate = Math.abs(j.stride) * alloc_extent(j);
+      if (candidate >= min) {
+        continue;
+      } else if (!is_stride_ok(candidate, alloc_extent_i, dims)) {
+        continue;
+      }
+      min = candidate;
+    }
+    i.stride = min;
+  }
+}
 function allocate(name, elem_size, dims, hidden = false) {
+  init_strides(elem_size, dims);
   let flat_min = 0;
   let flat_max = 0;
   for (let i = 0; i < dims.length; ++i) {
@@ -282,23 +336,23 @@ function pipeline(in1, in2, out) {
   check(((buffer_max(out, 1) + 2) <= buffer_max(in2, 1)));
   check((((buffer_max(out, 1) - buffer_min(out, 1)) + 5) <= buffer_fold_factor(in2, 1)));
   { let intm4 = allocate('intm4', 2, [
-      {bounds:{min:buffer_min(out, 0), max:buffer_max(out, 0)}, stride:2, fold_factor:9223372036854775807},
-      {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:(((buffer_max(out, 0) - buffer_min(out, 0)) * 2) + 2), fold_factor:2}
+      {bounds:{min:buffer_min(out, 0), max:buffer_max(out, 0)}, stride:NaN, fold_factor:9223372036854775807},
+      {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:NaN, fold_factor:2}
     ]);
     { let intm4_uncropped = clone_buffer(intm4);
       { let intm2 = allocate('intm2', 2, [
-          {bounds:{min:(buffer_min(out, 0) + -2), max:(buffer_max(out, 0) + 2)}, stride:2, fold_factor:9223372036854775807},
-          {bounds:{min:(buffer_min(out, 1) + -2), max:(buffer_max(out, 1) + 2)}, stride:(((buffer_max(out, 0) - buffer_min(out, 0)) * 2) + 10), fold_factor:6}
+          {bounds:{min:(buffer_min(out, 0) + -2), max:(buffer_max(out, 0) + 2)}, stride:NaN, fold_factor:9223372036854775807},
+          {bounds:{min:(buffer_min(out, 1) + -2), max:(buffer_max(out, 1) + 2)}, stride:NaN, fold_factor:6}
         ]);
         { let intm2_uncropped = clone_buffer(intm2);
           { let intm3 = allocate('intm3', 2, [
-              {bounds:{min:buffer_min(out, 0), max:buffer_max(out, 0)}, stride:2, fold_factor:9223372036854775807},
-              {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:(((buffer_max(out, 0) - buffer_min(out, 0)) * 2) + 2), fold_factor:2}
+              {bounds:{min:buffer_min(out, 0), max:buffer_max(out, 0)}, stride:NaN, fold_factor:9223372036854775807},
+              {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:NaN, fold_factor:2}
             ]);
             { let intm3_uncropped = clone_buffer(intm3);
               { let intm1 = allocate('intm1', 2, [
-                  {bounds:{min:(buffer_min(out, 0) + -1), max:(buffer_max(out, 0) + 1)}, stride:2, fold_factor:9223372036854775807},
-                  {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:(((buffer_max(out, 0) - buffer_min(out, 0)) * 2) + 6), fold_factor:9223372036854775807}
+                  {bounds:{min:(buffer_min(out, 0) + -1), max:(buffer_max(out, 0) + 1)}, stride:NaN, fold_factor:9223372036854775807},
+                  {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:NaN, fold_factor:9223372036854775807}
                 ]);
                 consume(in1);
                 produce(intm1);

--- a/builder/test/visualize/parallel_stencils_2.html
+++ b/builder/test/visualize/parallel_stencils_2.html
@@ -77,7 +77,6 @@ function make_color(a) {
 }
 function buffer_min(b, d) { return b.dims[d].bounds.min; }
 function buffer_max(b, d) { return b.dims[d].bounds.max; }
-function buffer_extent(b, d) { return b.dims[d].bounds.max - b.dims[d].bounds.min + 1; }
 function buffer_stride(b, d) { return b.dims[d].stride; }
 function buffer_fold_factor(b, d) { return b.dims[d].fold_factor; }
 function buffer_rank(b) { return b.dims.length; }

--- a/builder/test/visualize/parallel_stencils_2.html
+++ b/builder/test/visualize/parallel_stencils_2.html
@@ -188,7 +188,61 @@ function next_color() {
   }
   return colors[(next_color.next++) % colors.length];
 }
+function alloc_extent(dim) {
+  let extent = dim.bounds.max - dim.bounds.min + 1;
+  return isNaN(dim.fold_factor) ? extent : Math.min(extent, dim.fold_factor);
+}
+function is_stride_ok_dim(stride, extent, dim) {
+  if (isNaN(dim.stride)) {
+    return true;
+  } else if (extent == 1 && Math.abs(stride) == Math.abs(dim.stride) && alloc_extent(dim) > 1) {
+    return false;
+  } else if (alloc_extent(dim) * Math.abs(dim.stride) <= stride) {
+    return true;
+  }
+  return Math.abs(dim.stride) >= extent * stride;
+}
+function is_stride_ok(stride, extent, dims) {
+  for (let i of dims) {
+    if (!is_stride_ok_dim(stride, extent, i)) {
+      return false;
+    }
+  }
+  return true;
+}
+function init_strides(elem_size, dims) {
+  for (let i of dims) {
+    if (!isNaN(i.stride)) continue;
+
+    let alloc_extent_i = alloc_extent(i);
+
+    if (is_stride_ok(elem_size, alloc_extent_i, dims)) {
+      i.stride = elem_size;
+      continue;
+    }
+
+    let min = Infinity;
+    for (let j of dims) {
+      if (isNaN(j.stride)) {
+        continue;
+      } else if (j.bounds.max < j.bounds.min) {
+        min = 0;
+        break;
+      }
+
+      let candidate = Math.abs(j.stride) * alloc_extent(j);
+      if (candidate >= min) {
+        continue;
+      } else if (!is_stride_ok(candidate, alloc_extent_i, dims)) {
+        continue;
+      }
+      min = candidate;
+    }
+    i.stride = min;
+  }
+}
 function allocate(name, elem_size, dims, hidden = false) {
+  init_strides(elem_size, dims);
   let flat_min = 0;
   let flat_max = 0;
   for (let i = 0; i < dims.length; ++i) {
@@ -282,23 +336,23 @@ function pipeline(in1, in2, out) {
   check(((buffer_max(out, 1) + 2) <= buffer_max(in2, 1)));
   check((((buffer_max(out, 1) - buffer_min(out, 1)) + 5) <= buffer_fold_factor(in2, 1)));
   { let intm4 = allocate('intm4', 2, [
-      {bounds:{min:buffer_min(out, 0), max:buffer_max(out, 0)}, stride:2, fold_factor:9223372036854775807},
-      {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:(((buffer_max(out, 0) - buffer_min(out, 0)) * 2) + 2), fold_factor:2}
+      {bounds:{min:buffer_min(out, 0), max:buffer_max(out, 0)}, stride:NaN, fold_factor:9223372036854775807},
+      {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:NaN, fold_factor:2}
     ]);
     { let intm4_uncropped = clone_buffer(intm4);
       { let intm2 = allocate('intm2', 2, [
-          {bounds:{min:(buffer_min(out, 0) + -2), max:(buffer_max(out, 0) + 2)}, stride:2, fold_factor:9223372036854775807},
-          {bounds:{min:(buffer_min(out, 1) + -2), max:(buffer_max(out, 1) + 2)}, stride:(((buffer_max(out, 0) - buffer_min(out, 0)) * 2) + 10), fold_factor:6}
+          {bounds:{min:(buffer_min(out, 0) + -2), max:(buffer_max(out, 0) + 2)}, stride:NaN, fold_factor:9223372036854775807},
+          {bounds:{min:(buffer_min(out, 1) + -2), max:(buffer_max(out, 1) + 2)}, stride:NaN, fold_factor:6}
         ]);
         { let intm2_uncropped = clone_buffer(intm2);
           { let intm3 = allocate('intm3', 2, [
-              {bounds:{min:buffer_min(out, 0), max:buffer_max(out, 0)}, stride:2, fold_factor:9223372036854775807},
-              {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:(((buffer_max(out, 0) - buffer_min(out, 0)) * 2) + 2), fold_factor:2}
+              {bounds:{min:buffer_min(out, 0), max:buffer_max(out, 0)}, stride:NaN, fold_factor:9223372036854775807},
+              {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:NaN, fold_factor:2}
             ]);
             { let intm3_uncropped = clone_buffer(intm3);
               { let intm1 = allocate('intm1', 2, [
-                  {bounds:{min:(buffer_min(out, 0) + -1), max:(buffer_max(out, 0) + 1)}, stride:2, fold_factor:9223372036854775807},
-                  {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:(((buffer_max(out, 0) - buffer_min(out, 0)) * 2) + 6), fold_factor:4}
+                  {bounds:{min:(buffer_min(out, 0) + -1), max:(buffer_max(out, 0) + 1)}, stride:NaN, fold_factor:9223372036854775807},
+                  {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:NaN, fold_factor:4}
                 ]);
                 { let intm1_uncropped = clone_buffer(intm1);
                   {

--- a/builder/test/visualize/softmax_split_0.html
+++ b/builder/test/visualize/softmax_split_0.html
@@ -77,7 +77,6 @@ function make_color(a) {
 }
 function buffer_min(b, d) { return b.dims[d].bounds.min; }
 function buffer_max(b, d) { return b.dims[d].bounds.max; }
-function buffer_extent(b, d) { return b.dims[d].bounds.max - b.dims[d].bounds.min + 1; }
 function buffer_stride(b, d) { return b.dims[d].stride; }
 function buffer_fold_factor(b, d) { return b.dims[d].fold_factor; }
 function buffer_rank(b) { return b.dims.length; }
@@ -198,7 +197,61 @@ function next_color() {
   }
   return colors[(next_color.next++) % colors.length];
 }
+function alloc_extent(dim) {
+  let extent = dim.bounds.max - dim.bounds.min + 1;
+  return isNaN(dim.fold_factor) ? extent : Math.min(extent, dim.fold_factor);
+}
+function is_stride_ok_dim(stride, extent, dim) {
+  if (isNaN(dim.stride)) {
+    return true;
+  } else if (extent == 1 && Math.abs(stride) == Math.abs(dim.stride) && alloc_extent(dim) > 1) {
+    return false;
+  } else if (alloc_extent(dim) * Math.abs(dim.stride) <= stride) {
+    return true;
+  }
+  return Math.abs(dim.stride) >= extent * stride;
+}
+function is_stride_ok(stride, extent, dims) {
+  for (let i of dims) {
+    if (!is_stride_ok_dim(stride, extent, i)) {
+      return false;
+    }
+  }
+  return true;
+}
+function init_strides(elem_size, dims) {
+  for (let i of dims) {
+    if (!isNaN(i.stride)) continue;
+
+    let alloc_extent_i = alloc_extent(i);
+
+    if (is_stride_ok(elem_size, alloc_extent_i, dims)) {
+      i.stride = elem_size;
+      continue;
+    }
+
+    let min = Infinity;
+    for (let j of dims) {
+      if (isNaN(j.stride)) {
+        continue;
+      } else if (j.bounds.max < j.bounds.min) {
+        min = 0;
+        break;
+      }
+
+      let candidate = Math.abs(j.stride) * alloc_extent(j);
+      if (candidate >= min) {
+        continue;
+      } else if (!is_stride_ok(candidate, alloc_extent_i, dims)) {
+        continue;
+      }
+      min = candidate;
+    }
+    i.stride = min;
+  }
+}
 function allocate(name, elem_size, dims, hidden = false) {
+  init_strides(elem_size, dims);
   let flat_min = 0;
   let flat_max = 0;
   for (let i = 0; i < dims.length; ++i) {
@@ -286,23 +339,23 @@ function pipeline(__in, out) {
     check((buffer_max(out, 1) <= buffer_max(__in, 1)));
     check((((buffer_max(out, 1) - buffer_min(out, 1)) + 1) <= buffer_fold_factor(__in, 1)));
     { let softmax_out = allocate('softmax_out', 4, [
-        {bounds:{min:buffer_min(out, 0), max:buffer_max(out, 0)}, stride:4, fold_factor:9223372036854775807},
-        {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:(((buffer_max(out, 0) - buffer_min(out, 0)) * 4) + 4), fold_factor:9223372036854775807}
+        {bounds:{min:buffer_min(out, 0), max:buffer_max(out, 0)}, stride:NaN, fold_factor:9223372036854775807},
+        {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:NaN, fold_factor:9223372036854775807}
       ]);
       { let sum_exp_in = allocate('sum_exp_in', 4, [
-          {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:4, fold_factor:9223372036854775807}
+          {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:NaN, fold_factor:9223372036854775807}
         ]);
         { let sum_exp_in_uncropped = clone_buffer(sum_exp_in);
           { let exp_in = allocate('exp_in', 4, [
-              {bounds:{min:min(g, g0), max:max(g, g0)}, stride:4, fold_factor:9223372036854775807},
-              {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:((abs((g - g0)) * 4) + 4), fold_factor:9223372036854775807}
+              {bounds:{min:min(g, g0), max:max(g, g0)}, stride:NaN, fold_factor:9223372036854775807},
+              {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:NaN, fold_factor:9223372036854775807}
             ]);
             { let max_in = allocate('max_in', 4, [
-                {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:4, fold_factor:9223372036854775807}
+                {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:NaN, fold_factor:9223372036854775807}
               ]);
               { let softmax_in = allocate('softmax_in', 4, [
-                  {bounds:{min:min(g, g0), max:max(g, g0)}, stride:4, fold_factor:9223372036854775807},
-                  {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:((abs((g - g0)) * 4) + 4), fold_factor:9223372036854775807}
+                  {bounds:{min:min(g, g0), max:max(g, g0)}, stride:NaN, fold_factor:9223372036854775807},
+                  {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:NaN, fold_factor:9223372036854775807}
                 ]);
                 consume(__in);
                 produce(softmax_in);

--- a/builder/test/visualize/softmax_split_1.html
+++ b/builder/test/visualize/softmax_split_1.html
@@ -77,7 +77,6 @@ function make_color(a) {
 }
 function buffer_min(b, d) { return b.dims[d].bounds.min; }
 function buffer_max(b, d) { return b.dims[d].bounds.max; }
-function buffer_extent(b, d) { return b.dims[d].bounds.max - b.dims[d].bounds.min + 1; }
 function buffer_stride(b, d) { return b.dims[d].stride; }
 function buffer_fold_factor(b, d) { return b.dims[d].fold_factor; }
 function buffer_rank(b) { return b.dims.length; }
@@ -198,7 +197,61 @@ function next_color() {
   }
   return colors[(next_color.next++) % colors.length];
 }
+function alloc_extent(dim) {
+  let extent = dim.bounds.max - dim.bounds.min + 1;
+  return isNaN(dim.fold_factor) ? extent : Math.min(extent, dim.fold_factor);
+}
+function is_stride_ok_dim(stride, extent, dim) {
+  if (isNaN(dim.stride)) {
+    return true;
+  } else if (extent == 1 && Math.abs(stride) == Math.abs(dim.stride) && alloc_extent(dim) > 1) {
+    return false;
+  } else if (alloc_extent(dim) * Math.abs(dim.stride) <= stride) {
+    return true;
+  }
+  return Math.abs(dim.stride) >= extent * stride;
+}
+function is_stride_ok(stride, extent, dims) {
+  for (let i of dims) {
+    if (!is_stride_ok_dim(stride, extent, i)) {
+      return false;
+    }
+  }
+  return true;
+}
+function init_strides(elem_size, dims) {
+  for (let i of dims) {
+    if (!isNaN(i.stride)) continue;
+
+    let alloc_extent_i = alloc_extent(i);
+
+    if (is_stride_ok(elem_size, alloc_extent_i, dims)) {
+      i.stride = elem_size;
+      continue;
+    }
+
+    let min = Infinity;
+    for (let j of dims) {
+      if (isNaN(j.stride)) {
+        continue;
+      } else if (j.bounds.max < j.bounds.min) {
+        min = 0;
+        break;
+      }
+
+      let candidate = Math.abs(j.stride) * alloc_extent(j);
+      if (candidate >= min) {
+        continue;
+      } else if (!is_stride_ok(candidate, alloc_extent_i, dims)) {
+        continue;
+      }
+      min = candidate;
+    }
+    i.stride = min;
+  }
+}
 function allocate(name, elem_size, dims, hidden = false) {
+  init_strides(elem_size, dims);
   let flat_min = 0;
   let flat_max = 0;
   for (let i = 0; i < dims.length; ++i) {
@@ -286,26 +339,26 @@ function pipeline(__in, out) {
     check((buffer_max(out, 1) <= buffer_max(__in, 1)));
     check((((buffer_max(out, 1) - buffer_min(out, 1)) + 1) <= buffer_fold_factor(__in, 1)));
     { let softmax_out = allocate('softmax_out', 4, [
-        {bounds:{min:buffer_min(out, 0), max:buffer_max(out, 0)}, stride:4, fold_factor:9223372036854775807},
-        {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:(((buffer_max(out, 0) - buffer_min(out, 0)) * 4) + 4), fold_factor:1}
+        {bounds:{min:buffer_min(out, 0), max:buffer_max(out, 0)}, stride:NaN, fold_factor:9223372036854775807},
+        {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:NaN, fold_factor:1}
       ]);
       { let softmax_out_uncropped = clone_buffer(softmax_out);
         { let sum_exp_in = allocate('sum_exp_in', 4, [
-            {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:4, fold_factor:1}
+            {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:NaN, fold_factor:1}
           ]);
           { let sum_exp_in_uncropped = clone_buffer(sum_exp_in);
             { let exp_in = allocate('exp_in', 4, [
-                {bounds:{min:min(g, g0), max:max(g, g0)}, stride:4, fold_factor:9223372036854775807},
-                {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:((abs((g - g0)) * 4) + 4), fold_factor:1}
+                {bounds:{min:min(g, g0), max:max(g, g0)}, stride:NaN, fold_factor:9223372036854775807},
+                {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:NaN, fold_factor:1}
               ]);
               { let exp_in_uncropped = clone_buffer(exp_in);
                 { let max_in = allocate('max_in', 4, [
-                    {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:4, fold_factor:1}
+                    {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:NaN, fold_factor:1}
                   ]);
                   { let max_in_uncropped = clone_buffer(max_in);
                     { let softmax_in = allocate('softmax_in', 4, [
-                        {bounds:{min:min(g, g0), max:max(g, g0)}, stride:4, fold_factor:9223372036854775807},
-                        {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:((abs((g - g0)) * 4) + 4), fold_factor:1}
+                        {bounds:{min:min(g, g0), max:max(g, g0)}, stride:NaN, fold_factor:9223372036854775807},
+                        {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:NaN, fold_factor:1}
                       ]);
                       { let softmax_in_uncropped = clone_buffer(softmax_in);
                         {

--- a/builder/test/visualize/softmax_split_4.html
+++ b/builder/test/visualize/softmax_split_4.html
@@ -77,7 +77,6 @@ function make_color(a) {
 }
 function buffer_min(b, d) { return b.dims[d].bounds.min; }
 function buffer_max(b, d) { return b.dims[d].bounds.max; }
-function buffer_extent(b, d) { return b.dims[d].bounds.max - b.dims[d].bounds.min + 1; }
 function buffer_stride(b, d) { return b.dims[d].stride; }
 function buffer_fold_factor(b, d) { return b.dims[d].fold_factor; }
 function buffer_rank(b) { return b.dims.length; }
@@ -198,7 +197,61 @@ function next_color() {
   }
   return colors[(next_color.next++) % colors.length];
 }
+function alloc_extent(dim) {
+  let extent = dim.bounds.max - dim.bounds.min + 1;
+  return isNaN(dim.fold_factor) ? extent : Math.min(extent, dim.fold_factor);
+}
+function is_stride_ok_dim(stride, extent, dim) {
+  if (isNaN(dim.stride)) {
+    return true;
+  } else if (extent == 1 && Math.abs(stride) == Math.abs(dim.stride) && alloc_extent(dim) > 1) {
+    return false;
+  } else if (alloc_extent(dim) * Math.abs(dim.stride) <= stride) {
+    return true;
+  }
+  return Math.abs(dim.stride) >= extent * stride;
+}
+function is_stride_ok(stride, extent, dims) {
+  for (let i of dims) {
+    if (!is_stride_ok_dim(stride, extent, i)) {
+      return false;
+    }
+  }
+  return true;
+}
+function init_strides(elem_size, dims) {
+  for (let i of dims) {
+    if (!isNaN(i.stride)) continue;
+
+    let alloc_extent_i = alloc_extent(i);
+
+    if (is_stride_ok(elem_size, alloc_extent_i, dims)) {
+      i.stride = elem_size;
+      continue;
+    }
+
+    let min = Infinity;
+    for (let j of dims) {
+      if (isNaN(j.stride)) {
+        continue;
+      } else if (j.bounds.max < j.bounds.min) {
+        min = 0;
+        break;
+      }
+
+      let candidate = Math.abs(j.stride) * alloc_extent(j);
+      if (candidate >= min) {
+        continue;
+      } else if (!is_stride_ok(candidate, alloc_extent_i, dims)) {
+        continue;
+      }
+      min = candidate;
+    }
+    i.stride = min;
+  }
+}
 function allocate(name, elem_size, dims, hidden = false) {
+  init_strides(elem_size, dims);
   let flat_min = 0;
   let flat_max = 0;
   for (let i = 0; i < dims.length; ++i) {
@@ -286,26 +339,26 @@ function pipeline(__in, out) {
     check((buffer_max(out, 1) <= buffer_max(__in, 1)));
     check((((buffer_max(out, 1) - buffer_min(out, 1)) + 1) <= buffer_fold_factor(__in, 1)));
     { let softmax_out = allocate('softmax_out', 4, [
-        {bounds:{min:buffer_min(out, 0), max:buffer_max(out, 0)}, stride:4, fold_factor:9223372036854775807},
-        {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:(((buffer_max(out, 0) - buffer_min(out, 0)) * 4) + 4), fold_factor:4}
+        {bounds:{min:buffer_min(out, 0), max:buffer_max(out, 0)}, stride:NaN, fold_factor:9223372036854775807},
+        {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:NaN, fold_factor:4}
       ]);
       { let softmax_out_uncropped = clone_buffer(softmax_out);
         { let sum_exp_in = allocate('sum_exp_in', 4, [
-            {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:4, fold_factor:4}
+            {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:NaN, fold_factor:4}
           ]);
           { let sum_exp_in_uncropped = clone_buffer(sum_exp_in);
             { let exp_in = allocate('exp_in', 4, [
-                {bounds:{min:min(g, g0), max:max(g, g0)}, stride:4, fold_factor:9223372036854775807},
-                {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:((abs((g - g0)) * 4) + 4), fold_factor:4}
+                {bounds:{min:min(g, g0), max:max(g, g0)}, stride:NaN, fold_factor:9223372036854775807},
+                {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:NaN, fold_factor:4}
               ]);
               { let exp_in_uncropped = clone_buffer(exp_in);
                 { let max_in = allocate('max_in', 4, [
-                    {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:4, fold_factor:4}
+                    {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:NaN, fold_factor:4}
                   ]);
                   { let max_in_uncropped = clone_buffer(max_in);
                     { let softmax_in = allocate('softmax_in', 4, [
-                        {bounds:{min:min(g, g0), max:max(g, g0)}, stride:4, fold_factor:9223372036854775807},
-                        {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:((abs((g - g0)) * 4) + 4), fold_factor:4}
+                        {bounds:{min:min(g, g0), max:max(g, g0)}, stride:NaN, fold_factor:9223372036854775807},
+                        {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:NaN, fold_factor:4}
                       ]);
                       { let softmax_in_uncropped = clone_buffer(softmax_in);
                         {

--- a/builder/test/visualize/stencil_chain_split_serial_split_0.html
+++ b/builder/test/visualize/stencil_chain_split_serial_split_0.html
@@ -77,7 +77,6 @@ function make_color(a) {
 }
 function buffer_min(b, d) { return b.dims[d].bounds.min; }
 function buffer_max(b, d) { return b.dims[d].bounds.max; }
-function buffer_extent(b, d) { return b.dims[d].bounds.max - b.dims[d].bounds.min + 1; }
 function buffer_stride(b, d) { return b.dims[d].stride; }
 function buffer_fold_factor(b, d) { return b.dims[d].fold_factor; }
 function buffer_rank(b) { return b.dims.length; }

--- a/builder/test/visualize/stencil_chain_split_serial_split_0.html
+++ b/builder/test/visualize/stencil_chain_split_serial_split_0.html
@@ -188,7 +188,61 @@ function next_color() {
   }
   return colors[(next_color.next++) % colors.length];
 }
+function alloc_extent(dim) {
+  let extent = dim.bounds.max - dim.bounds.min + 1;
+  return isNaN(dim.fold_factor) ? extent : Math.min(extent, dim.fold_factor);
+}
+function is_stride_ok_dim(stride, extent, dim) {
+  if (isNaN(dim.stride)) {
+    return true;
+  } else if (extent == 1 && Math.abs(stride) == Math.abs(dim.stride) && alloc_extent(dim) > 1) {
+    return false;
+  } else if (alloc_extent(dim) * Math.abs(dim.stride) <= stride) {
+    return true;
+  }
+  return Math.abs(dim.stride) >= extent * stride;
+}
+function is_stride_ok(stride, extent, dims) {
+  for (let i of dims) {
+    if (!is_stride_ok_dim(stride, extent, i)) {
+      return false;
+    }
+  }
+  return true;
+}
+function init_strides(elem_size, dims) {
+  for (let i of dims) {
+    if (!isNaN(i.stride)) continue;
+
+    let alloc_extent_i = alloc_extent(i);
+
+    if (is_stride_ok(elem_size, alloc_extent_i, dims)) {
+      i.stride = elem_size;
+      continue;
+    }
+
+    let min = Infinity;
+    for (let j of dims) {
+      if (isNaN(j.stride)) {
+        continue;
+      } else if (j.bounds.max < j.bounds.min) {
+        min = 0;
+        break;
+      }
+
+      let candidate = Math.abs(j.stride) * alloc_extent(j);
+      if (candidate >= min) {
+        continue;
+      } else if (!is_stride_ok(candidate, alloc_extent_i, dims)) {
+        continue;
+      }
+      min = candidate;
+    }
+    i.stride = min;
+  }
+}
 function allocate(name, elem_size, dims, hidden = false) {
+  init_strides(elem_size, dims);
   let flat_min = 0;
   let flat_max = 0;
   for (let i = 0; i < dims.length; ++i) {
@@ -275,12 +329,12 @@ function pipeline(__in, out) {
     check(((buffer_max(out, 1) + 2) <= buffer_max(__in, 1)));
     check((((buffer_max(out, 1) - buffer_min(out, 1)) + 5) <= buffer_fold_factor(__in, 1)));
     { let stencil1_result = allocate('stencil1_result', 2, [
-        {bounds:{min:(buffer_min(out, 0) + -1), max:(buffer_max(out, 0) + 1)}, stride:2, fold_factor:9223372036854775807},
-        {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:(((buffer_max(out, 0) - buffer_min(out, 0)) * 2) + 6), fold_factor:9223372036854775807}
+        {bounds:{min:(buffer_min(out, 0) + -1), max:(buffer_max(out, 0) + 1)}, stride:NaN, fold_factor:9223372036854775807},
+        {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:NaN, fold_factor:9223372036854775807}
       ]);
       { let add_result = allocate('add_result', 2, [
-          {bounds:{min:(buffer_min(out, 0) + -2), max:(buffer_max(out, 0) + 2)}, stride:2, fold_factor:9223372036854775807},
-          {bounds:{min:(buffer_min(out, 1) + -2), max:(buffer_max(out, 1) + 2)}, stride:(((buffer_max(out, 0) - buffer_min(out, 0)) * 2) + 10), fold_factor:9223372036854775807}
+          {bounds:{min:(buffer_min(out, 0) + -2), max:(buffer_max(out, 0) + 2)}, stride:NaN, fold_factor:9223372036854775807},
+          {bounds:{min:(buffer_min(out, 1) + -2), max:(buffer_max(out, 1) + 2)}, stride:NaN, fold_factor:9223372036854775807}
         ]);
         {
           let __trace_token = trace_begin(buffer_at(__trace_names, 0));

--- a/builder/test/visualize/stencil_chain_split_serial_split_1.html
+++ b/builder/test/visualize/stencil_chain_split_serial_split_1.html
@@ -77,7 +77,6 @@ function make_color(a) {
 }
 function buffer_min(b, d) { return b.dims[d].bounds.min; }
 function buffer_max(b, d) { return b.dims[d].bounds.max; }
-function buffer_extent(b, d) { return b.dims[d].bounds.max - b.dims[d].bounds.min + 1; }
 function buffer_stride(b, d) { return b.dims[d].stride; }
 function buffer_fold_factor(b, d) { return b.dims[d].fold_factor; }
 function buffer_rank(b) { return b.dims.length; }

--- a/builder/test/visualize/stencil_chain_split_serial_split_1.html
+++ b/builder/test/visualize/stencil_chain_split_serial_split_1.html
@@ -188,7 +188,61 @@ function next_color() {
   }
   return colors[(next_color.next++) % colors.length];
 }
+function alloc_extent(dim) {
+  let extent = dim.bounds.max - dim.bounds.min + 1;
+  return isNaN(dim.fold_factor) ? extent : Math.min(extent, dim.fold_factor);
+}
+function is_stride_ok_dim(stride, extent, dim) {
+  if (isNaN(dim.stride)) {
+    return true;
+  } else if (extent == 1 && Math.abs(stride) == Math.abs(dim.stride) && alloc_extent(dim) > 1) {
+    return false;
+  } else if (alloc_extent(dim) * Math.abs(dim.stride) <= stride) {
+    return true;
+  }
+  return Math.abs(dim.stride) >= extent * stride;
+}
+function is_stride_ok(stride, extent, dims) {
+  for (let i of dims) {
+    if (!is_stride_ok_dim(stride, extent, i)) {
+      return false;
+    }
+  }
+  return true;
+}
+function init_strides(elem_size, dims) {
+  for (let i of dims) {
+    if (!isNaN(i.stride)) continue;
+
+    let alloc_extent_i = alloc_extent(i);
+
+    if (is_stride_ok(elem_size, alloc_extent_i, dims)) {
+      i.stride = elem_size;
+      continue;
+    }
+
+    let min = Infinity;
+    for (let j of dims) {
+      if (isNaN(j.stride)) {
+        continue;
+      } else if (j.bounds.max < j.bounds.min) {
+        min = 0;
+        break;
+      }
+
+      let candidate = Math.abs(j.stride) * alloc_extent(j);
+      if (candidate >= min) {
+        continue;
+      } else if (!is_stride_ok(candidate, alloc_extent_i, dims)) {
+        continue;
+      }
+      min = candidate;
+    }
+    i.stride = min;
+  }
+}
 function allocate(name, elem_size, dims, hidden = false) {
+  init_strides(elem_size, dims);
   let flat_min = 0;
   let flat_max = 0;
   for (let i = 0; i < dims.length; ++i) {
@@ -275,13 +329,13 @@ function pipeline(__in, out) {
     check(((buffer_max(out, 1) + 2) <= buffer_max(__in, 1)));
     check((((buffer_max(out, 1) - buffer_min(out, 1)) + 5) <= buffer_fold_factor(__in, 1)));
     { let stencil1_result = allocate('stencil1_result', 2, [
-        {bounds:{min:(buffer_min(out, 0) + -1), max:(buffer_max(out, 0) + 1)}, stride:2, fold_factor:9223372036854775807},
-        {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:(((buffer_max(out, 0) - buffer_min(out, 0)) * 2) + 6), fold_factor:3}
+        {bounds:{min:(buffer_min(out, 0) + -1), max:(buffer_max(out, 0) + 1)}, stride:NaN, fold_factor:9223372036854775807},
+        {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:NaN, fold_factor:3}
       ]);
       { let stencil1_result_uncropped = clone_buffer(stencil1_result);
         { let add_result = allocate('add_result', 2, [
-            {bounds:{min:(buffer_min(out, 0) + -2), max:(buffer_max(out, 0) + 2)}, stride:2, fold_factor:9223372036854775807},
-            {bounds:{min:(buffer_min(out, 1) + -2), max:(buffer_max(out, 1) + 2)}, stride:(((buffer_max(out, 0) - buffer_min(out, 0)) * 2) + 10), fold_factor:3}
+            {bounds:{min:(buffer_min(out, 0) + -2), max:(buffer_max(out, 0) + 2)}, stride:NaN, fold_factor:9223372036854775807},
+            {bounds:{min:(buffer_min(out, 1) + -2), max:(buffer_max(out, 1) + 2)}, stride:NaN, fold_factor:3}
           ]);
           { let add_result_uncropped = clone_buffer(add_result);
             {

--- a/builder/test/visualize/stencil_chain_split_serial_split_2.html
+++ b/builder/test/visualize/stencil_chain_split_serial_split_2.html
@@ -77,7 +77,6 @@ function make_color(a) {
 }
 function buffer_min(b, d) { return b.dims[d].bounds.min; }
 function buffer_max(b, d) { return b.dims[d].bounds.max; }
-function buffer_extent(b, d) { return b.dims[d].bounds.max - b.dims[d].bounds.min + 1; }
 function buffer_stride(b, d) { return b.dims[d].stride; }
 function buffer_fold_factor(b, d) { return b.dims[d].fold_factor; }
 function buffer_rank(b) { return b.dims.length; }

--- a/builder/test/visualize/stencil_chain_split_serial_split_2.html
+++ b/builder/test/visualize/stencil_chain_split_serial_split_2.html
@@ -188,7 +188,61 @@ function next_color() {
   }
   return colors[(next_color.next++) % colors.length];
 }
+function alloc_extent(dim) {
+  let extent = dim.bounds.max - dim.bounds.min + 1;
+  return isNaN(dim.fold_factor) ? extent : Math.min(extent, dim.fold_factor);
+}
+function is_stride_ok_dim(stride, extent, dim) {
+  if (isNaN(dim.stride)) {
+    return true;
+  } else if (extent == 1 && Math.abs(stride) == Math.abs(dim.stride) && alloc_extent(dim) > 1) {
+    return false;
+  } else if (alloc_extent(dim) * Math.abs(dim.stride) <= stride) {
+    return true;
+  }
+  return Math.abs(dim.stride) >= extent * stride;
+}
+function is_stride_ok(stride, extent, dims) {
+  for (let i of dims) {
+    if (!is_stride_ok_dim(stride, extent, i)) {
+      return false;
+    }
+  }
+  return true;
+}
+function init_strides(elem_size, dims) {
+  for (let i of dims) {
+    if (!isNaN(i.stride)) continue;
+
+    let alloc_extent_i = alloc_extent(i);
+
+    if (is_stride_ok(elem_size, alloc_extent_i, dims)) {
+      i.stride = elem_size;
+      continue;
+    }
+
+    let min = Infinity;
+    for (let j of dims) {
+      if (isNaN(j.stride)) {
+        continue;
+      } else if (j.bounds.max < j.bounds.min) {
+        min = 0;
+        break;
+      }
+
+      let candidate = Math.abs(j.stride) * alloc_extent(j);
+      if (candidate >= min) {
+        continue;
+      } else if (!is_stride_ok(candidate, alloc_extent_i, dims)) {
+        continue;
+      }
+      min = candidate;
+    }
+    i.stride = min;
+  }
+}
 function allocate(name, elem_size, dims, hidden = false) {
+  init_strides(elem_size, dims);
   let flat_min = 0;
   let flat_max = 0;
   for (let i = 0; i < dims.length; ++i) {
@@ -275,13 +329,13 @@ function pipeline(__in, out) {
     check(((buffer_max(out, 1) + 2) <= buffer_max(__in, 1)));
     check((((buffer_max(out, 1) - buffer_min(out, 1)) + 5) <= buffer_fold_factor(__in, 1)));
     { let stencil1_result = allocate('stencil1_result', 2, [
-        {bounds:{min:(buffer_min(out, 0) + -1), max:(buffer_max(out, 0) + 1)}, stride:2, fold_factor:9223372036854775807},
-        {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:(((buffer_max(out, 0) - buffer_min(out, 0)) * 2) + 6), fold_factor:4}
+        {bounds:{min:(buffer_min(out, 0) + -1), max:(buffer_max(out, 0) + 1)}, stride:NaN, fold_factor:9223372036854775807},
+        {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:NaN, fold_factor:4}
       ]);
       { let stencil1_result_uncropped = clone_buffer(stencil1_result);
         { let add_result = allocate('add_result', 2, [
-            {bounds:{min:(buffer_min(out, 0) + -2), max:(buffer_max(out, 0) + 2)}, stride:2, fold_factor:9223372036854775807},
-            {bounds:{min:(buffer_min(out, 1) + -2), max:(buffer_max(out, 1) + 2)}, stride:(((buffer_max(out, 0) - buffer_min(out, 0)) * 2) + 10), fold_factor:4}
+            {bounds:{min:(buffer_min(out, 0) + -2), max:(buffer_max(out, 0) + 2)}, stride:NaN, fold_factor:9223372036854775807},
+            {bounds:{min:(buffer_min(out, 1) + -2), max:(buffer_max(out, 1) + 2)}, stride:NaN, fold_factor:4}
           ]);
           { let add_result_uncropped = clone_buffer(add_result);
             {

--- a/builder/test/visualize/stencil_split_0.html
+++ b/builder/test/visualize/stencil_split_0.html
@@ -77,7 +77,6 @@ function make_color(a) {
 }
 function buffer_min(b, d) { return b.dims[d].bounds.min; }
 function buffer_max(b, d) { return b.dims[d].bounds.max; }
-function buffer_extent(b, d) { return b.dims[d].bounds.max - b.dims[d].bounds.min + 1; }
 function buffer_stride(b, d) { return b.dims[d].stride; }
 function buffer_fold_factor(b, d) { return b.dims[d].fold_factor; }
 function buffer_rank(b) { return b.dims.length; }

--- a/builder/test/visualize/stencil_split_0.html
+++ b/builder/test/visualize/stencil_split_0.html
@@ -188,7 +188,61 @@ function next_color() {
   }
   return colors[(next_color.next++) % colors.length];
 }
+function alloc_extent(dim) {
+  let extent = dim.bounds.max - dim.bounds.min + 1;
+  return isNaN(dim.fold_factor) ? extent : Math.min(extent, dim.fold_factor);
+}
+function is_stride_ok_dim(stride, extent, dim) {
+  if (isNaN(dim.stride)) {
+    return true;
+  } else if (extent == 1 && Math.abs(stride) == Math.abs(dim.stride) && alloc_extent(dim) > 1) {
+    return false;
+  } else if (alloc_extent(dim) * Math.abs(dim.stride) <= stride) {
+    return true;
+  }
+  return Math.abs(dim.stride) >= extent * stride;
+}
+function is_stride_ok(stride, extent, dims) {
+  for (let i of dims) {
+    if (!is_stride_ok_dim(stride, extent, i)) {
+      return false;
+    }
+  }
+  return true;
+}
+function init_strides(elem_size, dims) {
+  for (let i of dims) {
+    if (!isNaN(i.stride)) continue;
+
+    let alloc_extent_i = alloc_extent(i);
+
+    if (is_stride_ok(elem_size, alloc_extent_i, dims)) {
+      i.stride = elem_size;
+      continue;
+    }
+
+    let min = Infinity;
+    for (let j of dims) {
+      if (isNaN(j.stride)) {
+        continue;
+      } else if (j.bounds.max < j.bounds.min) {
+        min = 0;
+        break;
+      }
+
+      let candidate = Math.abs(j.stride) * alloc_extent(j);
+      if (candidate >= min) {
+        continue;
+      } else if (!is_stride_ok(candidate, alloc_extent_i, dims)) {
+        continue;
+      }
+      min = candidate;
+    }
+    i.stride = min;
+  }
+}
 function allocate(name, elem_size, dims, hidden = false) {
+  init_strides(elem_size, dims);
   let flat_min = 0;
   let flat_max = 0;
   for (let i = 0; i < dims.length; ++i) {
@@ -273,8 +327,8 @@ function pipeline(__in, out) {
   check(((buffer_max(out, 1) + 1) <= buffer_max(__in, 1)));
   check((((buffer_max(out, 1) - buffer_min(out, 1)) + 3) <= buffer_fold_factor(__in, 1)));
   { let intm = allocate('intm', 2, [
-      {bounds:{min:(buffer_min(out, 0) + -1), max:(buffer_max(out, 0) + 1)}, stride:2, fold_factor:9223372036854775807},
-      {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:(((buffer_max(out, 0) - buffer_min(out, 0)) * 2) + 6), fold_factor:9223372036854775807}
+      {bounds:{min:(buffer_min(out, 0) + -1), max:(buffer_max(out, 0) + 1)}, stride:NaN, fold_factor:9223372036854775807},
+      {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:NaN, fold_factor:9223372036854775807}
     ]);
     consume(__in);
     produce(intm);

--- a/builder/test/visualize/stencil_split_1.html
+++ b/builder/test/visualize/stencil_split_1.html
@@ -77,7 +77,6 @@ function make_color(a) {
 }
 function buffer_min(b, d) { return b.dims[d].bounds.min; }
 function buffer_max(b, d) { return b.dims[d].bounds.max; }
-function buffer_extent(b, d) { return b.dims[d].bounds.max - b.dims[d].bounds.min + 1; }
 function buffer_stride(b, d) { return b.dims[d].stride; }
 function buffer_fold_factor(b, d) { return b.dims[d].fold_factor; }
 function buffer_rank(b) { return b.dims.length; }

--- a/builder/test/visualize/stencil_split_1.html
+++ b/builder/test/visualize/stencil_split_1.html
@@ -188,7 +188,61 @@ function next_color() {
   }
   return colors[(next_color.next++) % colors.length];
 }
+function alloc_extent(dim) {
+  let extent = dim.bounds.max - dim.bounds.min + 1;
+  return isNaN(dim.fold_factor) ? extent : Math.min(extent, dim.fold_factor);
+}
+function is_stride_ok_dim(stride, extent, dim) {
+  if (isNaN(dim.stride)) {
+    return true;
+  } else if (extent == 1 && Math.abs(stride) == Math.abs(dim.stride) && alloc_extent(dim) > 1) {
+    return false;
+  } else if (alloc_extent(dim) * Math.abs(dim.stride) <= stride) {
+    return true;
+  }
+  return Math.abs(dim.stride) >= extent * stride;
+}
+function is_stride_ok(stride, extent, dims) {
+  for (let i of dims) {
+    if (!is_stride_ok_dim(stride, extent, i)) {
+      return false;
+    }
+  }
+  return true;
+}
+function init_strides(elem_size, dims) {
+  for (let i of dims) {
+    if (!isNaN(i.stride)) continue;
+
+    let alloc_extent_i = alloc_extent(i);
+
+    if (is_stride_ok(elem_size, alloc_extent_i, dims)) {
+      i.stride = elem_size;
+      continue;
+    }
+
+    let min = Infinity;
+    for (let j of dims) {
+      if (isNaN(j.stride)) {
+        continue;
+      } else if (j.bounds.max < j.bounds.min) {
+        min = 0;
+        break;
+      }
+
+      let candidate = Math.abs(j.stride) * alloc_extent(j);
+      if (candidate >= min) {
+        continue;
+      } else if (!is_stride_ok(candidate, alloc_extent_i, dims)) {
+        continue;
+      }
+      min = candidate;
+    }
+    i.stride = min;
+  }
+}
 function allocate(name, elem_size, dims, hidden = false) {
+  init_strides(elem_size, dims);
   let flat_min = 0;
   let flat_max = 0;
   for (let i = 0; i < dims.length; ++i) {
@@ -273,8 +327,8 @@ function pipeline(__in, out) {
   check(((buffer_max(out, 1) + 1) <= buffer_max(__in, 1)));
   check((((buffer_max(out, 1) - buffer_min(out, 1)) + 3) <= buffer_fold_factor(__in, 1)));
   { let intm = allocate('intm', 2, [
-      {bounds:{min:(buffer_min(out, 0) + -1), max:(buffer_max(out, 0) + 1)}, stride:2, fold_factor:9223372036854775807},
-      {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:(((buffer_max(out, 0) - buffer_min(out, 0)) * 2) + 6), fold_factor:3}
+      {bounds:{min:(buffer_min(out, 0) + -1), max:(buffer_max(out, 0) + 1)}, stride:NaN, fold_factor:9223372036854775807},
+      {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:NaN, fold_factor:3}
     ]);
     { let intm_uncropped = clone_buffer(intm);
       {

--- a/builder/test/visualize/stencil_split_2.html
+++ b/builder/test/visualize/stencil_split_2.html
@@ -77,7 +77,6 @@ function make_color(a) {
 }
 function buffer_min(b, d) { return b.dims[d].bounds.min; }
 function buffer_max(b, d) { return b.dims[d].bounds.max; }
-function buffer_extent(b, d) { return b.dims[d].bounds.max - b.dims[d].bounds.min + 1; }
 function buffer_stride(b, d) { return b.dims[d].stride; }
 function buffer_fold_factor(b, d) { return b.dims[d].fold_factor; }
 function buffer_rank(b) { return b.dims.length; }

--- a/builder/test/visualize/stencil_split_2.html
+++ b/builder/test/visualize/stencil_split_2.html
@@ -188,7 +188,61 @@ function next_color() {
   }
   return colors[(next_color.next++) % colors.length];
 }
+function alloc_extent(dim) {
+  let extent = dim.bounds.max - dim.bounds.min + 1;
+  return isNaN(dim.fold_factor) ? extent : Math.min(extent, dim.fold_factor);
+}
+function is_stride_ok_dim(stride, extent, dim) {
+  if (isNaN(dim.stride)) {
+    return true;
+  } else if (extent == 1 && Math.abs(stride) == Math.abs(dim.stride) && alloc_extent(dim) > 1) {
+    return false;
+  } else if (alloc_extent(dim) * Math.abs(dim.stride) <= stride) {
+    return true;
+  }
+  return Math.abs(dim.stride) >= extent * stride;
+}
+function is_stride_ok(stride, extent, dims) {
+  for (let i of dims) {
+    if (!is_stride_ok_dim(stride, extent, i)) {
+      return false;
+    }
+  }
+  return true;
+}
+function init_strides(elem_size, dims) {
+  for (let i of dims) {
+    if (!isNaN(i.stride)) continue;
+
+    let alloc_extent_i = alloc_extent(i);
+
+    if (is_stride_ok(elem_size, alloc_extent_i, dims)) {
+      i.stride = elem_size;
+      continue;
+    }
+
+    let min = Infinity;
+    for (let j of dims) {
+      if (isNaN(j.stride)) {
+        continue;
+      } else if (j.bounds.max < j.bounds.min) {
+        min = 0;
+        break;
+      }
+
+      let candidate = Math.abs(j.stride) * alloc_extent(j);
+      if (candidate >= min) {
+        continue;
+      } else if (!is_stride_ok(candidate, alloc_extent_i, dims)) {
+        continue;
+      }
+      min = candidate;
+    }
+    i.stride = min;
+  }
+}
 function allocate(name, elem_size, dims, hidden = false) {
+  init_strides(elem_size, dims);
   let flat_min = 0;
   let flat_max = 0;
   for (let i = 0; i < dims.length; ++i) {
@@ -273,8 +327,8 @@ function pipeline(__in, out) {
   check(((buffer_max(out, 1) + 1) <= buffer_max(__in, 1)));
   check((((buffer_max(out, 1) - buffer_min(out, 1)) + 3) <= buffer_fold_factor(__in, 1)));
   { let intm = allocate('intm', 2, [
-      {bounds:{min:(buffer_min(out, 0) + -1), max:(buffer_max(out, 0) + 1)}, stride:2, fold_factor:9223372036854775807},
-      {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:(((buffer_max(out, 0) - buffer_min(out, 0)) * 2) + 6), fold_factor:4}
+      {bounds:{min:(buffer_min(out, 0) + -1), max:(buffer_max(out, 0) + 1)}, stride:NaN, fold_factor:9223372036854775807},
+      {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:NaN, fold_factor:4}
     ]);
     { let intm_uncropped = clone_buffer(intm);
       {

--- a/builder/test/visualize/stencil_split_3.html
+++ b/builder/test/visualize/stencil_split_3.html
@@ -77,7 +77,6 @@ function make_color(a) {
 }
 function buffer_min(b, d) { return b.dims[d].bounds.min; }
 function buffer_max(b, d) { return b.dims[d].bounds.max; }
-function buffer_extent(b, d) { return b.dims[d].bounds.max - b.dims[d].bounds.min + 1; }
 function buffer_stride(b, d) { return b.dims[d].stride; }
 function buffer_fold_factor(b, d) { return b.dims[d].fold_factor; }
 function buffer_rank(b) { return b.dims.length; }

--- a/builder/test/visualize/stencil_split_3.html
+++ b/builder/test/visualize/stencil_split_3.html
@@ -188,7 +188,61 @@ function next_color() {
   }
   return colors[(next_color.next++) % colors.length];
 }
+function alloc_extent(dim) {
+  let extent = dim.bounds.max - dim.bounds.min + 1;
+  return isNaN(dim.fold_factor) ? extent : Math.min(extent, dim.fold_factor);
+}
+function is_stride_ok_dim(stride, extent, dim) {
+  if (isNaN(dim.stride)) {
+    return true;
+  } else if (extent == 1 && Math.abs(stride) == Math.abs(dim.stride) && alloc_extent(dim) > 1) {
+    return false;
+  } else if (alloc_extent(dim) * Math.abs(dim.stride) <= stride) {
+    return true;
+  }
+  return Math.abs(dim.stride) >= extent * stride;
+}
+function is_stride_ok(stride, extent, dims) {
+  for (let i of dims) {
+    if (!is_stride_ok_dim(stride, extent, i)) {
+      return false;
+    }
+  }
+  return true;
+}
+function init_strides(elem_size, dims) {
+  for (let i of dims) {
+    if (!isNaN(i.stride)) continue;
+
+    let alloc_extent_i = alloc_extent(i);
+
+    if (is_stride_ok(elem_size, alloc_extent_i, dims)) {
+      i.stride = elem_size;
+      continue;
+    }
+
+    let min = Infinity;
+    for (let j of dims) {
+      if (isNaN(j.stride)) {
+        continue;
+      } else if (j.bounds.max < j.bounds.min) {
+        min = 0;
+        break;
+      }
+
+      let candidate = Math.abs(j.stride) * alloc_extent(j);
+      if (candidate >= min) {
+        continue;
+      } else if (!is_stride_ok(candidate, alloc_extent_i, dims)) {
+        continue;
+      }
+      min = candidate;
+    }
+    i.stride = min;
+  }
+}
 function allocate(name, elem_size, dims, hidden = false) {
+  init_strides(elem_size, dims);
   let flat_min = 0;
   let flat_max = 0;
   for (let i = 0; i < dims.length; ++i) {
@@ -273,8 +327,8 @@ function pipeline(__in, out) {
   check(((buffer_max(out, 1) + 1) <= buffer_max(__in, 1)));
   check((((buffer_max(out, 1) - buffer_min(out, 1)) + 3) <= buffer_fold_factor(__in, 1)));
   { let intm = allocate('intm', 2, [
-      {bounds:{min:(buffer_min(out, 0) + -1), max:(buffer_max(out, 0) + 1)}, stride:2, fold_factor:9223372036854775807},
-      {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:(((buffer_max(out, 0) - buffer_min(out, 0)) * 2) + 6), fold_factor:6}
+      {bounds:{min:(buffer_min(out, 0) + -1), max:(buffer_max(out, 0) + 1)}, stride:NaN, fold_factor:9223372036854775807},
+      {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:NaN, fold_factor:6}
     ]);
     { let intm_uncropped = clone_buffer(intm);
       {

--- a/runtime/buffer.cc
+++ b/runtime/buffer.cc
@@ -80,7 +80,7 @@ bool is_stride_ok(index_t stride, index_t extent, const dim& dim) {
     // If the dimension has an unknown stride, it's OK, we're
     // resolving the current dim first.
     return true;
-  } else if (extent == 1 && abs(stride) == abs(dim.stride()) && alloc_extent(dim) > 1) {
+  } else if (extent == 1 && std::abs(stride) == std::abs(dim.stride()) && alloc_extent(dim) > 1) {
     // If a dimension is extent 1, avoid giving this dimension the same stride
     // as another dimension with extent greater than 1. This doesn't affect the
     // results of most programs (because the stride only ever multiplied with
@@ -88,10 +88,10 @@ bool is_stride_ok(index_t stride, index_t extent, const dim& dim) {
     // other libraries that make extra assumptions about images, and may be
     // easier to understand.
     return false;
-  } else if (alloc_extent(dim) * abs(dim.stride()) <= stride) {
+  } else if (alloc_extent(dim) * std::abs(dim.stride()) <= stride) {
     // The dim is completely inside the proposed stride.
     return true;
-  } else if (abs(dim.stride()) >= extent * stride) {
+  } else if (std::abs(dim.stride()) >= extent * stride) {
     // The dim is completely outside the proposed stride.
     return true;
   } else {

--- a/runtime/buffer.cc
+++ b/runtime/buffer.cc
@@ -73,7 +73,8 @@ namespace {
 //
 // 1. https://github.com/dsharlet/array/blob/38f8ce332fc4e26af08325ad0654c8516a445e8c/include/array/array.h#L835-L907
 
-// A proposed stride is "OK" w.r.t. `dim` if the proposed stride does not intersect the dim.
+// A proposed stride is "OK" w.r.t. `dim` if the proposed stride does not cause this dimension's memory to overlap with
+// any other dimension's memory.
 bool is_stride_ok(index_t stride, index_t extent, const dim& dim) {
   if (dim.stride() == dim::auto_stride) {
     // If the dimension has an unknown stride, it's OK, we're
@@ -90,9 +91,7 @@ bool is_stride_ok(index_t stride, index_t extent, const dim& dim) {
   } else if (alloc_extent(dim) * abs(dim.stride()) <= stride) {
     // The dim is completely inside the proposed stride.
     return true;
-  }
-  index_t flat_extent = extent * stride;
-  if (abs(dim.stride()) >= flat_extent) {
+  } else if (abs(dim.stride()) >= extent * stride) {
     // The dim is completely outside the proposed stride.
     return true;
   } else {

--- a/runtime/buffer.cc
+++ b/runtime/buffer.cc
@@ -14,11 +14,13 @@ namespace slinky {
 
 namespace {
 
+index_t alloc_extent(const dim& dim) { return std::min(dim.extent(), dim.fold_factor()); }
+
 std::size_t alloc_size(std::size_t rank, std::size_t elem_size, const dim* dims) {
   index_t flat_min = 0;
   index_t flat_max = 0;
   for (std::size_t i = 0; i < rank; ++i) {
-    index_t extent = std::min(dims[i].extent(), dims[i].fold_factor());
+    index_t extent = alloc_extent(dims[i]);
     flat_min += (extent - 1) * std::min<index_t>(0, dims[i].stride());
     flat_max += (extent - 1) * std::max<index_t>(0, dims[i].stride());
   }
@@ -64,7 +66,91 @@ raw_buffer_ptr raw_buffer::make_copy(const raw_buffer& src) {
   return buf;
 }
 
+namespace {
+
+// This algorithm is the same idea as [1], but here it does not need to attempt to support compile-time constant
+// strides, which makes it a lot easier to implement.
+//
+// 1. https://github.com/dsharlet/array/blob/38f8ce332fc4e26af08325ad0654c8516a445e8c/include/array/array.h#L835-L907
+
+// A proposed stride is "OK" w.r.t. `dim` if the proposed stride does not intersect the dim.
+bool is_stride_ok(index_t stride, index_t extent, const dim& dim) {
+  if (dim.stride() == dim::auto_stride) {
+    // If the dimension has an unknown stride, it's OK, we're
+    // resolving the current dim first.
+    return true;
+  } else if (extent == 1 && abs(stride) == abs(dim.stride()) && alloc_extent(dim) > 1) {
+    // If a dimension is extent 1, avoid giving this dimension the same stride
+    // as another dimension with extent greater than 1. This doesn't affect the
+    // results of most programs (because the stride only ever multiplied with
+    // zero), but it makes the strides less objectionable to asserts in some
+    // other libraries that make extra assumptions about images, and may be
+    // easier to understand.
+    return false;
+  } else if (alloc_extent(dim) * abs(dim.stride()) <= stride) {
+    // The dim is completely inside the proposed stride.
+    return true;
+  }
+  index_t flat_extent = extent * stride;
+  if (abs(dim.stride()) >= flat_extent) {
+    // The dim is completely outside the proposed stride.
+    return true;
+  } else {
+    return false;
+  }
+}
+
+bool is_stride_ok(index_t stride, index_t extent, span<const dim> dims) {
+  for (const dim& i : dims) {
+    if (!is_stride_ok(stride, extent, i)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+}  // namespace
+
+void raw_buffer::init_strides(index_t alignment) {
+  for (std::size_t i = 0; i < rank; ++i) {
+    if (dim(i).stride() != dim::auto_stride) continue;
+
+    index_t alloc_extent_i = alloc_extent(dim(i));
+
+    if (is_stride_ok(elem_size, alloc_extent_i, {dims, rank})) {
+      // This dimension can have stride elem_size, no other stride could be better.
+      dim(i).set_stride(elem_size);
+      continue;
+    }
+
+    // Loop through all the dimensions and see if a stride that is just outside any dimension is OK.
+    index_t min = std::numeric_limits<index_t>::max();
+    for (std::size_t j = 0; j < rank; ++j) {
+      if (dim(j).stride() == dim::auto_stride) {
+        // We don't know the stride of this dimension, it can't help us decide a stride for this dimension.
+        continue;
+      } else if (dim(j).extent() <= 0) {
+        // This dimension (and this buffer) is empty.
+        min = 0;
+        break;
+      }
+
+      index_t candidate = align_up(std::abs(dim(j).stride()) * alloc_extent(dim(j)), alignment);
+      if (candidate >= min) {
+        // This candidate stride is not better than the current stride.
+        continue;
+      } else if (!is_stride_ok(candidate, alloc_extent_i, {dims, rank})) {
+        continue;
+      }
+      min = candidate;
+    }
+    assert(min < std::numeric_limits<index_t>::max());
+    dim(i).set_stride(min);
+  }
+}
+
 void* raw_buffer::allocate() {
+  init_strides();
   void* allocation = malloc(size_bytes());
   base = allocation;
   return allocation;

--- a/runtime/buffer.h
+++ b/runtime/buffer.h
@@ -80,7 +80,7 @@ public:
   bool contains(index_t a, index_t b) const {
     // Conceptually, accesses may be out of bounds, but in practice, if the stride is 0, the accesses will not read
     // invalid memory. It's a bit messy to allow this, but it feels really overzealous to disallow it when attempting to
-    // implement broadcasting in callbacks.
+    // implement broadcasting.
     return stride() == 0 || (min() <= a && b <= max());
   }
   bool contains(index_t x) const { return contains(x, x); }
@@ -93,6 +93,11 @@ public:
     } else {
       return euclidean_mod(i - min(), fold_factor()) * stride();
     }
+  }
+
+  bool is_folded() const {
+    if (fold_factor() == unfolded) return false;
+    return min() / fold_factor() != max() / fold_factor();
   }
 };
 
@@ -268,7 +273,7 @@ public:
 
     dim(d).set_bounds(min, max);
     // Crops can't span a folding boundary if they move the base pointer.
-    assert(offset == 0 || dim(d).min() / dim(d).fold_factor() == dim(d).max() / dim(d).fold_factor());
+    assert(offset == 0 || !dim(d).is_folded());
     return *this;
   }
 

--- a/runtime/buffer.h
+++ b/runtime/buffer.h
@@ -77,12 +77,7 @@ public:
   }
 
   // Returns true if the interval [a, b] is in bounds of this dimension.
-  bool contains(index_t a, index_t b) const {
-    // Conceptually, accesses may be out of bounds, but in practice, if the stride is 0, the accesses will not read
-    // invalid memory. It's a bit messy to allow this, but it feels really overzealous to disallow it when attempting to
-    // implement broadcasting.
-    return stride() == 0 || (min() <= a && b <= max());
-  }
+  bool contains(index_t a, index_t b) const { return min() <= a && b <= max(); }
   bool contains(index_t x) const { return contains(x, x); }
   bool contains(const dim& other) const { return contains(other.min(), other.max()); }
 

--- a/runtime/depends_on.cc
+++ b/runtime/depends_on.cc
@@ -131,7 +131,7 @@ public:
     for (const dim_expr& i : op->dims) {
       i.bounds.min.accept(this);
       i.bounds.max.accept(this);
-      i.stride.accept(this);
+      if (i.stride.defined()) i.stride.accept(this);
       if (i.fold_factor.defined()) i.fold_factor.accept(this);
     }
     visit_sym_body(op);

--- a/runtime/evaluate.cc
+++ b/runtime/evaluate.cc
@@ -131,7 +131,7 @@ public:
     dim result;
     interval bounds = eval(x.bounds);
     result.set_bounds(bounds.min, bounds.max);
-    result.set_stride(eval(x.stride));
+    result.set_stride(eval(x.stride, dim::auto_stride));
     result.set_fold_factor(eval(x.fold_factor, dim::unfolded));
     return result;
   }
@@ -475,6 +475,7 @@ public:
     }
 
     if (op->storage == memory_type::stack) {
+      buffer.init_strides();
       buffer.base = alloca(buffer.size_bytes());
       buffer.allocation = nullptr;
     } else {

--- a/runtime/expr_stmt.cc
+++ b/runtime/expr_stmt.cc
@@ -705,7 +705,7 @@ void recursive_node_visitor::visit(const allocate* op) {
   for (const dim_expr& i : op->dims) {
     i.bounds.min.accept(this);
     i.bounds.max.accept(this);
-    i.stride.accept(this);
+    if (i.stride.defined()) i.stride.accept(this);
     if (i.fold_factor.defined()) i.fold_factor.accept(this);
   }
   if (op->body.defined()) op->body.accept(this);

--- a/runtime/test/buffer.cc
+++ b/runtime/test/buffer.cc
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
+#include <iostream>
 #include <numeric>
 #include <random>
 
@@ -16,6 +17,21 @@ std::mt19937& rng() {
 namespace slinky {
 
 bool operator==(const dim& a, const dim& b) { return memcmp(&a, &b, sizeof(dim)) == 0; }
+
+std::ostream& operator<<(std::ostream& os, const dim& d) {
+  return os << "{min: " << d.min() << ", max: " << d.max() << ", stride: " << d.stride()
+            << ", fold_factor: " << d.fold_factor() << "}";
+}
+
+std::ostream& operator<<(std::ostream& os, const raw_buffer& buf) {
+  os << "{base: " << buf.base << ", elem_size: " << buf.elem_size << ", dims = {";
+  for (std::size_t i = 0; i < buf.rank; ++i) {
+    if (i > 0) os << ", ";
+    os << buf.dim(i);
+  }
+  os << "}";
+  return os;
+}
 
 int random(int min, int max) { return rng()() % (max - min + 1) + min; }
 
@@ -93,6 +109,7 @@ void randomize_strides_and_padding(buffer<T, N>& buf, const randomize_options& o
     if (options.allow_broadcast && random(0, 9) == 0) {
       // Make this a broadcast.
       dim.set_stride(0);
+      dim.set_bounds(std::numeric_limits<index_t>::min(), std::numeric_limits<index_t>::max());
     } else {
       dim.set_stride(stride);
       // Add some extra random padding.
@@ -733,17 +750,14 @@ TEST(buffer, copy) {
     std::fill(padding.begin(), padding.end(), 7);
 
     buffer<void, max_rank> src(rank, elem_size);
-    for (std::size_t d = 0; d < src.rank; ++d) {
-      src.dim(d).set_min_extent(0, 5);
-    }
-    randomize_strides_and_padding(src, {-1, 1, true, false});
-    init_random(src);
-
     buffer<void, max_rank> dst(rank, elem_size);
     for (std::size_t d = 0; d < src.rank; ++d) {
-      dst.dim(d) = src.dim(d);
+      src.dim(d).set_min_extent(0, 5);
+      dst.dim(d).set_min_extent(0, 5);
     }
+    randomize_strides_and_padding(src, {-1, 1, true, false});
     randomize_strides_and_padding(dst, {-1, 1, false, false});
+    init_random(src);
     dst.allocate();
 
     slinky::copy(src, dst, padding.data());

--- a/runtime/test/buffer.cc
+++ b/runtime/test/buffer.cc
@@ -916,18 +916,15 @@ TEST(fuse_contiguous_dims, copy) {
     std::fill(padding.begin(), padding.end(), 7);
 
     buffer<void, max_rank> src(rank, elem_size);
-    for (std::size_t d = 0; d < src.rank; ++d) {
-      src.dim(d).set_min_extent(0, 5);
-    }
-    randomize_strides_and_padding(src, {-1, 1, true, true});
-    init_random(src);
-    buffer<void, max_rank> src_opt = src;
-
     buffer<void, max_rank> dst(rank, elem_size);
     for (std::size_t d = 0; d < src.rank; ++d) {
-      dst.dim(d) = src.dim(d);
+      src.dim(d).set_min_extent(0, 5);
+      dst.dim(d).set_min_extent(0, 5);
     }
+    randomize_strides_and_padding(src, {-1, 1, true, true});
     randomize_strides_and_padding(dst, {-1, 1, false, false});
+    init_random(src);
+    buffer<void, max_rank> src_opt = src;
     buffer<void, max_rank> dst_opt = dst;
     dst.allocate();
     dst_opt.allocate();

--- a/runtime/visualize.cc
+++ b/runtime/visualize.cc
@@ -374,7 +374,6 @@ function make_color(a) {
 }
 function buffer_min(b, d) { return b.dims[d].bounds.min; }
 function buffer_max(b, d) { return b.dims[d].bounds.max; }
-function buffer_extent(b, d) { return b.dims[d].bounds.max - b.dims[d].bounds.min + 1; }
 function buffer_stride(b, d) { return b.dims[d].stride; }
 function buffer_fold_factor(b, d) { return b.dims[d].fold_factor; }
 function buffer_rank(b) { return b.dims.length; }

--- a/runtime/visualize.cc
+++ b/runtime/visualize.cc
@@ -485,7 +485,61 @@ function next_color() {
   }
   return colors[(next_color.next++) % colors.length];
 }
+function alloc_extent(dim) {
+  let extent = dim.bounds.max - dim.bounds.min + 1;
+  return isNaN(dim.fold_factor) ? extent : Math.min(extent, dim.fold_factor);
+}
+function is_stride_ok_dim(stride, extent, dim) {
+  if (isNaN(dim.stride)) {
+    return true;
+  } else if (extent == 1 && Math.abs(stride) == Math.abs(dim.stride) && alloc_extent(dim) > 1) {
+    return false;
+  } else if (alloc_extent(dim) * Math.abs(dim.stride) <= stride) {
+    return true;
+  }
+  return Math.abs(dim.stride) >= extent * stride;
+}
+function is_stride_ok(stride, extent, dims) {
+  for (let i of dims) {
+    if (!is_stride_ok_dim(stride, extent, i)) {
+      return false;
+    }
+  }
+  return true;
+}
+function init_strides(elem_size, dims) {
+  for (let i of dims) {
+    if (!isNaN(i.stride)) continue;
+
+    let alloc_extent_i = alloc_extent(i);
+
+    if (is_stride_ok(elem_size, alloc_extent_i, dims)) {
+      i.stride = elem_size;
+      continue;
+    }
+
+    let min = Infinity;
+    for (let j of dims) {
+      if (isNaN(j.stride)) {
+        continue;
+      } else if (j.bounds.max < j.bounds.min) {
+        min = 0;
+        break;
+      }
+
+      let candidate = Math.abs(j.stride) * alloc_extent(j);
+      if (candidate >= min) {
+        continue;
+      } else if (!is_stride_ok(candidate, alloc_extent_i, dims)) {
+        continue;
+      }
+      min = candidate;
+    }
+    i.stride = min;
+  }
+}
 function allocate(name, elem_size, dims, hidden = false) {
+  init_strides(elem_size, dims);
   let flat_min = 0;
   let flat_max = 0;
   for (let i = 0; i < dims.length; ++i) {


### PR DESCRIPTION
Before this PR, default strides were set during pipeline construction. This was flawed because if a user set some strides and not others, the default generated strides would be confused. This issue is now fixed.

It additionally allows quite a few improvements:
- Allows the calling program more control over strides, such as to control alignment/padding. 
- Allows us to tell when strides are fixed vs. flexible. Right now, aliased buffers will ignore the strides set by the user, potentially invalidating them and violating assumptions the callbacks have made.
- The automatically generated strides algorithm is much more robust (taken from https://github.com/dsharlet/array/blob/38f8ce332fc4e26af08325ad0654c8516a445e8c/include/array/array.h#L897-L907, but we don't need to accommodate compile time constants, so the implementation is simpler).
- Very minor, but this removes some of the cruftiest expressions from the programs we generate.