### PR TITLE
`simplify` and `substitute` fixes

### DIFF
--- a/builder/simplify.cc
+++ b/builder/simplify.cc
@@ -739,9 +739,10 @@ public:
     } else if (!crop_needed(deps)) {
       // Add clamps for the implicit bounds like crop would have done.
       for (index_t d = 0; d < static_cast<index_t>(new_bounds.size()); ++d) {
-        new_bounds[d] &= slinky::buffer_bounds(sym_var, d);
+        new_bounds[d] &= slinky::buffer_bounds(op->src, d);
       }
       body = substitute_bounds(body, op->sym, new_bounds);
+      body = substitute(body, op->sym, op->src);
       set_result(mutate(body));
       return;
     }
@@ -801,7 +802,8 @@ public:
       set_result(std::move(body));
       return;
     } else if (!crop_needed(deps)) {
-      body = substitute_bounds(body, op->sym, op->dim, bounds & slinky::buffer_bounds(sym_var, op->dim));
+      body = substitute_bounds(body, op->sym, op->dim, bounds & slinky::buffer_bounds(op->src, op->dim));
+      body = substitute(body, op->sym, op->src);
       set_result(mutate(body));
       return;
     }

--- a/builder/simplify.cc
+++ b/builder/simplify.cc
@@ -711,7 +711,6 @@ public:
     box_expr new_bounds(op->bounds.size());
 
     // If possible, rewrite crop_buffer of one dimension to crop_dim.
-    expr sym_var = variable::make(op->sym);
     const std::optional<box_expr>& prev_bounds = buffer_bounds[op->sym];
     index_t dims_count = 0;
     bool changed = false;
@@ -774,7 +773,6 @@ public:
   }
 
   void visit(const crop_dim* op) override {
-    expr sym_var = variable::make(op->sym);
     interval_expr bounds = simplify_crop_bounds(mutate(op->bounds), op->src, op->dim);
     bounds = simplify_redundant_bounds(bounds, slinky::buffer_bounds(op->src, op->dim));
     if (!bounds.min.defined() && !bounds.max.defined()) {

--- a/builder/test/simplify.cc
+++ b/builder/test/simplify.cc
@@ -201,6 +201,12 @@ TEST(simplify, bounds) {
       matches(check::make(max(1, buffer_min(y, 1)) == max(buffer_min(y, 1), buffer_min(x, 1)))));
 }
 
+TEST(simplify, crop_not_needed) {
+  ASSERT_THAT(simplify(crop_dim::make(b0, b0, 1, {x, y}, check::make(b0))), matches(check::make(b0)));
+  ASSERT_THAT(simplify(crop_dim::make(b1, b0, 1, {y, z}, check::make(b1))), matches(check::make(b0)));
+  ASSERT_THAT(simplify(crop_dim::make(b1, b0, 1, {y, z}, check::make(b0))), matches(check::make(b0)));
+}
+
 TEST(simplify, clone) {
   // Clone is shadowed
   ASSERT_THAT(
@@ -238,8 +244,8 @@ TEST(simplify, make_buffer) {
     return make_buffer::make(buf, buffer_at(buf, at), buffer_elem_size(buf), dims, body);
   };
 
-  auto make_crop = [body](var buf, std::vector<expr> at, std::vector<interval_expr> bounds,
-                       std::vector<dim_expr> dims) {
+  auto make_crop = [body](
+                       var buf, std::vector<expr> at, std::vector<interval_expr> bounds, std::vector<dim_expr> dims) {
     for (int d = 0; d < static_cast<int>(bounds.size()); ++d) {
       if (bounds[d].min.defined()) dims[d].bounds.min = bounds[d].min;
       if (bounds[d].max.defined()) dims[d].bounds.max = bounds[d].max;

--- a/builder/test/substitute.cc
+++ b/builder/test/substitute.cc
@@ -28,20 +28,21 @@ TEST(substitute, basic) {
   ASSERT_THAT(
       substitute(check::make(y == buffer_min(x, 3)), buffer_min(x, 3), z), matches(check::make(expr(y) == expr(z))));
   ASSERT_THAT(substitute(crop_dim::make(x, y, 0, {0, 0}, call_stmt::make(nullptr, {}, {x}, {})), y, z),
-      matches(
-          crop_dim::make(x, z, 0, buffer_bounds(z, 0) & interval_expr{0, 0}, call_stmt::make(nullptr, {}, {x}, {}))));
+      matches(crop_dim::make(x, z, 0, interval_expr{0, 0}, call_stmt::make(nullptr, {}, {x}, {}))));
   ASSERT_THAT(substitute(crop_dim::make(y, z, 0, {0, 0}, call_stmt::make(nullptr, {x}, {y}, {})), x, w),
       matches(crop_dim::make(y, z, 0, {0, 0}, call_stmt::make(nullptr, {w}, {y}, {}))));
   ASSERT_THAT(substitute(crop_dim::make(
                              y, y, 0, {0, 0}, crop_dim::make(y, y, 0, {0, 0}, call_stmt::make(nullptr, {x}, {y}, {}))),
                   x, w),
-      matches(crop_dim::make(y, y, 0, {0, 0}, crop_dim::make(y, y, 0, {0, 0}, call_stmt::make(nullptr, {w}, {y}, {})))));
+      matches(
+          crop_dim::make(y, y, 0, {0, 0}, crop_dim::make(y, y, 0, {0, 0}, call_stmt::make(nullptr, {w}, {y}, {})))));
 }
 
 TEST(substitute, shadowed) {
   ASSERT_THAT(substitute(let::make(x, y, x + z), x, w), matches(let::make(x, y, x + z)));
 
-  ASSERT_THAT(substitute(let::make({{x, 1}, {y, 2}}, z + 1), z, z + w), matches(let::make({{x, 1}, {y, 2}}, z + w + 1)));
+  ASSERT_THAT(
+      substitute(let::make({{x, 1}, {y, 2}}, z + 1), z, z + w), matches(let::make({{x, 1}, {y, 2}}, z + w + 1)));
 
   ASSERT_THAT(substitute(crop_dim::make(x, x, 1, {y, z}, check::make(0 < buffer_min(x, 1))), buffer_min(x, 1), w),
       matches(crop_dim::make(x, x, 1, {max(y, w), z}, check::make(0 < buffer_min(x, 1)))));


### PR DESCRIPTION
- Don't add redundant clamps in `substitute`
- Fix a few bugs due to non-shadowed crop simplification.