### PR TITLE
Replace `truncate_rank` with `transpose`

### DIFF
--- a/builder/node_mutator.cc
+++ b/builder/node_mutator.cc
@@ -65,8 +65,8 @@ stmt clone_with_new_body(const slice_buffer* op, stmt new_body) {
 stmt clone_with_new_body(const slice_dim* op, stmt new_body) {
   return slice_dim::make(op->sym, op->src, op->dim, op->at, std::move(new_body));
 }
-stmt clone_with_new_body(const truncate_rank* op, stmt new_body) {
-  return truncate_rank::make(op->sym, op->src, op->rank, std::move(new_body));
+stmt clone_with_new_body(const transpose* op, stmt new_body) {
+  return transpose::make(op->sym, op->src, op->dims, std::move(new_body));
 }
 
 void node_mutator::visit(const let* op) { set_result(mutate_let(this, op)); }
@@ -249,12 +249,12 @@ void node_mutator::visit(const slice_dim* op) {
     set_result(slice_dim::make(op->sym, op->src, op->dim, std::move(at), std::move(body)));
   }
 }
-void node_mutator::visit(const truncate_rank* op) {
+void node_mutator::visit(const transpose* op) {
   stmt body = mutate(op->body);
   if (body.same_as(op->body)) {
     set_result(op);
   } else {
-    set_result(truncate_rank::make(op->sym, op->src, op->rank, std::move(body)));
+    set_result(transpose::make(op->sym, op->src, op->dims, std::move(body)));
   }
 }
 

--- a/builder/node_mutator.h
+++ b/builder/node_mutator.h
@@ -74,7 +74,7 @@ public:
   void visit(const crop_dim*) override;
   void visit(const slice_buffer*) override;
   void visit(const slice_dim*) override;
-  void visit(const truncate_rank*) override;
+  void visit(const transpose*) override;
   void visit(const check*) override;
 };
 
@@ -88,7 +88,7 @@ stmt clone_with_new_body(const crop_buffer* op, stmt new_body);
 stmt clone_with_new_body(const crop_dim* op, stmt new_body);
 stmt clone_with_new_body(const slice_buffer* op, stmt new_body);
 stmt clone_with_new_body(const slice_dim* op, stmt new_body);
-stmt clone_with_new_body(const truncate_rank* op, stmt new_body);
+stmt clone_with_new_body(const transpose* op, stmt new_body);
 
 // Helper for single statement mutators.
 template <typename T>

--- a/builder/optimizations.cc
+++ b/builder/optimizations.cc
@@ -444,7 +444,7 @@ public:
     }
   }
 
-  void visit(const truncate_rank*) override { std::abort(); }
+  void visit(const transpose*) override { std::abort(); }
 };
 
 }  // namespace
@@ -583,7 +583,7 @@ public:
   void visit(const crop_dim* op) override { visit_buffer_mutator(op); }
   void visit(const slice_buffer* op) override { visit_buffer_mutator(op); }
   void visit(const slice_dim* op) override { visit_buffer_mutator(op); }
-  void visit(const truncate_rank* op) override { visit_buffer_mutator(op); }
+  void visit(const transpose* op) override { visit_buffer_mutator(op); }
 };
 
 }  // namespace

--- a/builder/simplify.cc
+++ b/builder/simplify.cc
@@ -595,7 +595,7 @@ public:
     }
 
     if (const call* bc = base.as<call>()) {
-      // Check if this make_buffer is equivalent to slice_buffer or crop_buffer
+      // Check if this make_buffer is equivalent to transpose, slice_buffer or crop_buffer
       if (bc->intrinsic == intrinsic::buffer_at && match(elem_size, buffer_elem_size(op->sym))) {
         const var* src_buf = as_variable(bc->args[0]);
         assert(src_buf);
@@ -652,6 +652,39 @@ public:
           stmt result = crop_buffer::make(op->sym, *src_buf, std::move(crop_bounds), std::move(body));
           result = transpose::make_truncate(op->sym, op->sym, dims.size(), std::move(result));
           set_result(mutate(result));
+          return;
+        }
+
+        // To be a transpose, we need buffer_at to be the base of src_buf, and each dimension to be a dimension of the original buffer.
+        // TODO: This could probably be built into the slice check above.
+        bool is_transpose = true;
+        std::vector<int> permutation;
+        permutation.reserve(dims.size());
+        // Returns the dimension of a buffer intrinsic, or -1 if not the expected intrinsic.
+        auto buffer_intrinsic_dim = [=](intrinsic fn, const expr& x) -> int {
+          if (const call* c = x.as<call>()) {
+            if (c->intrinsic != fn) return -1;
+            assert(c->args.size() == 2);
+
+            if (*as_variable(c->args[0]) != *src_buf) return -1;
+            return *as_constant(c->args[1]);
+          }
+          return -1;
+        };
+        for (std::size_t d = 0; d < dims.size(); ++d) {
+          int min_dim = buffer_intrinsic_dim(intrinsic::buffer_min, dims[d].bounds.min);
+          int max_dim = buffer_intrinsic_dim(intrinsic::buffer_max, dims[d].bounds.max);
+          int stride_dim = buffer_intrinsic_dim(intrinsic::buffer_stride, dims[d].stride);
+          int fold_factor_dim = buffer_intrinsic_dim(intrinsic::buffer_fold_factor, dims[d].fold_factor);
+          if (min_dim >= 0 && min_dim == max_dim && min_dim == stride_dim && fold_factor_dim == min_dim) {
+            permutation.push_back(min_dim);
+          } else {
+            is_transpose = false;
+            break;
+          }
+        }
+        if (is_transpose) {
+          set_result(mutate(transpose::make(op->sym, *src_buf, std::move(permutation), std::move(body))));
           return;
         }
       }

--- a/builder/slide_and_fold_storage.cc
+++ b/builder/slide_and_fold_storage.cc
@@ -522,7 +522,7 @@ public:
       set_result(clone_with_new_body(op, std::move(body)));
     }
   }
-  void visit(const truncate_rank*) override { std::abort(); }
+  void visit(const transpose*) override { std::abort(); }
 
   void visit(const loop* op) override {
     var orig_min(ctx, ctx.name(op->sym) + ".min_orig");

--- a/builder/substitute.cc
+++ b/builder/substitute.cc
@@ -287,13 +287,13 @@ public:
     if (!try_match(cds->body, op->body)) return;
   }
 
-  void visit(const truncate_rank* op) override {
-    const truncate_rank* trs = static_cast<const truncate_rank*>(self);
+  void visit(const transpose* op) override {
+    const transpose* trs = static_cast<const transpose*>(self);
     assert(trs);
 
     if (!try_match(trs->sym, op->sym)) return;
     if (!try_match(trs->src, op->src)) return;
-    if (!try_match(trs->rank, op->rank)) return;
+    if (!try_match(trs->dims, op->dims)) return;
     if (!try_match(trs->body, op->body)) return;
   }
 
@@ -622,13 +622,13 @@ public:
     node_mutator::visit(op);
   }
 
-  void visit(const truncate_rank* op) override {
-    // TODO: truncate_rank is a bit tricky, the replacements for expressions might be invalid if they access truncated
+  void visit(const transpose* op) override {
+    // TODO: transpose is a bit tricky, the replacements for expressions might be invalid if they access truncated
     // dims.
     var src = visit_symbol(op->src);
     stmt body = mutate_decl_body(op->sym, op->body);
     if (src != op->src || !body.same_as(op->body)) {
-      set_result(truncate_rank::make(op->sym, src, op->rank, std::move(body)));
+      set_result(transpose::make(op->sym, src, op->dims, std::move(body)));
     } else {
       set_result(op);
     }

--- a/builder/test/copy.cc
+++ b/builder/test/copy.cc
@@ -384,16 +384,16 @@ TEST_P(upsample_y, copy) {
   ASSERT_EQ(eval_ctx.copy_elements, W * H);
 }
 
-class transpose : public testing::TestWithParam<std::vector<int>> {};
+class transpose_test : public testing::TestWithParam<std::vector<int>> {};
 
-INSTANTIATE_TEST_SUITE_P(schedule, transpose,
+INSTANTIATE_TEST_SUITE_P(schedule, transpose_test,
     testing::Values(std::vector<int>{}, std::vector<int>{0}, std::vector<int>{1}, std::vector<int>{2},
         std::vector<int>{0, 1}, std::vector<int>{1, 0}, std::vector<int>{0, 2}, std::vector<int>{2, 0},
         std::vector<int>{1, 2}, std::vector<int>{2, 1}, std::vector<int>{0, 1, 2}, std::vector<int>{2, 1, 0},
         std::vector<int>{1, 0, 2}, std::vector<int>{0, 0, 0}, std::vector<int>{1, 1, 1}, std::vector<int>{2, 2, 2},
         std::vector<int>{1, 0, 2}, std::vector<int>{0, 0, 0}, std::vector<int>{0, 0, 1}));
 
-TEST_P(transpose, copy) {
+TEST_P(transpose_test, copy) {
   std::vector<int> permutation = GetParam();
 
   // Make the pipeline

--- a/builder/test/simplify.cc
+++ b/builder/test/simplify.cc
@@ -303,6 +303,13 @@ TEST(simplify, make_buffer) {
       matches(make_crop(b0, {}, {{x, y}}, buffer_dims(b0, 1))));
   ASSERT_THAT(simplify(make_crop(b0, {y}, {{x, y}}, buffer_dims(b0, 1))),
       matches(make_crop(b0, {y}, {{x, y}}, buffer_dims(b0, 1))));
+
+  // Transpose
+  ASSERT_THAT(simplify(make_buffer::make(b0, buffer_at(b0), buffer_elem_size(b0), {buffer_dim(b0, 2)}, body)),
+      matches(transpose::make(b0, b0, {2}, body)));
+  ASSERT_THAT(simplify(make_buffer::make(
+                  b0, buffer_at(b0), buffer_elem_size(b0), {buffer_dim(b0, 0), buffer_dim(b0, 2)}, body)),
+      matches(transpose::make(b0, b0, {0, 2}, body)));
 }
 
 TEST(simplify, bounds_of) {

--- a/builder/test/simplify.cc
+++ b/builder/test/simplify.cc
@@ -263,19 +263,19 @@ TEST(simplify, make_buffer) {
   };
 
   // Slices
-  ASSERT_THAT(simplify(make_slice(b0, {}, buffer_dims(b0, 0))), matches(truncate_rank::make(b0, b0, 0, body)));
-  ASSERT_THAT(simplify(make_slice(b0, {}, buffer_dims(b0, 1))), matches(truncate_rank::make(b0, b0, 1, body)));
-  ASSERT_THAT(simplify(make_slice(b0, {}, buffer_dims(b0, 3))), matches(truncate_rank::make(b0, b0, 3, body)));
+  ASSERT_THAT(simplify(make_slice(b0, {}, buffer_dims(b0, 0))), matches(transpose::make_truncate(b0, b0, 0, body)));
+  ASSERT_THAT(simplify(make_slice(b0, {}, buffer_dims(b0, 1))), matches(transpose::make_truncate(b0, b0, 1, body)));
+  ASSERT_THAT(simplify(make_slice(b0, {}, buffer_dims(b0, 3))), matches(transpose::make_truncate(b0, b0, 3, body)));
   ASSERT_THAT(simplify(make_slice(b0, {x}, buffer_dims(b0, 1))),
-      matches(truncate_rank::make(b0, b0, 1, slice_dim::make(b0, b0, 0, x, body))));
+      matches(transpose::make_truncate(b0, b0, 1, slice_dim::make(b0, b0, 0, x, body))));
   ASSERT_THAT(simplify(make_slice(b0, {x}, buffer_dims(b0, 2))),
-      matches(truncate_rank::make(b0, b0, 2, slice_dim::make(b0, b0, 0, x, body))));
+      matches(transpose::make_truncate(b0, b0, 2, slice_dim::make(b0, b0, 0, x, body))));
   ASSERT_THAT(simplify(make_slice(b0, {x, y}, buffer_dims(b0, 2))),
-      matches(truncate_rank::make(b0, b0, 2, slice_buffer::make(b0, b0, {x, y}, body))));
+      matches(transpose::make_truncate(b0, b0, 2, slice_buffer::make(b0, b0, {x, y}, body))));
   ASSERT_THAT(simplify(make_slice(b0, {expr(), y}, buffer_dims(b0, 2))),
-      matches(truncate_rank::make(b0, b0, 2, slice_dim::make(b0, b0, 1, y, body))));
+      matches(transpose::make_truncate(b0, b0, 2, slice_dim::make(b0, b0, 1, y, body))));
   ASSERT_THAT(simplify(make_slice(b0, {expr(), y}, buffer_dims(b0, 3))),
-      matches(truncate_rank::make(b0, b0, 3, slice_dim::make(b0, b0, 1, y, body))));
+      matches(transpose::make_truncate(b0, b0, 3, slice_dim::make(b0, b0, 1, y, body))));
 
   // Not slices
   ASSERT_THAT(simplify(make_slice(b0, {}, buffer_dims(b1, 1))), matches(make_slice(b0, {}, buffer_dims(b1, 1))));
@@ -283,20 +283,20 @@ TEST(simplify, make_buffer) {
       matches(make_crop(b0, {}, {buffer_bounds(b0, 0)}, buffer_dims(b1, 1))));
 
   // Crops
-  ASSERT_THAT(simplify(make_crop(b0, {}, {}, buffer_dims(b0, 0))), matches(truncate_rank::make(b0, b0, 0, body)));
-  ASSERT_THAT(simplify(make_crop(b0, {}, {}, buffer_dims(b0, 1))), matches(truncate_rank::make(b0, b0, 1, body)));
+  ASSERT_THAT(simplify(make_crop(b0, {}, {}, buffer_dims(b0, 0))), matches(transpose::make_truncate(b0, b0, 0, body)));
+  ASSERT_THAT(simplify(make_crop(b0, {}, {}, buffer_dims(b0, 1))), matches(transpose::make_truncate(b0, b0, 1, body)));
   ASSERT_THAT(simplify(make_crop(b0, {x}, {{x, y}}, buffer_dims(b0, 1))),
-      matches(truncate_rank::make(b0, b0, 1, crop_dim::make(b0, b0, 0, {x, y}, body))));
+      matches(transpose::make_truncate(b0, b0, 1, crop_dim::make(b0, b0, 0, {x, y}, body))));
   ASSERT_THAT(simplify(make_crop(b0, {x}, {{x, y}}, buffer_dims(b0, 2))),
-      matches(truncate_rank::make(b0, b0, 2, crop_dim::make(b0, b0, 0, {x, y}, body))));
+      matches(transpose::make_truncate(b0, b0, 2, crop_dim::make(b0, b0, 0, {x, y}, body))));
   ASSERT_THAT(simplify(make_crop(b0, {x, z}, {{x, y}, {z, w}}, buffer_dims(b0, 2))),
-      matches(truncate_rank::make(b0, b0, 2, crop_buffer::make(b0, b0, {{x, y}, {z, w}}, body))));
+      matches(transpose::make_truncate(b0, b0, 2, crop_buffer::make(b0, b0, {{x, y}, {z, w}}, body))));
   ASSERT_THAT(simplify(make_crop(b0, {expr(), z}, {{expr(), expr()}, {z, w}}, buffer_dims(b0, 2))),
-      matches(truncate_rank::make(b0, b0, 2, crop_dim::make(b0, b0, 1, {z, w}, body))));
+      matches(transpose::make_truncate(b0, b0, 2, crop_dim::make(b0, b0, 1, {z, w}, body))));
   ASSERT_THAT(simplify(make_crop(b0, {expr(), z}, {{expr(), expr()}, {z, w}}, buffer_dims(b0, 3))),
-      matches(truncate_rank::make(b0, b0, 3, crop_dim::make(b0, b0, 1, {z, w}, body))));
+      matches(transpose::make_truncate(b0, b0, 3, crop_dim::make(b0, b0, 1, {z, w}, body))));
   ASSERT_THAT(simplify(make_crop(b0, {expr(), z}, {{expr(), expr()}, {z, w}}, buffer_dims(b0, 3))),
-      matches(truncate_rank::make(b0, b0, 3, crop_dim::make(b0, b0, 1, {z, w}, body))));
+      matches(transpose::make_truncate(b0, b0, 3, crop_dim::make(b0, b0, 1, {z, w}, body))));
 
   // Not crops
   ASSERT_THAT(simplify(make_crop(b0, {}, {{x, y}}, buffer_dims(b0, 1))),

--- a/builder/test/visualize/padded_stencil_0.html
+++ b/builder/test/visualize/padded_stencil_0.html
@@ -305,9 +305,9 @@ function slice_buffer(b, at) {
   }
   return result;
 }
-function truncate_rank(b, rank) {
+function transpose(b, dims) {
   let result = clone_buffer(b);
-  b.dims.length = rank;
+  b.dims = dims.map(i => b.dims[i]);
   return result;
 }
 function produce(b) {

--- a/builder/test/visualize/padded_stencil_1.html
+++ b/builder/test/visualize/padded_stencil_1.html
@@ -305,9 +305,9 @@ function slice_buffer(b, at) {
   }
   return result;
 }
-function truncate_rank(b, rank) {
+function transpose(b, dims) {
   let result = clone_buffer(b);
-  b.dims.length = rank;
+  b.dims = dims.map(i => b.dims[i]);
   return result;
 }
 function produce(b) {

--- a/builder/test/visualize/padded_stencil_2.html
+++ b/builder/test/visualize/padded_stencil_2.html
@@ -305,9 +305,9 @@ function slice_buffer(b, at) {
   }
   return result;
 }
-function truncate_rank(b, rank) {
+function transpose(b, dims) {
   let result = clone_buffer(b);
-  b.dims.length = rank;
+  b.dims = dims.map(i => b.dims[i]);
   return result;
 }
 function produce(b) {

--- a/builder/test/visualize/parallel_stencils_0.html
+++ b/builder/test/visualize/parallel_stencils_0.html
@@ -305,9 +305,9 @@ function slice_buffer(b, at) {
   }
   return result;
 }
-function truncate_rank(b, rank) {
+function transpose(b, dims) {
   let result = clone_buffer(b);
-  b.dims.length = rank;
+  b.dims = dims.map(i => b.dims[i]);
   return result;
 }
 function produce(b) {

--- a/builder/test/visualize/parallel_stencils_1.html
+++ b/builder/test/visualize/parallel_stencils_1.html
@@ -305,9 +305,9 @@ function slice_buffer(b, at) {
   }
   return result;
 }
-function truncate_rank(b, rank) {
+function transpose(b, dims) {
   let result = clone_buffer(b);
-  b.dims.length = rank;
+  b.dims = dims.map(i => b.dims[i]);
   return result;
 }
 function produce(b) {

--- a/builder/test/visualize/parallel_stencils_2.html
+++ b/builder/test/visualize/parallel_stencils_2.html
@@ -305,9 +305,9 @@ function slice_buffer(b, at) {
   }
   return result;
 }
-function truncate_rank(b, rank) {
+function transpose(b, dims) {
   let result = clone_buffer(b);
-  b.dims.length = rank;
+  b.dims = dims.map(i => b.dims[i]);
   return result;
 }
 function produce(b) {

--- a/builder/test/visualize/softmax_split_0.html
+++ b/builder/test/visualize/softmax_split_0.html
@@ -305,9 +305,9 @@ function slice_buffer(b, at) {
   }
   return result;
 }
-function truncate_rank(b, rank) {
+function transpose(b, dims) {
   let result = clone_buffer(b);
-  b.dims.length = rank;
+  b.dims = dims.map(i => b.dims[i]);
   return result;
 }
 function produce(b) {

--- a/builder/test/visualize/softmax_split_1.html
+++ b/builder/test/visualize/softmax_split_1.html
@@ -305,9 +305,9 @@ function slice_buffer(b, at) {
   }
   return result;
 }
-function truncate_rank(b, rank) {
+function transpose(b, dims) {
   let result = clone_buffer(b);
-  b.dims.length = rank;
+  b.dims = dims.map(i => b.dims[i]);
   return result;
 }
 function produce(b) {

--- a/builder/test/visualize/softmax_split_4.html
+++ b/builder/test/visualize/softmax_split_4.html
@@ -305,9 +305,9 @@ function slice_buffer(b, at) {
   }
   return result;
 }
-function truncate_rank(b, rank) {
+function transpose(b, dims) {
   let result = clone_buffer(b);
-  b.dims.length = rank;
+  b.dims = dims.map(i => b.dims[i]);
   return result;
 }
 function produce(b) {

--- a/builder/test/visualize/stencil_chain_split_serial_split_0.html
+++ b/builder/test/visualize/stencil_chain_split_serial_split_0.html
@@ -305,9 +305,9 @@ function slice_buffer(b, at) {
   }
   return result;
 }
-function truncate_rank(b, rank) {
+function transpose(b, dims) {
   let result = clone_buffer(b);
-  b.dims.length = rank;
+  b.dims = dims.map(i => b.dims[i]);
   return result;
 }
 function produce(b) {

--- a/builder/test/visualize/stencil_chain_split_serial_split_1.html
+++ b/builder/test/visualize/stencil_chain_split_serial_split_1.html
@@ -305,9 +305,9 @@ function slice_buffer(b, at) {
   }
   return result;
 }
-function truncate_rank(b, rank) {
+function transpose(b, dims) {
   let result = clone_buffer(b);
-  b.dims.length = rank;
+  b.dims = dims.map(i => b.dims[i]);
   return result;
 }
 function produce(b) {

--- a/builder/test/visualize/stencil_chain_split_serial_split_2.html
+++ b/builder/test/visualize/stencil_chain_split_serial_split_2.html
@@ -305,9 +305,9 @@ function slice_buffer(b, at) {
   }
   return result;
 }
-function truncate_rank(b, rank) {
+function transpose(b, dims) {
   let result = clone_buffer(b);
-  b.dims.length = rank;
+  b.dims = dims.map(i => b.dims[i]);
   return result;
 }
 function produce(b) {

--- a/builder/test/visualize/stencil_split_0.html
+++ b/builder/test/visualize/stencil_split_0.html
@@ -305,9 +305,9 @@ function slice_buffer(b, at) {
   }
   return result;
 }
-function truncate_rank(b, rank) {
+function transpose(b, dims) {
   let result = clone_buffer(b);
-  b.dims.length = rank;
+  b.dims = dims.map(i => b.dims[i]);
   return result;
 }
 function produce(b) {

--- a/builder/test/visualize/stencil_split_1.html
+++ b/builder/test/visualize/stencil_split_1.html
@@ -305,9 +305,9 @@ function slice_buffer(b, at) {
   }
   return result;
 }
-function truncate_rank(b, rank) {
+function transpose(b, dims) {
   let result = clone_buffer(b);
-  b.dims.length = rank;
+  b.dims = dims.map(i => b.dims[i]);
   return result;
 }
 function produce(b) {

--- a/builder/test/visualize/stencil_split_2.html
+++ b/builder/test/visualize/stencil_split_2.html
@@ -305,9 +305,9 @@ function slice_buffer(b, at) {
   }
   return result;
 }
-function truncate_rank(b, rank) {
+function transpose(b, dims) {
   let result = clone_buffer(b);
-  b.dims.length = rank;
+  b.dims = dims.map(i => b.dims[i]);
   return result;
 }
 function produce(b) {

--- a/builder/test/visualize/stencil_split_3.html
+++ b/builder/test/visualize/stencil_split_3.html
@@ -305,9 +305,9 @@ function slice_buffer(b, at) {
   }
   return result;
 }
-function truncate_rank(b, rank) {
+function transpose(b, dims) {
   let result = clone_buffer(b);
-  b.dims.length = rank;
+  b.dims = dims.map(i => b.dims[i]);
   return result;
 }
 function produce(b) {

--- a/runtime/depends_on.cc
+++ b/runtime/depends_on.cc
@@ -186,7 +186,7 @@ public:
     depends_on_result sym_deps = visit_sym_body(op);
     propagate_deps(sym_deps, op->src);
   }
-  void visit(const truncate_rank* op) override {
+  void visit(const transpose* op) override {
     update_deps(op->src, [](depends_on_result& deps) { deps.buffer_meta = true; });
     depends_on_result sym_deps = visit_sym_body(op);
     propagate_deps(sym_deps, op->src);

--- a/runtime/expr_stmt.cc
+++ b/runtime/expr_stmt.cc
@@ -6,6 +6,7 @@
 #include <cstddef>
 #include <functional>
 #include <limits>
+#include <numeric>
 #include <optional>
 #include <string>
 #include <utility>
@@ -484,13 +485,19 @@ stmt slice_dim::make(var sym, var src, int dim, expr at, stmt body) {
   return n;
 }
 
-stmt truncate_rank::make(var sym, var src, int rank, stmt body) {
-  auto n = new truncate_rank();
+stmt transpose::make(var sym, var src, std::vector<int> dims, stmt body) {
+  auto n = new transpose();
   n->sym = sym;
   n->src = src;
-  n->rank = rank;
+  n->dims = dims;
   n->body = std::move(body);
   return n;
+}
+
+stmt transpose::make_truncate(var sym, var src, int rank, stmt body) {
+  std::vector<int> dims(rank);
+  std::iota(dims.begin(), dims.end(), 0);
+  return make(sym, src, std::move(dims), std::move(body));
 }
 
 stmt check::make(expr condition) {
@@ -752,7 +759,7 @@ void recursive_node_visitor::visit(const slice_dim* op) {
   op->at.accept(this);
   if (op->body.defined()) op->body.accept(this);
 }
-void recursive_node_visitor::visit(const truncate_rank* op) {
+void recursive_node_visitor::visit(const transpose* op) {
   if (op->body.defined()) op->body.accept(this);
 }
 void recursive_node_visitor::visit(const check* op) {

--- a/runtime/print.cc
+++ b/runtime/print.cc
@@ -296,8 +296,8 @@ public:
     *this << indent() << "}\n";
   }
 
-  void visit(const truncate_rank* n) override {
-    *this << indent() << n->sym << " = truncate_rank(" << n->src << ", " << n->rank << ") {\n";
+  void visit(const transpose* n) override {
+    *this << indent() << n->sym << " = transpose(" << n->src << ", " << n->dims << ") {\n";
     *this << n->body;
     *this << indent() << "}\n";
   }

--- a/runtime/test/evaluate.cc
+++ b/runtime/test/evaluate.cc
@@ -145,13 +145,15 @@ TEST(evaluate, slice_buffer) {
   assert_buffer_extents_are(buf, {10, 20, 30, 40});
 }
 
-TEST(evaluate, truncate_rank) {
+TEST(evaluate, transpose) {
   eval_context ctx;
   buffer<void, 4> buf({10, 20, 30, 40});
   ctx[x] = reinterpret_cast<index_t>(&buf);
 
-  evaluate(truncate_rank::make(x, x, 2, make_check(x, {10, 20})), ctx);
-  evaluate(truncate_rank::make(y, x, 2, block::make({make_check(x, {10, 20, 30, 40}), make_check(y, {10, 20})})), ctx);
+  evaluate(transpose::make(x, x, {0, 1}, make_check(x, {10, 20})), ctx);
+  evaluate(transpose::make(x, x, {3, 1}, make_check(x, {40, 20})), ctx);
+  evaluate(transpose::make(y, x, {0, 1}, block::make({make_check(x, {10, 20, 30, 40}), make_check(y, {10, 20})})), ctx);
+  evaluate(transpose::make(y, x, {2, 1}, block::make({make_check(x, {10, 20, 30, 40}), make_check(y, {30, 20})})), ctx);
   assert_buffer_extents_are(buf, {10, 20, 30, 40});
 }
 

--- a/runtime/visualize.cc
+++ b/runtime/visualize.cc
@@ -289,8 +289,8 @@ public:
     *this << indent() << "}\n";
   }
 
-  void visit(const truncate_rank* n) override {
-    *this << indent() << "{ let __" << n->sym << " = truncate_rank(" << n->src << ", " << n->rank << ");\n";
+  void visit(const transpose* n) override {
+    *this << indent() << "{ let __" << n->sym << " = transpose(" << n->src << ", [" << n->dims << "]);\n";
     *this << n->body;
     *this << indent(1) << n->sym << " = __" << n->sym << ";\n";
     *this << indent() << "}\n";
@@ -606,9 +606,9 @@ function slice_buffer(b, at) {
   }
   return result;
 }
-function truncate_rank(b, rank) {
+function transpose(b, dims) {
   let result = clone_buffer(b);
-  b.dims.length = rank;
+  b.dims = dims.map(i => b.dims[i]);
   return result;
 }
 function produce(b) {


### PR DESCRIPTION
I've been wanting to add a `transpose` buffer mutator for a while (to make it more obvious when a `make_buffer` is a transpose in a large pipeline), but didn't want to add a new one, because it makes writing mutators a pain.

I realized that `truncate_rank` could be generalized a little bit to become `transpose`, by replacing the number of dimensions with an array of dimensions. `truncate_rank(x, rank, body)` is equivalent to `transpose(x, {0, 1, ..., rank - 1}, body)`.

This could also use a placeholder to include any trailing dimensions, but for now we don't have any simplifications that need that, because `make_buffer` has no way to express such a thing.