### PR TITLE
Check that alias targets are big enough

### DIFF
--- a/builder/optimizations.cc
+++ b/builder/optimizations.cc
@@ -263,6 +263,7 @@ public:
           buffer_alias a;
           a.dims = buffer_dims(o, input_info->dims.size());
           a.at = buffer_mins(o, input_info->dims.size());
+          // We assume that op->attrs.allow_in_place means that the input is in bounds of the entire output.
           a.assume_in_bounds = true;
           input_info->maybe_alias(o, std::move(a));
         }

--- a/builder/optimizations.cc
+++ b/builder/optimizations.cc
@@ -133,6 +133,7 @@ class buffer_aliaser : public node_mutator {
   struct buffer_alias {
     std::vector<dim_expr> dims;
     std::vector<expr> at;
+    bool assume_in_bounds = false;
   };
 
   class buffer_info {
@@ -154,6 +155,14 @@ class buffer_aliaser : public node_mutator {
 
       assert(dims.size() == a.dims.size());
       for (std::size_t d = 0; d < dims.size(); ++d) {
+        if (!a.assume_in_bounds) {
+          if (!prove_true(dims[d].bounds.min >= a.dims[d].bounds.min) ||
+              !prove_true(dims[d].bounds.max <= a.dims[d].bounds.max)) {
+            // This alias is not compatible because it isn't big enough for the original allocation.
+            // TODO: We could maybe grow the original allocation instead of giving up here.
+            return;
+          }
+        }
         if (dims[d].stride.defined()) {
           if (!prove_true(dims[d].stride == a.dims[d].stride)) {
             // This alias is not compatible because it would violate a constraint on the stride of the buffer.
@@ -254,6 +263,7 @@ public:
           buffer_alias a;
           a.dims = buffer_dims(o, input_info->dims.size());
           a.at = buffer_mins(o, input_info->dims.size());
+          a.assume_in_bounds = true;
           input_info->maybe_alias(o, std::move(a));
         }
       }
@@ -289,6 +299,8 @@ public:
       }
     }
 
+    // If there is no padding, we can assume that the src is always in bounds of dst.
+    a.assume_in_bounds = !op->padding || op->padding->empty();
     info->maybe_alias(op->src, std::move(a));
   }
 

--- a/builder/pipeline.cc
+++ b/builder/pipeline.cc
@@ -827,7 +827,8 @@ public:
       for (int d = 0; d < static_cast<int>(bounds->size()); ++d) {
         checks.push_back(check::make(buffer_min(buf_var, d) <= (*bounds)[d].min));
         checks.push_back(check::make(buffer_max(buf_var, d) >= (*bounds)[d].max));
-        checks.push_back(check::make((*bounds)[d].extent() <= buffer_fold_factor(buf_var, d)));
+        checks.push_back(check::make(buffer_fold_factor(buf_var, d) == dim::unfolded ||
+                                     (*bounds)[d].extent() <= buffer_fold_factor(buf_var, d)));
       }
     }
     return block::make(std::move(checks), std::move(body));
@@ -863,7 +864,7 @@ void add_buffer_checks(const buffer_expr_ptr& b, bool output, std::vector<stmt>&
     checks.push_back(check::make(b->dim(d).stride == buffer_stride(buf_var, d)));
     checks.push_back(check::make(b->dim(d).fold_factor == fold_factor));
     if (output) {
-      checks.push_back(check::make(b->dim(d).extent() <= fold_factor));
+      checks.push_back(check::make(fold_factor == dim::unfolded || b->dim(d).extent() <= fold_factor));
     }
   }
 }

--- a/builder/replica_pipeline.cc
+++ b/builder/replica_pipeline.cc
@@ -305,9 +305,15 @@ public:
     funcs_emitted_[&f] = fn_name;
 
     if (!f.defined() && f.outputs().size() == 1) {
-      std::string func_inputs = print(f.inputs());
       std::string func_outputs = print(f.outputs()[0]);
-      (void)print_assignment_explicit(fn_name, "func::make_copy(", func_inputs, ", ", func_outputs, ")");
+      if (f.padding()) {
+        std::string func_inputs = print(f.inputs()[0]);
+        std::string padding = print_vector(*f.padding());
+        (void)print_assignment_explicit(fn_name, "func::make_copy(", func_inputs, ", ", func_outputs, ", ", padding, ")");
+      } else {
+        std::string func_inputs = print(f.inputs());
+        (void)print_assignment_explicit(fn_name, "func::make_copy(", func_inputs, ", ", func_outputs, ")");
+      }
     } else {
       std::string callback = print_callback(f.inputs(), f.outputs());
       std::string func_inputs = print(f.inputs());
@@ -443,6 +449,8 @@ private:
         } else {
           os << "expr()";
         }
+      } else if constexpr (std::is_same_v<T, char>) {
+        os << (int)vi;
       } else {
         os << vi;
       }

--- a/builder/rewrite.h
+++ b/builder/rewrite.h
@@ -11,7 +11,7 @@ namespace slinky {
 namespace rewrite {
 
 // The maximum number of values pattern_wildcard::idx and pattern_constant::idx can have, starting from 0.
-constexpr int symbol_count = 4;
+constexpr int symbol_count = 5;
 constexpr int constant_count = 5;
 
 template <int N>
@@ -372,6 +372,8 @@ template <typename T>
 auto is_finite(const T& x) { return make_predicate(x, slinky::is_finite); }
 template <typename T>
 auto is_constant(const T& x) { return make_predicate(x, slinky::as_constant); }
+template <typename T>
+auto is_zero(const T& x) { return make_predicate(x, slinky::is_zero); }
 // clang-format on
 
 template <int N1, int N2>

--- a/builder/simplify_exprs.cc
+++ b/builder/simplify_exprs.cc
@@ -663,6 +663,7 @@ expr simplify(const less* op, expr a, expr b) {
       r.rewrite(max(x, y) < min(x, y), false) ||
         
       // Subtract terms from both sides within a min/max.
+      // These are only enabled for non-constants because they loop with rules that pull constants out of min/max.
       r.rewrite(min(x, y) < x + z, min(y - x, 0) < z, !is_constant(x)) ||
       r.rewrite(min(x, y) < x - z, z < max(x - y, 0), !is_constant(x)) ||
       r.rewrite(max(x, y) < x + z, max(y - x, 0) < z, !is_constant(x)) ||

--- a/builder/test/cannot_alias.cc
+++ b/builder/test/cannot_alias.cc
@@ -169,7 +169,8 @@ TEST_P(may_alias, aligned) {
     }
   }
 
-  ASSERT_EQ(eval_ctx.heap.total_count, may_alias ? 0 : 1);
+  // TODO: Enable this to alias.
+  //ASSERT_EQ(eval_ctx.heap.total_count, may_alias ? 0 : 1);
 }
 
 TEST_P(may_alias, same_bounds) {
@@ -222,7 +223,8 @@ TEST_P(may_alias, same_bounds) {
     }
   }
 
-  ASSERT_EQ(eval_ctx.heap.total_count, may_alias ? 0 : 1);
+  // TODO: Enable this to alias.
+  //ASSERT_EQ(eval_ctx.heap.total_count, may_alias ? 0 : 1);
 }
 
 }  // namespace slinky

--- a/builder/test/cannot_alias.cc
+++ b/builder/test/cannot_alias.cc
@@ -12,7 +12,11 @@ namespace slinky {
 // This set of tests ensures that we don't alias buffers when doing so would violate assumptions that the client code
 // asked slinky to maintain.
 
-TEST(cannot_alias_transpose_input, pipeline) {
+class may_alias : public testing::TestWithParam<bool> {};
+
+INSTANTIATE_TEST_SUITE_P(constrain, may_alias, testing::Values(false, true));
+
+TEST_P(may_alias, transpose_input) {
   // Make the pipeline
   node_context ctx;
 
@@ -21,16 +25,20 @@ TEST(cannot_alias_transpose_input, pipeline) {
 
   auto in_t = buffer_expr::make(ctx, "in_t", 2, sizeof(int));
 
-  // Our callback requires the stride to be 1 element.
-  in_t->dim(0).stride = static_cast<index_t>(sizeof(int));
+  const bool may_alias = GetParam();
+
+  if (!may_alias) {
+    // Our callback requires the stride to be 1 element.
+    in_t->dim(0).stride = static_cast<index_t>(sizeof(int));
+  }
 
   var x(ctx, "x");
   var y(ctx, "y");
 
   func transposed = func::make_copy({in, {point(y), point(x)}}, {in_t, {x, y}});
   func add1 = func::make(
-      [](const buffer<const int>& a, const buffer<int>& b) -> index_t {
-        if (a.dim(0).stride() != 4) return 1;
+      [=](const buffer<const int>& a, const buffer<int>& b) -> index_t {
+        if (!may_alias && a.dim(0).stride() != 4) return 1;
         return add_1<int>(a, b);
       },
       {{{in_t, {point(x), point(y)}}}}, {{{out, {x, y}}}}, call_stmt::attributes{.name = "add1"});
@@ -57,9 +65,11 @@ TEST(cannot_alias_transpose_input, pipeline) {
       ASSERT_EQ(out_buf(x, y), in_buf(y, x) + 1);
     }
   }
+
+  ASSERT_EQ(eval_ctx.heap.total_count, may_alias ? 0 : 1);
 }
 
-TEST(cannot_alias_transpose_output, pipeline) {
+TEST_P(may_alias, transpose_output) {
   // Make the pipeline
   node_context ctx;
 
@@ -68,15 +78,19 @@ TEST(cannot_alias_transpose_output, pipeline) {
 
   auto out_t = buffer_expr::make(ctx, "out_t", 2, sizeof(int));
 
-  // Our callback requires the stride to be 1 element.
-  out_t->dim(0).stride = static_cast<index_t>(sizeof(int));
+  const bool may_alias = GetParam();
+
+  if (!may_alias) {
+    // Our callback requires the stride to be 1 element.
+    out_t->dim(0).stride = static_cast<index_t>(sizeof(int));
+  }
 
   var x(ctx, "x");
   var y(ctx, "y");
 
   func add1 = func::make(
-      [](const buffer<const int>& a, const buffer<int>& b) -> index_t {
-        if (b.dim(0).stride() != 4) return 1;
+      [=](const buffer<const int>& a, const buffer<int>& b) -> index_t {
+        if (!may_alias && b.dim(0).stride() != 4) return 1;
         return add_1<int>(a, b);
       },
       {{{in, {point(x), point(y)}}}}, {{{out_t, {x, y}}}}, call_stmt::attributes{.name = "add1"});
@@ -104,6 +118,111 @@ TEST(cannot_alias_transpose_output, pipeline) {
       ASSERT_EQ(out_buf(x, y), in_buf(y, x) + 1);
     }
   }
+
+  ASSERT_EQ(eval_ctx.heap.total_count, may_alias ? 0 : 1);
+}
+
+
+TEST_P(may_alias, aligned) {
+  // Make the pipeline
+  node_context ctx;
+
+  auto in = buffer_expr::make(ctx, "in", 2, sizeof(short));
+  auto out = buffer_expr::make(ctx, "out", 2, sizeof(short));
+  
+  auto intm = buffer_expr::make(ctx, "intm", 2, sizeof(short));
+
+  var x(ctx, "x");
+  var y(ctx, "y");
+
+  intm->dim(0).bounds = align(intm->dim(0).bounds, 2);
+
+  // In this pipeline, the result is copied to two outputs. We can only alias in this case if we know the two outputs
+  // have the same bounds.
+  const bool may_alias = GetParam();
+  if (may_alias) {
+    out->dim(0).bounds = align(out->dim(0).bounds, 2);
+  }
+  func add = func::make(add_1<short>, {{in, {point(x), point(y)}}}, {{intm, {x, y}}});
+  func copied = func::make_copy({intm, {point(x), point(y)}}, {out, {x, y}});
+
+  pipeline p = build_pipeline(ctx, {in}, {out});
+
+  // Run the pipeline.
+  const int W = 20;
+  const int H = 10;
+  buffer<short, 2> in_buf({W, H});
+  init_random(in_buf);
+
+  buffer<short, 2> out_buf({W, H});
+  out_buf.allocate();
+
+  // Not having span(std::initializer_list<T>) is unfortunate.
+  const raw_buffer* inputs[] = {&in_buf};
+  const raw_buffer* outputs[] = {&out_buf};
+  test_context eval_ctx;
+  p.evaluate(inputs, outputs, eval_ctx);
+
+  for (int y = 0; y < H; ++y) {
+    for (int x = 0; x < W; ++x) {
+      ASSERT_EQ(out_buf(x, y), in_buf(x, y) + 1);
+    }
+  }
+
+  ASSERT_EQ(eval_ctx.heap.total_count, may_alias ? 0 : 1);
+}
+
+TEST_P(may_alias, same_bounds) {
+  // Make the pipeline
+  node_context ctx;
+
+  auto in = buffer_expr::make(ctx, "in", 2, sizeof(short));
+  auto out1 = buffer_expr::make(ctx, "out1", 2, sizeof(short));
+  auto out2 = buffer_expr::make(ctx, "out2", 2, sizeof(short));
+
+  auto intm = buffer_expr::make(ctx, "intm", 2, sizeof(short));
+
+  var x(ctx, "x");
+  var y(ctx, "y");
+
+  // In this pipeline, the result is copied to two outputs. We can only alias in this case if we know the two outputs
+  // have the same bounds.
+  const bool may_alias = GetParam();
+  if (may_alias) {
+    out2->dim(0).bounds = out1->dim(0).bounds;
+    out2->dim(1).bounds = out1->dim(1).bounds;
+  }
+  func add = func::make(add_1<short>, {{in, {point(x), point(y)}}}, {{intm, {x, y}}});
+  func copied1 = func::make_copy({intm, {point(x), point(y)}}, {out1, {x, y}});
+  func copied2 = func::make_copy({intm, {point(x), point(y)}}, {out2, {x, y}});
+
+  pipeline p = build_pipeline(ctx, {in}, {out1, out2});
+
+  // Run the pipeline.
+  const int W = 20;
+  const int H = 10;
+  buffer<short, 2> in_buf({W, H});
+  init_random(in_buf);
+
+  buffer<short, 2> out1_buf({W, H});
+  buffer<short, 2> out2_buf({W, H});
+  out1_buf.allocate();
+  out2_buf.allocate();
+
+  // Not having span(std::initializer_list<T>) is unfortunate.
+  const raw_buffer* inputs[] = {&in_buf};
+  const raw_buffer* outputs[] = {&out1_buf, &out2_buf};
+  test_context eval_ctx;
+  p.evaluate(inputs, outputs, eval_ctx);
+
+  for (int y = 0; y < H; ++y) {
+    for (int x = 0; x < W; ++x) {
+      ASSERT_EQ(out1_buf(x, y), in_buf(x, y) + 1);
+      ASSERT_EQ(out2_buf(x, y), in_buf(x, y) + 1);
+    }
+  }
+
+  ASSERT_EQ(eval_ctx.heap.total_count, may_alias ? 0 : 1);
 }
 
 }  // namespace slinky

--- a/builder/test/pipeline.cc
+++ b/builder/test/pipeline.cc
@@ -859,7 +859,8 @@ TEST_P(padded_stencil, pipeline) {
     ASSERT_EQ(eval_ctx.heap.total_size, intm_size + padded_intm_size);
     ASSERT_EQ(eval_ctx.heap.total_count, 2);
   } else {
-    ASSERT_EQ(eval_ctx.heap.total_count, 1);
+    // TODO: Enable this to alias again.
+    //ASSERT_EQ(eval_ctx.heap.total_count, 1);
   }
 
   // Also visualize this pipeline.

--- a/builder/test/replica_pipeline.cc
+++ b/builder/test/replica_pipeline.cc
@@ -256,9 +256,9 @@ auto p = []() -> ::slinky::pipeline {
   auto in1 = buffer_expr::make(ctx, "in1", /*rank=*/2, /*elem_size=*/2);
   auto in2 = buffer_expr::make(ctx, "in2", /*rank=*/2, /*elem_size=*/2);
   auto out = buffer_expr::make(ctx, "out", /*rank=*/2, /*elem_size=*/2);
-  auto intm1 = buffer_expr::make(ctx, "intm1", /*rank=*/2, /*elem_size=*/2);
   auto x = var(ctx, "x");
   auto y = var(ctx, "y");
+  auto intm1 = buffer_expr::make(ctx, "intm1", /*rank=*/2, /*elem_size=*/2);
   auto _replica_fn_2 = [=](const buffer<const void>& i0, const buffer<void>& o0) -> index_t {
     const buffer<const void>* input_buffers[] = {&i0};
     const buffer<void>* output_buffers[] = {&o0};
@@ -312,9 +312,9 @@ auto p = []() -> ::slinky::pipeline {
   auto in1 = buffer_expr::make(ctx, "in1", /*rank=*/2, /*elem_size=*/2);
   auto in2 = buffer_expr::make(ctx, "in2", /*rank=*/2, /*elem_size=*/2);
   auto out = buffer_expr::make(ctx, "out", /*rank=*/3, /*elem_size=*/2);
-  auto intm1 = buffer_expr::make(ctx, "intm1", /*rank=*/2, /*elem_size=*/2);
   auto x = var(ctx, "x");
   auto y = var(ctx, "y");
+  auto intm1 = buffer_expr::make(ctx, "intm1", /*rank=*/2, /*elem_size=*/2);
   auto _replica_fn_2 = [=](const buffer<const void>& i0, const buffer<void>& o0) -> index_t {
     const buffer<const void>* input_buffers[] = {&i0};
     const buffer<void>* output_buffers[] = {&o0};
@@ -377,7 +377,7 @@ auto p = []() -> ::slinky::pipeline {
   };
   auto _fn_2 = func::make(std::move(_replica_fn_3), {{in, {point(x), point(y)}}}, {{intm, {x, y}}}, {});
   auto _4 = variable::make(in->sym());
-  auto _fn_1 = func::make_copy({{intm, {point(x), point(y)}, {{(buffer_min(_4, 0)), (buffer_max(_4, 0))}, {(buffer_min(_4, 1)), (buffer_max(_4, 1))}}, {}, {}}}, {padded_intm, {x, y}});
+  auto _fn_1 = func::make_copy({intm, {point(x), point(y)}, {{(buffer_min(_4, 0)), (buffer_max(_4, 0))}, {(buffer_min(_4, 1)), (buffer_max(_4, 1))}}, {}, {}}, {padded_intm, {x, y}}, {6, 0});
   _fn_1.compute_root();
   auto _replica_fn_5 = [=](const buffer<const void>& i0, const buffer<void>& o0) -> index_t {
     const buffer<const void>* input_buffers[] = {&i0};

--- a/builder/test/visualize/padded_stencil_0.html
+++ b/builder/test/visualize/padded_stencil_0.html
@@ -327,42 +327,30 @@ function pipeline(__in, out) {
   check((out != 0));
   check((buffer_rank(out) == 2));
   check((buffer_elem_size(out) == 2));
-  check((((buffer_max(out, 0) - buffer_min(out, 0)) + 1) <= buffer_fold_factor(out, 0)));
-  check((((buffer_max(out, 1) - buffer_min(out, 1)) + 1) <= buffer_fold_factor(out, 1)));
+  check(((buffer_fold_factor(out, 0) == 9223372036854775807) || ((buffer_max(out, 0) + 1) <= (buffer_fold_factor(out, 0) + buffer_min(out, 0)))));
+  check(((buffer_fold_factor(out, 1) == 9223372036854775807) || ((buffer_max(out, 1) + 1) <= (buffer_fold_factor(out, 1) + buffer_min(out, 1)))));
   {
     let g = buffer_min(__in, 0);
     let g1 = buffer_min(__in, 1);
     let g0 = buffer_max(__in, 0);
     let g2 = buffer_max(__in, 1);
-    check((((min(g0, (buffer_max(out, 0) + 1)) - max(g, (buffer_min(out, 0) + -1))) + 1) <= buffer_fold_factor(__in, 0)));
-    check((((min(g2, (buffer_max(out, 1) + 1)) - max(g1, (buffer_min(out, 1) + -1))) + 1) <= buffer_fold_factor(__in, 1)));
+    check(((buffer_fold_factor(__in, 0) == 9223372036854775807) || ((min(g0, (buffer_max(out, 0) + 1)) + 1) <= (max(g, (buffer_min(out, 0) + -1)) + buffer_fold_factor(__in, 0)))));
+    check(((buffer_fold_factor(__in, 1) == 9223372036854775807) || ((min(g2, (buffer_max(out, 1) + 1)) + 1) <= (max(g1, (buffer_min(out, 1) + -1)) + buffer_fold_factor(__in, 1)))));
     { let padded_intm = allocate('padded_intm', 2, [
         {bounds:{min:(buffer_min(out, 0) + -1), max:(buffer_max(out, 0) + 1)}, stride:NaN, fold_factor:9223372036854775807},
         {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:NaN, fold_factor:9223372036854775807}
       ]);
-      {
-        let __base = buffer_at(padded_intm, max(g, (buffer_min(out, 0) + -1)), max(g1, (buffer_min(out, 1) + -1)));
-        let __elem_size = 2;
-        let __dims = [
-            {bounds:{min:max(g, (buffer_min(out, 0) + -1)), max:min(g0, (buffer_max(out, 0) + 1))}, stride:buffer_stride(padded_intm, 0), fold_factor:buffer_fold_factor(padded_intm, 0)},
-            {bounds:{min:max(g1, (buffer_min(out, 1) + -1)), max:min(g2, (buffer_max(out, 1) + 1))}, stride:buffer_stride(padded_intm, 1), fold_factor:buffer_fold_factor(padded_intm, 1)}
-        ];
-        { let intm = make_buffer('intm', __base, __elem_size, __dims);          consume(__in);
-          produce(intm);
-          __event_t++;
-        }
-      }
-      {
-        let __base = buffer_at(padded_intm, max(g, (buffer_min(out, 0) + -1)), max(g1, (buffer_min(out, 1) + -1)));
-        let __elem_size = 2;
-        let __dims = [
-            {bounds:{min:max(g, (buffer_min(out, 0) + -1)), max:min(g0, (buffer_max(out, 0) + 1))}, stride:buffer_stride(padded_intm, 0), fold_factor:buffer_fold_factor(padded_intm, 0)},
-            {bounds:{min:max(g1, (buffer_min(out, 1) + -1)), max:min(g2, (buffer_max(out, 1) + 1))}, stride:buffer_stride(padded_intm, 1), fold_factor:buffer_fold_factor(padded_intm, 1)}
-        ];
-        { let intm = make_buffer('intm', __base, __elem_size, __dims);          consume(intm);
-          produce(padded_intm);
-          __event_t++;
-        }
+      { let intm = allocate('intm', 2, [
+          {bounds:{min:max(g, (buffer_min(out, 0) + -1)), max:min(g0, (buffer_max(out, 0) + 1))}, stride:NaN, fold_factor:9223372036854775807},
+          {bounds:{min:max(g1, (buffer_min(out, 1) + -1)), max:min(g2, (buffer_max(out, 1) + 1))}, stride:NaN, fold_factor:9223372036854775807}
+        ]);
+        consume(__in);
+        produce(intm);
+        __event_t++;
+        consume(intm);
+        produce(padded_intm);
+        __event_t++;
+        free(intm);
       }
       consume(padded_intm);
       produce(out);

--- a/builder/test/visualize/padded_stencil_1.html
+++ b/builder/test/visualize/padded_stencil_1.html
@@ -327,42 +327,30 @@ function pipeline(__in, out) {
   check((out != 0));
   check((buffer_rank(out) == 2));
   check((buffer_elem_size(out) == 2));
-  check((((buffer_max(out, 0) - buffer_min(out, 0)) + 1) <= buffer_fold_factor(out, 0)));
-  check((((buffer_max(out, 1) - buffer_min(out, 1)) + 1) <= buffer_fold_factor(out, 1)));
+  check(((buffer_fold_factor(out, 0) == 9223372036854775807) || ((buffer_max(out, 0) + 1) <= (buffer_fold_factor(out, 0) + buffer_min(out, 0)))));
+  check(((buffer_fold_factor(out, 1) == 9223372036854775807) || ((buffer_max(out, 1) + 1) <= (buffer_fold_factor(out, 1) + buffer_min(out, 1)))));
   {
     let g = buffer_min(__in, 0);
     let g1 = buffer_min(__in, 1);
     let g0 = buffer_max(__in, 0);
     let g2 = buffer_max(__in, 1);
-    check((((min(g0, (buffer_max(out, 0) + 1)) - max(g, (buffer_min(out, 0) + -1))) + 1) <= buffer_fold_factor(__in, 0)));
-    check((((min(g2, (buffer_max(out, 1) + 1)) - max(g1, (buffer_min(out, 1) + -1))) + 1) <= buffer_fold_factor(__in, 1)));
+    check(((buffer_fold_factor(__in, 0) == 9223372036854775807) || ((min(g0, (buffer_max(out, 0) + 1)) + 1) <= (max(g, (buffer_min(out, 0) + -1)) + buffer_fold_factor(__in, 0)))));
+    check(((buffer_fold_factor(__in, 1) == 9223372036854775807) || ((min(g2, (buffer_max(out, 1) + 1)) + 1) <= (max(g1, (buffer_min(out, 1) + -1)) + buffer_fold_factor(__in, 1)))));
     { let padded_intm = allocate('padded_intm', 2, [
         {bounds:{min:(buffer_min(out, 0) + -1), max:(buffer_max(out, 0) + 1)}, stride:NaN, fold_factor:9223372036854775807},
         {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:NaN, fold_factor:9223372036854775807}
       ]);
-      {
-        let __base = buffer_at(padded_intm, max(g, (buffer_min(out, 0) + -1)), max(g1, (buffer_min(out, 1) + -1)));
-        let __elem_size = 2;
-        let __dims = [
-            {bounds:{min:max(g, (buffer_min(out, 0) + -1)), max:min(g0, (buffer_max(out, 0) + 1))}, stride:buffer_stride(padded_intm, 0), fold_factor:buffer_fold_factor(padded_intm, 0)},
-            {bounds:{min:max(g1, (buffer_min(out, 1) + -1)), max:min(g2, (buffer_max(out, 1) + 1))}, stride:buffer_stride(padded_intm, 1), fold_factor:buffer_fold_factor(padded_intm, 1)}
-        ];
-        { let intm = make_buffer('intm', __base, __elem_size, __dims);          consume(__in);
-          produce(intm);
-          __event_t++;
-        }
-      }
-      {
-        let __base = buffer_at(padded_intm, max(g, (buffer_min(out, 0) + -1)), max(g1, (buffer_min(out, 1) + -1)));
-        let __elem_size = 2;
-        let __dims = [
-            {bounds:{min:max(g, (buffer_min(out, 0) + -1)), max:min(g0, (buffer_max(out, 0) + 1))}, stride:buffer_stride(padded_intm, 0), fold_factor:buffer_fold_factor(padded_intm, 0)},
-            {bounds:{min:max(g1, (buffer_min(out, 1) + -1)), max:min(g2, (buffer_max(out, 1) + 1))}, stride:buffer_stride(padded_intm, 1), fold_factor:buffer_fold_factor(padded_intm, 1)}
-        ];
-        { let intm = make_buffer('intm', __base, __elem_size, __dims);          consume(intm);
-          produce(padded_intm);
-          __event_t++;
-        }
+      { let intm = allocate('intm', 2, [
+          {bounds:{min:max(g, (buffer_min(out, 0) + -1)), max:min(g0, (buffer_max(out, 0) + 1))}, stride:NaN, fold_factor:9223372036854775807},
+          {bounds:{min:max(g1, (buffer_min(out, 1) + -1)), max:min(g2, (buffer_max(out, 1) + 1))}, stride:NaN, fold_factor:9223372036854775807}
+        ]);
+        consume(__in);
+        produce(intm);
+        __event_t++;
+        consume(intm);
+        produce(padded_intm);
+        __event_t++;
+        free(intm);
       }
       consume(padded_intm);
       produce(out);

--- a/builder/test/visualize/padded_stencil_2.html
+++ b/builder/test/visualize/padded_stencil_2.html
@@ -327,15 +327,15 @@ function pipeline(__in, out) {
   check((out != 0));
   check((buffer_rank(out) == 2));
   check((buffer_elem_size(out) == 2));
-  check((((buffer_max(out, 0) - buffer_min(out, 0)) + 1) <= buffer_fold_factor(out, 0)));
-  check((((buffer_max(out, 1) - buffer_min(out, 1)) + 1) <= buffer_fold_factor(out, 1)));
+  check(((buffer_fold_factor(out, 0) == 9223372036854775807) || ((buffer_max(out, 0) + 1) <= (buffer_fold_factor(out, 0) + buffer_min(out, 0)))));
+  check(((buffer_fold_factor(out, 1) == 9223372036854775807) || ((buffer_max(out, 1) + 1) <= (buffer_fold_factor(out, 1) + buffer_min(out, 1)))));
   {
     let g = buffer_min(__in, 0);
     let g1 = buffer_min(__in, 1);
     let g0 = buffer_max(__in, 0);
     let g2 = buffer_max(__in, 1);
-    check((((min(g0, (buffer_max(out, 0) + 1)) - max(g, (buffer_min(out, 0) + -1))) + 1) <= buffer_fold_factor(__in, 0)));
-    check((((min(g2, (buffer_max(out, 1) + 1)) - max(g1, (buffer_min(out, 1) + -1))) + 1) <= buffer_fold_factor(__in, 1)));
+    check(((buffer_fold_factor(__in, 0) == 9223372036854775807) || ((min(g0, (buffer_max(out, 0) + 1)) + 1) <= (max(g, (buffer_min(out, 0) + -1)) + buffer_fold_factor(__in, 0)))));
+    check(((buffer_fold_factor(__in, 1) == 9223372036854775807) || ((min(g2, (buffer_max(out, 1) + 1)) + 1) <= (max(g1, (buffer_min(out, 1) + -1)) + buffer_fold_factor(__in, 1)))));
     { let padded_intm = allocate('padded_intm', 2, [
         {bounds:{min:(buffer_min(out, 0) + -1), max:(buffer_max(out, 0) + 1)}, stride:NaN, fold_factor:9223372036854775807},
         {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:NaN, fold_factor:3}

--- a/builder/test/visualize/parallel_stencils_0.html
+++ b/builder/test/visualize/parallel_stencils_0.html
@@ -330,20 +330,20 @@ function pipeline(in1, in2, out) {
   check((out != 0));
   check((buffer_rank(out) == 2));
   check((buffer_elem_size(out) == 2));
-  check((((buffer_max(out, 0) - buffer_min(out, 0)) + 1) <= buffer_fold_factor(out, 0)));
-  check((((buffer_max(out, 1) - buffer_min(out, 1)) + 1) <= buffer_fold_factor(out, 1)));
+  check(((buffer_fold_factor(out, 0) == 9223372036854775807) || ((buffer_max(out, 0) + 1) <= (buffer_fold_factor(out, 0) + buffer_min(out, 0)))));
+  check(((buffer_fold_factor(out, 1) == 9223372036854775807) || ((buffer_max(out, 1) + 1) <= (buffer_fold_factor(out, 1) + buffer_min(out, 1)))));
   check(((buffer_min(in1, 0) + 1) <= buffer_min(out, 0)));
   check(((buffer_max(out, 0) + 1) <= buffer_max(in1, 0)));
-  check((((buffer_max(out, 0) - buffer_min(out, 0)) + 3) <= buffer_fold_factor(in1, 0)));
+  check(((buffer_fold_factor(in1, 0) == 9223372036854775807) || ((buffer_max(out, 0) + 3) <= (buffer_fold_factor(in1, 0) + buffer_min(out, 0)))));
   check(((buffer_min(in1, 1) + 1) <= buffer_min(out, 1)));
   check(((buffer_max(out, 1) + 1) <= buffer_max(in1, 1)));
-  check((((buffer_max(out, 1) - buffer_min(out, 1)) + 3) <= buffer_fold_factor(in1, 1)));
+  check(((buffer_fold_factor(in1, 1) == 9223372036854775807) || ((buffer_max(out, 1) + 3) <= (buffer_fold_factor(in1, 1) + buffer_min(out, 1)))));
   check(((buffer_min(in2, 0) + 2) <= buffer_min(out, 0)));
   check(((buffer_max(out, 0) + 2) <= buffer_max(in2, 0)));
-  check((((buffer_max(out, 0) - buffer_min(out, 0)) + 5) <= buffer_fold_factor(in2, 0)));
+  check(((buffer_fold_factor(in2, 0) == 9223372036854775807) || ((buffer_max(out, 0) + 5) <= (buffer_fold_factor(in2, 0) + buffer_min(out, 0)))));
   check(((buffer_min(in2, 1) + 2) <= buffer_min(out, 1)));
   check(((buffer_max(out, 1) + 2) <= buffer_max(in2, 1)));
-  check((((buffer_max(out, 1) - buffer_min(out, 1)) + 5) <= buffer_fold_factor(in2, 1)));
+  check(((buffer_fold_factor(in2, 1) == 9223372036854775807) || ((buffer_max(out, 1) + 5) <= (buffer_fold_factor(in2, 1) + buffer_min(out, 1)))));
   { let intm4 = allocate('intm4', 2, [
       {bounds:{min:buffer_min(out, 0), max:buffer_max(out, 0)}, stride:NaN, fold_factor:9223372036854775807},
       {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:NaN, fold_factor:1}

--- a/builder/test/visualize/parallel_stencils_1.html
+++ b/builder/test/visualize/parallel_stencils_1.html
@@ -330,20 +330,20 @@ function pipeline(in1, in2, out) {
   check((out != 0));
   check((buffer_rank(out) == 2));
   check((buffer_elem_size(out) == 2));
-  check((((buffer_max(out, 0) - buffer_min(out, 0)) + 1) <= buffer_fold_factor(out, 0)));
-  check((((buffer_max(out, 1) - buffer_min(out, 1)) + 1) <= buffer_fold_factor(out, 1)));
+  check(((buffer_fold_factor(out, 0) == 9223372036854775807) || ((buffer_max(out, 0) + 1) <= (buffer_fold_factor(out, 0) + buffer_min(out, 0)))));
+  check(((buffer_fold_factor(out, 1) == 9223372036854775807) || ((buffer_max(out, 1) + 1) <= (buffer_fold_factor(out, 1) + buffer_min(out, 1)))));
   check(((buffer_min(in1, 0) + 1) <= buffer_min(out, 0)));
   check(((buffer_max(out, 0) + 1) <= buffer_max(in1, 0)));
-  check((((buffer_max(out, 0) - buffer_min(out, 0)) + 3) <= buffer_fold_factor(in1, 0)));
+  check(((buffer_fold_factor(in1, 0) == 9223372036854775807) || ((buffer_max(out, 0) + 3) <= (buffer_fold_factor(in1, 0) + buffer_min(out, 0)))));
   check(((buffer_min(in1, 1) + 1) <= buffer_min(out, 1)));
   check(((buffer_max(out, 1) + 1) <= buffer_max(in1, 1)));
-  check((((buffer_max(out, 1) - buffer_min(out, 1)) + 3) <= buffer_fold_factor(in1, 1)));
+  check(((buffer_fold_factor(in1, 1) == 9223372036854775807) || ((buffer_max(out, 1) + 3) <= (buffer_fold_factor(in1, 1) + buffer_min(out, 1)))));
   check(((buffer_min(in2, 0) + 2) <= buffer_min(out, 0)));
   check(((buffer_max(out, 0) + 2) <= buffer_max(in2, 0)));
-  check((((buffer_max(out, 0) - buffer_min(out, 0)) + 5) <= buffer_fold_factor(in2, 0)));
+  check(((buffer_fold_factor(in2, 0) == 9223372036854775807) || ((buffer_max(out, 0) + 5) <= (buffer_fold_factor(in2, 0) + buffer_min(out, 0)))));
   check(((buffer_min(in2, 1) + 2) <= buffer_min(out, 1)));
   check(((buffer_max(out, 1) + 2) <= buffer_max(in2, 1)));
-  check((((buffer_max(out, 1) - buffer_min(out, 1)) + 5) <= buffer_fold_factor(in2, 1)));
+  check(((buffer_fold_factor(in2, 1) == 9223372036854775807) || ((buffer_max(out, 1) + 5) <= (buffer_fold_factor(in2, 1) + buffer_min(out, 1)))));
   { let intm4 = allocate('intm4', 2, [
       {bounds:{min:buffer_min(out, 0), max:buffer_max(out, 0)}, stride:NaN, fold_factor:9223372036854775807},
       {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:NaN, fold_factor:2}

--- a/builder/test/visualize/parallel_stencils_2.html
+++ b/builder/test/visualize/parallel_stencils_2.html
@@ -330,20 +330,20 @@ function pipeline(in1, in2, out) {
   check((out != 0));
   check((buffer_rank(out) == 2));
   check((buffer_elem_size(out) == 2));
-  check((((buffer_max(out, 0) - buffer_min(out, 0)) + 1) <= buffer_fold_factor(out, 0)));
-  check((((buffer_max(out, 1) - buffer_min(out, 1)) + 1) <= buffer_fold_factor(out, 1)));
+  check(((buffer_fold_factor(out, 0) == 9223372036854775807) || ((buffer_max(out, 0) + 1) <= (buffer_fold_factor(out, 0) + buffer_min(out, 0)))));
+  check(((buffer_fold_factor(out, 1) == 9223372036854775807) || ((buffer_max(out, 1) + 1) <= (buffer_fold_factor(out, 1) + buffer_min(out, 1)))));
   check(((buffer_min(in1, 0) + 1) <= buffer_min(out, 0)));
   check(((buffer_max(out, 0) + 1) <= buffer_max(in1, 0)));
-  check((((buffer_max(out, 0) - buffer_min(out, 0)) + 3) <= buffer_fold_factor(in1, 0)));
+  check(((buffer_fold_factor(in1, 0) == 9223372036854775807) || ((buffer_max(out, 0) + 3) <= (buffer_fold_factor(in1, 0) + buffer_min(out, 0)))));
   check(((buffer_min(in1, 1) + 1) <= buffer_min(out, 1)));
   check(((buffer_max(out, 1) + 1) <= buffer_max(in1, 1)));
-  check((((buffer_max(out, 1) - buffer_min(out, 1)) + 3) <= buffer_fold_factor(in1, 1)));
+  check(((buffer_fold_factor(in1, 1) == 9223372036854775807) || ((buffer_max(out, 1) + 3) <= (buffer_fold_factor(in1, 1) + buffer_min(out, 1)))));
   check(((buffer_min(in2, 0) + 2) <= buffer_min(out, 0)));
   check(((buffer_max(out, 0) + 2) <= buffer_max(in2, 0)));
-  check((((buffer_max(out, 0) - buffer_min(out, 0)) + 5) <= buffer_fold_factor(in2, 0)));
+  check(((buffer_fold_factor(in2, 0) == 9223372036854775807) || ((buffer_max(out, 0) + 5) <= (buffer_fold_factor(in2, 0) + buffer_min(out, 0)))));
   check(((buffer_min(in2, 1) + 2) <= buffer_min(out, 1)));
   check(((buffer_max(out, 1) + 2) <= buffer_max(in2, 1)));
-  check((((buffer_max(out, 1) - buffer_min(out, 1)) + 5) <= buffer_fold_factor(in2, 1)));
+  check(((buffer_fold_factor(in2, 1) == 9223372036854775807) || ((buffer_max(out, 1) + 5) <= (buffer_fold_factor(in2, 1) + buffer_min(out, 1)))));
   { let intm4 = allocate('intm4', 2, [
       {bounds:{min:buffer_min(out, 0), max:buffer_max(out, 0)}, stride:NaN, fold_factor:9223372036854775807},
       {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:NaN, fold_factor:2}

--- a/builder/test/visualize/softmax_split_0.html
+++ b/builder/test/visualize/softmax_split_0.html
@@ -327,17 +327,17 @@ function pipeline(__in, out) {
   check((out != 0));
   check((buffer_rank(out) == 2));
   check((buffer_elem_size(out) == 4));
-  check((((buffer_max(out, 0) - buffer_min(out, 0)) + 1) <= buffer_fold_factor(out, 0)));
-  check((((buffer_max(out, 1) - buffer_min(out, 1)) + 1) <= buffer_fold_factor(out, 1)));
+  check(((buffer_fold_factor(out, 0) == 9223372036854775807) || ((buffer_max(out, 0) + 1) <= (buffer_fold_factor(out, 0) + buffer_min(out, 0)))));
+  check(((buffer_fold_factor(out, 1) == 9223372036854775807) || ((buffer_max(out, 1) + 1) <= (buffer_fold_factor(out, 1) + buffer_min(out, 1)))));
   {
     let g = buffer_min(out, 0);
     let g0 = buffer_max(out, 0);
     check((buffer_min(__in, 0) <= min(g, g0)));
     check((max(g, g0) <= buffer_max(__in, 0)));
-    check(((abs((g - g0)) + 1) <= buffer_fold_factor(__in, 0)));
+    check(((buffer_fold_factor(__in, 0) == 9223372036854775807) || ((abs((g - g0)) + 1) <= buffer_fold_factor(__in, 0))));
     check((buffer_min(__in, 1) <= buffer_min(out, 1)));
     check((buffer_max(out, 1) <= buffer_max(__in, 1)));
-    check((((buffer_max(out, 1) - buffer_min(out, 1)) + 1) <= buffer_fold_factor(__in, 1)));
+    check(((buffer_fold_factor(__in, 1) == 9223372036854775807) || ((buffer_max(out, 1) + 1) <= (buffer_fold_factor(__in, 1) + buffer_min(out, 1)))));
     { let softmax_out = allocate('softmax_out', 4, [
         {bounds:{min:buffer_min(out, 0), max:buffer_max(out, 0)}, stride:NaN, fold_factor:9223372036854775807},
         {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:NaN, fold_factor:9223372036854775807}

--- a/builder/test/visualize/softmax_split_1.html
+++ b/builder/test/visualize/softmax_split_1.html
@@ -327,17 +327,17 @@ function pipeline(__in, out) {
   check((out != 0));
   check((buffer_rank(out) == 2));
   check((buffer_elem_size(out) == 4));
-  check((((buffer_max(out, 0) - buffer_min(out, 0)) + 1) <= buffer_fold_factor(out, 0)));
-  check((((buffer_max(out, 1) - buffer_min(out, 1)) + 1) <= buffer_fold_factor(out, 1)));
+  check(((buffer_fold_factor(out, 0) == 9223372036854775807) || ((buffer_max(out, 0) + 1) <= (buffer_fold_factor(out, 0) + buffer_min(out, 0)))));
+  check(((buffer_fold_factor(out, 1) == 9223372036854775807) || ((buffer_max(out, 1) + 1) <= (buffer_fold_factor(out, 1) + buffer_min(out, 1)))));
   {
     let g = buffer_min(out, 0);
     let g0 = buffer_max(out, 0);
     check((buffer_min(__in, 0) <= min(g, g0)));
     check((max(g, g0) <= buffer_max(__in, 0)));
-    check(((abs((g - g0)) + 1) <= buffer_fold_factor(__in, 0)));
+    check(((buffer_fold_factor(__in, 0) == 9223372036854775807) || ((abs((g - g0)) + 1) <= buffer_fold_factor(__in, 0))));
     check((buffer_min(__in, 1) <= buffer_min(out, 1)));
     check((buffer_max(out, 1) <= buffer_max(__in, 1)));
-    check((((buffer_max(out, 1) - buffer_min(out, 1)) + 1) <= buffer_fold_factor(__in, 1)));
+    check(((buffer_fold_factor(__in, 1) == 9223372036854775807) || ((buffer_max(out, 1) + 1) <= (buffer_fold_factor(__in, 1) + buffer_min(out, 1)))));
     { let softmax_out = allocate('softmax_out', 4, [
         {bounds:{min:buffer_min(out, 0), max:buffer_max(out, 0)}, stride:NaN, fold_factor:9223372036854775807},
         {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:NaN, fold_factor:1}

--- a/builder/test/visualize/softmax_split_4.html
+++ b/builder/test/visualize/softmax_split_4.html
@@ -327,17 +327,17 @@ function pipeline(__in, out) {
   check((out != 0));
   check((buffer_rank(out) == 2));
   check((buffer_elem_size(out) == 4));
-  check((((buffer_max(out, 0) - buffer_min(out, 0)) + 1) <= buffer_fold_factor(out, 0)));
-  check((((buffer_max(out, 1) - buffer_min(out, 1)) + 1) <= buffer_fold_factor(out, 1)));
+  check(((buffer_fold_factor(out, 0) == 9223372036854775807) || ((buffer_max(out, 0) + 1) <= (buffer_fold_factor(out, 0) + buffer_min(out, 0)))));
+  check(((buffer_fold_factor(out, 1) == 9223372036854775807) || ((buffer_max(out, 1) + 1) <= (buffer_fold_factor(out, 1) + buffer_min(out, 1)))));
   {
     let g = buffer_min(out, 0);
     let g0 = buffer_max(out, 0);
     check((buffer_min(__in, 0) <= min(g, g0)));
     check((max(g, g0) <= buffer_max(__in, 0)));
-    check(((abs((g - g0)) + 1) <= buffer_fold_factor(__in, 0)));
+    check(((buffer_fold_factor(__in, 0) == 9223372036854775807) || ((abs((g - g0)) + 1) <= buffer_fold_factor(__in, 0))));
     check((buffer_min(__in, 1) <= buffer_min(out, 1)));
     check((buffer_max(out, 1) <= buffer_max(__in, 1)));
-    check((((buffer_max(out, 1) - buffer_min(out, 1)) + 1) <= buffer_fold_factor(__in, 1)));
+    check(((buffer_fold_factor(__in, 1) == 9223372036854775807) || ((buffer_max(out, 1) + 1) <= (buffer_fold_factor(__in, 1) + buffer_min(out, 1)))));
     { let softmax_out = allocate('softmax_out', 4, [
         {bounds:{min:buffer_min(out, 0), max:buffer_max(out, 0)}, stride:NaN, fold_factor:9223372036854775807},
         {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:NaN, fold_factor:4}

--- a/builder/test/visualize/stencil_chain_split_serial_split_0.html
+++ b/builder/test/visualize/stencil_chain_split_serial_split_0.html
@@ -329,14 +329,14 @@ function pipeline(__in, out) {
     check((out != 0));
     check((buffer_rank(out) == 2));
     check((buffer_elem_size(out) == 2));
-    check((((buffer_max(out, 0) - buffer_min(out, 0)) + 1) <= buffer_fold_factor(out, 0)));
-    check((((buffer_max(out, 1) - buffer_min(out, 1)) + 1) <= buffer_fold_factor(out, 1)));
+    check(((buffer_fold_factor(out, 0) == 9223372036854775807) || ((buffer_max(out, 0) + 1) <= (buffer_fold_factor(out, 0) + buffer_min(out, 0)))));
+    check(((buffer_fold_factor(out, 1) == 9223372036854775807) || ((buffer_max(out, 1) + 1) <= (buffer_fold_factor(out, 1) + buffer_min(out, 1)))));
     check(((buffer_min(__in, 0) + 2) <= buffer_min(out, 0)));
     check(((buffer_max(out, 0) + 2) <= buffer_max(__in, 0)));
-    check((((buffer_max(out, 0) - buffer_min(out, 0)) + 5) <= buffer_fold_factor(__in, 0)));
+    check(((buffer_fold_factor(__in, 0) == 9223372036854775807) || ((buffer_max(out, 0) + 5) <= (buffer_fold_factor(__in, 0) + buffer_min(out, 0)))));
     check(((buffer_min(__in, 1) + 2) <= buffer_min(out, 1)));
     check(((buffer_max(out, 1) + 2) <= buffer_max(__in, 1)));
-    check((((buffer_max(out, 1) - buffer_min(out, 1)) + 5) <= buffer_fold_factor(__in, 1)));
+    check(((buffer_fold_factor(__in, 1) == 9223372036854775807) || ((buffer_max(out, 1) + 5) <= (buffer_fold_factor(__in, 1) + buffer_min(out, 1)))));
     { let stencil1_result = allocate('stencil1_result', 2, [
         {bounds:{min:(buffer_min(out, 0) + -1), max:(buffer_max(out, 0) + 1)}, stride:NaN, fold_factor:9223372036854775807},
         {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:NaN, fold_factor:9223372036854775807}

--- a/builder/test/visualize/stencil_chain_split_serial_split_1.html
+++ b/builder/test/visualize/stencil_chain_split_serial_split_1.html
@@ -329,14 +329,14 @@ function pipeline(__in, out) {
     check((out != 0));
     check((buffer_rank(out) == 2));
     check((buffer_elem_size(out) == 2));
-    check((((buffer_max(out, 0) - buffer_min(out, 0)) + 1) <= buffer_fold_factor(out, 0)));
-    check((((buffer_max(out, 1) - buffer_min(out, 1)) + 1) <= buffer_fold_factor(out, 1)));
+    check(((buffer_fold_factor(out, 0) == 9223372036854775807) || ((buffer_max(out, 0) + 1) <= (buffer_fold_factor(out, 0) + buffer_min(out, 0)))));
+    check(((buffer_fold_factor(out, 1) == 9223372036854775807) || ((buffer_max(out, 1) + 1) <= (buffer_fold_factor(out, 1) + buffer_min(out, 1)))));
     check(((buffer_min(__in, 0) + 2) <= buffer_min(out, 0)));
     check(((buffer_max(out, 0) + 2) <= buffer_max(__in, 0)));
-    check((((buffer_max(out, 0) - buffer_min(out, 0)) + 5) <= buffer_fold_factor(__in, 0)));
+    check(((buffer_fold_factor(__in, 0) == 9223372036854775807) || ((buffer_max(out, 0) + 5) <= (buffer_fold_factor(__in, 0) + buffer_min(out, 0)))));
     check(((buffer_min(__in, 1) + 2) <= buffer_min(out, 1)));
     check(((buffer_max(out, 1) + 2) <= buffer_max(__in, 1)));
-    check((((buffer_max(out, 1) - buffer_min(out, 1)) + 5) <= buffer_fold_factor(__in, 1)));
+    check(((buffer_fold_factor(__in, 1) == 9223372036854775807) || ((buffer_max(out, 1) + 5) <= (buffer_fold_factor(__in, 1) + buffer_min(out, 1)))));
     { let stencil1_result = allocate('stencil1_result', 2, [
         {bounds:{min:(buffer_min(out, 0) + -1), max:(buffer_max(out, 0) + 1)}, stride:NaN, fold_factor:9223372036854775807},
         {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:NaN, fold_factor:3}

--- a/builder/test/visualize/stencil_chain_split_serial_split_2.html
+++ b/builder/test/visualize/stencil_chain_split_serial_split_2.html
@@ -329,14 +329,14 @@ function pipeline(__in, out) {
     check((out != 0));
     check((buffer_rank(out) == 2));
     check((buffer_elem_size(out) == 2));
-    check((((buffer_max(out, 0) - buffer_min(out, 0)) + 1) <= buffer_fold_factor(out, 0)));
-    check((((buffer_max(out, 1) - buffer_min(out, 1)) + 1) <= buffer_fold_factor(out, 1)));
+    check(((buffer_fold_factor(out, 0) == 9223372036854775807) || ((buffer_max(out, 0) + 1) <= (buffer_fold_factor(out, 0) + buffer_min(out, 0)))));
+    check(((buffer_fold_factor(out, 1) == 9223372036854775807) || ((buffer_max(out, 1) + 1) <= (buffer_fold_factor(out, 1) + buffer_min(out, 1)))));
     check(((buffer_min(__in, 0) + 2) <= buffer_min(out, 0)));
     check(((buffer_max(out, 0) + 2) <= buffer_max(__in, 0)));
-    check((((buffer_max(out, 0) - buffer_min(out, 0)) + 5) <= buffer_fold_factor(__in, 0)));
+    check(((buffer_fold_factor(__in, 0) == 9223372036854775807) || ((buffer_max(out, 0) + 5) <= (buffer_fold_factor(__in, 0) + buffer_min(out, 0)))));
     check(((buffer_min(__in, 1) + 2) <= buffer_min(out, 1)));
     check(((buffer_max(out, 1) + 2) <= buffer_max(__in, 1)));
-    check((((buffer_max(out, 1) - buffer_min(out, 1)) + 5) <= buffer_fold_factor(__in, 1)));
+    check(((buffer_fold_factor(__in, 1) == 9223372036854775807) || ((buffer_max(out, 1) + 5) <= (buffer_fold_factor(__in, 1) + buffer_min(out, 1)))));
     { let stencil1_result = allocate('stencil1_result', 2, [
         {bounds:{min:(buffer_min(out, 0) + -1), max:(buffer_max(out, 0) + 1)}, stride:NaN, fold_factor:9223372036854775807},
         {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:NaN, fold_factor:4}

--- a/builder/test/visualize/stencil_split_0.html
+++ b/builder/test/visualize/stencil_split_0.html
@@ -327,14 +327,14 @@ function pipeline(__in, out) {
   check((out != 0));
   check((buffer_rank(out) == 2));
   check((buffer_elem_size(out) == 2));
-  check((((buffer_max(out, 0) - buffer_min(out, 0)) + 1) <= buffer_fold_factor(out, 0)));
-  check((((buffer_max(out, 1) - buffer_min(out, 1)) + 1) <= buffer_fold_factor(out, 1)));
+  check(((buffer_fold_factor(out, 0) == 9223372036854775807) || ((buffer_max(out, 0) + 1) <= (buffer_fold_factor(out, 0) + buffer_min(out, 0)))));
+  check(((buffer_fold_factor(out, 1) == 9223372036854775807) || ((buffer_max(out, 1) + 1) <= (buffer_fold_factor(out, 1) + buffer_min(out, 1)))));
   check(((buffer_min(__in, 0) + 1) <= buffer_min(out, 0)));
   check(((buffer_max(out, 0) + 1) <= buffer_max(__in, 0)));
-  check((((buffer_max(out, 0) - buffer_min(out, 0)) + 3) <= buffer_fold_factor(__in, 0)));
+  check(((buffer_fold_factor(__in, 0) == 9223372036854775807) || ((buffer_max(out, 0) + 3) <= (buffer_fold_factor(__in, 0) + buffer_min(out, 0)))));
   check(((buffer_min(__in, 1) + 1) <= buffer_min(out, 1)));
   check(((buffer_max(out, 1) + 1) <= buffer_max(__in, 1)));
-  check((((buffer_max(out, 1) - buffer_min(out, 1)) + 3) <= buffer_fold_factor(__in, 1)));
+  check(((buffer_fold_factor(__in, 1) == 9223372036854775807) || ((buffer_max(out, 1) + 3) <= (buffer_fold_factor(__in, 1) + buffer_min(out, 1)))));
   { let intm = allocate('intm', 2, [
       {bounds:{min:(buffer_min(out, 0) + -1), max:(buffer_max(out, 0) + 1)}, stride:NaN, fold_factor:9223372036854775807},
       {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:NaN, fold_factor:9223372036854775807}

--- a/builder/test/visualize/stencil_split_1.html
+++ b/builder/test/visualize/stencil_split_1.html
@@ -327,14 +327,14 @@ function pipeline(__in, out) {
   check((out != 0));
   check((buffer_rank(out) == 2));
   check((buffer_elem_size(out) == 2));
-  check((((buffer_max(out, 0) - buffer_min(out, 0)) + 1) <= buffer_fold_factor(out, 0)));
-  check((((buffer_max(out, 1) - buffer_min(out, 1)) + 1) <= buffer_fold_factor(out, 1)));
+  check(((buffer_fold_factor(out, 0) == 9223372036854775807) || ((buffer_max(out, 0) + 1) <= (buffer_fold_factor(out, 0) + buffer_min(out, 0)))));
+  check(((buffer_fold_factor(out, 1) == 9223372036854775807) || ((buffer_max(out, 1) + 1) <= (buffer_fold_factor(out, 1) + buffer_min(out, 1)))));
   check(((buffer_min(__in, 0) + 1) <= buffer_min(out, 0)));
   check(((buffer_max(out, 0) + 1) <= buffer_max(__in, 0)));
-  check((((buffer_max(out, 0) - buffer_min(out, 0)) + 3) <= buffer_fold_factor(__in, 0)));
+  check(((buffer_fold_factor(__in, 0) == 9223372036854775807) || ((buffer_max(out, 0) + 3) <= (buffer_fold_factor(__in, 0) + buffer_min(out, 0)))));
   check(((buffer_min(__in, 1) + 1) <= buffer_min(out, 1)));
   check(((buffer_max(out, 1) + 1) <= buffer_max(__in, 1)));
-  check((((buffer_max(out, 1) - buffer_min(out, 1)) + 3) <= buffer_fold_factor(__in, 1)));
+  check(((buffer_fold_factor(__in, 1) == 9223372036854775807) || ((buffer_max(out, 1) + 3) <= (buffer_fold_factor(__in, 1) + buffer_min(out, 1)))));
   { let intm = allocate('intm', 2, [
       {bounds:{min:(buffer_min(out, 0) + -1), max:(buffer_max(out, 0) + 1)}, stride:NaN, fold_factor:9223372036854775807},
       {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:NaN, fold_factor:3}

--- a/builder/test/visualize/stencil_split_2.html
+++ b/builder/test/visualize/stencil_split_2.html
@@ -327,14 +327,14 @@ function pipeline(__in, out) {
   check((out != 0));
   check((buffer_rank(out) == 2));
   check((buffer_elem_size(out) == 2));
-  check((((buffer_max(out, 0) - buffer_min(out, 0)) + 1) <= buffer_fold_factor(out, 0)));
-  check((((buffer_max(out, 1) - buffer_min(out, 1)) + 1) <= buffer_fold_factor(out, 1)));
+  check(((buffer_fold_factor(out, 0) == 9223372036854775807) || ((buffer_max(out, 0) + 1) <= (buffer_fold_factor(out, 0) + buffer_min(out, 0)))));
+  check(((buffer_fold_factor(out, 1) == 9223372036854775807) || ((buffer_max(out, 1) + 1) <= (buffer_fold_factor(out, 1) + buffer_min(out, 1)))));
   check(((buffer_min(__in, 0) + 1) <= buffer_min(out, 0)));
   check(((buffer_max(out, 0) + 1) <= buffer_max(__in, 0)));
-  check((((buffer_max(out, 0) - buffer_min(out, 0)) + 3) <= buffer_fold_factor(__in, 0)));
+  check(((buffer_fold_factor(__in, 0) == 9223372036854775807) || ((buffer_max(out, 0) + 3) <= (buffer_fold_factor(__in, 0) + buffer_min(out, 0)))));
   check(((buffer_min(__in, 1) + 1) <= buffer_min(out, 1)));
   check(((buffer_max(out, 1) + 1) <= buffer_max(__in, 1)));
-  check((((buffer_max(out, 1) - buffer_min(out, 1)) + 3) <= buffer_fold_factor(__in, 1)));
+  check(((buffer_fold_factor(__in, 1) == 9223372036854775807) || ((buffer_max(out, 1) + 3) <= (buffer_fold_factor(__in, 1) + buffer_min(out, 1)))));
   { let intm = allocate('intm', 2, [
       {bounds:{min:(buffer_min(out, 0) + -1), max:(buffer_max(out, 0) + 1)}, stride:NaN, fold_factor:9223372036854775807},
       {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:NaN, fold_factor:4}

--- a/builder/test/visualize/stencil_split_3.html
+++ b/builder/test/visualize/stencil_split_3.html
@@ -327,14 +327,14 @@ function pipeline(__in, out) {
   check((out != 0));
   check((buffer_rank(out) == 2));
   check((buffer_elem_size(out) == 2));
-  check((((buffer_max(out, 0) - buffer_min(out, 0)) + 1) <= buffer_fold_factor(out, 0)));
-  check((((buffer_max(out, 1) - buffer_min(out, 1)) + 1) <= buffer_fold_factor(out, 1)));
+  check(((buffer_fold_factor(out, 0) == 9223372036854775807) || ((buffer_max(out, 0) + 1) <= (buffer_fold_factor(out, 0) + buffer_min(out, 0)))));
+  check(((buffer_fold_factor(out, 1) == 9223372036854775807) || ((buffer_max(out, 1) + 1) <= (buffer_fold_factor(out, 1) + buffer_min(out, 1)))));
   check(((buffer_min(__in, 0) + 1) <= buffer_min(out, 0)));
   check(((buffer_max(out, 0) + 1) <= buffer_max(__in, 0)));
-  check((((buffer_max(out, 0) - buffer_min(out, 0)) + 3) <= buffer_fold_factor(__in, 0)));
+  check(((buffer_fold_factor(__in, 0) == 9223372036854775807) || ((buffer_max(out, 0) + 3) <= (buffer_fold_factor(__in, 0) + buffer_min(out, 0)))));
   check(((buffer_min(__in, 1) + 1) <= buffer_min(out, 1)));
   check(((buffer_max(out, 1) + 1) <= buffer_max(__in, 1)));
-  check((((buffer_max(out, 1) - buffer_min(out, 1)) + 3) <= buffer_fold_factor(__in, 1)));
+  check(((buffer_fold_factor(__in, 1) == 9223372036854775807) || ((buffer_max(out, 1) + 3) <= (buffer_fold_factor(__in, 1) + buffer_min(out, 1)))));
   { let intm = allocate('intm', 2, [
       {bounds:{min:(buffer_min(out, 0) + -1), max:(buffer_max(out, 0) + 1)}, stride:NaN, fold_factor:9223372036854775807},
       {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:NaN, fold_factor:6}


### PR DESCRIPTION
This PR adds a check when considering a buffer for aliasing that the aliasing target is big enough.

This required a bunch of new simplifier rules to enable proving that x <= y where x, y are bounds of buffers.

Also fixes a bug where the replica pipeline generator dropped the padding of copies.

This PR adds a few new tests that aren't passing the way they should yet (the checks are commented with TODOs). It also disables the check for aliasing in padded_stencil, which either needs major simplifier upgrades to be able to prove is safe for aliasing, or needs the alias_buffers pass to grow the allocation to the union of the original and the aliases (I'm going to attempt that in my next aliasing PR).