### PR TITLE
Improve sliding window and storage folding robustness

### DIFF
--- a/builder/simplify.cc
+++ b/builder/simplify.cc
@@ -1043,8 +1043,8 @@ interval_expr bounds_of(const interval_expr& x, const bounds_map& expr_bounds) {
 namespace {
 
 class constant_bound : public node_mutator {
-  // 1 -> we are looking for an upper bound
-  // 0 -> we are looking for a lower bound
+  // > 0 -> we are looking for an upper bound
+  // < 0 -> we are looking for a lower bound
   int sign;
 
 public:

--- a/builder/simplify.h
+++ b/builder/simplify.h
@@ -13,9 +13,12 @@ expr simplify(const expr& e, const bounds_map& bounds = bounds_map());
 stmt simplify(const stmt& s, const bounds_map& bounds = bounds_map());
 interval_expr simplify(const interval_expr& e, const bounds_map& bounds = bounds_map());
 
-// Determine an interval such that e is always inside the interval.
+// Determine an interval such that x is always inside the interval.
 interval_expr bounds_of(const expr& x, const bounds_map& bounds = bounds_map());
 interval_expr bounds_of(const interval_expr& x, const bounds_map& bounds = bounds_map());
+
+// Determine an upper bound of x that is conservative if the bound can be made constant.
+expr constant_upper_bound(const expr& x);
 
 // Attempts to determine if e can be proven to be always true or false.
 std::optional<bool> attempt_to_prove(const expr& condition, const bounds_map& bounds = bounds_map());

--- a/builder/simplify_exprs.cc
+++ b/builder/simplify_exprs.cc
@@ -133,6 +133,8 @@ expr simplify(const class min* op, expr a, expr b) {
       // Selects
       r.rewrite(min(select(x, y, z), select(x, y, w)), select(x, y, min(z, w))) ||
       r.rewrite(min(select(x, y, z), select(x, w, z)), select(x, min(y, w), z)) ||
+      r.rewrite(min(y, select(x, y, w)), select(x, y, min(y, w))) ||
+      r.rewrite(min(z, select(x, w, z)), select(x, min(z, w), z)) ||
       false) {
     return r.result;
   }
@@ -248,6 +250,8 @@ expr simplify(const class max* op, expr a, expr b) {
       // Selects
       r.rewrite(max(select(x, y, z), select(x, y, w)), select(x, y, max(z, w))) ||
       r.rewrite(max(select(x, y, z), select(x, w, z)), select(x, max(y, w), z)) ||
+      r.rewrite(max(y, select(x, y, w)), select(x, y, max(y, w))) ||
+      r.rewrite(max(z, select(x, w, z)), select(x, max(z, w), z)) ||
       false) {
     return r.result;
   }
@@ -611,24 +615,33 @@ expr simplify(const less* op, expr a, expr b) {
       r.rewrite(max(y, c0) < c1, y < c1 && eval(c0 < c1)) ||
       r.rewrite(c1 < min(y, c0), c1 < y && eval(c1 < c0)) ||
       r.rewrite(c1 < max(y, c0), c1 < y || eval(c1 < c0)) ||
+    
+      // TODO: This rule seems a bit specialized, but it's hard to find a more general rule.
+      r.rewrite(min(x, y + c0) < min(x, y) + c1, eval(0 < c1 || c0 < c1)) ||
 
       // Cases where we can remove a min on one side because
       // one term dominates another. These rules were
       // synthesized then extended by hand.
       r.rewrite(min(z, y) < min(x, y), z < min(x, y)) ||
-      r.rewrite(min(z, y) < min(x, y + c0), min(z, y) < x, c0 > 0) ||
+      r.rewrite(min(z, y) < min(x, y + c0), min(z, y) < x, eval(c0 > 0)) ||
+      r.rewrite(min(z, y + c0) < min(x, y), min(z, y + c0) < x, eval(c0 < 0)) ||
 
       // Equivalents with max
       r.rewrite(max(z, y) < max(x, y), max(z, y) < x) ||
+      r.rewrite(max(z, y) < max(x, y + c0), max(z, y) < x, eval(c0 < 0)) ||
+      r.rewrite(max(z, y + c0) < max(x, y), max(z, y + c0) < x, eval(c0 > 0)) ||
 
-    
       r.rewrite(min(x, min(y, z)) < y, min(x, z) < y) ||
       r.rewrite(min(x, y) < max(x, y), x != y) ||
       r.rewrite(max(x, y) < min(x, y), false) ||
-      r.rewrite(min(x, y) < min(x, z), y < min(x, z)) ||
 
       // Selects
-      r.rewrite(select(x, y, z) < select(x, y, w), select(x, 0, z < w)) ||
+      r.rewrite(select(x, y, z) < select(x, y, w), select(x, false, z < w)) ||
+      r.rewrite(select(x, y, z) < select(x, w, z), select(x, y < w, false)) ||
+      r.rewrite(select(x, y, z) < y, select(x, false, z < y)) ||
+      r.rewrite(select(x, y, z) < z, select(x, y < z, false)) ||
+      r.rewrite(y < select(x, y, w), select(x, false, y < w)) ||
+      r.rewrite(w < select(x, y, w), select(x, w < y, false)) ||
 
       false) {
     return r.result;

--- a/builder/simplify_exprs.cc
+++ b/builder/simplify_exprs.cc
@@ -534,6 +534,7 @@ expr simplify(const less* op, expr a, expr b) {
       r.rewrite(x + c0 < y + c1, x < y + eval(c1 - c0)) ||
       r.rewrite(x + c0 < c1 - y, x + y < eval(c1 - c0)) ||
       r.rewrite(x + c0 < c1, x < eval(c1 - c0)) ||
+      r.rewrite(x + c0 < y, x < y + eval(-c0)) ||
       r.rewrite(c0 - x < y + c1, eval(c0 - c1) < x + y) ||
       r.rewrite(c0 - x < c1 - y, y < x + eval(c1 - c0)) ||
       r.rewrite(c0 - x < c1, eval(c0 - c1) < x) ||

--- a/builder/slide_and_fold_storage.cc
+++ b/builder/slide_and_fold_storage.cc
@@ -132,8 +132,19 @@ bool is_produced_by(var v, const stmt& body) {
 class slide_and_fold : public node_mutator {
 public:
   node_context& ctx;
-  // Stores a pair of fold factor and the expression for overlap between iteration i and i+1.
-  symbol_map<std::vector<std::pair<expr, expr>>> fold_factors;
+
+  struct dim_fold_info {
+    // The fold factor
+    expr factor = positive_infinity();
+
+    // Overlap between iteration i and i + 1.
+    expr overlap;
+
+    // Which loop this fold is for.
+    std::size_t loop;
+  };
+  symbol_map<std::vector<dim_fold_info>> fold_factors;
+
   struct loop_info {
     var sym;
     expr orig_min;
@@ -178,6 +189,8 @@ public:
   };
   std::vector<loop_info> loops;
   symbol_map<std::size_t> allocation_loop_levels;
+
+  symbol_map<var> aliases;
 
   // We need an unknown to make equations of.
   var x;
@@ -233,8 +246,8 @@ public:
     }
     auto set_buffer_bounds = set_value_in_scope(current_buffer_bounds(), op->sym, bounds);
     // Initialize the fold factors to infinity.
-    auto set_fold_factors = set_value_in_scope(
-        fold_factors, op->sym, std::vector<std::pair<expr, expr>>(op->dims.size(), {positive_infinity(), expr()}));
+    auto set_fold_factors =
+        set_value_in_scope(fold_factors, op->sym, std::vector<dim_fold_info>(op->dims.size(), dim_fold_info()));
     auto set_loop_level = set_value_in_scope(allocation_loop_levels, op->sym, loops.size());
     stmt body = mutate(op->body);
 
@@ -244,11 +257,11 @@ public:
     // like buf->dim(0).extent = buf->dim(0).extent + 10 (i.e. pad the extent by 10), we'll add 10 to our
     // inferred value.
     // TODO: Is this actually a good design...?
-    const std::vector<std::pair<expr, expr>>& fold_info = *fold_factors[op->sym];
+    const std::vector<dim_fold_info>& fold_info = *fold_factors[op->sym];
     std::vector<std::pair<expr, expr>> replacements;
     expr alloc_var = variable::make(op->sym);
     for (index_t d = 0; d < static_cast<index_t>(op->dims.size()); ++d) {
-      replacements.emplace_back(buffer_fold_factor(alloc_var, d), fold_info[d].first);
+      replacements.emplace_back(buffer_fold_factor(alloc_var, d), fold_info[d].factor);
     }
     std::vector<dim_expr> dims = recursive_substitute(op->dims, replacements);
     // Replace infinite fold factors with undefined.
@@ -268,8 +281,8 @@ public:
 
     if (fold_factors[output]) {
       for (int d = 0; d < static_cast<int>(fold_factors[output]->size()); ++d) {
-        expr fold = (*fold_factors[output])[d].first;
-        expr overlap = (*fold_factors[output])[d].second;
+        expr fold = (*fold_factors[output])[d].factor;
+        expr overlap = (*fold_factors[output])[d].overlap;
         if (!is_finite(fold)) continue;
         // If fold is finite and bounds don't overlap the fold and overlap
         // will be set to the same expr.
@@ -290,7 +303,7 @@ public:
 
     for (int d = 0; d < static_cast<int>(bounds->size()); ++d) {
       if (fold_factors[output] && (d < static_cast<int>(fold_factors[output]->size()))) {
-        expr fold_factor = (*fold_factors[output])[d].first;
+        expr fold_factor = (*fold_factors[output])[d].factor;
         // Skip if we already folded this dimension.
         if (is_finite(fold_factor)) continue;
       }
@@ -339,8 +352,11 @@ public:
           fold_factor = constant_upper_bound(fold_factor);
           if (is_finite(fold_factor) && !depends_on(fold_factor, loop.sym).any()) {
             // Align the fold factor to the loop step size, so it doesn't try to crop across a folding boundary.
-            vector_at(fold_factors[output], d) = {simplify(fold_factor),
-                simplify(bounds_of(cur_bounds_d.max - new_min + 1, *loop.expr_bounds).max)};
+            vector_at(fold_factors[output], d) = {
+                simplify(fold_factor),
+                simplify(bounds_of(cur_bounds_d.max - new_min + 1, *loop.expr_bounds).max),
+                loops.size() - 1,
+            };
             did_overlapped_fold = true;
           } else {
             // The fold factor didn't simplify to something that doesn't depend on the loop variable.
@@ -370,8 +386,27 @@ public:
   }
 
   template <typename T>
-  void visit_call_or_copy(const T* op, span<const var> outputs) {
+  void visit_call_or_copy(const T* op, span<const var> inputs, span<const var> outputs) {
     set_result(op);
+
+    for (var input : inputs) {
+      // Remove folding for an input that was folded in a more deeply nested loop than the current loop.
+      // We need to do this for any aliased symbols of the input as well.
+      var a = input;
+      while(true) {
+        if (fold_factors[a]) {
+          for (dim_fold_info& i : *fold_factors[a]) {
+            if (i.loop >= loops.size()) {
+              // We found a consumer of a buffer outside the loop it was folded in, remove the folding.
+              i = dim_fold_info();
+            }
+          }
+        }
+        std::optional<var> next_a = aliases[a];
+        if (!next_a || *next_a == a) break;
+        a = *next_a;
+      }
+    }
 
     for (var output : outputs) {
       // Start from 1 to skip the 'outermost' loop.
@@ -388,12 +423,13 @@ public:
         auto ignore_loop_bounds = set_value_in_scope(*loop.expr_bounds, loop.sym, interval_expr::all());
 
         expr loop_var = variable::make(loop.sym);
-        auto ff = fold_factors[output];
-        if (!ff) continue;
-        for (int d = 0; d < static_cast<int>(ff->size()); ++d) {
-          expr fold_factor = (*ff)[d].first;
-          expr overlap = (*ff)[d].second;
-          if (!is_finite(fold_factor)) continue;
+        if (!fold_factors[output]) continue;
+        for (int d = 0; d < static_cast<int>(fold_factors[output]->size()); ++d) {
+          expr fold_factor = (*fold_factors[output])[d].factor;
+          expr overlap = (*fold_factors[output])[d].overlap;
+          if (!is_finite(fold_factor)) {
+            continue;
+          }
 
           if (!depends_on(fold_factor, loop.sym).any()) {
             // We need an extra fold per worker when parallelizing the loop.
@@ -411,15 +447,15 @@ public:
 
             fold_factor += (loop.worker_count - 1) * overlap;
             // Align the fold factor to the loop step size, so it doesn't try to crop across a folding boundary.
-            vector_at(fold_factors[output], d).first = simplify(align_up(fold_factor, loop.step));
+            vector_at(fold_factors[output], d).factor = simplify(align_up(fold_factor, loop.step));
           }
         }
       }
     }
   }
 
-  void visit(const call_stmt* op) override { visit_call_or_copy(op, op->outputs); }
-  void visit(const copy_stmt* op) override { visit_call_or_copy(op, {&op->dst, 1}); }
+  void visit(const call_stmt* op) override { visit_call_or_copy(op, op->inputs, op->outputs); }
+  void visit(const copy_stmt* op) override { visit_call_or_copy(op, {&op->src, 1}, {&op->dst, 1}); }
 
   void visit(const crop_buffer* op) override {
     std::optional<box_expr> bounds = current_buffer_bounds()[op->src];
@@ -440,6 +476,7 @@ public:
     }
 
     auto set_bounds = set_value_in_scope(current_buffer_bounds(), op->sym, bounds);
+    auto set_alias = set_value_in_scope(aliases, op->sym, op->src);
 
     slide_and_fold_buffer(op->sym, op->body);
 
@@ -469,6 +506,7 @@ public:
     }
 
     auto set_bounds = set_value_in_scope(current_buffer_bounds(), op->sym, bounds);
+    auto set_alias = set_value_in_scope(aliases, op->sym, op->src);
 
     slide_and_fold_buffer(op->sym, op->body);
 
@@ -492,6 +530,7 @@ public:
     }
 
     auto set_bounds = set_value_in_scope(current_buffer_bounds(), op->sym, bounds);
+    auto set_alias = set_value_in_scope(aliases, op->sym, op->src);
     stmt body = mutate(op->body);
     // TODO: If the bounds of the sliced dimensions are modified, do we need to insert an "if" here?
     if (body.same_as(op->body)) {
@@ -507,6 +546,7 @@ public:
     }
 
     auto set_bounds = set_value_in_scope(current_buffer_bounds(), op->sym, bounds);
+    auto set_alias = set_value_in_scope(aliases, op->sym, op->src);
     stmt body = mutate(op->body);
     // TODO: If the bounds of the sliced dimensions are modified, do we need to insert an "if" here?
     if (body.same_as(op->body)) {
@@ -516,6 +556,10 @@ public:
     }
   }
   void visit(const truncate_rank*) override { std::abort(); }
+  void visit(const clone_buffer* op) override { 
+    auto set_alias = set_value_in_scope(aliases, op->sym, op->src);
+    node_mutator::visit(op);
+  }
 
   void visit(const loop* op) override {
     var orig_min(ctx, ctx.name(op->sym) + ".min_orig");
@@ -550,10 +594,10 @@ public:
     // Substitute the placeholder worker_count.
     result = substitute(result, l.worker_count, max_workers);
     // We need to do this in the fold factors too.
-    for (std::optional<std::vector<std::pair<expr, expr>>>& i : fold_factors) {
+    for (std::optional<std::vector<dim_fold_info>>& i : fold_factors) {
       if (!i) continue;
-      for (std::pair<expr, expr>& j : *i) {
-        j.first = substitute(j.first, l.worker_count, max_workers);
+      for (dim_fold_info& j : *i) {
+        j.factor = substitute(j.factor, l.worker_count, max_workers);
       }
     }
 

--- a/builder/test/pipeline.cc
+++ b/builder/test/pipeline.cc
@@ -553,8 +553,9 @@ TEST_P(stencil_chain, pipeline) {
 
   if (split > 0) {
     const int parallel_extra = max_workers != loop::serial ? split * 2 : 0;
-    ASSERT_EQ(eval_ctx.heap.total_size, (W + 2) * align_up(split + parallel_extra + 2, split) * sizeof(short) +
-                                            (W + 4) * align_up(split + parallel_extra + 2, split) * sizeof(short));
+    const int intm_size = (W + 2) * align_up(split + parallel_extra + 2, split) * sizeof(short);
+    const int intm2_size = (W + 4) * align_up(split + parallel_extra + 2, split) * sizeof(short);
+    ASSERT_EQ(eval_ctx.heap.total_size, intm_size + intm2_size);
   }
   ASSERT_EQ(eval_ctx.heap.total_count, 2);
 
@@ -853,9 +854,9 @@ TEST_P(padded_stencil, pipeline) {
   }
 
   if (schedule == 2) {
-    // TODO: We need to be able to find the upper bound of
-    // max((x + 1), buffer_min(a, b)) - min((x + 1), buffer_max(a, b)) to fold this.
-    // ASSERT_EQ(eval_ctx.heap.total_size, W * 2 * sizeof(short) + (W + 2) * 3 * sizeof(short));
+    const index_t intm_size = W * sizeof(short);
+    const index_t padded_intm_size = (W + 2) * 3 * sizeof(short);
+    ASSERT_EQ(eval_ctx.heap.total_size, intm_size + padded_intm_size);
     ASSERT_EQ(eval_ctx.heap.total_count, 2);
   } else {
     ASSERT_EQ(eval_ctx.heap.total_count, 1);

--- a/builder/test/simplify.cc
+++ b/builder/test/simplify.cc
@@ -380,6 +380,21 @@ TEST(simplify, bounds_of) {
   }
 }
 
+TEST(simplify, constant_upper_bound) {
+  ASSERT_THAT(constant_upper_bound(min(x, 4)), matches(4));
+  ASSERT_THAT(constant_upper_bound(max(x, 4)), matches(max(x, 4)));
+  ASSERT_THAT(constant_upper_bound(x - min(y, 4)), matches(x - min(y, 4)));
+  ASSERT_THAT(constant_upper_bound(x - max(y, 4)), matches(x + -4));
+  ASSERT_THAT(constant_upper_bound(x * 3), matches(x * 3));
+  ASSERT_THAT(constant_upper_bound(min(x, 4) * 2), matches(8));
+  ASSERT_THAT(constant_upper_bound(min(x, 4) * -2), matches(min(x, 4) * -2));
+  ASSERT_THAT(constant_upper_bound(max(x, 4) * -2), matches(-8));
+  ASSERT_THAT(constant_upper_bound(min(x, 4) / 2), matches(2));
+  ASSERT_THAT(constant_upper_bound(max(x, 4) / 2), matches(max(x, 4) / 2));
+  ASSERT_THAT(constant_upper_bound(min(x, 4) / -2), matches(min(x, 4) / -2));
+  ASSERT_THAT(constant_upper_bound(max(x, 4) / -2), matches(-2));
+}
+
 TEST(simplify, where_true) {
   ASSERT_THAT(where_true(x < 5, x), matches(bounds(negative_infinity(), 4)));
   ASSERT_THAT(where_true(x < buffer_min(y, 0), x), matches(bounds(negative_infinity(), buffer_min(y, 0) + -1)));

--- a/builder/test/simplify.cc
+++ b/builder/test/simplify.cc
@@ -118,6 +118,7 @@ TEST(simplify, basic) {
   ASSERT_THAT(simplify((select(x, y, z) < select(x, y, w))), matches(select(x, 0, expr(z) < expr(w))));
 
   ASSERT_THAT(simplify(min(y, z) <= y + 1), matches(true));
+  ASSERT_THAT(simplify(min(x, y) - 1 <= min(x, y - 1)), matches(true));
 }
 
 TEST(simplify, let) {

--- a/builder/test/simplify.cc
+++ b/builder/test/simplify.cc
@@ -397,6 +397,7 @@ TEST(simplify, constant_upper_bound) {
   ASSERT_THAT(constant_upper_bound(max(x, 4) / 2), matches(max(x, 4) / 2));
   ASSERT_THAT(constant_upper_bound(min(x, 4) / -2), matches(min(x, 4) / -2));
   ASSERT_THAT(constant_upper_bound(max(x, 4) / -2), matches(-2));
+  ASSERT_THAT(constant_upper_bound(select(x, 3, 1)), matches(3));
 }
 
 TEST(simplify, where_true) {

--- a/builder/test/visualize/padded_stencil_2.html
+++ b/builder/test/visualize/padded_stencil_2.html
@@ -343,7 +343,7 @@ function pipeline(__in, out) {
       { let padded_intm_uncropped = clone_buffer(padded_intm);
         { let intm = allocate('intm', 2, [
             {bounds:{min:max(g, (buffer_min(out, 0) + -1)), max:min(g0, (buffer_max(out, 0) + 1))}, stride:NaN, fold_factor:9223372036854775807},
-            {bounds:{min:max(g1, (buffer_min(out, 1) + -1)), max:min(g2, (buffer_max(out, 1) + 1))}, stride:NaN, fold_factor:9223372036854775807}
+            {bounds:{min:max(g1, (buffer_min(out, 1) + -1)), max:min(g2, (buffer_max(out, 1) + 1))}, stride:NaN, fold_factor:1}
           ]);
           { let intm_uncropped = clone_buffer(intm);
             {
@@ -352,7 +352,7 @@ function pipeline(__in, out) {
               let __loop_max = buffer_max(out, 1);
               let __loop_step = 1;
               for(let y = __loop_min; y <= __loop_max; y += __loop_step) {
-                { let __intm = crop_dim(intm, 1, {min:max(g1, (y + 1)), max:min(g2, (y + 1))});
+                { let __intm = crop_dim(intm, 1, {min:select((y <= y_min_orig), max(g1, (y + 1)), (min(g2, y) + 1)), max:min(g2, (y + 1))});
                   consume(__in);
                   produce(intm);
                   __event_t++;

--- a/builder/test/visualize/parallel_stencils_0.html
+++ b/builder/test/visualize/parallel_stencils_0.html
@@ -332,16 +332,16 @@ function pipeline(in1, in2, out) {
   check((buffer_elem_size(out) == 2));
   check((((buffer_max(out, 0) - buffer_min(out, 0)) + 1) <= buffer_fold_factor(out, 0)));
   check((((buffer_max(out, 1) - buffer_min(out, 1)) + 1) <= buffer_fold_factor(out, 1)));
-  check((buffer_min(in1, 0) <= (buffer_min(out, 0) + -1)));
+  check(((buffer_min(in1, 0) + 1) <= buffer_min(out, 0)));
   check(((buffer_max(out, 0) + 1) <= buffer_max(in1, 0)));
   check((((buffer_max(out, 0) - buffer_min(out, 0)) + 3) <= buffer_fold_factor(in1, 0)));
-  check((buffer_min(in1, 1) <= (buffer_min(out, 1) + -1)));
+  check(((buffer_min(in1, 1) + 1) <= buffer_min(out, 1)));
   check(((buffer_max(out, 1) + 1) <= buffer_max(in1, 1)));
   check((((buffer_max(out, 1) - buffer_min(out, 1)) + 3) <= buffer_fold_factor(in1, 1)));
-  check((buffer_min(in2, 0) <= (buffer_min(out, 0) + -2)));
+  check(((buffer_min(in2, 0) + 2) <= buffer_min(out, 0)));
   check(((buffer_max(out, 0) + 2) <= buffer_max(in2, 0)));
   check((((buffer_max(out, 0) - buffer_min(out, 0)) + 5) <= buffer_fold_factor(in2, 0)));
-  check((buffer_min(in2, 1) <= (buffer_min(out, 1) + -2)));
+  check(((buffer_min(in2, 1) + 2) <= buffer_min(out, 1)));
   check(((buffer_max(out, 1) + 2) <= buffer_max(in2, 1)));
   check((((buffer_max(out, 1) - buffer_min(out, 1)) + 5) <= buffer_fold_factor(in2, 1)));
   { let intm4 = allocate('intm4', 2, [

--- a/builder/test/visualize/parallel_stencils_1.html
+++ b/builder/test/visualize/parallel_stencils_1.html
@@ -332,16 +332,16 @@ function pipeline(in1, in2, out) {
   check((buffer_elem_size(out) == 2));
   check((((buffer_max(out, 0) - buffer_min(out, 0)) + 1) <= buffer_fold_factor(out, 0)));
   check((((buffer_max(out, 1) - buffer_min(out, 1)) + 1) <= buffer_fold_factor(out, 1)));
-  check((buffer_min(in1, 0) <= (buffer_min(out, 0) + -1)));
+  check(((buffer_min(in1, 0) + 1) <= buffer_min(out, 0)));
   check(((buffer_max(out, 0) + 1) <= buffer_max(in1, 0)));
   check((((buffer_max(out, 0) - buffer_min(out, 0)) + 3) <= buffer_fold_factor(in1, 0)));
-  check((buffer_min(in1, 1) <= (buffer_min(out, 1) + -1)));
+  check(((buffer_min(in1, 1) + 1) <= buffer_min(out, 1)));
   check(((buffer_max(out, 1) + 1) <= buffer_max(in1, 1)));
   check((((buffer_max(out, 1) - buffer_min(out, 1)) + 3) <= buffer_fold_factor(in1, 1)));
-  check((buffer_min(in2, 0) <= (buffer_min(out, 0) + -2)));
+  check(((buffer_min(in2, 0) + 2) <= buffer_min(out, 0)));
   check(((buffer_max(out, 0) + 2) <= buffer_max(in2, 0)));
   check((((buffer_max(out, 0) - buffer_min(out, 0)) + 5) <= buffer_fold_factor(in2, 0)));
-  check((buffer_min(in2, 1) <= (buffer_min(out, 1) + -2)));
+  check(((buffer_min(in2, 1) + 2) <= buffer_min(out, 1)));
   check(((buffer_max(out, 1) + 2) <= buffer_max(in2, 1)));
   check((((buffer_max(out, 1) - buffer_min(out, 1)) + 5) <= buffer_fold_factor(in2, 1)));
   { let intm4 = allocate('intm4', 2, [

--- a/builder/test/visualize/parallel_stencils_2.html
+++ b/builder/test/visualize/parallel_stencils_2.html
@@ -332,16 +332,16 @@ function pipeline(in1, in2, out) {
   check((buffer_elem_size(out) == 2));
   check((((buffer_max(out, 0) - buffer_min(out, 0)) + 1) <= buffer_fold_factor(out, 0)));
   check((((buffer_max(out, 1) - buffer_min(out, 1)) + 1) <= buffer_fold_factor(out, 1)));
-  check((buffer_min(in1, 0) <= (buffer_min(out, 0) + -1)));
+  check(((buffer_min(in1, 0) + 1) <= buffer_min(out, 0)));
   check(((buffer_max(out, 0) + 1) <= buffer_max(in1, 0)));
   check((((buffer_max(out, 0) - buffer_min(out, 0)) + 3) <= buffer_fold_factor(in1, 0)));
-  check((buffer_min(in1, 1) <= (buffer_min(out, 1) + -1)));
+  check(((buffer_min(in1, 1) + 1) <= buffer_min(out, 1)));
   check(((buffer_max(out, 1) + 1) <= buffer_max(in1, 1)));
   check((((buffer_max(out, 1) - buffer_min(out, 1)) + 3) <= buffer_fold_factor(in1, 1)));
-  check((buffer_min(in2, 0) <= (buffer_min(out, 0) + -2)));
+  check(((buffer_min(in2, 0) + 2) <= buffer_min(out, 0)));
   check(((buffer_max(out, 0) + 2) <= buffer_max(in2, 0)));
   check((((buffer_max(out, 0) - buffer_min(out, 0)) + 5) <= buffer_fold_factor(in2, 0)));
-  check((buffer_min(in2, 1) <= (buffer_min(out, 1) + -2)));
+  check(((buffer_min(in2, 1) + 2) <= buffer_min(out, 1)));
   check(((buffer_max(out, 1) + 2) <= buffer_max(in2, 1)));
   check((((buffer_max(out, 1) - buffer_min(out, 1)) + 5) <= buffer_fold_factor(in2, 1)));
   { let intm4 = allocate('intm4', 2, [

--- a/builder/test/visualize/stencil_chain_split_serial_split_0.html
+++ b/builder/test/visualize/stencil_chain_split_serial_split_0.html
@@ -331,10 +331,10 @@ function pipeline(__in, out) {
     check((buffer_elem_size(out) == 2));
     check((((buffer_max(out, 0) - buffer_min(out, 0)) + 1) <= buffer_fold_factor(out, 0)));
     check((((buffer_max(out, 1) - buffer_min(out, 1)) + 1) <= buffer_fold_factor(out, 1)));
-    check((buffer_min(__in, 0) <= (buffer_min(out, 0) + -2)));
+    check(((buffer_min(__in, 0) + 2) <= buffer_min(out, 0)));
     check(((buffer_max(out, 0) + 2) <= buffer_max(__in, 0)));
     check((((buffer_max(out, 0) - buffer_min(out, 0)) + 5) <= buffer_fold_factor(__in, 0)));
-    check((buffer_min(__in, 1) <= (buffer_min(out, 1) + -2)));
+    check(((buffer_min(__in, 1) + 2) <= buffer_min(out, 1)));
     check(((buffer_max(out, 1) + 2) <= buffer_max(__in, 1)));
     check((((buffer_max(out, 1) - buffer_min(out, 1)) + 5) <= buffer_fold_factor(__in, 1)));
     { let stencil1_result = allocate('stencil1_result', 2, [

--- a/builder/test/visualize/stencil_chain_split_serial_split_1.html
+++ b/builder/test/visualize/stencil_chain_split_serial_split_1.html
@@ -331,10 +331,10 @@ function pipeline(__in, out) {
     check((buffer_elem_size(out) == 2));
     check((((buffer_max(out, 0) - buffer_min(out, 0)) + 1) <= buffer_fold_factor(out, 0)));
     check((((buffer_max(out, 1) - buffer_min(out, 1)) + 1) <= buffer_fold_factor(out, 1)));
-    check((buffer_min(__in, 0) <= (buffer_min(out, 0) + -2)));
+    check(((buffer_min(__in, 0) + 2) <= buffer_min(out, 0)));
     check(((buffer_max(out, 0) + 2) <= buffer_max(__in, 0)));
     check((((buffer_max(out, 0) - buffer_min(out, 0)) + 5) <= buffer_fold_factor(__in, 0)));
-    check((buffer_min(__in, 1) <= (buffer_min(out, 1) + -2)));
+    check(((buffer_min(__in, 1) + 2) <= buffer_min(out, 1)));
     check(((buffer_max(out, 1) + 2) <= buffer_max(__in, 1)));
     check((((buffer_max(out, 1) - buffer_min(out, 1)) + 5) <= buffer_fold_factor(__in, 1)));
     { let stencil1_result = allocate('stencil1_result', 2, [

--- a/builder/test/visualize/stencil_chain_split_serial_split_2.html
+++ b/builder/test/visualize/stencil_chain_split_serial_split_2.html
@@ -331,10 +331,10 @@ function pipeline(__in, out) {
     check((buffer_elem_size(out) == 2));
     check((((buffer_max(out, 0) - buffer_min(out, 0)) + 1) <= buffer_fold_factor(out, 0)));
     check((((buffer_max(out, 1) - buffer_min(out, 1)) + 1) <= buffer_fold_factor(out, 1)));
-    check((buffer_min(__in, 0) <= (buffer_min(out, 0) + -2)));
+    check(((buffer_min(__in, 0) + 2) <= buffer_min(out, 0)));
     check(((buffer_max(out, 0) + 2) <= buffer_max(__in, 0)));
     check((((buffer_max(out, 0) - buffer_min(out, 0)) + 5) <= buffer_fold_factor(__in, 0)));
-    check((buffer_min(__in, 1) <= (buffer_min(out, 1) + -2)));
+    check(((buffer_min(__in, 1) + 2) <= buffer_min(out, 1)));
     check(((buffer_max(out, 1) + 2) <= buffer_max(__in, 1)));
     check((((buffer_max(out, 1) - buffer_min(out, 1)) + 5) <= buffer_fold_factor(__in, 1)));
     { let stencil1_result = allocate('stencil1_result', 2, [

--- a/builder/test/visualize/stencil_split_0.html
+++ b/builder/test/visualize/stencil_split_0.html
@@ -329,10 +329,10 @@ function pipeline(__in, out) {
   check((buffer_elem_size(out) == 2));
   check((((buffer_max(out, 0) - buffer_min(out, 0)) + 1) <= buffer_fold_factor(out, 0)));
   check((((buffer_max(out, 1) - buffer_min(out, 1)) + 1) <= buffer_fold_factor(out, 1)));
-  check((buffer_min(__in, 0) <= (buffer_min(out, 0) + -1)));
+  check(((buffer_min(__in, 0) + 1) <= buffer_min(out, 0)));
   check(((buffer_max(out, 0) + 1) <= buffer_max(__in, 0)));
   check((((buffer_max(out, 0) - buffer_min(out, 0)) + 3) <= buffer_fold_factor(__in, 0)));
-  check((buffer_min(__in, 1) <= (buffer_min(out, 1) + -1)));
+  check(((buffer_min(__in, 1) + 1) <= buffer_min(out, 1)));
   check(((buffer_max(out, 1) + 1) <= buffer_max(__in, 1)));
   check((((buffer_max(out, 1) - buffer_min(out, 1)) + 3) <= buffer_fold_factor(__in, 1)));
   { let intm = allocate('intm', 2, [

--- a/builder/test/visualize/stencil_split_1.html
+++ b/builder/test/visualize/stencil_split_1.html
@@ -329,10 +329,10 @@ function pipeline(__in, out) {
   check((buffer_elem_size(out) == 2));
   check((((buffer_max(out, 0) - buffer_min(out, 0)) + 1) <= buffer_fold_factor(out, 0)));
   check((((buffer_max(out, 1) - buffer_min(out, 1)) + 1) <= buffer_fold_factor(out, 1)));
-  check((buffer_min(__in, 0) <= (buffer_min(out, 0) + -1)));
+  check(((buffer_min(__in, 0) + 1) <= buffer_min(out, 0)));
   check(((buffer_max(out, 0) + 1) <= buffer_max(__in, 0)));
   check((((buffer_max(out, 0) - buffer_min(out, 0)) + 3) <= buffer_fold_factor(__in, 0)));
-  check((buffer_min(__in, 1) <= (buffer_min(out, 1) + -1)));
+  check(((buffer_min(__in, 1) + 1) <= buffer_min(out, 1)));
   check(((buffer_max(out, 1) + 1) <= buffer_max(__in, 1)));
   check((((buffer_max(out, 1) - buffer_min(out, 1)) + 3) <= buffer_fold_factor(__in, 1)));
   { let intm = allocate('intm', 2, [

--- a/builder/test/visualize/stencil_split_2.html
+++ b/builder/test/visualize/stencil_split_2.html
@@ -329,10 +329,10 @@ function pipeline(__in, out) {
   check((buffer_elem_size(out) == 2));
   check((((buffer_max(out, 0) - buffer_min(out, 0)) + 1) <= buffer_fold_factor(out, 0)));
   check((((buffer_max(out, 1) - buffer_min(out, 1)) + 1) <= buffer_fold_factor(out, 1)));
-  check((buffer_min(__in, 0) <= (buffer_min(out, 0) + -1)));
+  check(((buffer_min(__in, 0) + 1) <= buffer_min(out, 0)));
   check(((buffer_max(out, 0) + 1) <= buffer_max(__in, 0)));
   check((((buffer_max(out, 0) - buffer_min(out, 0)) + 3) <= buffer_fold_factor(__in, 0)));
-  check((buffer_min(__in, 1) <= (buffer_min(out, 1) + -1)));
+  check(((buffer_min(__in, 1) + 1) <= buffer_min(out, 1)));
   check(((buffer_max(out, 1) + 1) <= buffer_max(__in, 1)));
   check((((buffer_max(out, 1) - buffer_min(out, 1)) + 3) <= buffer_fold_factor(__in, 1)));
   { let intm = allocate('intm', 2, [

--- a/builder/test/visualize/stencil_split_3.html
+++ b/builder/test/visualize/stencil_split_3.html
@@ -329,10 +329,10 @@ function pipeline(__in, out) {
   check((buffer_elem_size(out) == 2));
   check((((buffer_max(out, 0) - buffer_min(out, 0)) + 1) <= buffer_fold_factor(out, 0)));
   check((((buffer_max(out, 1) - buffer_min(out, 1)) + 1) <= buffer_fold_factor(out, 1)));
-  check((buffer_min(__in, 0) <= (buffer_min(out, 0) + -1)));
+  check(((buffer_min(__in, 0) + 1) <= buffer_min(out, 0)));
   check(((buffer_max(out, 0) + 1) <= buffer_max(__in, 0)));
   check((((buffer_max(out, 0) - buffer_min(out, 0)) + 3) <= buffer_fold_factor(__in, 0)));
-  check((buffer_min(__in, 1) <= (buffer_min(out, 1) + -1)));
+  check(((buffer_min(__in, 1) + 1) <= buffer_min(out, 1)));
   check(((buffer_max(out, 1) + 1) <= buffer_max(__in, 1)));
   check((((buffer_max(out, 1) - buffer_min(out, 1)) + 3) <= buffer_fold_factor(__in, 1)));
   { let intm = allocate('intm', 2, [


### PR DESCRIPTION
This started out by adding one little rule to canonicalize constants to the RHS of less than, and it turned out that this unlocked a bunch of improvements.

- Add rule to canonicalize constants to the RHS of <, which helps some things simplify more.
- Add rules for finding bounds of `min(x, y) - max(z, w)`. When terms from each side of the subtract are correlated, we might have a tighter bound. This appears in fold factor expressions.
- Add `constant_upper_bound` helper, useful for fold factors.

The combination of these things means slide_and_fold_storage doesn't need hacks to replace loop bounds with infinity any more.

This also fixes an issue identified by @vksnk: we currently allowed folding to happen even when there was a consumer outside the loop we fold in. We simply missed this by accident because we failed to slide due to simplifier weakness.