### PR TITLE
Avoid aliasing buffers that would violate constraints

### DIFF
--- a/builder/optimizations.cc
+++ b/builder/optimizations.cc
@@ -105,6 +105,30 @@ std::vector<expr> buffer_mins(var buf, std::size_t rank) {
   return result;
 }
 
+stmt replace_copy_with_pad(const stmt& s, var a, var b) {
+  return recursive_mutate<copy_stmt>(s, [a, b](const copy_stmt* op) {
+    if (!((op->src == a && op->dst == b) || (op->src == b && op->dst == a))) {
+      // Not this copy.
+      return stmt(op);
+    }
+    if (!op->padding || op->padding->empty()) {
+      // No padding, this copy is now a no-op.
+      return stmt();
+    }
+    // Make a call to `pad`.
+    call_stmt::attributes pad_attrs;
+    pad_attrs.name = "pad";
+    return call_stmt::make(
+        [padding = *op->padding](const call_stmt* op, const eval_context& ctx) -> index_t {
+          const raw_buffer* src_buf = ctx.lookup_buffer(op->inputs[0]);
+          const raw_buffer* dst_buf = ctx.lookup_buffer(op->outputs[0]);
+          ctx.pad(src_buf->dims, *dst_buf, padding.data());
+          return 0;
+        },
+        {op->src}, {op->dst}, std::move(pad_attrs));
+  });
+}
+
 class buffer_aliaser : public node_mutator {
   struct buffer_alias {
     std::vector<dim_expr> dims;
@@ -181,27 +205,7 @@ public:
       stmt result =
           make_buffer::make(op->sym, buffer_at(target_var, alias.at), op->elem_size, alias.dims, std::move(body));
       // If we aliased the source and destination of a copy, replace the copy with a pad.
-      stmt pad_result = recursive_mutate<copy_stmt>(result, [a = op->sym, b = target_var](const copy_stmt* op) {
-        if (!((op->src == a && op->dst == b) || (op->src == b && op->dst == a))) {
-          // Not this copy.
-          return stmt(op);
-        }
-        if (!op->padding || op->padding->empty()) {
-          // No padding, this copy is now a no-op.
-          return stmt();
-        }
-        // Make a call to `pad`.
-        call_stmt::attributes pad_attrs;
-        pad_attrs.name = "pad";
-        return call_stmt::make(
-            [padding = *op->padding](const call_stmt* op, const eval_context& ctx) -> index_t {
-              const raw_buffer* src_buf = ctx.lookup_buffer(op->inputs[0]);
-              const raw_buffer* dst_buf = ctx.lookup_buffer(op->outputs[0]);
-              ctx.pad(src_buf->dims, *dst_buf, padding.data());
-              return 0;
-            },
-            {op->src}, {op->dst}, std::move(pad_attrs));
-      });
+      stmt pad_result = replace_copy_with_pad(result, op->sym, target_var);
       if (pad_result.same_as(result)) {
         // This wasn't a copy, we actually did some computation in place. We can't alias another buffer to this target
         // without understanding the lifetimes more carefully.

--- a/builder/test/BUILD
+++ b/builder/test/BUILD
@@ -146,6 +146,18 @@ cc_test(
 )
 
 cc_test(
+    name = "cannot_alias",
+    srcs = ["cannot_alias.cc"],
+    deps = [
+        ":util",
+        "//builder",
+        "//runtime",
+        "@googletest//:gtest_main",
+    ],
+    size = "small",
+)
+
+cc_test(
     name = "replica_pipeline",
     srcs = ["replica_pipeline.cc"],
     deps = [

--- a/builder/test/cannot_alias.cc
+++ b/builder/test/cannot_alias.cc
@@ -1,0 +1,109 @@
+#include <gtest/gtest.h>
+
+#include "builder/pipeline.h"
+#include "builder/test/context.h"
+#include "builder/test/funcs.h"
+#include "builder/test/util.h"
+#include "runtime/expr.h"
+#include "runtime/pipeline.h"
+
+namespace slinky {
+
+// This set of tests ensures that we don't alias buffers when doing so would violate assumptions that the client code
+// asked slinky to maintain.
+
+TEST(cannot_alias_transpose_input, pipeline) {
+  // Make the pipeline
+  node_context ctx;
+
+  auto in = buffer_expr::make(ctx, "in", 2, sizeof(int));
+  auto out = buffer_expr::make(ctx, "out", 2, sizeof(int));
+
+  auto in_t = buffer_expr::make(ctx, "in_t", 2, sizeof(int));
+
+  // Our callback requires the stride to be 1 element.
+  in_t->dim(0).stride = static_cast<index_t>(sizeof(int));
+
+  var x(ctx, "x");
+  var y(ctx, "y");
+
+  func transposed = func::make_copy({in, {point(y), point(x)}}, {in_t, {x, y}});
+  func add1 = func::make(
+      [](const buffer<const int>& a, const buffer<int>& b) -> index_t {
+        if (a.dim(0).stride() != 4) return 1;
+        return add_1<int>(a, b);
+      },
+      {{{in_t, {point(x), point(y)}}}}, {{{out, {x, y}}}}, call_stmt::attributes{.name = "add1"});
+
+  pipeline p = build_pipeline(ctx, {in}, {out});
+
+  // Run the pipeline.
+  const int W = 20;
+  const int H = 10;
+  buffer<int, 2> in_buf({H, W});
+  init_random(in_buf);
+
+  buffer<int, 2> out_buf({W, H});
+  out_buf.allocate();
+
+  // Not having span(std::initializer_list<T>) is unfortunate.
+  const raw_buffer* inputs[] = {&in_buf};
+  const raw_buffer* outputs[] = {&out_buf};
+  test_context eval_ctx;
+  ASSERT_EQ(0, p.evaluate(inputs, outputs, eval_ctx));
+
+  for (int y = 0; y < H; ++y) {
+    for (int x = 0; x < W; ++x) {
+      ASSERT_EQ(out_buf(x, y), in_buf(y, x) + 1);
+    }
+  }
+}
+
+TEST(cannot_alias_transpose_output, pipeline) {
+  // Make the pipeline
+  node_context ctx;
+
+  auto in = buffer_expr::make(ctx, "in", 2, sizeof(int));
+  auto out = buffer_expr::make(ctx, "out", 2, sizeof(int));
+
+  auto out_t = buffer_expr::make(ctx, "out_t", 2, sizeof(int));
+
+  // Our callback requires the stride to be 1 element.
+  out_t->dim(0).stride = static_cast<index_t>(sizeof(int));
+
+  var x(ctx, "x");
+  var y(ctx, "y");
+
+  func add1 = func::make(
+      [](const buffer<const int>& a, const buffer<int>& b) -> index_t {
+        if (b.dim(0).stride() != 4) return 1;
+        return add_1<int>(a, b);
+      },
+      {{{in, {point(x), point(y)}}}}, {{{out_t, {x, y}}}}, call_stmt::attributes{.name = "add1"});
+  func transposed = func::make_copy({out_t, {point(y), point(x)}}, {out, {x, y}});
+
+  pipeline p = build_pipeline(ctx, {in}, {out});
+
+  // Run the pipeline.
+  const int W = 20;
+  const int H = 10;
+  buffer<int, 2> in_buf({H, W});
+  init_random(in_buf);
+
+  buffer<int, 2> out_buf({W, H});
+  out_buf.allocate();
+
+  // Not having span(std::initializer_list<T>) is unfortunate.
+  const raw_buffer* inputs[] = {&in_buf};
+  const raw_buffer* outputs[] = {&out_buf};
+  test_context eval_ctx;
+  ASSERT_EQ(0, p.evaluate(inputs, outputs, eval_ctx));
+
+  for (int y = 0; y < H; ++y) {
+    for (int x = 0; x < W; ++x) {
+      ASSERT_EQ(out_buf(x, y), in_buf(y, x) + 1);
+    }
+  }
+}
+
+}  // namespace slinky


### PR DESCRIPTION
If the client code sets a constraint on the stride of an allocation, we should not violate that constraint with an alias with a different stride in that dimension.

This PR adds a test that verifies this, and implements the logic necessary to implement this.