### PR TITLE
Fix aliased copies when the src is aliased to a translated dst

### DIFF
--- a/builder/optimizations.cc
+++ b/builder/optimizations.cc
@@ -259,9 +259,9 @@ public:
     }
   }
 
-  void alias_copy_src_to_dst(const copy_stmt* op) {
+  void alias_copy_dst(const copy_stmt* op) {
     if (!alloc_info[op->dst] || !can_alias(op->src)) {
-      // We didn't allocate the dst, don't alias to it.
+      // We didn't allocate the dst.
       return;
     }
 
@@ -291,9 +291,9 @@ public:
     info->maybe_alias(op->src, std::move(a));
   }
 
-  void alias_copy_dst_to_src(const copy_stmt* op) {
+  void alias_copy_src(const copy_stmt* op) {
     if (!alloc_info[op->src] || !can_alias(op->dst)) {
-      // We didn't allocate the src, don't alias to it.
+      // We didn't allocate the src.
       return;
     }
 
@@ -345,8 +345,8 @@ public:
   void visit(const copy_stmt* op) override {
     set_result(op);
 
-    alias_copy_src_to_dst(op);
-    alias_copy_dst_to_src(op);
+    alias_copy_dst(op);
+    alias_copy_src(op);
   }
 
   void merge_alloc_info(symbol_map<buffer_info> add) {

--- a/builder/optimizations.cc
+++ b/builder/optimizations.cc
@@ -326,11 +326,11 @@ public:
       }
 
       a.dims[src_d] = {
-          buffer_bounds(op->dst, dst_d) & info->dims[src_d].bounds,
+          (buffer_bounds(op->dst, dst_d) + offset) & info->dims[src_d].bounds,
           buffer_stride(op->dst, dst_d),
           buffer_fold_factor(op->dst, dst_d),
       };
-      a.at[dst_d] = max(buffer_min(op->dst, dst_d) - offset, info->dims[dst_d].bounds.min);
+      a.at[dst_d] = max(buffer_min(op->dst, dst_d), info->dims[src_d].bounds.min - offset);
     }
 
     for (const dim_expr& d : a.dims) {

--- a/builder/test/copy_pipeline.cc
+++ b/builder/test/copy_pipeline.cc
@@ -121,7 +121,7 @@ TEST(padded_copy, pipeline) {
 
 class copied_result : public testing::TestWithParam<std::tuple<int, int, int>> {};
 
-auto offsets = testing::Values(0, 1, 3);
+auto offsets = testing::Values(0, 3);
 
 INSTANTIATE_TEST_SUITE_P(schedule, copied_result, testing::Combine(testing::Range(0, 3), offsets, offsets),
     test_params_to_string<copied_result::ParamType>);


### PR DESCRIPTION
Also some minor refactors that hopefully make it easier for me to keep it straight which buffer is which when aliasing, and a small lifetime cleanup.