### PR TITLE
Aliasing can now grow allocations when necessary

### DIFF
--- a/builder/optimizations.cc
+++ b/builder/optimizations.cc
@@ -163,7 +163,6 @@ class buffer_aliaser : public node_mutator {
   public:
     std::vector<dim_expr> dims;
     std::map<var, buffer_alias> can_alias_;
-    std::set<var> cannot_alias_;
 
     // If we decided to alias this buffer, we might have grown the bounds. If so, we need to make a new allocation with
     // this symbol, but make a crop of it for the original bounds.
@@ -176,16 +175,11 @@ class buffer_aliaser : public node_mutator {
     const std::map<var, buffer_alias>& can_alias() const { return can_alias_; }
 
     void maybe_alias(var s, buffer_alias a) {
-      if (cannot_alias_.count(s)) {
-        return;
-      }
-
       can_alias_[s] = std::move(a);
     }
 
     void do_not_alias(var s) {
       can_alias_.erase(s);
-      cannot_alias_.insert(s);
     }
   };
   symbol_map<buffer_info> alloc_info;

--- a/builder/optimizations.cc
+++ b/builder/optimizations.cc
@@ -323,10 +323,10 @@ public:
       // This call does not allow aliasing an input to an output.
       return;
     }
-    for (var o : op->outputs) {
-      for (var i : op->inputs) {
-        std::optional<alloc_info>& input_info = lookup_alloc(i);
-        if (input_info) {
+    for (var i : op->inputs) {
+      std::optional<alloc_info>& input_info = lookup_alloc(i);
+      if (input_info) {
+        for (var o : op->outputs) {
           buffer_alias a;
           a.dims = buffer_dims(o, input_info->dims.size());
           a.at = buffer_mins(o, input_info->dims.size());

--- a/builder/optimizations.cc
+++ b/builder/optimizations.cc
@@ -31,15 +31,15 @@ dim_expr select(const expr& c, dim_expr t, dim_expr f) {
 }
 
 // Checks if the copy operands `src_x` and `dst_x` represent a simple copy that can be handled by slinky::copy.
-bool is_copy(var src, expr src_x, int src_d, var dst, var dst_x, int dst_d, expr& at, dim_expr& src_dim) {
+bool is_copy(bool padded, var src, expr src_x, int src_d, var dst, var dst_x, int dst_d, expr& at, dim_expr& src_dim) {
   if (const class select* s = src_x.as<class select>()) {
     // The src is a select of two things that might both be copies.
     expr at_t = at;
     expr at_f = at;
     dim_expr src_dim_t = src_dim;
     dim_expr src_dim_f = src_dim;
-    if (is_copy(src, s->true_value, src_d, dst, dst_x, dst_d, at_t, src_dim_t) &&
-        is_copy(src, s->false_value, src_d, dst, dst_x, dst_d, at_f, src_dim_f)) {
+    if (is_copy(padded, src, s->true_value, src_d, dst, dst_x, dst_d, at_t, src_dim_t) &&
+        is_copy(padded, src, s->false_value, src_d, dst, dst_x, dst_d, at_f, src_dim_f)) {
       at = select(s->condition, at_t, at_f);
       src_dim = select(s->condition, src_dim_t, src_dim_f);
       return true;
@@ -74,10 +74,18 @@ bool is_copy(var src, expr src_x, int src_d, var dst, var dst_x, int dst_d, expr
       return false;
     }
 
-    src_dim.bounds = (buffer_bounds(src, src_d) - offset) / scale;
+    if (padded) {
+      // When the copy is padded, we should use the src bounds.
+      src_dim.bounds = (buffer_bounds(src, src_d) - offset) / scale;
+      at = buffer_min(src, src_d) + offset * (scale - 1);
+    } else {
+      // When the copy is not padded, we should use the dst bounds.
+      src_dim.bounds = buffer_bounds(dst, dst_d);
+      at = buffer_min(dst, dst_d) * scale + offset;
+    }
+    // We always want the memory layout of the src buffer.
     src_dim.stride = buffer_stride(src, src_d) * scale;
     src_dim.fold_factor = buffer_fold_factor(src, src_d);
-    at = buffer_min(src, src_d) + offset * (scale - 1);
     return true;
   }
 }
@@ -85,7 +93,8 @@ bool is_copy(var src, expr src_x, int src_d, var dst, var dst_x, int dst_d, expr
 bool is_copy(const copy_stmt* op, int src_d, int dst_d, expr& at, dim_expr& src_dim) {
   // We might not have an src dim if we're trying to broadcast.
   expr src_x = src_d >= 0 ? op->src_x[src_d] : expr();
-  return is_copy(op->src, src_x, src_d, op->dst, op->dst_x[dst_d], dst_d, at, src_dim);
+  bool padded = op->padding && !op->padding->empty();
+  return is_copy(padded, op->src, src_x, src_d, op->dst, op->dst_x[dst_d], dst_d, at, src_dim);
 }
 
 // `dst_d` may be a copy dim of `op` if it is used by exactly one src dim, where it might be a copy, or zero src dims,

--- a/builder/optimizations.h
+++ b/builder/optimizations.h
@@ -8,7 +8,7 @@ namespace slinky {
 // Where possible, replace `allocate` with `make_buffer` referring to another buffer with appropriate metadata:
 // - `copy_stmt`s that only do simple copies or broadcasts in each dimension.
 // - `call_stmt`s that can be in-place may be able to replace an allocation for the output with an alias of an input.
-stmt alias_buffers(const stmt& s);
+stmt alias_buffers(const stmt& s, node_context& ctx);
 
 // Given a copy_stmt, produce an implementation that calls `slinky::copy`, possibly inside loops that implement copy
 // operations that `slinky::copy` cannot express.

--- a/builder/pipeline.cc
+++ b/builder/pipeline.cc
@@ -955,6 +955,9 @@ stmt build_pipeline(node_context& ctx, const std::vector<buffer_expr_ptr>& input
 
   result = simplify(result);
 
+  if (is_verbose()) {
+    std::cout << result << std::endl;
+  }
   // Try to reuse buffers and eliminate copies where possible.
   if (!options.no_alias_buffers) {
     result = alias_buffers(result);
@@ -971,7 +974,7 @@ stmt build_pipeline(node_context& ctx, const std::vector<buffer_expr_ptr>& input
 
   result = fix_buffer_races(result);
 
-  result = insert_early_free(result);
+  //result = insert_early_free(result);
 
   if (options.trace) {
     result = inject_traces(result, ctx, constants);

--- a/builder/pipeline.cc
+++ b/builder/pipeline.cc
@@ -971,7 +971,7 @@ stmt build_pipeline(node_context& ctx, const std::vector<buffer_expr_ptr>& input
 
   result = fix_buffer_races(result);
 
-  //result = insert_early_free(result);
+  result = insert_early_free(result);
 
   if (options.trace) {
     result = inject_traces(result, ctx, constants);

--- a/builder/pipeline.cc
+++ b/builder/pipeline.cc
@@ -955,12 +955,9 @@ stmt build_pipeline(node_context& ctx, const std::vector<buffer_expr_ptr>& input
 
   result = simplify(result);
 
-  if (is_verbose()) {
-    std::cout << result << std::endl;
-  }
   // Try to reuse buffers and eliminate copies where possible.
   if (!options.no_alias_buffers) {
-    result = alias_buffers(result);
+    result = alias_buffers(result, ctx);
   }
 
   // `evaluate` currently can't handle `copy_stmt`, so this is required.

--- a/builder/pipeline.cc
+++ b/builder/pipeline.cc
@@ -780,8 +780,7 @@ public:
 
     symbol_map<var> uncropped_subs;
     // Add all allocations at this loop level.
-    for (auto i = order_.rbegin(); i != order_.rend(); ++i) {
-      const func* f = *i;
+    for (const func* f : order_) {
       for (const func::output& o : f->outputs()) {
         const buffer_expr_ptr& b = o.buffer;
         if (output_syms_.count(b->sym())) continue;

--- a/builder/test/cannot_alias.cc
+++ b/builder/test/cannot_alias.cc
@@ -122,14 +122,13 @@ TEST_P(may_alias, transpose_output) {
   ASSERT_EQ(eval_ctx.heap.total_count, may_alias ? 0 : 1);
 }
 
-
 TEST_P(may_alias, aligned) {
   // Make the pipeline
   node_context ctx;
 
   auto in = buffer_expr::make(ctx, "in", 2, sizeof(short));
   auto out = buffer_expr::make(ctx, "out", 2, sizeof(short));
-  
+
   auto intm = buffer_expr::make(ctx, "intm", 2, sizeof(short));
 
   var x(ctx, "x");
@@ -169,8 +168,10 @@ TEST_P(may_alias, aligned) {
     }
   }
 
-  // TODO: Enable this to alias.
-  //ASSERT_EQ(eval_ctx.heap.total_count, may_alias ? 0 : 1);
+  // TODO: This test actually currently requires that the input and output are aligned, so it can alias.
+  // I think there is a similar pipeline where this would not be true, and in that case it should not alias.
+  // ASSERT_EQ(eval_ctx.heap.total_count, may_alias ? 0 : 1);
+  ASSERT_EQ(eval_ctx.heap.total_count, 0);
 }
 
 TEST_P(may_alias, same_bounds) {
@@ -223,8 +224,10 @@ TEST_P(may_alias, same_bounds) {
     }
   }
 
-  // TODO: Enable this to alias.
-  //ASSERT_EQ(eval_ctx.heap.total_count, may_alias ? 0 : 1);
+  // TODO: This test actually currently requires that the input and output bounds are the same, so it can alias.
+  // I think there is a similar pipeline where this would not be true, and in that case it should not alias.
+  // ASSERT_EQ(eval_ctx.heap.total_count, may_alias ? 0 : 1);
+  ASSERT_EQ(eval_ctx.heap.total_count, 0);
 }
 
 }  // namespace slinky

--- a/builder/test/copy_pipeline.cc
+++ b/builder/test/copy_pipeline.cc
@@ -516,8 +516,8 @@ TEST_P(broadcasted_elementwise, internal) {
       select(in2->dim(1).extent() == 1, point(in2->dim(1).min()), point(y)),
   };
   func broadcast = func::make_copy({intm, bounds}, {intm_broadcasted, {x, y}});
-  func g = func::make(
-      subtract<int>, {{in1, {point(x), point(y)}}, {intm_broadcasted, {point(x), point(y)}}}, {{out, {x, y}}});
+  func g = func::make(subtract<int>, {{in1, {point(x), point(y)}}, {intm_broadcasted, {point(x), point(y)}}},
+      {{out, {x, y}}}, call_stmt::attributes{.name = "g"});
 
   pipeline p = build_pipeline(ctx, {in1, in2}, {out}, build_options{.no_alias_buffers = no_alias_buffers});
 
@@ -548,8 +548,7 @@ TEST_P(broadcasted_elementwise, internal) {
   }
 
   if (!no_alias_buffers) {
-    // TODO: This should alias, but can't due to https://github.com/dsharlet/slinky/issues/313
-    ASSERT_EQ(eval_ctx.heap.total_count, 2);
+    ASSERT_EQ(eval_ctx.heap.total_count, 1);
   }
 }
 

--- a/builder/test/funcs.h
+++ b/builder/test/funcs.h
@@ -97,6 +97,16 @@ index_t sum3x3(const buffer<const T>& in, const buffer<T>& out) {
   return sum_stencil<T, -1, -1, 1, 1>(in, out);
 }
 
+// Centered 1D separable stencil operations.
+template <typename T>
+index_t sum1x3(const buffer<const T>& in, const buffer<T>& out) {
+  return sum_stencil<T, 0, -1, 0, 1>(in, out);
+}
+template <typename T>
+index_t sum3x1(const buffer<const T>& in, const buffer<T>& out) {
+  return sum_stencil<T, -1, 0, 1, 0>(in, out);
+}
+
 // A centered 2D 5x5 stencil operation.
 template <typename T>
 index_t sum5x5(const buffer<const T>& in, const buffer<T>& out) {

--- a/builder/test/pipeline.cc
+++ b/builder/test/pipeline.cc
@@ -971,10 +971,19 @@ TEST_P(padded_stencil_separable, pipeline) {
   const index_t padded_intm_t_size = (W + 2) * H * sizeof(short);
   const index_t stencil_y_size = W * (schedule != 0 ? 1 : H) * sizeof(short);
   const index_t padded_intm_size = W * (schedule != 0 ? 3 : (H + 2)) * sizeof(short);
-  ASSERT_EQ(eval_ctx.heap.total_size, intm_size + padded_intm_t_size + stencil_y_size + padded_intm_size);
-  ASSERT_EQ(eval_ctx.heap.total_count, 4);
-
-  // TODO: We should get aliasing for some of these buffers.
+  if (no_alias_buffers) {
+    ASSERT_EQ(eval_ctx.heap.total_size, intm_size + padded_intm_t_size + stencil_y_size + padded_intm_size);
+    ASSERT_EQ(eval_ctx.heap.total_count, 4);
+  } else {
+    if (schedule != 0) {
+      // The folded buffers don't alias.
+      ASSERT_EQ(eval_ctx.heap.total_size, padded_intm_t_size + stencil_y_size + padded_intm_size);
+      ASSERT_EQ(eval_ctx.heap.total_count, 3);
+    } else {
+      ASSERT_EQ(eval_ctx.heap.total_size, padded_intm_t_size + padded_intm_size);
+      ASSERT_EQ(eval_ctx.heap.total_count, 2);
+    }
+  }
 }
 
 TEST(constant, pipeline) {

--- a/builder/test/visualize/padded_stencil_0.html
+++ b/builder/test/visualize/padded_stencil_0.html
@@ -336,26 +336,50 @@ function pipeline(__in, out) {
     let g2 = buffer_max(__in, 1);
     check(((buffer_fold_factor(__in, 0) == 9223372036854775807) || ((min(g0, (buffer_max(out, 0) + 1)) + 1) <= (max(g, (buffer_min(out, 0) + -1)) + buffer_fold_factor(__in, 0)))));
     check(((buffer_fold_factor(__in, 1) == 9223372036854775807) || ((min(g2, (buffer_max(out, 1) + 1)) + 1) <= (max(g1, (buffer_min(out, 1) + -1)) + buffer_fold_factor(__in, 1)))));
-    { let intm = allocate('intm', 2, [
-        {bounds:{min:max(g, (buffer_min(out, 0) + -1)), max:min(g0, (buffer_max(out, 0) + 1))}, stride:NaN, fold_factor:9223372036854775807},
-        {bounds:{min:max(g1, (buffer_min(out, 1) + -1)), max:min(g2, (buffer_max(out, 1) + 1))}, stride:NaN, fold_factor:9223372036854775807}
+    { let intm_padded_intm = allocate('intm/padded_intm', 2, [
+        {bounds:{min:(buffer_min(out, 0) + -1), max:(buffer_max(out, 0) + 1)}, stride:NaN, fold_factor:9223372036854775807},
+        {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:NaN, fold_factor:9223372036854775807}
       ]);
-      consume(__in);
-      produce(intm);
-      __event_t++;
-      { let padded_intm = allocate('padded_intm', 2, [
-          {bounds:{min:(buffer_min(out, 0) + -1), max:(buffer_max(out, 0) + 1)}, stride:NaN, fold_factor:9223372036854775807},
-          {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:NaN, fold_factor:9223372036854775807}
-        ]);
-        consume(intm);
-        produce(padded_intm);
+      { let __intm = crop_buffer(intm_padded_intm, [
+          {min:max(g, (buffer_min(out, 0) + -1)), max:min(g0, (buffer_max(out, 0) + 1))},
+          {min:max(g1, (buffer_min(out, 1) + -1)), max:min(g2, (buffer_max(out, 1) + 1))}
+      ]);
+        consume(__in);
+        produce(intm);
         __event_t++;
-        consume(padded_intm);
-        produce(out);
-        __event_t++;
-        free(padded_intm);
+        intm = __intm;
       }
-      free(intm);
+      { let __intm = crop_buffer(intm_padded_intm, [
+          {min:max(g, (buffer_min(out, 0) + -1)), max:min(g0, (buffer_max(out, 0) + 1))},
+          {min:max(g1, (buffer_min(out, 1) + -1)), max:min(g2, (buffer_max(out, 1) + 1))}
+      ]);
+        {
+          let __base = buffer_at(intm_padded_intm, (buffer_min(out, 0) + -1), (buffer_min(out, 1) + -1));
+          let __elem_size = 2;
+          let __dims = [
+              {bounds:{min:(buffer_min(out, 0) + -1), max:(buffer_max(out, 0) + 1)}, stride:buffer_stride(intm, 0), fold_factor:buffer_fold_factor(intm, 0)},
+              {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:buffer_stride(intm, 1), fold_factor:buffer_fold_factor(intm, 1)}
+          ];
+          { let padded_intm = make_buffer('padded_intm', __base, __elem_size, __dims);            produce(intm);
+            produce(padded_intm);
+            __event_t++;
+          }
+        }
+        intm = __intm;
+      }
+      {
+        let __base = buffer_at(intm_padded_intm, (buffer_min(out, 0) + -1), (buffer_min(out, 1) + -1));
+        let __elem_size = 2;
+        let __dims = [
+            {bounds:{min:(buffer_min(out, 0) + -1), max:(buffer_max(out, 0) + 1)}, stride:buffer_stride(intm_padded_intm, 0), fold_factor:buffer_fold_factor(intm_padded_intm, 0)},
+            {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:buffer_stride(intm_padded_intm, 1), fold_factor:buffer_fold_factor(intm_padded_intm, 1)}
+        ];
+        { let padded_intm = make_buffer('padded_intm', __base, __elem_size, __dims);          consume(padded_intm);
+          produce(out);
+          __event_t++;
+        }
+      }
+      free(intm_padded_intm);
     }
   }
 }

--- a/builder/test/visualize/padded_stencil_0.html
+++ b/builder/test/visualize/padded_stencil_0.html
@@ -276,38 +276,38 @@ function make_buffer(name, base, elem_size, dims) {
 function clone_buffer(b) { return structuredClone(b); }
 function crop_dim(b, d, bounds) {
   let result = clone_buffer(b);
-  let new_min = max(b.dims[d].bounds.min, bounds.min);
-  let new_max = min(b.dims[d].bounds.max, bounds.max);
+  let new_min = max(result.dims[d].bounds.min, bounds.min);
+  let new_max = min(result.dims[d].bounds.max, bounds.max);
   if (new_max >= new_min) {
-    b.base += flat_offset_dim(b.dims[d], new_min);
+    result.base += flat_offset_dim(result.dims[d], new_min);
   }
-  b.dims[d].bounds.min = new_min;
-  b.dims[d].bounds.max = new_max;
+  result.dims[d].bounds.min = new_min;
+  result.dims[d].bounds.max = new_max;
   return result;
 }
 function crop_buffer(b, bounds) {
   let result = clone_buffer(b);
   for (let d = 0; d < bounds.length; ++d) {
-    crop_dim(b, d, bounds[d]);
+    result = crop_dim(result, d, bounds[d]);
   }
   return result;
 }
 function slice_dim(b, d, at) {
   let result = clone_buffer(b);
-  b.base += flat_offset_dim(b.dims[d], at);
-  b.dims.splice(d, 1);
+  result.base += flat_offset_dim(result.dims[d], at);
+  result.dims.splice(d, 1);
   return result;
 }
 function slice_buffer(b, at) {
   let result = clone_buffer(b);
   for (let d = at.length - 1; d >= 0; --d) {
-    slice_dim(b, d, at[d]);
+    result = slice_dim(result, d, at[d]);
   }
   return result;
 }
 function transpose(b, dims) {
   let result = clone_buffer(b);
-  b.dims = dims.map(i => b.dims[i]);
+  result.dims = dims.map(i => result.dims[i]);
   return result;
 }
 function produce(b) {
@@ -343,16 +343,17 @@ function pipeline(__in, out) {
       { let __intm = crop_buffer(intm_padded_intm, [
           {min:max(g, (buffer_min(out, 0) + -1)), max:min(g0, (buffer_max(out, 0) + 1))},
           {min:max(g1, (buffer_min(out, 1) + -1)), max:min(g2, (buffer_max(out, 1) + 1))}
-      ]);
+      ]); {
+        let intm = __intm;
         consume(__in);
         produce(intm);
         __event_t++;
-        intm = __intm;
-      }
+      }}
       { let __intm = crop_buffer(intm_padded_intm, [
           {min:max(g, (buffer_min(out, 0) + -1)), max:min(g0, (buffer_max(out, 0) + 1))},
           {min:max(g1, (buffer_min(out, 1) + -1)), max:min(g2, (buffer_max(out, 1) + 1))}
-      ]);
+      ]); {
+        let intm = __intm;
         {
           let __base = buffer_at(intm_padded_intm, (buffer_min(out, 0) + -1), (buffer_min(out, 1) + -1));
           let __elem_size = 2;
@@ -365,8 +366,7 @@ function pipeline(__in, out) {
             __event_t++;
           }
         }
-        intm = __intm;
-      }
+      }}
       {
         let __base = buffer_at(intm_padded_intm, (buffer_min(out, 0) + -1), (buffer_min(out, 1) + -1));
         let __elem_size = 2;

--- a/builder/test/visualize/padded_stencil_0.html
+++ b/builder/test/visualize/padded_stencil_0.html
@@ -336,26 +336,27 @@ function pipeline(__in, out) {
     let g2 = buffer_max(__in, 1);
     check(((buffer_fold_factor(__in, 0) == 9223372036854775807) || ((min(g0, (buffer_max(out, 0) + 1)) + 1) <= (max(g, (buffer_min(out, 0) + -1)) + buffer_fold_factor(__in, 0)))));
     check(((buffer_fold_factor(__in, 1) == 9223372036854775807) || ((min(g2, (buffer_max(out, 1) + 1)) + 1) <= (max(g1, (buffer_min(out, 1) + -1)) + buffer_fold_factor(__in, 1)))));
-    { let padded_intm = allocate('padded_intm', 2, [
-        {bounds:{min:(buffer_min(out, 0) + -1), max:(buffer_max(out, 0) + 1)}, stride:NaN, fold_factor:9223372036854775807},
-        {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:NaN, fold_factor:9223372036854775807}
+    { let intm = allocate('intm', 2, [
+        {bounds:{min:max(g, (buffer_min(out, 0) + -1)), max:min(g0, (buffer_max(out, 0) + 1))}, stride:NaN, fold_factor:9223372036854775807},
+        {bounds:{min:max(g1, (buffer_min(out, 1) + -1)), max:min(g2, (buffer_max(out, 1) + 1))}, stride:NaN, fold_factor:9223372036854775807}
       ]);
-      { let intm = allocate('intm', 2, [
-          {bounds:{min:max(g, (buffer_min(out, 0) + -1)), max:min(g0, (buffer_max(out, 0) + 1))}, stride:NaN, fold_factor:9223372036854775807},
-          {bounds:{min:max(g1, (buffer_min(out, 1) + -1)), max:min(g2, (buffer_max(out, 1) + 1))}, stride:NaN, fold_factor:9223372036854775807}
+      consume(__in);
+      produce(intm);
+      __event_t++;
+      { let padded_intm = allocate('padded_intm', 2, [
+          {bounds:{min:(buffer_min(out, 0) + -1), max:(buffer_max(out, 0) + 1)}, stride:NaN, fold_factor:9223372036854775807},
+          {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:NaN, fold_factor:9223372036854775807}
         ]);
-        consume(__in);
-        produce(intm);
-        __event_t++;
         consume(intm);
         produce(padded_intm);
         __event_t++;
-        free(intm);
+        check(free(intm));
+        consume(padded_intm);
+        produce(out);
+        __event_t++;
+        free(padded_intm);
       }
-      consume(padded_intm);
-      produce(out);
-      __event_t++;
-      free(padded_intm);
+      free(intm);
     }
   }
 }

--- a/builder/test/visualize/padded_stencil_0.html
+++ b/builder/test/visualize/padded_stencil_0.html
@@ -350,7 +350,6 @@ function pipeline(__in, out) {
         consume(intm);
         produce(padded_intm);
         __event_t++;
-        check(free(intm));
         consume(padded_intm);
         produce(out);
         __event_t++;

--- a/builder/test/visualize/padded_stencil_1.html
+++ b/builder/test/visualize/padded_stencil_1.html
@@ -336,26 +336,50 @@ function pipeline(__in, out) {
     let g2 = buffer_max(__in, 1);
     check(((buffer_fold_factor(__in, 0) == 9223372036854775807) || ((min(g0, (buffer_max(out, 0) + 1)) + 1) <= (max(g, (buffer_min(out, 0) + -1)) + buffer_fold_factor(__in, 0)))));
     check(((buffer_fold_factor(__in, 1) == 9223372036854775807) || ((min(g2, (buffer_max(out, 1) + 1)) + 1) <= (max(g1, (buffer_min(out, 1) + -1)) + buffer_fold_factor(__in, 1)))));
-    { let intm = allocate('intm', 2, [
-        {bounds:{min:max(g, (buffer_min(out, 0) + -1)), max:min(g0, (buffer_max(out, 0) + 1))}, stride:NaN, fold_factor:9223372036854775807},
-        {bounds:{min:max(g1, (buffer_min(out, 1) + -1)), max:min(g2, (buffer_max(out, 1) + 1))}, stride:NaN, fold_factor:9223372036854775807}
+    { let intm_padded_intm = allocate('intm/padded_intm', 2, [
+        {bounds:{min:(buffer_min(out, 0) + -1), max:(buffer_max(out, 0) + 1)}, stride:NaN, fold_factor:9223372036854775807},
+        {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:NaN, fold_factor:9223372036854775807}
       ]);
-      consume(__in);
-      produce(intm);
-      __event_t++;
-      { let padded_intm = allocate('padded_intm', 2, [
-          {bounds:{min:(buffer_min(out, 0) + -1), max:(buffer_max(out, 0) + 1)}, stride:NaN, fold_factor:9223372036854775807},
-          {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:NaN, fold_factor:9223372036854775807}
-        ]);
-        consume(intm);
-        produce(padded_intm);
+      { let __intm = crop_buffer(intm_padded_intm, [
+          {min:max(g, (buffer_min(out, 0) + -1)), max:min(g0, (buffer_max(out, 0) + 1))},
+          {min:max(g1, (buffer_min(out, 1) + -1)), max:min(g2, (buffer_max(out, 1) + 1))}
+      ]);
+        consume(__in);
+        produce(intm);
         __event_t++;
-        consume(padded_intm);
-        produce(out);
-        __event_t++;
-        free(padded_intm);
+        intm = __intm;
       }
-      free(intm);
+      { let __intm = crop_buffer(intm_padded_intm, [
+          {min:max(g, (buffer_min(out, 0) + -1)), max:min(g0, (buffer_max(out, 0) + 1))},
+          {min:max(g1, (buffer_min(out, 1) + -1)), max:min(g2, (buffer_max(out, 1) + 1))}
+      ]);
+        {
+          let __base = buffer_at(intm_padded_intm, (buffer_min(out, 0) + -1), (buffer_min(out, 1) + -1));
+          let __elem_size = 2;
+          let __dims = [
+              {bounds:{min:(buffer_min(out, 0) + -1), max:(buffer_max(out, 0) + 1)}, stride:buffer_stride(intm, 0), fold_factor:buffer_fold_factor(intm, 0)},
+              {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:buffer_stride(intm, 1), fold_factor:buffer_fold_factor(intm, 1)}
+          ];
+          { let padded_intm = make_buffer('padded_intm', __base, __elem_size, __dims);            produce(intm);
+            produce(padded_intm);
+            __event_t++;
+          }
+        }
+        intm = __intm;
+      }
+      {
+        let __base = buffer_at(intm_padded_intm, (buffer_min(out, 0) + -1), (buffer_min(out, 1) + -1));
+        let __elem_size = 2;
+        let __dims = [
+            {bounds:{min:(buffer_min(out, 0) + -1), max:(buffer_max(out, 0) + 1)}, stride:buffer_stride(intm_padded_intm, 0), fold_factor:buffer_fold_factor(intm_padded_intm, 0)},
+            {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:buffer_stride(intm_padded_intm, 1), fold_factor:buffer_fold_factor(intm_padded_intm, 1)}
+        ];
+        { let padded_intm = make_buffer('padded_intm', __base, __elem_size, __dims);          consume(padded_intm);
+          produce(out);
+          __event_t++;
+        }
+      }
+      free(intm_padded_intm);
     }
   }
 }

--- a/builder/test/visualize/padded_stencil_1.html
+++ b/builder/test/visualize/padded_stencil_1.html
@@ -276,38 +276,38 @@ function make_buffer(name, base, elem_size, dims) {
 function clone_buffer(b) { return structuredClone(b); }
 function crop_dim(b, d, bounds) {
   let result = clone_buffer(b);
-  let new_min = max(b.dims[d].bounds.min, bounds.min);
-  let new_max = min(b.dims[d].bounds.max, bounds.max);
+  let new_min = max(result.dims[d].bounds.min, bounds.min);
+  let new_max = min(result.dims[d].bounds.max, bounds.max);
   if (new_max >= new_min) {
-    b.base += flat_offset_dim(b.dims[d], new_min);
+    result.base += flat_offset_dim(result.dims[d], new_min);
   }
-  b.dims[d].bounds.min = new_min;
-  b.dims[d].bounds.max = new_max;
+  result.dims[d].bounds.min = new_min;
+  result.dims[d].bounds.max = new_max;
   return result;
 }
 function crop_buffer(b, bounds) {
   let result = clone_buffer(b);
   for (let d = 0; d < bounds.length; ++d) {
-    crop_dim(b, d, bounds[d]);
+    result = crop_dim(result, d, bounds[d]);
   }
   return result;
 }
 function slice_dim(b, d, at) {
   let result = clone_buffer(b);
-  b.base += flat_offset_dim(b.dims[d], at);
-  b.dims.splice(d, 1);
+  result.base += flat_offset_dim(result.dims[d], at);
+  result.dims.splice(d, 1);
   return result;
 }
 function slice_buffer(b, at) {
   let result = clone_buffer(b);
   for (let d = at.length - 1; d >= 0; --d) {
-    slice_dim(b, d, at[d]);
+    result = slice_dim(result, d, at[d]);
   }
   return result;
 }
 function transpose(b, dims) {
   let result = clone_buffer(b);
-  b.dims = dims.map(i => b.dims[i]);
+  result.dims = dims.map(i => result.dims[i]);
   return result;
 }
 function produce(b) {
@@ -343,16 +343,17 @@ function pipeline(__in, out) {
       { let __intm = crop_buffer(intm_padded_intm, [
           {min:max(g, (buffer_min(out, 0) + -1)), max:min(g0, (buffer_max(out, 0) + 1))},
           {min:max(g1, (buffer_min(out, 1) + -1)), max:min(g2, (buffer_max(out, 1) + 1))}
-      ]);
+      ]); {
+        let intm = __intm;
         consume(__in);
         produce(intm);
         __event_t++;
-        intm = __intm;
-      }
+      }}
       { let __intm = crop_buffer(intm_padded_intm, [
           {min:max(g, (buffer_min(out, 0) + -1)), max:min(g0, (buffer_max(out, 0) + 1))},
           {min:max(g1, (buffer_min(out, 1) + -1)), max:min(g2, (buffer_max(out, 1) + 1))}
-      ]);
+      ]); {
+        let intm = __intm;
         {
           let __base = buffer_at(intm_padded_intm, (buffer_min(out, 0) + -1), (buffer_min(out, 1) + -1));
           let __elem_size = 2;
@@ -365,8 +366,7 @@ function pipeline(__in, out) {
             __event_t++;
           }
         }
-        intm = __intm;
-      }
+      }}
       {
         let __base = buffer_at(intm_padded_intm, (buffer_min(out, 0) + -1), (buffer_min(out, 1) + -1));
         let __elem_size = 2;

--- a/builder/test/visualize/padded_stencil_1.html
+++ b/builder/test/visualize/padded_stencil_1.html
@@ -336,26 +336,27 @@ function pipeline(__in, out) {
     let g2 = buffer_max(__in, 1);
     check(((buffer_fold_factor(__in, 0) == 9223372036854775807) || ((min(g0, (buffer_max(out, 0) + 1)) + 1) <= (max(g, (buffer_min(out, 0) + -1)) + buffer_fold_factor(__in, 0)))));
     check(((buffer_fold_factor(__in, 1) == 9223372036854775807) || ((min(g2, (buffer_max(out, 1) + 1)) + 1) <= (max(g1, (buffer_min(out, 1) + -1)) + buffer_fold_factor(__in, 1)))));
-    { let padded_intm = allocate('padded_intm', 2, [
-        {bounds:{min:(buffer_min(out, 0) + -1), max:(buffer_max(out, 0) + 1)}, stride:NaN, fold_factor:9223372036854775807},
-        {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:NaN, fold_factor:9223372036854775807}
+    { let intm = allocate('intm', 2, [
+        {bounds:{min:max(g, (buffer_min(out, 0) + -1)), max:min(g0, (buffer_max(out, 0) + 1))}, stride:NaN, fold_factor:9223372036854775807},
+        {bounds:{min:max(g1, (buffer_min(out, 1) + -1)), max:min(g2, (buffer_max(out, 1) + 1))}, stride:NaN, fold_factor:9223372036854775807}
       ]);
-      { let intm = allocate('intm', 2, [
-          {bounds:{min:max(g, (buffer_min(out, 0) + -1)), max:min(g0, (buffer_max(out, 0) + 1))}, stride:NaN, fold_factor:9223372036854775807},
-          {bounds:{min:max(g1, (buffer_min(out, 1) + -1)), max:min(g2, (buffer_max(out, 1) + 1))}, stride:NaN, fold_factor:9223372036854775807}
+      consume(__in);
+      produce(intm);
+      __event_t++;
+      { let padded_intm = allocate('padded_intm', 2, [
+          {bounds:{min:(buffer_min(out, 0) + -1), max:(buffer_max(out, 0) + 1)}, stride:NaN, fold_factor:9223372036854775807},
+          {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:NaN, fold_factor:9223372036854775807}
         ]);
-        consume(__in);
-        produce(intm);
-        __event_t++;
         consume(intm);
         produce(padded_intm);
         __event_t++;
-        free(intm);
+        check(free(intm));
+        consume(padded_intm);
+        produce(out);
+        __event_t++;
+        free(padded_intm);
       }
-      consume(padded_intm);
-      produce(out);
-      __event_t++;
-      free(padded_intm);
+      free(intm);
     }
   }
 }

--- a/builder/test/visualize/padded_stencil_1.html
+++ b/builder/test/visualize/padded_stencil_1.html
@@ -350,7 +350,6 @@ function pipeline(__in, out) {
         consume(intm);
         produce(padded_intm);
         __event_t++;
-        check(free(intm));
         consume(padded_intm);
         produce(out);
         __event_t++;

--- a/builder/test/visualize/padded_stencil_2.html
+++ b/builder/test/visualize/padded_stencil_2.html
@@ -336,16 +336,16 @@ function pipeline(__in, out) {
     let g2 = buffer_max(__in, 1);
     check(((buffer_fold_factor(__in, 0) == 9223372036854775807) || ((min(g0, (buffer_max(out, 0) + 1)) + 1) <= (max(g, (buffer_min(out, 0) + -1)) + buffer_fold_factor(__in, 0)))));
     check(((buffer_fold_factor(__in, 1) == 9223372036854775807) || ((min(g2, (buffer_max(out, 1) + 1)) + 1) <= (max(g1, (buffer_min(out, 1) + -1)) + buffer_fold_factor(__in, 1)))));
-    { let padded_intm = allocate('padded_intm', 2, [
-        {bounds:{min:(buffer_min(out, 0) + -1), max:(buffer_max(out, 0) + 1)}, stride:NaN, fold_factor:9223372036854775807},
-        {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:NaN, fold_factor:3}
+    { let intm = allocate('intm', 2, [
+        {bounds:{min:max(g, (buffer_min(out, 0) + -1)), max:min(g0, (buffer_max(out, 0) + 1))}, stride:NaN, fold_factor:9223372036854775807},
+        {bounds:{min:max(g1, (buffer_min(out, 1) + -1)), max:min(g2, (buffer_max(out, 1) + 1))}, stride:NaN, fold_factor:1}
       ]);
-      { let padded_intm_uncropped = clone_buffer(padded_intm);
-        { let intm = allocate('intm', 2, [
-            {bounds:{min:max(g, (buffer_min(out, 0) + -1)), max:min(g0, (buffer_max(out, 0) + 1))}, stride:NaN, fold_factor:9223372036854775807},
-            {bounds:{min:max(g1, (buffer_min(out, 1) + -1)), max:min(g2, (buffer_max(out, 1) + 1))}, stride:NaN, fold_factor:1}
+      { let intm_uncropped = clone_buffer(intm);
+        { let padded_intm = allocate('padded_intm', 2, [
+            {bounds:{min:(buffer_min(out, 0) + -1), max:(buffer_max(out, 0) + 1)}, stride:NaN, fold_factor:9223372036854775807},
+            {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:NaN, fold_factor:3}
           ]);
-          { let intm_uncropped = clone_buffer(intm);
+          { let padded_intm_uncropped = clone_buffer(padded_intm);
             {
               let y_min_orig = buffer_min(out, 1);
               let __loop_min = (buffer_min(out, 1) + -2);
@@ -373,10 +373,10 @@ function pipeline(__in, out) {
               }
             }
           }
-          free(intm);
+          free(padded_intm);
         }
       }
-      free(padded_intm);
+      free(intm);
     }
   }
 }

--- a/builder/test/visualize/padded_stencil_2.html
+++ b/builder/test/visualize/padded_stencil_2.html
@@ -276,38 +276,38 @@ function make_buffer(name, base, elem_size, dims) {
 function clone_buffer(b) { return structuredClone(b); }
 function crop_dim(b, d, bounds) {
   let result = clone_buffer(b);
-  let new_min = max(b.dims[d].bounds.min, bounds.min);
-  let new_max = min(b.dims[d].bounds.max, bounds.max);
+  let new_min = max(result.dims[d].bounds.min, bounds.min);
+  let new_max = min(result.dims[d].bounds.max, bounds.max);
   if (new_max >= new_min) {
-    b.base += flat_offset_dim(b.dims[d], new_min);
+    result.base += flat_offset_dim(result.dims[d], new_min);
   }
-  b.dims[d].bounds.min = new_min;
-  b.dims[d].bounds.max = new_max;
+  result.dims[d].bounds.min = new_min;
+  result.dims[d].bounds.max = new_max;
   return result;
 }
 function crop_buffer(b, bounds) {
   let result = clone_buffer(b);
   for (let d = 0; d < bounds.length; ++d) {
-    crop_dim(b, d, bounds[d]);
+    result = crop_dim(result, d, bounds[d]);
   }
   return result;
 }
 function slice_dim(b, d, at) {
   let result = clone_buffer(b);
-  b.base += flat_offset_dim(b.dims[d], at);
-  b.dims.splice(d, 1);
+  result.base += flat_offset_dim(result.dims[d], at);
+  result.dims.splice(d, 1);
   return result;
 }
 function slice_buffer(b, at) {
   let result = clone_buffer(b);
   for (let d = at.length - 1; d >= 0; --d) {
-    slice_dim(b, d, at[d]);
+    result = slice_dim(result, d, at[d]);
   }
   return result;
 }
 function transpose(b, dims) {
   let result = clone_buffer(b);
-  b.dims = dims.map(i => b.dims[i]);
+  result.dims = dims.map(i => result.dims[i]);
   return result;
 }
 function produce(b) {
@@ -352,24 +352,24 @@ function pipeline(__in, out) {
               let __loop_max = buffer_max(out, 1);
               let __loop_step = 1;
               for(let y = __loop_min; y <= __loop_max; y += __loop_step) {
-                { let __intm = crop_dim(intm, 1, {min:select((y <= y_min_orig), max(g1, (y + 1)), (min(g2, y) + 1)), max:min(g2, (y + 1))});
+                { let __intm = crop_dim(intm, 1, {min:select((y <= y_min_orig), max(g1, (y + 1)), (min(g2, y) + 1)), max:min(g2, (y + 1))}); {
+                  let intm = __intm;
                   consume(__in);
                   produce(intm);
                   __event_t++;
-                  intm = __intm;
-                }
-                { let __padded_intm = crop_dim(padded_intm, 1, {min:(y + 1), max:(y + 1)});
+                }}
+                { let __padded_intm = crop_dim(padded_intm, 1, {min:(y + 1), max:(y + 1)}); {
+                  let padded_intm = __padded_intm;
                   consume(intm_uncropped);
                   produce(padded_intm);
                   __event_t++;
-                  padded_intm = __padded_intm;
-                }
-                { let __out = crop_dim(out, 1, {min:y, max:y});
+                }}
+                { let __out = crop_dim(out, 1, {min:y, max:y}); {
+                  let out = __out;
                   consume(padded_intm_uncropped);
                   produce(out);
                   __event_t++;
-                  out = __out;
-                }
+                }}
               }
             }
           }

--- a/builder/test/visualize/parallel_stencils_0.html
+++ b/builder/test/visualize/parallel_stencils_0.html
@@ -276,38 +276,38 @@ function make_buffer(name, base, elem_size, dims) {
 function clone_buffer(b) { return structuredClone(b); }
 function crop_dim(b, d, bounds) {
   let result = clone_buffer(b);
-  let new_min = max(b.dims[d].bounds.min, bounds.min);
-  let new_max = min(b.dims[d].bounds.max, bounds.max);
+  let new_min = max(result.dims[d].bounds.min, bounds.min);
+  let new_max = min(result.dims[d].bounds.max, bounds.max);
   if (new_max >= new_min) {
-    b.base += flat_offset_dim(b.dims[d], new_min);
+    result.base += flat_offset_dim(result.dims[d], new_min);
   }
-  b.dims[d].bounds.min = new_min;
-  b.dims[d].bounds.max = new_max;
+  result.dims[d].bounds.min = new_min;
+  result.dims[d].bounds.max = new_max;
   return result;
 }
 function crop_buffer(b, bounds) {
   let result = clone_buffer(b);
   for (let d = 0; d < bounds.length; ++d) {
-    crop_dim(b, d, bounds[d]);
+    result = crop_dim(result, d, bounds[d]);
   }
   return result;
 }
 function slice_dim(b, d, at) {
   let result = clone_buffer(b);
-  b.base += flat_offset_dim(b.dims[d], at);
-  b.dims.splice(d, 1);
+  result.base += flat_offset_dim(result.dims[d], at);
+  result.dims.splice(d, 1);
   return result;
 }
 function slice_buffer(b, at) {
   let result = clone_buffer(b);
   for (let d = at.length - 1; d >= 0; --d) {
-    slice_dim(b, d, at[d]);
+    result = slice_dim(result, d, at[d]);
   }
   return result;
 }
 function transpose(b, dims) {
   let result = clone_buffer(b);
-  b.dims = dims.map(i => b.dims[i]);
+  result.dims = dims.map(i => result.dims[i]);
   return result;
 }
 function produce(b) {
@@ -368,37 +368,37 @@ function pipeline(in1, in2, out) {
                   let __loop_max = buffer_max(out, 1);
                   let __loop_step = 1;
                   for(let y = __loop_min; y <= __loop_max; y += __loop_step) {
-                    { let __intm1 = crop_dim(intm1, 1, {min:(y + 1), max:(y + 1)});
+                    { let __intm1 = crop_dim(intm1, 1, {min:(y + 1), max:(y + 1)}); {
+                      let intm1 = __intm1;
                       consume(in1);
                       produce(intm1);
                       __event_t++;
-                      intm1 = __intm1;
-                    }
-                    { let __intm3 = crop_dim(intm3, 1, {min:y, max:y});
+                    }}
+                    { let __intm3 = crop_dim(intm3, 1, {min:y, max:y}); {
+                      let intm3 = __intm3;
                       consume(intm1_uncropped);
                       produce(intm3);
                       __event_t++;
-                      intm3 = __intm3;
-                    }
-                    { let __intm2 = crop_dim(intm2, 1, {min:(y + 2), max:(y + 2)});
+                    }}
+                    { let __intm2 = crop_dim(intm2, 1, {min:(y + 2), max:(y + 2)}); {
+                      let intm2 = __intm2;
                       consume(in2);
                       produce(intm2);
                       __event_t++;
-                      intm2 = __intm2;
-                    }
-                    { let __intm4 = crop_dim(intm4, 1, {min:y, max:y});
+                    }}
+                    { let __intm4 = crop_dim(intm4, 1, {min:y, max:y}); {
+                      let intm4 = __intm4;
                       consume(intm2_uncropped);
                       produce(intm4);
                       __event_t++;
-                      intm4 = __intm4;
-                    }
-                    { let __out = crop_dim(out, 1, {min:y, max:y});
+                    }}
+                    { let __out = crop_dim(out, 1, {min:y, max:y}); {
+                      let out = __out;
                       consume(intm3_uncropped);
                       consume(intm4_uncropped);
                       produce(out);
                       __event_t++;
-                      out = __out;
-                    }
+                    }}
                   }
                 }
                 free(intm4);

--- a/builder/test/visualize/parallel_stencils_0.html
+++ b/builder/test/visualize/parallel_stencils_0.html
@@ -344,26 +344,26 @@ function pipeline(in1, in2, out) {
   check(((buffer_min(in2, 1) + 2) <= buffer_min(out, 1)));
   check(((buffer_max(out, 1) + 2) <= buffer_max(in2, 1)));
   check(((buffer_fold_factor(in2, 1) == 9223372036854775807) || ((buffer_max(out, 1) + 5) <= (buffer_fold_factor(in2, 1) + buffer_min(out, 1)))));
-  { let intm4 = allocate('intm4', 2, [
-      {bounds:{min:buffer_min(out, 0), max:buffer_max(out, 0)}, stride:NaN, fold_factor:9223372036854775807},
-      {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:NaN, fold_factor:1}
+  { let intm1 = allocate('intm1', 2, [
+      {bounds:{min:(buffer_min(out, 0) + -1), max:(buffer_max(out, 0) + 1)}, stride:NaN, fold_factor:9223372036854775807},
+      {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:NaN, fold_factor:3}
     ]);
-    { let intm4_uncropped = clone_buffer(intm4);
-      { let intm2 = allocate('intm2', 2, [
-          {bounds:{min:(buffer_min(out, 0) + -2), max:(buffer_max(out, 0) + 2)}, stride:NaN, fold_factor:9223372036854775807},
-          {bounds:{min:(buffer_min(out, 1) + -2), max:(buffer_max(out, 1) + 2)}, stride:NaN, fold_factor:5}
+    { let intm1_uncropped = clone_buffer(intm1);
+      { let intm3 = allocate('intm3', 2, [
+          {bounds:{min:buffer_min(out, 0), max:buffer_max(out, 0)}, stride:NaN, fold_factor:9223372036854775807},
+          {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:NaN, fold_factor:1}
         ]);
-        { let intm2_uncropped = clone_buffer(intm2);
-          { let intm3 = allocate('intm3', 2, [
-              {bounds:{min:buffer_min(out, 0), max:buffer_max(out, 0)}, stride:NaN, fold_factor:9223372036854775807},
-              {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:NaN, fold_factor:1}
+        { let intm3_uncropped = clone_buffer(intm3);
+          { let intm2 = allocate('intm2', 2, [
+              {bounds:{min:(buffer_min(out, 0) + -2), max:(buffer_max(out, 0) + 2)}, stride:NaN, fold_factor:9223372036854775807},
+              {bounds:{min:(buffer_min(out, 1) + -2), max:(buffer_max(out, 1) + 2)}, stride:NaN, fold_factor:5}
             ]);
-            { let intm3_uncropped = clone_buffer(intm3);
-              { let intm1 = allocate('intm1', 2, [
-                  {bounds:{min:(buffer_min(out, 0) + -1), max:(buffer_max(out, 0) + 1)}, stride:NaN, fold_factor:9223372036854775807},
-                  {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:NaN, fold_factor:3}
+            { let intm2_uncropped = clone_buffer(intm2);
+              { let intm4 = allocate('intm4', 2, [
+                  {bounds:{min:buffer_min(out, 0), max:buffer_max(out, 0)}, stride:NaN, fold_factor:9223372036854775807},
+                  {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:NaN, fold_factor:1}
                 ]);
-                { let intm1_uncropped = clone_buffer(intm1);
+                { let intm4_uncropped = clone_buffer(intm4);
                   let __loop_min = (buffer_min(out, 1) + -6);
                   let __loop_max = buffer_max(out, 1);
                   let __loop_step = 1;
@@ -401,16 +401,16 @@ function pipeline(in1, in2, out) {
                     }
                   }
                 }
-                free(intm1);
+                free(intm4);
               }
             }
-            free(intm3);
+            free(intm2);
           }
         }
-        free(intm2);
+        free(intm3);
       }
     }
-    free(intm4);
+    free(intm1);
   }
 }
 let in1 = allocate('in1', 2, [{bounds: {min:-1, max:20}, stride:2, fold_factor:9223372036854775807}, {bounds: {min:-1, max:30}, stride:44, fold_factor:9223372036854775807}], true);

--- a/builder/test/visualize/parallel_stencils_1.html
+++ b/builder/test/visualize/parallel_stencils_1.html
@@ -276,38 +276,38 @@ function make_buffer(name, base, elem_size, dims) {
 function clone_buffer(b) { return structuredClone(b); }
 function crop_dim(b, d, bounds) {
   let result = clone_buffer(b);
-  let new_min = max(b.dims[d].bounds.min, bounds.min);
-  let new_max = min(b.dims[d].bounds.max, bounds.max);
+  let new_min = max(result.dims[d].bounds.min, bounds.min);
+  let new_max = min(result.dims[d].bounds.max, bounds.max);
   if (new_max >= new_min) {
-    b.base += flat_offset_dim(b.dims[d], new_min);
+    result.base += flat_offset_dim(result.dims[d], new_min);
   }
-  b.dims[d].bounds.min = new_min;
-  b.dims[d].bounds.max = new_max;
+  result.dims[d].bounds.min = new_min;
+  result.dims[d].bounds.max = new_max;
   return result;
 }
 function crop_buffer(b, bounds) {
   let result = clone_buffer(b);
   for (let d = 0; d < bounds.length; ++d) {
-    crop_dim(b, d, bounds[d]);
+    result = crop_dim(result, d, bounds[d]);
   }
   return result;
 }
 function slice_dim(b, d, at) {
   let result = clone_buffer(b);
-  b.base += flat_offset_dim(b.dims[d], at);
-  b.dims.splice(d, 1);
+  result.base += flat_offset_dim(result.dims[d], at);
+  result.dims.splice(d, 1);
   return result;
 }
 function slice_buffer(b, at) {
   let result = clone_buffer(b);
   for (let d = at.length - 1; d >= 0; --d) {
-    slice_dim(b, d, at[d]);
+    result = slice_dim(result, d, at[d]);
   }
   return result;
 }
 function transpose(b, dims) {
   let result = clone_buffer(b);
-  b.dims = dims.map(i => b.dims[i]);
+  result.dims = dims.map(i => result.dims[i]);
   return result;
 }
 function produce(b) {
@@ -370,39 +370,39 @@ function pipeline(in1, in2, out) {
                 let __loop_max = buffer_max(out, 1);
                 let __loop_step = 2;
                 for(let y = __loop_min; y <= __loop_max; y += __loop_step) {
-                  { let __intm3 = crop_dim(intm3, 1, {min:y, max:min((y + 1), buffer_max(out, 1))});
+                  { let __intm3 = crop_dim(intm3, 1, {min:y, max:min((y + 1), buffer_max(out, 1))}); {
+                    let intm3 = __intm3;
                     let __loop_min = max(y, buffer_min(out, 1));
                     let __loop_max = min((y + 1), buffer_max(out, 1));
                     let __loop_step = 1;
                     for(let y = __loop_min; y <= __loop_max; y += __loop_step) {
-                      { let __intm3 = crop_dim(intm3, 1, {min:NaN, max:y});
+                      { let __intm3 = crop_dim(intm3, 1, {min:NaN, max:y}); {
+                        let intm3 = __intm3;
                         consume(intm1);
                         produce(intm3);
                         __event_t++;
-                        intm3 = __intm3;
-                      }
+                      }}
                     }
-                    intm3 = __intm3;
-                  }
-                  { let __intm2 = crop_dim(intm2, 1, {min:(y + 2), max:(min((y + 1), buffer_max(out, 1)) + 2)});
+                  }}
+                  { let __intm2 = crop_dim(intm2, 1, {min:(y + 2), max:(min((y + 1), buffer_max(out, 1)) + 2)}); {
+                    let intm2 = __intm2;
                     consume(in2);
                     produce(intm2);
                     __event_t++;
-                    intm2 = __intm2;
-                  }
-                  { let __intm4 = crop_dim(intm4, 1, {min:y, max:min((y + 1), buffer_max(out, 1))});
+                  }}
+                  { let __intm4 = crop_dim(intm4, 1, {min:y, max:min((y + 1), buffer_max(out, 1))}); {
+                    let intm4 = __intm4;
                     consume(intm2_uncropped);
                     produce(intm4);
                     __event_t++;
-                    intm4 = __intm4;
-                  }
-                  { let __out = crop_dim(out, 1, {min:y, max:(y + 1)});
+                  }}
+                  { let __out = crop_dim(out, 1, {min:y, max:(y + 1)}); {
+                    let out = __out;
                     consume(intm3_uncropped);
                     consume(intm4_uncropped);
                     produce(out);
                     __event_t++;
-                    out = __out;
-                  }
+                  }}
                 }
               }
               free(intm4);

--- a/builder/test/visualize/parallel_stencils_1.html
+++ b/builder/test/visualize/parallel_stencils_1.html
@@ -344,28 +344,28 @@ function pipeline(in1, in2, out) {
   check(((buffer_min(in2, 1) + 2) <= buffer_min(out, 1)));
   check(((buffer_max(out, 1) + 2) <= buffer_max(in2, 1)));
   check(((buffer_fold_factor(in2, 1) == 9223372036854775807) || ((buffer_max(out, 1) + 5) <= (buffer_fold_factor(in2, 1) + buffer_min(out, 1)))));
-  { let intm4 = allocate('intm4', 2, [
-      {bounds:{min:buffer_min(out, 0), max:buffer_max(out, 0)}, stride:NaN, fold_factor:9223372036854775807},
-      {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:NaN, fold_factor:2}
+  { let intm1 = allocate('intm1', 2, [
+      {bounds:{min:(buffer_min(out, 0) + -1), max:(buffer_max(out, 0) + 1)}, stride:NaN, fold_factor:9223372036854775807},
+      {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:NaN, fold_factor:9223372036854775807}
     ]);
-    { let intm4_uncropped = clone_buffer(intm4);
-      { let intm2 = allocate('intm2', 2, [
-          {bounds:{min:(buffer_min(out, 0) + -2), max:(buffer_max(out, 0) + 2)}, stride:NaN, fold_factor:9223372036854775807},
-          {bounds:{min:(buffer_min(out, 1) + -2), max:(buffer_max(out, 1) + 2)}, stride:NaN, fold_factor:6}
-        ]);
-        { let intm2_uncropped = clone_buffer(intm2);
-          { let intm3 = allocate('intm3', 2, [
-              {bounds:{min:buffer_min(out, 0), max:buffer_max(out, 0)}, stride:NaN, fold_factor:9223372036854775807},
-              {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:NaN, fold_factor:2}
-            ]);
-            { let intm3_uncropped = clone_buffer(intm3);
-              { let intm1 = allocate('intm1', 2, [
-                  {bounds:{min:(buffer_min(out, 0) + -1), max:(buffer_max(out, 0) + 1)}, stride:NaN, fold_factor:9223372036854775807},
-                  {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:NaN, fold_factor:9223372036854775807}
-                ]);
-                consume(in1);
-                produce(intm1);
-                __event_t++;
+    consume(in1);
+    produce(intm1);
+    __event_t++;
+    { let intm3 = allocate('intm3', 2, [
+        {bounds:{min:buffer_min(out, 0), max:buffer_max(out, 0)}, stride:NaN, fold_factor:9223372036854775807},
+        {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:NaN, fold_factor:2}
+      ]);
+      { let intm3_uncropped = clone_buffer(intm3);
+        { let intm2 = allocate('intm2', 2, [
+            {bounds:{min:(buffer_min(out, 0) + -2), max:(buffer_max(out, 0) + 2)}, stride:NaN, fold_factor:9223372036854775807},
+            {bounds:{min:(buffer_min(out, 1) + -2), max:(buffer_max(out, 1) + 2)}, stride:NaN, fold_factor:6}
+          ]);
+          { let intm2_uncropped = clone_buffer(intm2);
+            { let intm4 = allocate('intm4', 2, [
+                {bounds:{min:buffer_min(out, 0), max:buffer_max(out, 0)}, stride:NaN, fold_factor:9223372036854775807},
+                {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:NaN, fold_factor:2}
+              ]);
+              { let intm4_uncropped = clone_buffer(intm4);
                 let __loop_min = (buffer_min(out, 1) + -4);
                 let __loop_max = buffer_max(out, 1);
                 let __loop_step = 2;
@@ -404,16 +404,16 @@ function pipeline(in1, in2, out) {
                     out = __out;
                   }
                 }
-                free(intm1);
               }
+              free(intm4);
             }
-            free(intm3);
           }
+          free(intm2);
         }
-        free(intm2);
       }
+      free(intm3);
     }
-    free(intm4);
+    free(intm1);
   }
 }
 let in1 = allocate('in1', 2, [{bounds: {min:-1, max:20}, stride:2, fold_factor:9223372036854775807}, {bounds: {min:-1, max:30}, stride:44, fold_factor:9223372036854775807}], true);

--- a/builder/test/visualize/parallel_stencils_2.html
+++ b/builder/test/visualize/parallel_stencils_2.html
@@ -344,26 +344,26 @@ function pipeline(in1, in2, out) {
   check(((buffer_min(in2, 1) + 2) <= buffer_min(out, 1)));
   check(((buffer_max(out, 1) + 2) <= buffer_max(in2, 1)));
   check(((buffer_fold_factor(in2, 1) == 9223372036854775807) || ((buffer_max(out, 1) + 5) <= (buffer_fold_factor(in2, 1) + buffer_min(out, 1)))));
-  { let intm4 = allocate('intm4', 2, [
-      {bounds:{min:buffer_min(out, 0), max:buffer_max(out, 0)}, stride:NaN, fold_factor:9223372036854775807},
-      {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:NaN, fold_factor:2}
+  { let intm1 = allocate('intm1', 2, [
+      {bounds:{min:(buffer_min(out, 0) + -1), max:(buffer_max(out, 0) + 1)}, stride:NaN, fold_factor:9223372036854775807},
+      {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:NaN, fold_factor:4}
     ]);
-    { let intm4_uncropped = clone_buffer(intm4);
-      { let intm2 = allocate('intm2', 2, [
-          {bounds:{min:(buffer_min(out, 0) + -2), max:(buffer_max(out, 0) + 2)}, stride:NaN, fold_factor:9223372036854775807},
-          {bounds:{min:(buffer_min(out, 1) + -2), max:(buffer_max(out, 1) + 2)}, stride:NaN, fold_factor:6}
+    { let intm1_uncropped = clone_buffer(intm1);
+      { let intm3 = allocate('intm3', 2, [
+          {bounds:{min:buffer_min(out, 0), max:buffer_max(out, 0)}, stride:NaN, fold_factor:9223372036854775807},
+          {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:NaN, fold_factor:2}
         ]);
-        { let intm2_uncropped = clone_buffer(intm2);
-          { let intm3 = allocate('intm3', 2, [
-              {bounds:{min:buffer_min(out, 0), max:buffer_max(out, 0)}, stride:NaN, fold_factor:9223372036854775807},
-              {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:NaN, fold_factor:2}
+        { let intm3_uncropped = clone_buffer(intm3);
+          { let intm2 = allocate('intm2', 2, [
+              {bounds:{min:(buffer_min(out, 0) + -2), max:(buffer_max(out, 0) + 2)}, stride:NaN, fold_factor:9223372036854775807},
+              {bounds:{min:(buffer_min(out, 1) + -2), max:(buffer_max(out, 1) + 2)}, stride:NaN, fold_factor:6}
             ]);
-            { let intm3_uncropped = clone_buffer(intm3);
-              { let intm1 = allocate('intm1', 2, [
-                  {bounds:{min:(buffer_min(out, 0) + -1), max:(buffer_max(out, 0) + 1)}, stride:NaN, fold_factor:9223372036854775807},
-                  {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:NaN, fold_factor:4}
+            { let intm2_uncropped = clone_buffer(intm2);
+              { let intm4 = allocate('intm4', 2, [
+                  {bounds:{min:buffer_min(out, 0), max:buffer_max(out, 0)}, stride:NaN, fold_factor:9223372036854775807},
+                  {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:NaN, fold_factor:2}
                 ]);
-                { let intm1_uncropped = clone_buffer(intm1);
+                { let intm4_uncropped = clone_buffer(intm4);
                   let __loop_min = (buffer_min(out, 1) + -6);
                   let __loop_max = buffer_max(out, 1);
                   let __loop_step = 2;
@@ -401,16 +401,16 @@ function pipeline(in1, in2, out) {
                     }
                   }
                 }
-                free(intm1);
+                free(intm4);
               }
             }
-            free(intm3);
+            free(intm2);
           }
         }
-        free(intm2);
+        free(intm3);
       }
     }
-    free(intm4);
+    free(intm1);
   }
 }
 let in1 = allocate('in1', 2, [{bounds: {min:-1, max:20}, stride:2, fold_factor:9223372036854775807}, {bounds: {min:-1, max:30}, stride:44, fold_factor:9223372036854775807}], true);

--- a/builder/test/visualize/parallel_stencils_2.html
+++ b/builder/test/visualize/parallel_stencils_2.html
@@ -276,38 +276,38 @@ function make_buffer(name, base, elem_size, dims) {
 function clone_buffer(b) { return structuredClone(b); }
 function crop_dim(b, d, bounds) {
   let result = clone_buffer(b);
-  let new_min = max(b.dims[d].bounds.min, bounds.min);
-  let new_max = min(b.dims[d].bounds.max, bounds.max);
+  let new_min = max(result.dims[d].bounds.min, bounds.min);
+  let new_max = min(result.dims[d].bounds.max, bounds.max);
   if (new_max >= new_min) {
-    b.base += flat_offset_dim(b.dims[d], new_min);
+    result.base += flat_offset_dim(result.dims[d], new_min);
   }
-  b.dims[d].bounds.min = new_min;
-  b.dims[d].bounds.max = new_max;
+  result.dims[d].bounds.min = new_min;
+  result.dims[d].bounds.max = new_max;
   return result;
 }
 function crop_buffer(b, bounds) {
   let result = clone_buffer(b);
   for (let d = 0; d < bounds.length; ++d) {
-    crop_dim(b, d, bounds[d]);
+    result = crop_dim(result, d, bounds[d]);
   }
   return result;
 }
 function slice_dim(b, d, at) {
   let result = clone_buffer(b);
-  b.base += flat_offset_dim(b.dims[d], at);
-  b.dims.splice(d, 1);
+  result.base += flat_offset_dim(result.dims[d], at);
+  result.dims.splice(d, 1);
   return result;
 }
 function slice_buffer(b, at) {
   let result = clone_buffer(b);
   for (let d = at.length - 1; d >= 0; --d) {
-    slice_dim(b, d, at[d]);
+    result = slice_dim(result, d, at[d]);
   }
   return result;
 }
 function transpose(b, dims) {
   let result = clone_buffer(b);
-  b.dims = dims.map(i => b.dims[i]);
+  result.dims = dims.map(i => result.dims[i]);
   return result;
 }
 function produce(b) {
@@ -368,37 +368,37 @@ function pipeline(in1, in2, out) {
                   let __loop_max = buffer_max(out, 1);
                   let __loop_step = 2;
                   for(let y = __loop_min; y <= __loop_max; y += __loop_step) {
-                    { let __intm1 = crop_dim(intm1, 1, {min:(y + 1), max:(min((y + 1), buffer_max(out, 1)) + 1)});
+                    { let __intm1 = crop_dim(intm1, 1, {min:(y + 1), max:(min((y + 1), buffer_max(out, 1)) + 1)}); {
+                      let intm1 = __intm1;
                       consume(in1);
                       produce(intm1);
                       __event_t++;
-                      intm1 = __intm1;
-                    }
-                    { let __intm3 = crop_dim(intm3, 1, {min:y, max:min((y + 1), buffer_max(out, 1))});
+                    }}
+                    { let __intm3 = crop_dim(intm3, 1, {min:y, max:min((y + 1), buffer_max(out, 1))}); {
+                      let intm3 = __intm3;
                       consume(intm1_uncropped);
                       produce(intm3);
                       __event_t++;
-                      intm3 = __intm3;
-                    }
-                    { let __intm2 = crop_dim(intm2, 1, {min:(y + 2), max:(min((y + 1), buffer_max(out, 1)) + 2)});
+                    }}
+                    { let __intm2 = crop_dim(intm2, 1, {min:(y + 2), max:(min((y + 1), buffer_max(out, 1)) + 2)}); {
+                      let intm2 = __intm2;
                       consume(in2);
                       produce(intm2);
                       __event_t++;
-                      intm2 = __intm2;
-                    }
-                    { let __intm4 = crop_dim(intm4, 1, {min:y, max:min((y + 1), buffer_max(out, 1))});
+                    }}
+                    { let __intm4 = crop_dim(intm4, 1, {min:y, max:min((y + 1), buffer_max(out, 1))}); {
+                      let intm4 = __intm4;
                       consume(intm2_uncropped);
                       produce(intm4);
                       __event_t++;
-                      intm4 = __intm4;
-                    }
-                    { let __out = crop_dim(out, 1, {min:y, max:(y + 1)});
+                    }}
+                    { let __out = crop_dim(out, 1, {min:y, max:(y + 1)}); {
+                      let out = __out;
                       consume(intm3_uncropped);
                       consume(intm4_uncropped);
                       produce(out);
                       __event_t++;
-                      out = __out;
-                    }
+                    }}
                   }
                 }
                 free(intm4);

--- a/builder/test/visualize/softmax_split_0.html
+++ b/builder/test/visualize/softmax_split_0.html
@@ -351,7 +351,6 @@ function pipeline(__in, out) {
         consume(softmax_in);
         produce(max_in);
         __event_t++;
-        check(free(softmax_in));
         { let sum_exp_in = allocate('sum_exp_in', 4, [
             {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:NaN, fold_factor:9223372036854775807}
           ]);
@@ -365,7 +364,6 @@ function pipeline(__in, out) {
               produce(exp_in);
               produce(sum_exp_in);
               __event_t++;
-              check(free(max_in));
               { let softmax_out = allocate('softmax_out', 4, [
                   {bounds:{min:buffer_min(out, 0), max:buffer_max(out, 0)}, stride:NaN, fold_factor:9223372036854775807},
                   {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:NaN, fold_factor:9223372036854775807}
@@ -374,8 +372,6 @@ function pipeline(__in, out) {
                 consume(sum_exp_in_uncropped);
                 produce(softmax_out);
                 __event_t++;
-                check(free(sum_exp_in));
-                check(free(exp_in));
                 consume(softmax_out);
                 produce(out);
                 __event_t++;

--- a/builder/test/visualize/softmax_split_0.html
+++ b/builder/test/visualize/softmax_split_0.html
@@ -338,53 +338,57 @@ function pipeline(__in, out) {
     check((buffer_min(__in, 1) <= buffer_min(out, 1)));
     check((buffer_max(out, 1) <= buffer_max(__in, 1)));
     check(((buffer_fold_factor(__in, 1) == 9223372036854775807) || ((buffer_max(out, 1) + 1) <= (buffer_fold_factor(__in, 1) + buffer_min(out, 1)))));
-    { let softmax_out = allocate('softmax_out', 4, [
-        {bounds:{min:buffer_min(out, 0), max:buffer_max(out, 0)}, stride:NaN, fold_factor:9223372036854775807},
+    { let softmax_in = allocate('softmax_in', 4, [
+        {bounds:{min:min(g, g0), max:max(g, g0)}, stride:NaN, fold_factor:9223372036854775807},
         {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:NaN, fold_factor:9223372036854775807}
       ]);
-      { let sum_exp_in = allocate('sum_exp_in', 4, [
+      consume(__in);
+      produce(softmax_in);
+      __event_t++;
+      { let max_in = allocate('max_in', 4, [
           {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:NaN, fold_factor:9223372036854775807}
         ]);
-        { let sum_exp_in_uncropped = clone_buffer(sum_exp_in);
-          { let exp_in = allocate('exp_in', 4, [
-              {bounds:{min:min(g, g0), max:max(g, g0)}, stride:NaN, fold_factor:9223372036854775807},
-              {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:NaN, fold_factor:9223372036854775807}
-            ]);
-            { let max_in = allocate('max_in', 4, [
+        consume(softmax_in);
+        produce(max_in);
+        __event_t++;
+        check(free(softmax_in));
+        { let sum_exp_in = allocate('sum_exp_in', 4, [
+            {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:NaN, fold_factor:9223372036854775807}
+          ]);
+          { let sum_exp_in_uncropped = clone_buffer(sum_exp_in);
+            { let exp_in = allocate('exp_in', 4, [
+                {bounds:{min:min(g, g0), max:max(g, g0)}, stride:NaN, fold_factor:9223372036854775807},
                 {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:NaN, fold_factor:9223372036854775807}
               ]);
-              { let softmax_in = allocate('softmax_in', 4, [
-                  {bounds:{min:min(g, g0), max:max(g, g0)}, stride:NaN, fold_factor:9223372036854775807},
-                  {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:NaN, fold_factor:9223372036854775807}
-                ]);
-                consume(__in);
-                produce(softmax_in);
-                __event_t++;
-                consume(softmax_in);
-                produce(max_in);
-                __event_t++;
-                free(softmax_in);
-              }
               consume(__in);
               consume(max_in);
               produce(exp_in);
               produce(sum_exp_in);
               __event_t++;
-              free(max_in);
+              check(free(max_in));
+              { let softmax_out = allocate('softmax_out', 4, [
+                  {bounds:{min:buffer_min(out, 0), max:buffer_max(out, 0)}, stride:NaN, fold_factor:9223372036854775807},
+                  {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:NaN, fold_factor:9223372036854775807}
+                ]);
+                consume(exp_in);
+                consume(sum_exp_in_uncropped);
+                produce(softmax_out);
+                __event_t++;
+                check(free(sum_exp_in));
+                check(free(exp_in));
+                consume(softmax_out);
+                produce(out);
+                __event_t++;
+                free(softmax_out);
+              }
+              free(exp_in);
             }
-            consume(exp_in);
-            consume(sum_exp_in_uncropped);
-            produce(softmax_out);
-            __event_t++;
-            free(exp_in);
           }
+          free(sum_exp_in);
         }
-        free(sum_exp_in);
+        free(max_in);
       }
-      consume(softmax_out);
-      produce(out);
-      __event_t++;
-      free(softmax_out);
+      free(softmax_in);
     }
   }
 }

--- a/builder/test/visualize/softmax_split_0.html
+++ b/builder/test/visualize/softmax_split_0.html
@@ -276,38 +276,38 @@ function make_buffer(name, base, elem_size, dims) {
 function clone_buffer(b) { return structuredClone(b); }
 function crop_dim(b, d, bounds) {
   let result = clone_buffer(b);
-  let new_min = max(b.dims[d].bounds.min, bounds.min);
-  let new_max = min(b.dims[d].bounds.max, bounds.max);
+  let new_min = max(result.dims[d].bounds.min, bounds.min);
+  let new_max = min(result.dims[d].bounds.max, bounds.max);
   if (new_max >= new_min) {
-    b.base += flat_offset_dim(b.dims[d], new_min);
+    result.base += flat_offset_dim(result.dims[d], new_min);
   }
-  b.dims[d].bounds.min = new_min;
-  b.dims[d].bounds.max = new_max;
+  result.dims[d].bounds.min = new_min;
+  result.dims[d].bounds.max = new_max;
   return result;
 }
 function crop_buffer(b, bounds) {
   let result = clone_buffer(b);
   for (let d = 0; d < bounds.length; ++d) {
-    crop_dim(b, d, bounds[d]);
+    result = crop_dim(result, d, bounds[d]);
   }
   return result;
 }
 function slice_dim(b, d, at) {
   let result = clone_buffer(b);
-  b.base += flat_offset_dim(b.dims[d], at);
-  b.dims.splice(d, 1);
+  result.base += flat_offset_dim(result.dims[d], at);
+  result.dims.splice(d, 1);
   return result;
 }
 function slice_buffer(b, at) {
   let result = clone_buffer(b);
   for (let d = at.length - 1; d >= 0; --d) {
-    slice_dim(b, d, at[d]);
+    result = slice_dim(result, d, at[d]);
   }
   return result;
 }
 function transpose(b, dims) {
   let result = clone_buffer(b);
-  b.dims = dims.map(i => b.dims[i]);
+  result.dims = dims.map(i => result.dims[i]);
   return result;
 }
 function produce(b) {

--- a/builder/test/visualize/softmax_split_0.html
+++ b/builder/test/visualize/softmax_split_0.html
@@ -351,6 +351,7 @@ function pipeline(__in, out) {
         consume(softmax_in);
         produce(max_in);
         __event_t++;
+        check(free(softmax_in));
         { let sum_exp_in = allocate('sum_exp_in', 4, [
             {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:NaN, fold_factor:9223372036854775807}
           ]);
@@ -364,6 +365,7 @@ function pipeline(__in, out) {
               produce(exp_in);
               produce(sum_exp_in);
               __event_t++;
+              check(free(max_in));
               { let softmax_out = allocate('softmax_out', 4, [
                   {bounds:{min:buffer_min(out, 0), max:buffer_max(out, 0)}, stride:NaN, fold_factor:9223372036854775807},
                   {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:NaN, fold_factor:9223372036854775807}
@@ -372,6 +374,7 @@ function pipeline(__in, out) {
                 consume(sum_exp_in_uncropped);
                 produce(softmax_out);
                 __event_t++;
+                check(free(exp_in));
                 consume(softmax_out);
                 produce(out);
                 __event_t++;

--- a/builder/test/visualize/softmax_split_1.html
+++ b/builder/test/visualize/softmax_split_1.html
@@ -338,29 +338,29 @@ function pipeline(__in, out) {
     check((buffer_min(__in, 1) <= buffer_min(out, 1)));
     check((buffer_max(out, 1) <= buffer_max(__in, 1)));
     check(((buffer_fold_factor(__in, 1) == 9223372036854775807) || ((buffer_max(out, 1) + 1) <= (buffer_fold_factor(__in, 1) + buffer_min(out, 1)))));
-    { let softmax_out = allocate('softmax_out', 4, [
-        {bounds:{min:buffer_min(out, 0), max:buffer_max(out, 0)}, stride:NaN, fold_factor:9223372036854775807},
+    { let softmax_in = allocate('softmax_in', 4, [
+        {bounds:{min:min(g, g0), max:max(g, g0)}, stride:NaN, fold_factor:9223372036854775807},
         {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:NaN, fold_factor:1}
       ]);
-      { let softmax_out_uncropped = clone_buffer(softmax_out);
-        { let sum_exp_in = allocate('sum_exp_in', 4, [
+      { let softmax_in_uncropped = clone_buffer(softmax_in);
+        { let max_in = allocate('max_in', 4, [
             {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:NaN, fold_factor:1}
           ]);
-          { let sum_exp_in_uncropped = clone_buffer(sum_exp_in);
-            { let exp_in = allocate('exp_in', 4, [
-                {bounds:{min:min(g, g0), max:max(g, g0)}, stride:NaN, fold_factor:9223372036854775807},
+          { let max_in_uncropped = clone_buffer(max_in);
+            { let sum_exp_in = allocate('sum_exp_in', 4, [
                 {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:NaN, fold_factor:1}
               ]);
-              { let exp_in_uncropped = clone_buffer(exp_in);
-                { let max_in = allocate('max_in', 4, [
+              { let sum_exp_in_uncropped = clone_buffer(sum_exp_in);
+                { let exp_in = allocate('exp_in', 4, [
+                    {bounds:{min:min(g, g0), max:max(g, g0)}, stride:NaN, fold_factor:9223372036854775807},
                     {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:NaN, fold_factor:1}
                   ]);
-                  { let max_in_uncropped = clone_buffer(max_in);
-                    { let softmax_in = allocate('softmax_in', 4, [
-                        {bounds:{min:min(g, g0), max:max(g, g0)}, stride:NaN, fold_factor:9223372036854775807},
+                  { let exp_in_uncropped = clone_buffer(exp_in);
+                    { let softmax_out = allocate('softmax_out', 4, [
+                        {bounds:{min:buffer_min(out, 0), max:buffer_max(out, 0)}, stride:NaN, fold_factor:9223372036854775807},
                         {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:NaN, fold_factor:1}
                       ]);
-                      { let softmax_in_uncropped = clone_buffer(softmax_in);
+                      { let softmax_out_uncropped = clone_buffer(softmax_out);
                         let __loop_min = buffer_min(out, 1);
                         let __loop_max = buffer_max(out, 1);
                         let __loop_step = 1;
@@ -403,19 +403,19 @@ function pipeline(__in, out) {
                           }
                         }
                       }
-                      free(softmax_in);
+                      free(softmax_out);
                     }
                   }
-                  free(max_in);
+                  free(exp_in);
                 }
               }
-              free(exp_in);
+              free(sum_exp_in);
             }
           }
-          free(sum_exp_in);
+          free(max_in);
         }
       }
-      free(softmax_out);
+      free(softmax_in);
     }
   }
 }

--- a/builder/test/visualize/softmax_split_1.html
+++ b/builder/test/visualize/softmax_split_1.html
@@ -276,38 +276,38 @@ function make_buffer(name, base, elem_size, dims) {
 function clone_buffer(b) { return structuredClone(b); }
 function crop_dim(b, d, bounds) {
   let result = clone_buffer(b);
-  let new_min = max(b.dims[d].bounds.min, bounds.min);
-  let new_max = min(b.dims[d].bounds.max, bounds.max);
+  let new_min = max(result.dims[d].bounds.min, bounds.min);
+  let new_max = min(result.dims[d].bounds.max, bounds.max);
   if (new_max >= new_min) {
-    b.base += flat_offset_dim(b.dims[d], new_min);
+    result.base += flat_offset_dim(result.dims[d], new_min);
   }
-  b.dims[d].bounds.min = new_min;
-  b.dims[d].bounds.max = new_max;
+  result.dims[d].bounds.min = new_min;
+  result.dims[d].bounds.max = new_max;
   return result;
 }
 function crop_buffer(b, bounds) {
   let result = clone_buffer(b);
   for (let d = 0; d < bounds.length; ++d) {
-    crop_dim(b, d, bounds[d]);
+    result = crop_dim(result, d, bounds[d]);
   }
   return result;
 }
 function slice_dim(b, d, at) {
   let result = clone_buffer(b);
-  b.base += flat_offset_dim(b.dims[d], at);
-  b.dims.splice(d, 1);
+  result.base += flat_offset_dim(result.dims[d], at);
+  result.dims.splice(d, 1);
   return result;
 }
 function slice_buffer(b, at) {
   let result = clone_buffer(b);
   for (let d = at.length - 1; d >= 0; --d) {
-    slice_dim(b, d, at[d]);
+    result = slice_dim(result, d, at[d]);
   }
   return result;
 }
 function transpose(b, dims) {
   let result = clone_buffer(b);
-  b.dims = dims.map(i => b.dims[i]);
+  result.dims = dims.map(i => result.dims[i]);
   return result;
 }
 function produce(b) {
@@ -365,42 +365,42 @@ function pipeline(__in, out) {
                         let __loop_max = buffer_max(out, 1);
                         let __loop_step = 1;
                         for(let b = __loop_min; b <= __loop_max; b += __loop_step) {
-                          { let __softmax_in = crop_dim(softmax_in, 1, {min:b, max:b});
+                          { let __softmax_in = crop_dim(softmax_in, 1, {min:b, max:b}); {
+                            let softmax_in = __softmax_in;
                             consume(__in);
                             produce(softmax_in);
                             __event_t++;
-                            softmax_in = __softmax_in;
-                          }
-                          { let __max_in = crop_dim(max_in, 0, {min:b, max:b});
+                          }}
+                          { let __max_in = crop_dim(max_in, 0, {min:b, max:b}); {
+                            let max_in = __max_in;
                             consume(softmax_in_uncropped);
                             produce(max_in);
                             __event_t++;
-                            max_in = __max_in;
-                          }
-                          { let __sum_exp_in = crop_dim(sum_exp_in, 0, {min:b, max:b});
-                            { let __exp_in = crop_dim(exp_in, 1, {min:b, max:b});
+                          }}
+                          { let __sum_exp_in = crop_dim(sum_exp_in, 0, {min:b, max:b}); {
+                            let sum_exp_in = __sum_exp_in;
+                            { let __exp_in = crop_dim(exp_in, 1, {min:b, max:b}); {
+                              let exp_in = __exp_in;
                               consume(__in);
                               consume(max_in_uncropped);
                               produce(exp_in);
                               produce(sum_exp_in);
                               __event_t++;
-                              exp_in = __exp_in;
-                            }
-                            sum_exp_in = __sum_exp_in;
-                          }
-                          { let __softmax_out = crop_dim(softmax_out, 1, {min:b, max:b});
+                            }}
+                          }}
+                          { let __softmax_out = crop_dim(softmax_out, 1, {min:b, max:b}); {
+                            let softmax_out = __softmax_out;
                             consume(exp_in_uncropped);
                             consume(sum_exp_in_uncropped);
                             produce(softmax_out);
                             __event_t++;
-                            softmax_out = __softmax_out;
-                          }
-                          { let __out = crop_dim(out, 1, {min:b, max:b});
+                          }}
+                          { let __out = crop_dim(out, 1, {min:b, max:b}); {
+                            let out = __out;
                             consume(softmax_out_uncropped);
                             produce(out);
                             __event_t++;
-                            out = __out;
-                          }
+                          }}
                         }
                       }
                       free(softmax_out);

--- a/builder/test/visualize/softmax_split_4.html
+++ b/builder/test/visualize/softmax_split_4.html
@@ -276,38 +276,38 @@ function make_buffer(name, base, elem_size, dims) {
 function clone_buffer(b) { return structuredClone(b); }
 function crop_dim(b, d, bounds) {
   let result = clone_buffer(b);
-  let new_min = max(b.dims[d].bounds.min, bounds.min);
-  let new_max = min(b.dims[d].bounds.max, bounds.max);
+  let new_min = max(result.dims[d].bounds.min, bounds.min);
+  let new_max = min(result.dims[d].bounds.max, bounds.max);
   if (new_max >= new_min) {
-    b.base += flat_offset_dim(b.dims[d], new_min);
+    result.base += flat_offset_dim(result.dims[d], new_min);
   }
-  b.dims[d].bounds.min = new_min;
-  b.dims[d].bounds.max = new_max;
+  result.dims[d].bounds.min = new_min;
+  result.dims[d].bounds.max = new_max;
   return result;
 }
 function crop_buffer(b, bounds) {
   let result = clone_buffer(b);
   for (let d = 0; d < bounds.length; ++d) {
-    crop_dim(b, d, bounds[d]);
+    result = crop_dim(result, d, bounds[d]);
   }
   return result;
 }
 function slice_dim(b, d, at) {
   let result = clone_buffer(b);
-  b.base += flat_offset_dim(b.dims[d], at);
-  b.dims.splice(d, 1);
+  result.base += flat_offset_dim(result.dims[d], at);
+  result.dims.splice(d, 1);
   return result;
 }
 function slice_buffer(b, at) {
   let result = clone_buffer(b);
   for (let d = at.length - 1; d >= 0; --d) {
-    slice_dim(b, d, at[d]);
+    result = slice_dim(result, d, at[d]);
   }
   return result;
 }
 function transpose(b, dims) {
   let result = clone_buffer(b);
-  b.dims = dims.map(i => b.dims[i]);
+  result.dims = dims.map(i => result.dims[i]);
   return result;
 }
 function produce(b) {
@@ -365,42 +365,42 @@ function pipeline(__in, out) {
                         let __loop_max = buffer_max(out, 1);
                         let __loop_step = 4;
                         for(let b = __loop_min; b <= __loop_max; b += __loop_step) {
-                          { let __softmax_in = crop_dim(softmax_in, 1, {min:b, max:min((b + 3), buffer_max(out, 1))});
+                          { let __softmax_in = crop_dim(softmax_in, 1, {min:b, max:min((b + 3), buffer_max(out, 1))}); {
+                            let softmax_in = __softmax_in;
                             consume(__in);
                             produce(softmax_in);
                             __event_t++;
-                            softmax_in = __softmax_in;
-                          }
-                          { let __max_in = crop_dim(max_in, 0, {min:b, max:min((b + 3), buffer_max(out, 1))});
+                          }}
+                          { let __max_in = crop_dim(max_in, 0, {min:b, max:min((b + 3), buffer_max(out, 1))}); {
+                            let max_in = __max_in;
                             consume(softmax_in_uncropped);
                             produce(max_in);
                             __event_t++;
-                            max_in = __max_in;
-                          }
-                          { let __sum_exp_in = crop_dim(sum_exp_in, 0, {min:b, max:min((b + 3), buffer_max(out, 1))});
-                            { let __exp_in = crop_dim(exp_in, 1, {min:b, max:min((b + 3), buffer_max(out, 1))});
+                          }}
+                          { let __sum_exp_in = crop_dim(sum_exp_in, 0, {min:b, max:min((b + 3), buffer_max(out, 1))}); {
+                            let sum_exp_in = __sum_exp_in;
+                            { let __exp_in = crop_dim(exp_in, 1, {min:b, max:min((b + 3), buffer_max(out, 1))}); {
+                              let exp_in = __exp_in;
                               consume(__in);
                               consume(max_in_uncropped);
                               produce(exp_in);
                               produce(sum_exp_in);
                               __event_t++;
-                              exp_in = __exp_in;
-                            }
-                            sum_exp_in = __sum_exp_in;
-                          }
-                          { let __softmax_out = crop_dim(softmax_out, 1, {min:b, max:min((b + 3), buffer_max(out, 1))});
+                            }}
+                          }}
+                          { let __softmax_out = crop_dim(softmax_out, 1, {min:b, max:min((b + 3), buffer_max(out, 1))}); {
+                            let softmax_out = __softmax_out;
                             consume(exp_in_uncropped);
                             consume(sum_exp_in_uncropped);
                             produce(softmax_out);
                             __event_t++;
-                            softmax_out = __softmax_out;
-                          }
-                          { let __out = crop_dim(out, 1, {min:b, max:(b + 3)});
+                          }}
+                          { let __out = crop_dim(out, 1, {min:b, max:(b + 3)}); {
+                            let out = __out;
                             consume(softmax_out_uncropped);
                             produce(out);
                             __event_t++;
-                            out = __out;
-                          }
+                          }}
                         }
                       }
                       free(softmax_out);

--- a/builder/test/visualize/softmax_split_4.html
+++ b/builder/test/visualize/softmax_split_4.html
@@ -338,29 +338,29 @@ function pipeline(__in, out) {
     check((buffer_min(__in, 1) <= buffer_min(out, 1)));
     check((buffer_max(out, 1) <= buffer_max(__in, 1)));
     check(((buffer_fold_factor(__in, 1) == 9223372036854775807) || ((buffer_max(out, 1) + 1) <= (buffer_fold_factor(__in, 1) + buffer_min(out, 1)))));
-    { let softmax_out = allocate('softmax_out', 4, [
-        {bounds:{min:buffer_min(out, 0), max:buffer_max(out, 0)}, stride:NaN, fold_factor:9223372036854775807},
+    { let softmax_in = allocate('softmax_in', 4, [
+        {bounds:{min:min(g, g0), max:max(g, g0)}, stride:NaN, fold_factor:9223372036854775807},
         {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:NaN, fold_factor:4}
       ]);
-      { let softmax_out_uncropped = clone_buffer(softmax_out);
-        { let sum_exp_in = allocate('sum_exp_in', 4, [
+      { let softmax_in_uncropped = clone_buffer(softmax_in);
+        { let max_in = allocate('max_in', 4, [
             {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:NaN, fold_factor:4}
           ]);
-          { let sum_exp_in_uncropped = clone_buffer(sum_exp_in);
-            { let exp_in = allocate('exp_in', 4, [
-                {bounds:{min:min(g, g0), max:max(g, g0)}, stride:NaN, fold_factor:9223372036854775807},
+          { let max_in_uncropped = clone_buffer(max_in);
+            { let sum_exp_in = allocate('sum_exp_in', 4, [
                 {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:NaN, fold_factor:4}
               ]);
-              { let exp_in_uncropped = clone_buffer(exp_in);
-                { let max_in = allocate('max_in', 4, [
+              { let sum_exp_in_uncropped = clone_buffer(sum_exp_in);
+                { let exp_in = allocate('exp_in', 4, [
+                    {bounds:{min:min(g, g0), max:max(g, g0)}, stride:NaN, fold_factor:9223372036854775807},
                     {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:NaN, fold_factor:4}
                   ]);
-                  { let max_in_uncropped = clone_buffer(max_in);
-                    { let softmax_in = allocate('softmax_in', 4, [
-                        {bounds:{min:min(g, g0), max:max(g, g0)}, stride:NaN, fold_factor:9223372036854775807},
+                  { let exp_in_uncropped = clone_buffer(exp_in);
+                    { let softmax_out = allocate('softmax_out', 4, [
+                        {bounds:{min:buffer_min(out, 0), max:buffer_max(out, 0)}, stride:NaN, fold_factor:9223372036854775807},
                         {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:NaN, fold_factor:4}
                       ]);
-                      { let softmax_in_uncropped = clone_buffer(softmax_in);
+                      { let softmax_out_uncropped = clone_buffer(softmax_out);
                         let __loop_min = buffer_min(out, 1);
                         let __loop_max = buffer_max(out, 1);
                         let __loop_step = 4;
@@ -403,19 +403,19 @@ function pipeline(__in, out) {
                           }
                         }
                       }
-                      free(softmax_in);
+                      free(softmax_out);
                     }
                   }
-                  free(max_in);
+                  free(exp_in);
                 }
               }
-              free(exp_in);
+              free(sum_exp_in);
             }
           }
-          free(sum_exp_in);
+          free(max_in);
         }
       }
-      free(softmax_out);
+      free(softmax_in);
     }
   }
 }

--- a/builder/test/visualize/stencil_chain_split_serial_split_0.html
+++ b/builder/test/visualize/stencil_chain_split_serial_split_0.html
@@ -337,21 +337,21 @@ function pipeline(__in, out) {
     check(((buffer_min(__in, 1) + 2) <= buffer_min(out, 1)));
     check(((buffer_max(out, 1) + 2) <= buffer_max(__in, 1)));
     check(((buffer_fold_factor(__in, 1) == 9223372036854775807) || ((buffer_max(out, 1) + 5) <= (buffer_fold_factor(__in, 1) + buffer_min(out, 1)))));
-    { let stencil1_result = allocate('stencil1_result', 2, [
-        {bounds:{min:(buffer_min(out, 0) + -1), max:(buffer_max(out, 0) + 1)}, stride:NaN, fold_factor:9223372036854775807},
-        {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:NaN, fold_factor:9223372036854775807}
+    { let add_result = allocate('add_result', 2, [
+        {bounds:{min:(buffer_min(out, 0) + -2), max:(buffer_max(out, 0) + 2)}, stride:NaN, fold_factor:9223372036854775807},
+        {bounds:{min:(buffer_min(out, 1) + -2), max:(buffer_max(out, 1) + 2)}, stride:NaN, fold_factor:9223372036854775807}
       ]);
-      { let add_result = allocate('add_result', 2, [
-          {bounds:{min:(buffer_min(out, 0) + -2), max:(buffer_max(out, 0) + 2)}, stride:NaN, fold_factor:9223372036854775807},
-          {bounds:{min:(buffer_min(out, 1) + -2), max:(buffer_max(out, 1) + 2)}, stride:NaN, fold_factor:9223372036854775807}
+      {
+        let __trace_token = trace_begin(buffer_at(__trace_names, 0));
+        consume(__in);
+        produce(add_result);
+        __event_t++;
+        check(trace_end(__trace_token));
+      }
+      { let stencil1_result = allocate('stencil1_result', 2, [
+          {bounds:{min:(buffer_min(out, 0) + -1), max:(buffer_max(out, 0) + 1)}, stride:NaN, fold_factor:9223372036854775807},
+          {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:NaN, fold_factor:9223372036854775807}
         ]);
-        {
-          let __trace_token = trace_begin(buffer_at(__trace_names, 0));
-          consume(__in);
-          produce(add_result);
-          __event_t++;
-          check(trace_end(__trace_token));
-        }
         {
           let __trace_token = trace_begin(buffer_at(__trace_names, 6));
           consume(add_result);
@@ -359,16 +359,17 @@ function pipeline(__in, out) {
           __event_t++;
           check(trace_end(__trace_token));
         }
-        free(add_result);
+        check(free(add_result));
+        {
+          let __trace_token = trace_begin(buffer_at(__trace_names, 6));
+          consume(stencil1_result);
+          produce(out);
+          __event_t++;
+          check(trace_end(__trace_token));
+        }
+        free(stencil1_result);
       }
-      {
-        let __trace_token = trace_begin(buffer_at(__trace_names, 6));
-        consume(stencil1_result);
-        produce(out);
-        __event_t++;
-        check(trace_end(__trace_token));
-      }
-      free(stencil1_result);
+      free(add_result);
     }
     check(trace_end(__trace_token));
   }

--- a/builder/test/visualize/stencil_chain_split_serial_split_0.html
+++ b/builder/test/visualize/stencil_chain_split_serial_split_0.html
@@ -359,7 +359,6 @@ function pipeline(__in, out) {
           __event_t++;
           check(trace_end(__trace_token));
         }
-        check(free(add_result));
         {
           let __trace_token = trace_begin(buffer_at(__trace_names, 6));
           consume(stencil1_result);

--- a/builder/test/visualize/stencil_chain_split_serial_split_0.html
+++ b/builder/test/visualize/stencil_chain_split_serial_split_0.html
@@ -359,6 +359,7 @@ function pipeline(__in, out) {
           __event_t++;
           check(trace_end(__trace_token));
         }
+        check(free(add_result));
         {
           let __trace_token = trace_begin(buffer_at(__trace_names, 6));
           consume(stencil1_result);

--- a/builder/test/visualize/stencil_chain_split_serial_split_0.html
+++ b/builder/test/visualize/stencil_chain_split_serial_split_0.html
@@ -276,38 +276,38 @@ function make_buffer(name, base, elem_size, dims) {
 function clone_buffer(b) { return structuredClone(b); }
 function crop_dim(b, d, bounds) {
   let result = clone_buffer(b);
-  let new_min = max(b.dims[d].bounds.min, bounds.min);
-  let new_max = min(b.dims[d].bounds.max, bounds.max);
+  let new_min = max(result.dims[d].bounds.min, bounds.min);
+  let new_max = min(result.dims[d].bounds.max, bounds.max);
   if (new_max >= new_min) {
-    b.base += flat_offset_dim(b.dims[d], new_min);
+    result.base += flat_offset_dim(result.dims[d], new_min);
   }
-  b.dims[d].bounds.min = new_min;
-  b.dims[d].bounds.max = new_max;
+  result.dims[d].bounds.min = new_min;
+  result.dims[d].bounds.max = new_max;
   return result;
 }
 function crop_buffer(b, bounds) {
   let result = clone_buffer(b);
   for (let d = 0; d < bounds.length; ++d) {
-    crop_dim(b, d, bounds[d]);
+    result = crop_dim(result, d, bounds[d]);
   }
   return result;
 }
 function slice_dim(b, d, at) {
   let result = clone_buffer(b);
-  b.base += flat_offset_dim(b.dims[d], at);
-  b.dims.splice(d, 1);
+  result.base += flat_offset_dim(result.dims[d], at);
+  result.dims.splice(d, 1);
   return result;
 }
 function slice_buffer(b, at) {
   let result = clone_buffer(b);
   for (let d = at.length - 1; d >= 0; --d) {
-    slice_dim(b, d, at[d]);
+    result = slice_dim(result, d, at[d]);
   }
   return result;
 }
 function transpose(b, dims) {
   let result = clone_buffer(b);
-  b.dims = dims.map(i => b.dims[i]);
+  result.dims = dims.map(i => result.dims[i]);
   return result;
 }
 function produce(b) {

--- a/builder/test/visualize/stencil_chain_split_serial_split_1.html
+++ b/builder/test/visualize/stencil_chain_split_serial_split_1.html
@@ -337,16 +337,16 @@ function pipeline(__in, out) {
     check(((buffer_min(__in, 1) + 2) <= buffer_min(out, 1)));
     check(((buffer_max(out, 1) + 2) <= buffer_max(__in, 1)));
     check(((buffer_fold_factor(__in, 1) == 9223372036854775807) || ((buffer_max(out, 1) + 5) <= (buffer_fold_factor(__in, 1) + buffer_min(out, 1)))));
-    { let stencil1_result = allocate('stencil1_result', 2, [
-        {bounds:{min:(buffer_min(out, 0) + -1), max:(buffer_max(out, 0) + 1)}, stride:NaN, fold_factor:9223372036854775807},
-        {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:NaN, fold_factor:3}
+    { let add_result = allocate('add_result', 2, [
+        {bounds:{min:(buffer_min(out, 0) + -2), max:(buffer_max(out, 0) + 2)}, stride:NaN, fold_factor:9223372036854775807},
+        {bounds:{min:(buffer_min(out, 1) + -2), max:(buffer_max(out, 1) + 2)}, stride:NaN, fold_factor:3}
       ]);
-      { let stencil1_result_uncropped = clone_buffer(stencil1_result);
-        { let add_result = allocate('add_result', 2, [
-            {bounds:{min:(buffer_min(out, 0) + -2), max:(buffer_max(out, 0) + 2)}, stride:NaN, fold_factor:9223372036854775807},
-            {bounds:{min:(buffer_min(out, 1) + -2), max:(buffer_max(out, 1) + 2)}, stride:NaN, fold_factor:3}
+      { let add_result_uncropped = clone_buffer(add_result);
+        { let stencil1_result = allocate('stencil1_result', 2, [
+            {bounds:{min:(buffer_min(out, 0) + -1), max:(buffer_max(out, 0) + 1)}, stride:NaN, fold_factor:9223372036854775807},
+            {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:NaN, fold_factor:3}
           ]);
-          { let add_result_uncropped = clone_buffer(add_result);
+          { let stencil1_result_uncropped = clone_buffer(stencil1_result);
             {
               let __trace_token = trace_begin(buffer_at(__trace_names, 17));
               let __loop_min = (buffer_min(out, 1) + -4);
@@ -391,10 +391,10 @@ function pipeline(__in, out) {
               check(trace_end(__trace_token));
             }
           }
-          free(add_result);
+          free(stencil1_result);
         }
       }
-      free(stencil1_result);
+      free(add_result);
     }
     check(trace_end(__trace_token));
   }

--- a/builder/test/visualize/stencil_chain_split_serial_split_1.html
+++ b/builder/test/visualize/stencil_chain_split_serial_split_1.html
@@ -276,38 +276,38 @@ function make_buffer(name, base, elem_size, dims) {
 function clone_buffer(b) { return structuredClone(b); }
 function crop_dim(b, d, bounds) {
   let result = clone_buffer(b);
-  let new_min = max(b.dims[d].bounds.min, bounds.min);
-  let new_max = min(b.dims[d].bounds.max, bounds.max);
+  let new_min = max(result.dims[d].bounds.min, bounds.min);
+  let new_max = min(result.dims[d].bounds.max, bounds.max);
   if (new_max >= new_min) {
-    b.base += flat_offset_dim(b.dims[d], new_min);
+    result.base += flat_offset_dim(result.dims[d], new_min);
   }
-  b.dims[d].bounds.min = new_min;
-  b.dims[d].bounds.max = new_max;
+  result.dims[d].bounds.min = new_min;
+  result.dims[d].bounds.max = new_max;
   return result;
 }
 function crop_buffer(b, bounds) {
   let result = clone_buffer(b);
   for (let d = 0; d < bounds.length; ++d) {
-    crop_dim(b, d, bounds[d]);
+    result = crop_dim(result, d, bounds[d]);
   }
   return result;
 }
 function slice_dim(b, d, at) {
   let result = clone_buffer(b);
-  b.base += flat_offset_dim(b.dims[d], at);
-  b.dims.splice(d, 1);
+  result.base += flat_offset_dim(result.dims[d], at);
+  result.dims.splice(d, 1);
   return result;
 }
 function slice_buffer(b, at) {
   let result = clone_buffer(b);
   for (let d = at.length - 1; d >= 0; --d) {
-    slice_dim(b, d, at[d]);
+    result = slice_dim(result, d, at[d]);
   }
   return result;
 }
 function transpose(b, dims) {
   let result = clone_buffer(b);
-  b.dims = dims.map(i => b.dims[i]);
+  result.dims = dims.map(i => result.dims[i]);
   return result;
 }
 function produce(b) {
@@ -355,7 +355,8 @@ function pipeline(__in, out) {
               for(let y = __loop_min; y <= __loop_max; y += __loop_step) {
                 {
                   let __trace_token = trace_begin(buffer_at(__trace_names, 0));
-                  { let __add_result = crop_dim(add_result, 1, {min:(y + 2), max:(y + 2)});
+                  { let __add_result = crop_dim(add_result, 1, {min:(y + 2), max:(y + 2)}); {
+                    let add_result = __add_result;
                     {
                       let __trace_token = trace_begin(buffer_at(__trace_names, 24));
                       consume(__in);
@@ -363,9 +364,9 @@ function pipeline(__in, out) {
                       __event_t++;
                       check(trace_end(__trace_token));
                     }
-                    add_result = __add_result;
-                  }
-                  { let __stencil1_result = crop_dim(stencil1_result, 1, {min:(y + 1), max:(y + 1)});
+                  }}
+                  { let __stencil1_result = crop_dim(stencil1_result, 1, {min:(y + 1), max:(y + 1)}); {
+                    let stencil1_result = __stencil1_result;
                     {
                       let __trace_token = trace_begin(buffer_at(__trace_names, 30));
                       consume(add_result_uncropped);
@@ -373,9 +374,9 @@ function pipeline(__in, out) {
                       __event_t++;
                       check(trace_end(__trace_token));
                     }
-                    stencil1_result = __stencil1_result;
-                  }
-                  { let __out = crop_dim(out, 1, {min:y, max:y});
+                  }}
+                  { let __out = crop_dim(out, 1, {min:y, max:y}); {
+                    let out = __out;
                     {
                       let __trace_token = trace_begin(buffer_at(__trace_names, 30));
                       consume(stencil1_result_uncropped);
@@ -383,8 +384,7 @@ function pipeline(__in, out) {
                       __event_t++;
                       check(trace_end(__trace_token));
                     }
-                    out = __out;
-                  }
+                  }}
                   check(trace_end(__trace_token));
                 }
               }

--- a/builder/test/visualize/stencil_chain_split_serial_split_2.html
+++ b/builder/test/visualize/stencil_chain_split_serial_split_2.html
@@ -337,16 +337,16 @@ function pipeline(__in, out) {
     check(((buffer_min(__in, 1) + 2) <= buffer_min(out, 1)));
     check(((buffer_max(out, 1) + 2) <= buffer_max(__in, 1)));
     check(((buffer_fold_factor(__in, 1) == 9223372036854775807) || ((buffer_max(out, 1) + 5) <= (buffer_fold_factor(__in, 1) + buffer_min(out, 1)))));
-    { let stencil1_result = allocate('stencil1_result', 2, [
-        {bounds:{min:(buffer_min(out, 0) + -1), max:(buffer_max(out, 0) + 1)}, stride:NaN, fold_factor:9223372036854775807},
-        {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:NaN, fold_factor:4}
+    { let add_result = allocate('add_result', 2, [
+        {bounds:{min:(buffer_min(out, 0) + -2), max:(buffer_max(out, 0) + 2)}, stride:NaN, fold_factor:9223372036854775807},
+        {bounds:{min:(buffer_min(out, 1) + -2), max:(buffer_max(out, 1) + 2)}, stride:NaN, fold_factor:4}
       ]);
-      { let stencil1_result_uncropped = clone_buffer(stencil1_result);
-        { let add_result = allocate('add_result', 2, [
-            {bounds:{min:(buffer_min(out, 0) + -2), max:(buffer_max(out, 0) + 2)}, stride:NaN, fold_factor:9223372036854775807},
-            {bounds:{min:(buffer_min(out, 1) + -2), max:(buffer_max(out, 1) + 2)}, stride:NaN, fold_factor:4}
+      { let add_result_uncropped = clone_buffer(add_result);
+        { let stencil1_result = allocate('stencil1_result', 2, [
+            {bounds:{min:(buffer_min(out, 0) + -1), max:(buffer_max(out, 0) + 1)}, stride:NaN, fold_factor:9223372036854775807},
+            {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:NaN, fold_factor:4}
           ]);
-          { let add_result_uncropped = clone_buffer(add_result);
+          { let stencil1_result_uncropped = clone_buffer(stencil1_result);
             {
               let __trace_token = trace_begin(buffer_at(__trace_names, 17));
               let __loop_min = (buffer_min(out, 1) + -4);
@@ -391,10 +391,10 @@ function pipeline(__in, out) {
               check(trace_end(__trace_token));
             }
           }
-          free(add_result);
+          free(stencil1_result);
         }
       }
-      free(stencil1_result);
+      free(add_result);
     }
     check(trace_end(__trace_token));
   }

--- a/builder/test/visualize/stencil_chain_split_serial_split_2.html
+++ b/builder/test/visualize/stencil_chain_split_serial_split_2.html
@@ -276,38 +276,38 @@ function make_buffer(name, base, elem_size, dims) {
 function clone_buffer(b) { return structuredClone(b); }
 function crop_dim(b, d, bounds) {
   let result = clone_buffer(b);
-  let new_min = max(b.dims[d].bounds.min, bounds.min);
-  let new_max = min(b.dims[d].bounds.max, bounds.max);
+  let new_min = max(result.dims[d].bounds.min, bounds.min);
+  let new_max = min(result.dims[d].bounds.max, bounds.max);
   if (new_max >= new_min) {
-    b.base += flat_offset_dim(b.dims[d], new_min);
+    result.base += flat_offset_dim(result.dims[d], new_min);
   }
-  b.dims[d].bounds.min = new_min;
-  b.dims[d].bounds.max = new_max;
+  result.dims[d].bounds.min = new_min;
+  result.dims[d].bounds.max = new_max;
   return result;
 }
 function crop_buffer(b, bounds) {
   let result = clone_buffer(b);
   for (let d = 0; d < bounds.length; ++d) {
-    crop_dim(b, d, bounds[d]);
+    result = crop_dim(result, d, bounds[d]);
   }
   return result;
 }
 function slice_dim(b, d, at) {
   let result = clone_buffer(b);
-  b.base += flat_offset_dim(b.dims[d], at);
-  b.dims.splice(d, 1);
+  result.base += flat_offset_dim(result.dims[d], at);
+  result.dims.splice(d, 1);
   return result;
 }
 function slice_buffer(b, at) {
   let result = clone_buffer(b);
   for (let d = at.length - 1; d >= 0; --d) {
-    slice_dim(b, d, at[d]);
+    result = slice_dim(result, d, at[d]);
   }
   return result;
 }
 function transpose(b, dims) {
   let result = clone_buffer(b);
-  b.dims = dims.map(i => b.dims[i]);
+  result.dims = dims.map(i => result.dims[i]);
   return result;
 }
 function produce(b) {
@@ -355,7 +355,8 @@ function pipeline(__in, out) {
               for(let y = __loop_min; y <= __loop_max; y += __loop_step) {
                 {
                   let __trace_token = trace_begin(buffer_at(__trace_names, 0));
-                  { let __add_result = crop_dim(add_result, 1, {min:(y + 2), max:(min((y + 1), buffer_max(out, 1)) + 2)});
+                  { let __add_result = crop_dim(add_result, 1, {min:(y + 2), max:(min((y + 1), buffer_max(out, 1)) + 2)}); {
+                    let add_result = __add_result;
                     {
                       let __trace_token = trace_begin(buffer_at(__trace_names, 24));
                       consume(__in);
@@ -363,9 +364,9 @@ function pipeline(__in, out) {
                       __event_t++;
                       check(trace_end(__trace_token));
                     }
-                    add_result = __add_result;
-                  }
-                  { let __stencil1_result = crop_dim(stencil1_result, 1, {min:(y + 1), max:(min((y + 1), buffer_max(out, 1)) + 1)});
+                  }}
+                  { let __stencil1_result = crop_dim(stencil1_result, 1, {min:(y + 1), max:(min((y + 1), buffer_max(out, 1)) + 1)}); {
+                    let stencil1_result = __stencil1_result;
                     {
                       let __trace_token = trace_begin(buffer_at(__trace_names, 30));
                       consume(add_result_uncropped);
@@ -373,9 +374,9 @@ function pipeline(__in, out) {
                       __event_t++;
                       check(trace_end(__trace_token));
                     }
-                    stencil1_result = __stencil1_result;
-                  }
-                  { let __out = crop_dim(out, 1, {min:y, max:(y + 1)});
+                  }}
+                  { let __out = crop_dim(out, 1, {min:y, max:(y + 1)}); {
+                    let out = __out;
                     {
                       let __trace_token = trace_begin(buffer_at(__trace_names, 30));
                       consume(stencil1_result_uncropped);
@@ -383,8 +384,7 @@ function pipeline(__in, out) {
                       __event_t++;
                       check(trace_end(__trace_token));
                     }
-                    out = __out;
-                  }
+                  }}
                   check(trace_end(__trace_token));
                 }
               }

--- a/builder/test/visualize/stencil_split_0.html
+++ b/builder/test/visualize/stencil_split_0.html
@@ -276,38 +276,38 @@ function make_buffer(name, base, elem_size, dims) {
 function clone_buffer(b) { return structuredClone(b); }
 function crop_dim(b, d, bounds) {
   let result = clone_buffer(b);
-  let new_min = max(b.dims[d].bounds.min, bounds.min);
-  let new_max = min(b.dims[d].bounds.max, bounds.max);
+  let new_min = max(result.dims[d].bounds.min, bounds.min);
+  let new_max = min(result.dims[d].bounds.max, bounds.max);
   if (new_max >= new_min) {
-    b.base += flat_offset_dim(b.dims[d], new_min);
+    result.base += flat_offset_dim(result.dims[d], new_min);
   }
-  b.dims[d].bounds.min = new_min;
-  b.dims[d].bounds.max = new_max;
+  result.dims[d].bounds.min = new_min;
+  result.dims[d].bounds.max = new_max;
   return result;
 }
 function crop_buffer(b, bounds) {
   let result = clone_buffer(b);
   for (let d = 0; d < bounds.length; ++d) {
-    crop_dim(b, d, bounds[d]);
+    result = crop_dim(result, d, bounds[d]);
   }
   return result;
 }
 function slice_dim(b, d, at) {
   let result = clone_buffer(b);
-  b.base += flat_offset_dim(b.dims[d], at);
-  b.dims.splice(d, 1);
+  result.base += flat_offset_dim(result.dims[d], at);
+  result.dims.splice(d, 1);
   return result;
 }
 function slice_buffer(b, at) {
   let result = clone_buffer(b);
   for (let d = at.length - 1; d >= 0; --d) {
-    slice_dim(b, d, at[d]);
+    result = slice_dim(result, d, at[d]);
   }
   return result;
 }
 function transpose(b, dims) {
   let result = clone_buffer(b);
-  b.dims = dims.map(i => b.dims[i]);
+  result.dims = dims.map(i => result.dims[i]);
   return result;
 }
 function produce(b) {

--- a/builder/test/visualize/stencil_split_1.html
+++ b/builder/test/visualize/stencil_split_1.html
@@ -276,38 +276,38 @@ function make_buffer(name, base, elem_size, dims) {
 function clone_buffer(b) { return structuredClone(b); }
 function crop_dim(b, d, bounds) {
   let result = clone_buffer(b);
-  let new_min = max(b.dims[d].bounds.min, bounds.min);
-  let new_max = min(b.dims[d].bounds.max, bounds.max);
+  let new_min = max(result.dims[d].bounds.min, bounds.min);
+  let new_max = min(result.dims[d].bounds.max, bounds.max);
   if (new_max >= new_min) {
-    b.base += flat_offset_dim(b.dims[d], new_min);
+    result.base += flat_offset_dim(result.dims[d], new_min);
   }
-  b.dims[d].bounds.min = new_min;
-  b.dims[d].bounds.max = new_max;
+  result.dims[d].bounds.min = new_min;
+  result.dims[d].bounds.max = new_max;
   return result;
 }
 function crop_buffer(b, bounds) {
   let result = clone_buffer(b);
   for (let d = 0; d < bounds.length; ++d) {
-    crop_dim(b, d, bounds[d]);
+    result = crop_dim(result, d, bounds[d]);
   }
   return result;
 }
 function slice_dim(b, d, at) {
   let result = clone_buffer(b);
-  b.base += flat_offset_dim(b.dims[d], at);
-  b.dims.splice(d, 1);
+  result.base += flat_offset_dim(result.dims[d], at);
+  result.dims.splice(d, 1);
   return result;
 }
 function slice_buffer(b, at) {
   let result = clone_buffer(b);
   for (let d = at.length - 1; d >= 0; --d) {
-    slice_dim(b, d, at[d]);
+    result = slice_dim(result, d, at[d]);
   }
   return result;
 }
 function transpose(b, dims) {
   let result = clone_buffer(b);
-  b.dims = dims.map(i => b.dims[i]);
+  result.dims = dims.map(i => result.dims[i]);
   return result;
 }
 function produce(b) {
@@ -344,18 +344,18 @@ function pipeline(__in, out) {
       let __loop_max = buffer_max(out, 1);
       let __loop_step = 1;
       for(let y = __loop_min; y <= __loop_max; y += __loop_step) {
-        { let __intm = crop_dim(intm, 1, {min:(y + 1), max:(y + 1)});
+        { let __intm = crop_dim(intm, 1, {min:(y + 1), max:(y + 1)}); {
+          let intm = __intm;
           consume(__in);
           produce(intm);
           __event_t++;
-          intm = __intm;
-        }
-        { let __out = crop_dim(out, 1, {min:y, max:y});
+        }}
+        { let __out = crop_dim(out, 1, {min:y, max:y}); {
+          let out = __out;
           consume(intm_uncropped);
           produce(out);
           __event_t++;
-          out = __out;
-        }
+        }}
       }
     }
     free(intm);

--- a/builder/test/visualize/stencil_split_2.html
+++ b/builder/test/visualize/stencil_split_2.html
@@ -276,38 +276,38 @@ function make_buffer(name, base, elem_size, dims) {
 function clone_buffer(b) { return structuredClone(b); }
 function crop_dim(b, d, bounds) {
   let result = clone_buffer(b);
-  let new_min = max(b.dims[d].bounds.min, bounds.min);
-  let new_max = min(b.dims[d].bounds.max, bounds.max);
+  let new_min = max(result.dims[d].bounds.min, bounds.min);
+  let new_max = min(result.dims[d].bounds.max, bounds.max);
   if (new_max >= new_min) {
-    b.base += flat_offset_dim(b.dims[d], new_min);
+    result.base += flat_offset_dim(result.dims[d], new_min);
   }
-  b.dims[d].bounds.min = new_min;
-  b.dims[d].bounds.max = new_max;
+  result.dims[d].bounds.min = new_min;
+  result.dims[d].bounds.max = new_max;
   return result;
 }
 function crop_buffer(b, bounds) {
   let result = clone_buffer(b);
   for (let d = 0; d < bounds.length; ++d) {
-    crop_dim(b, d, bounds[d]);
+    result = crop_dim(result, d, bounds[d]);
   }
   return result;
 }
 function slice_dim(b, d, at) {
   let result = clone_buffer(b);
-  b.base += flat_offset_dim(b.dims[d], at);
-  b.dims.splice(d, 1);
+  result.base += flat_offset_dim(result.dims[d], at);
+  result.dims.splice(d, 1);
   return result;
 }
 function slice_buffer(b, at) {
   let result = clone_buffer(b);
   for (let d = at.length - 1; d >= 0; --d) {
-    slice_dim(b, d, at[d]);
+    result = slice_dim(result, d, at[d]);
   }
   return result;
 }
 function transpose(b, dims) {
   let result = clone_buffer(b);
-  b.dims = dims.map(i => b.dims[i]);
+  result.dims = dims.map(i => result.dims[i]);
   return result;
 }
 function produce(b) {
@@ -344,18 +344,18 @@ function pipeline(__in, out) {
       let __loop_max = buffer_max(out, 1);
       let __loop_step = 2;
       for(let y = __loop_min; y <= __loop_max; y += __loop_step) {
-        { let __intm = crop_dim(intm, 1, {min:(y + 1), max:(min((y + 1), buffer_max(out, 1)) + 1)});
+        { let __intm = crop_dim(intm, 1, {min:(y + 1), max:(min((y + 1), buffer_max(out, 1)) + 1)}); {
+          let intm = __intm;
           consume(__in);
           produce(intm);
           __event_t++;
-          intm = __intm;
-        }
-        { let __out = crop_dim(out, 1, {min:y, max:(y + 1)});
+        }}
+        { let __out = crop_dim(out, 1, {min:y, max:(y + 1)}); {
+          let out = __out;
           consume(intm_uncropped);
           produce(out);
           __event_t++;
-          out = __out;
-        }
+        }}
       }
     }
     free(intm);

--- a/builder/test/visualize/stencil_split_3.html
+++ b/builder/test/visualize/stencil_split_3.html
@@ -276,38 +276,38 @@ function make_buffer(name, base, elem_size, dims) {
 function clone_buffer(b) { return structuredClone(b); }
 function crop_dim(b, d, bounds) {
   let result = clone_buffer(b);
-  let new_min = max(b.dims[d].bounds.min, bounds.min);
-  let new_max = min(b.dims[d].bounds.max, bounds.max);
+  let new_min = max(result.dims[d].bounds.min, bounds.min);
+  let new_max = min(result.dims[d].bounds.max, bounds.max);
   if (new_max >= new_min) {
-    b.base += flat_offset_dim(b.dims[d], new_min);
+    result.base += flat_offset_dim(result.dims[d], new_min);
   }
-  b.dims[d].bounds.min = new_min;
-  b.dims[d].bounds.max = new_max;
+  result.dims[d].bounds.min = new_min;
+  result.dims[d].bounds.max = new_max;
   return result;
 }
 function crop_buffer(b, bounds) {
   let result = clone_buffer(b);
   for (let d = 0; d < bounds.length; ++d) {
-    crop_dim(b, d, bounds[d]);
+    result = crop_dim(result, d, bounds[d]);
   }
   return result;
 }
 function slice_dim(b, d, at) {
   let result = clone_buffer(b);
-  b.base += flat_offset_dim(b.dims[d], at);
-  b.dims.splice(d, 1);
+  result.base += flat_offset_dim(result.dims[d], at);
+  result.dims.splice(d, 1);
   return result;
 }
 function slice_buffer(b, at) {
   let result = clone_buffer(b);
   for (let d = at.length - 1; d >= 0; --d) {
-    slice_dim(b, d, at[d]);
+    result = slice_dim(result, d, at[d]);
   }
   return result;
 }
 function transpose(b, dims) {
   let result = clone_buffer(b);
-  b.dims = dims.map(i => b.dims[i]);
+  result.dims = dims.map(i => result.dims[i]);
   return result;
 }
 function produce(b) {
@@ -344,18 +344,18 @@ function pipeline(__in, out) {
       let __loop_max = buffer_max(out, 1);
       let __loop_step = 3;
       for(let y = __loop_min; y <= __loop_max; y += __loop_step) {
-        { let __intm = crop_dim(intm, 1, {min:(y + 1), max:(min((y + 2), buffer_max(out, 1)) + 1)});
+        { let __intm = crop_dim(intm, 1, {min:(y + 1), max:(min((y + 2), buffer_max(out, 1)) + 1)}); {
+          let intm = __intm;
           consume(__in);
           produce(intm);
           __event_t++;
-          intm = __intm;
-        }
-        { let __out = crop_dim(out, 1, {min:y, max:(y + 2)});
+        }}
+        { let __out = crop_dim(out, 1, {min:y, max:(y + 2)}); {
+          let out = __out;
           consume(intm_uncropped);
           produce(out);
           __event_t++;
-          out = __out;
-        }
+        }}
       }
     }
     free(intm);

--- a/runtime/depends_on.cc
+++ b/runtime/depends_on.cc
@@ -196,11 +196,13 @@ public:
 }  // namespace
 
 void depends_on(const expr& e, span<const std::pair<var, depends_on_result&>> var_deps) {
+  if (var_deps.empty()) return;
   dependencies v(var_deps);
   if (e.defined()) e.accept(&v);
 }
 
 void depends_on(const stmt& s, span<const std::pair<var, depends_on_result&>> var_deps) {
+  if (var_deps.empty()) return;
   dependencies v(var_deps);
   if (s.defined()) s.accept(&v);
 }

--- a/runtime/print.cc
+++ b/runtime/print.cc
@@ -297,7 +297,7 @@ public:
   }
 
   void visit(const transpose* n) override {
-    *this << indent() << n->sym << " = transpose(" << n->src << ", " << n->dims << ") {\n";
+    *this << indent() << n->sym << " = transpose(" << n->src << ", {" << n->dims << "}) {\n";
     *this << n->body;
     *this << indent() << "}\n";
   }

--- a/runtime/visualize.cc
+++ b/runtime/visualize.cc
@@ -42,6 +42,7 @@ public:
 
   std::string sanitize(std::string s) {
     std::replace(s.begin(), s.end(), '.', '_');
+    std::replace(s.begin(), s.end(), '/', '_');
     if (s == "in") {
       s = "__in";
     }

--- a/runtime/visualize.cc
+++ b/runtime/visualize.cc
@@ -262,39 +262,39 @@ public:
       *this << "\n";
       *this << indent();
     }
-    *this << "]);\n";
+    *this << "]); {\n";
+    *this << indent(1) << "let " << n->sym << " = __" << n->sym << ";\n";
     *this << n->body;
-    *this << indent(1) << n->sym << " = __" << n->sym << ";\n";
-    *this << indent() << "}\n";
+    *this << indent() << "}}\n";
   }
 
   void visit(const crop_dim* n) override {
     *this << indent() << "{ let __" << n->sym << " = crop_dim(" << n->src << ", " << n->dim << ", " << n->bounds
-          << ");\n";
+          << "); {\n";
+    *this << indent(1) << "let " << n->sym << " = __" << n->sym << ";\n";
     *this << n->body;
-    *this << indent(1) << n->sym << " = __" << n->sym << ";\n";
-    *this << indent() << "}\n";
+    *this << indent() << "}}\n";
   }
 
   void visit(const slice_buffer* n) override {
-    *this << indent() << "{ let __" << n->sym << " = slice_buffer(" << n->src << ", {" << n->at << "});\n";
+    *this << indent() << "{ let __" << n->sym << " = slice_buffer(" << n->src << ", {" << n->at << "}); {\n";
+    *this << indent(1) << "let " << n->sym << " = __" << n->sym << ";\n";
     *this << n->body;
-    *this << indent(1) << n->sym << " = __" << n->sym << ";\n";
-    *this << indent() << "}\n";
+    *this << indent() << "}}\n";
   }
 
   void visit(const slice_dim* n) override {
-    *this << indent() << "{ let __" << n->sym << " = slice_dim(" << n->src << ", " << n->dim << ", " << n->at << ");\n";
+    *this << indent() << "{ let __" << n->sym << " = slice_dim(" << n->src << ", " << n->dim << ", " << n->at << "); {\n";
+    *this << indent(1) << "let " << n->sym << " = __" << n->sym << ";\n";
     *this << n->body;
-    *this << indent(1) << n->sym << " = __" << n->sym << ";\n";
-    *this << indent() << "}\n";
+    *this << indent() << "}}\n";
   }
 
   void visit(const transpose* n) override {
-    *this << indent() << "{ let __" << n->sym << " = transpose(" << n->src << ", [" << n->dims << "]);\n";
+    *this << indent() << "{ let __" << n->sym << " = transpose(" << n->src << ", [" << n->dims << "]); {\n";
+    *this << indent(1) << "let " << n->sym << " = __" << n->sym << ";\n";
     *this << n->body;
-    *this << indent(1) << n->sym << " = __" << n->sym << ";\n";
-    *this << indent() << "}\n";
+    *this << indent() << "}}\n";
   }
 
   void visit(const check* n) override { *this << indent() << "check(" << n->condition << ");\n"; }
@@ -578,38 +578,38 @@ function make_buffer(name, base, elem_size, dims) {
 function clone_buffer(b) { return structuredClone(b); }
 function crop_dim(b, d, bounds) {
   let result = clone_buffer(b);
-  let new_min = max(b.dims[d].bounds.min, bounds.min);
-  let new_max = min(b.dims[d].bounds.max, bounds.max);
+  let new_min = max(result.dims[d].bounds.min, bounds.min);
+  let new_max = min(result.dims[d].bounds.max, bounds.max);
   if (new_max >= new_min) {
-    b.base += flat_offset_dim(b.dims[d], new_min);
+    result.base += flat_offset_dim(result.dims[d], new_min);
   }
-  b.dims[d].bounds.min = new_min;
-  b.dims[d].bounds.max = new_max;
+  result.dims[d].bounds.min = new_min;
+  result.dims[d].bounds.max = new_max;
   return result;
 }
 function crop_buffer(b, bounds) {
   let result = clone_buffer(b);
   for (let d = 0; d < bounds.length; ++d) {
-    crop_dim(b, d, bounds[d]);
+    result = crop_dim(result, d, bounds[d]);
   }
   return result;
 }
 function slice_dim(b, d, at) {
   let result = clone_buffer(b);
-  b.base += flat_offset_dim(b.dims[d], at);
-  b.dims.splice(d, 1);
+  result.base += flat_offset_dim(result.dims[d], at);
+  result.dims.splice(d, 1);
   return result;
 }
 function slice_buffer(b, at) {
   let result = clone_buffer(b);
   for (let d = at.length - 1; d >= 0; --d) {
-    slice_dim(b, d, at[d]);
+    result = slice_dim(result, d, at[d]);
   }
   return result;
 }
 function transpose(b, dims) {
   let result = clone_buffer(b);
-  b.dims = dims.map(i => b.dims[i]);
+  result.dims = dims.map(i => result.dims[i]);
   return result;
 }
 function produce(b) {


### PR DESCRIPTION
This is a major improvement to aliasing. Before this PR, aliasing of padded allocations mostly just worked by accident. It relied on the fact that padded allocations would be the outer allocation, and we'd alias the smaller allocation to the padded allocation.

This PR fixes this to actually be safe and independent of the allocation order. It now proves that buffers are big enough to accommodate an alias, or if not, grows the allocation if possible.

This means we can reorder allocations to be more likely to be possible to alias, which enables the broadcasted_elementwise test to alias.

This PR has some related changes and fixes:
- Added a new test that does a separable stencil with transposes in between.
- Early frees handle shadowing
- Visualize implements shadowing properly
- Some cleanup of aliasing that hopefully makes it easier to understand.