### PR TITLE
Remove undefined padding mode for `copy`

### DIFF
--- a/runtime/buffer.h
+++ b/runtime/buffer.h
@@ -469,9 +469,9 @@ const buffer<NewT>& raw_buffer::cast() const {
   return *reinterpret_cast<const buffer<NewT>*>(this);
 }
 
-// Copy the contents of `src` to `dst`. When the `src` is out of bounds of `dst`, fill with `padding`.
-// `padding` should point to `dst.elem_size` bytes, or if `padding` is null, out of bounds regions
-// are unmodified.
+// Copy the contents of `src` to `dst`.
+// If `padding` is null, `src` must contain every index that `dst` contains.
+// If `padding` is non-null, `dst` is filled with the padding when it is out of bounds of `src`.
 void copy(const raw_buffer& src, const raw_buffer& dst, const void* padding = nullptr);
 
 // Performs only the padding operation of a copy. The region that would have been copied is unmodified.

--- a/runtime/test/buffer.cc
+++ b/runtime/test/buffer.cc
@@ -752,36 +752,13 @@ TEST(buffer, copy) {
       }
     });
 
-    for_each_contiguous_slice(src, [&](index_t extent, void* base) {
-      for (index_t i = 0; i < extent * elem_size; ++i) {
-        reinterpret_cast<char*>(base)[i] += 1;
-      }
-    });
-
-    slinky::copy(src, dst, nullptr);
-    for_each_index(dst, [&](auto i) {
-      if (src.contains(i)) {
-        // The copied area should have been copied.
-        ASSERT_EQ(memcmp(dst.address_at(i), src.address_at(i), elem_size), 0);
-      } else {
-        // The padding should be unchanged.
-        ASSERT_EQ(memcmp(dst.address_at(i), padding.data(), elem_size), 0);
-      }
-    });
-
-    for_each_contiguous_slice(src, [&](index_t extent, void* base) {
-      for (index_t i = 0; i < extent * elem_size; ++i) {
-        reinterpret_cast<char*>(base)[i] += -1;
-      }
-    });
-
     std::vector<char> new_padding(elem_size);
     std::fill(new_padding.begin(), new_padding.end(), 3);
     pad(src.dims, dst, new_padding.data());
     for_each_index(dst, [&](auto i) {
       if (src.contains(i)) {
-        // The src should not have been copied.
-        ASSERT_NE(memcmp(dst.address_at(i), src.address_at(i), elem_size), 0);
+        // The src should not have been modified.
+        ASSERT_EQ(memcmp(dst.address_at(i), src.address_at(i), elem_size), 0);
       } else {
         // But we should have new padding.
         ASSERT_EQ(memcmp(dst.address_at(i), new_padding.data(), elem_size), 0);


### PR DESCRIPTION
We used to rely on this for concatenate to work, but now that that is cropped properly, we should stop doing this. It makes it easier to reason about copies for aliasing, and in general I think it's better.