### PR TITLE
Add a test that splits loops to a maximum total area

### DIFF
--- a/builder/pipeline.cc
+++ b/builder/pipeline.cc
@@ -602,7 +602,8 @@ class pipeline_builder {
       for (int d = 0; d < static_cast<int>(o.dims.size()); ++d) {
         if (o.dims[d] == loop.sym()) {
           expr loop_max = buffer_max(o.sym(), d);
-          interval_expr bounds = slinky::bounds(loop.var, min(simplify(loop.var + loop.step - 1), loop_max));
+          expr loop_step = sanitizer_.mutate(loop.step);
+          interval_expr bounds = slinky::bounds(loop.var, min(simplify(loop.var + loop_step - 1), loop_max));
           body = crop_dim::make(o.sym(), o.sym(), d, bounds, body);
         }
       }
@@ -657,7 +658,8 @@ class pipeline_builder {
       // The loop body is done, and we have an actual loop to make here. Crop the body.
       body = crop_for_loop(body, base_f, loop);
       // And make the actual loop.
-      body = loop::make(loop.sym(), loop.max_workers, get_loop_bounds(base_f, loop), loop.step, body);
+      expr loop_step = sanitizer_.mutate(loop.step);
+      body = loop::make(loop.sym(), loop.max_workers, get_loop_bounds(base_f, loop), loop_step, body);
     }
 
     return body;

--- a/builder/test/BUILD
+++ b/builder/test/BUILD
@@ -134,6 +134,18 @@ cc_test(
 )
 
 cc_test(
+    name = "tile_area",
+    srcs = ["tile_area.cc"],
+    deps = [
+        ":util",
+        "//builder",
+        "//runtime",
+        "@googletest//:gtest_main",
+    ],
+    size = "small",
+)
+
+cc_test(
     name = "replica_pipeline",
     srcs = ["replica_pipeline.cc"],
     deps = [

--- a/builder/test/tile_area.cc
+++ b/builder/test/tile_area.cc
@@ -1,0 +1,77 @@
+#include <gtest/gtest.h>
+
+#include "builder/pipeline.h"
+#include "builder/test/context.h"
+#include "builder/test/funcs.h"
+#include "builder/test/util.h"
+#include "runtime/expr.h"
+#include "runtime/pipeline.h"
+
+namespace slinky {
+
+// An example of two 2D elementwise operations in sequence.
+TEST(tile_area, pipeline) {
+  // Make the pipeline
+  node_context ctx;
+
+  auto in = buffer_expr::make(ctx, "in", 2, sizeof(int));
+  auto out = buffer_expr::make(ctx, "out", 2, sizeof(int));
+  auto intm = buffer_expr::make(ctx, "intm", 2, sizeof(int));
+
+  var x(ctx, "x");
+  var y(ctx, "y");
+
+  // Track the max number of elements produced by any one call.
+  int max_elem_count_seen = 0;
+
+  auto m2 = [&](const buffer<const int>& a, const buffer<int>& b) -> index_t { 
+    max_elem_count_seen = std::max<int>(max_elem_count_seen, b.elem_count());
+    return multiply_2<int>(a, b);
+  };
+  auto a1 = [&](const buffer<const int>& a, const buffer<int>& b) -> index_t {
+    max_elem_count_seen = std::max<int>(max_elem_count_seen, b.elem_count());
+    return add_1<int>(a, b);
+  };
+
+  func mul = func::make(std::move(m2), {{in, {point(x), point(y)}}}, {{intm, {x, y}}});
+  func add = func::make(std::move(a1), {{intm, {point(x), point(y)}}}, {{out, {x, y}}});
+
+  // Split the loops such that we limit the number of elements produced to a total number across both dimensions.
+  const int split_area = 20;
+  expr split_x = min(out->dim(0).extent(), split_area);
+  expr split_y = max(1, split_area / split_x);
+  add.loops({{x, split_x}, {y, split_y}});
+
+  pipeline p = build_pipeline(ctx, {in}, {out});
+
+  // Run the pipeline
+  const int W = 10;
+  const int H = 10;
+
+  buffer<int, 2> in_buf({W, H});
+  in_buf.allocate();
+  for (int y = 0; y < H; ++y) {
+    for (int x = 0; x < W; ++x) {
+      in_buf(x, y) = y * W + x;
+    }
+  }
+
+  buffer<int, 2> out_buf({W, H});
+  out_buf.allocate();
+
+  // Not having span(std::initializer_list<T>) is unfortunate.
+  const raw_buffer* inputs[] = {&in_buf};
+  const raw_buffer* outputs[] = {&out_buf};
+  test_context eval_ctx;
+  p.evaluate(inputs, outputs, eval_ctx);
+
+  for (int y = 0; y < H; ++y) {
+    for (int x = 0; x < W; ++x) {
+      ASSERT_EQ(out_buf(x, y), 2 * (y * W + x) + 1);
+    }
+  }
+
+  ASSERT_LE(max_elem_count_seen, split_area);
+}
+
+}  // namespace slinky


### PR DESCRIPTION
This required a small bug fix: we forgot to sanitize the loop steps (a user provided expression) of buffer metadata.