### PR TITLE
Add short-circuiting `and_then` and `or_else` intrinsics

### DIFF
--- a/builder/pipeline.cc
+++ b/builder/pipeline.cc
@@ -827,8 +827,8 @@ public:
       for (int d = 0; d < static_cast<int>(bounds->size()); ++d) {
         checks.push_back(check::make(buffer_min(buf_var, d) <= (*bounds)[d].min));
         checks.push_back(check::make(buffer_max(buf_var, d) >= (*bounds)[d].max));
-        checks.push_back(check::make(buffer_fold_factor(buf_var, d) == dim::unfolded ||
-                                     (*bounds)[d].extent() <= buffer_fold_factor(buf_var, d)));
+        checks.push_back(check::make(or_else({buffer_fold_factor(buf_var, d) == dim::unfolded,
+            (*bounds)[d].extent() <= buffer_fold_factor(buf_var, d)})));
       }
     }
     return block::make(std::move(checks), std::move(body));
@@ -864,7 +864,7 @@ void add_buffer_checks(const buffer_expr_ptr& b, bool output, std::vector<stmt>&
     checks.push_back(check::make(b->dim(d).stride == buffer_stride(buf_var, d)));
     checks.push_back(check::make(b->dim(d).fold_factor == fold_factor));
     if (output) {
-      checks.push_back(check::make(fold_factor == dim::unfolded || b->dim(d).extent() <= fold_factor));
+      checks.push_back(check::make(or_else({fold_factor == dim::unfolded, b->dim(d).extent() <= fold_factor})));
     }
   }
 }

--- a/builder/test/visualize/padded_stencil_0.html
+++ b/builder/test/visualize/padded_stencil_0.html
@@ -327,15 +327,15 @@ function pipeline(__in, out) {
   check((out != 0));
   check((buffer_rank(out) == 2));
   check((buffer_elem_size(out) == 2));
-  check(((buffer_fold_factor(out, 0) == 9223372036854775807) || (buffer_max(out, 0) < (buffer_fold_factor(out, 0) + buffer_min(out, 0)))));
-  check(((buffer_fold_factor(out, 1) == 9223372036854775807) || (buffer_max(out, 1) < (buffer_fold_factor(out, 1) + buffer_min(out, 1)))));
+  check(or_else((buffer_fold_factor(out, 0) == 9223372036854775807), (buffer_max(out, 0) < (buffer_fold_factor(out, 0) + buffer_min(out, 0)))));
+  check(or_else((buffer_fold_factor(out, 1) == 9223372036854775807), (buffer_max(out, 1) < (buffer_fold_factor(out, 1) + buffer_min(out, 1)))));
   {
     let g = buffer_min(__in, 0);
     let g1 = buffer_min(__in, 1);
     let g0 = buffer_max(__in, 0);
     let g2 = buffer_max(__in, 1);
-    check(((buffer_fold_factor(__in, 0) == 9223372036854775807) || (min(g0, (buffer_max(out, 0) + 1)) < (max(g, (buffer_min(out, 0) + -1)) + buffer_fold_factor(__in, 0)))));
-    check(((buffer_fold_factor(__in, 1) == 9223372036854775807) || (min(g2, (buffer_max(out, 1) + 1)) < (max(g1, (buffer_min(out, 1) + -1)) + buffer_fold_factor(__in, 1)))));
+    check(or_else((buffer_fold_factor(__in, 0) == 9223372036854775807), (min(g0, (buffer_max(out, 0) + 1)) < (max(g, (buffer_min(out, 0) + -1)) + buffer_fold_factor(__in, 0)))));
+    check(or_else((buffer_fold_factor(__in, 1) == 9223372036854775807), (min(g2, (buffer_max(out, 1) + 1)) < (max(g1, (buffer_min(out, 1) + -1)) + buffer_fold_factor(__in, 1)))));
     { let intm_padded_intm = allocate('intm/padded_intm', 2, [
         {bounds:{min:(buffer_min(out, 0) + -1), max:(buffer_max(out, 0) + 1)}, stride:NaN, fold_factor:9223372036854775807},
         {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:NaN, fold_factor:9223372036854775807}

--- a/builder/test/visualize/padded_stencil_1.html
+++ b/builder/test/visualize/padded_stencil_1.html
@@ -327,15 +327,15 @@ function pipeline(__in, out) {
   check((out != 0));
   check((buffer_rank(out) == 2));
   check((buffer_elem_size(out) == 2));
-  check(((buffer_fold_factor(out, 0) == 9223372036854775807) || (buffer_max(out, 0) < (buffer_fold_factor(out, 0) + buffer_min(out, 0)))));
-  check(((buffer_fold_factor(out, 1) == 9223372036854775807) || (buffer_max(out, 1) < (buffer_fold_factor(out, 1) + buffer_min(out, 1)))));
+  check(or_else((buffer_fold_factor(out, 0) == 9223372036854775807), (buffer_max(out, 0) < (buffer_fold_factor(out, 0) + buffer_min(out, 0)))));
+  check(or_else((buffer_fold_factor(out, 1) == 9223372036854775807), (buffer_max(out, 1) < (buffer_fold_factor(out, 1) + buffer_min(out, 1)))));
   {
     let g = buffer_min(__in, 0);
     let g1 = buffer_min(__in, 1);
     let g0 = buffer_max(__in, 0);
     let g2 = buffer_max(__in, 1);
-    check(((buffer_fold_factor(__in, 0) == 9223372036854775807) || (min(g0, (buffer_max(out, 0) + 1)) < (max(g, (buffer_min(out, 0) + -1)) + buffer_fold_factor(__in, 0)))));
-    check(((buffer_fold_factor(__in, 1) == 9223372036854775807) || (min(g2, (buffer_max(out, 1) + 1)) < (max(g1, (buffer_min(out, 1) + -1)) + buffer_fold_factor(__in, 1)))));
+    check(or_else((buffer_fold_factor(__in, 0) == 9223372036854775807), (min(g0, (buffer_max(out, 0) + 1)) < (max(g, (buffer_min(out, 0) + -1)) + buffer_fold_factor(__in, 0)))));
+    check(or_else((buffer_fold_factor(__in, 1) == 9223372036854775807), (min(g2, (buffer_max(out, 1) + 1)) < (max(g1, (buffer_min(out, 1) + -1)) + buffer_fold_factor(__in, 1)))));
     { let intm_padded_intm = allocate('intm/padded_intm', 2, [
         {bounds:{min:(buffer_min(out, 0) + -1), max:(buffer_max(out, 0) + 1)}, stride:NaN, fold_factor:9223372036854775807},
         {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:NaN, fold_factor:9223372036854775807}

--- a/builder/test/visualize/padded_stencil_2.html
+++ b/builder/test/visualize/padded_stencil_2.html
@@ -327,15 +327,15 @@ function pipeline(__in, out) {
   check((out != 0));
   check((buffer_rank(out) == 2));
   check((buffer_elem_size(out) == 2));
-  check(((buffer_fold_factor(out, 0) == 9223372036854775807) || (buffer_max(out, 0) < (buffer_fold_factor(out, 0) + buffer_min(out, 0)))));
-  check(((buffer_fold_factor(out, 1) == 9223372036854775807) || (buffer_max(out, 1) < (buffer_fold_factor(out, 1) + buffer_min(out, 1)))));
+  check(or_else((buffer_fold_factor(out, 0) == 9223372036854775807), (buffer_max(out, 0) < (buffer_fold_factor(out, 0) + buffer_min(out, 0)))));
+  check(or_else((buffer_fold_factor(out, 1) == 9223372036854775807), (buffer_max(out, 1) < (buffer_fold_factor(out, 1) + buffer_min(out, 1)))));
   {
     let g = buffer_min(__in, 0);
     let g1 = buffer_min(__in, 1);
     let g0 = buffer_max(__in, 0);
     let g2 = buffer_max(__in, 1);
-    check(((buffer_fold_factor(__in, 0) == 9223372036854775807) || (min(g0, (buffer_max(out, 0) + 1)) < (max(g, (buffer_min(out, 0) + -1)) + buffer_fold_factor(__in, 0)))));
-    check(((buffer_fold_factor(__in, 1) == 9223372036854775807) || (min(g2, (buffer_max(out, 1) + 1)) < (max(g1, (buffer_min(out, 1) + -1)) + buffer_fold_factor(__in, 1)))));
+    check(or_else((buffer_fold_factor(__in, 0) == 9223372036854775807), (min(g0, (buffer_max(out, 0) + 1)) < (max(g, (buffer_min(out, 0) + -1)) + buffer_fold_factor(__in, 0)))));
+    check(or_else((buffer_fold_factor(__in, 1) == 9223372036854775807), (min(g2, (buffer_max(out, 1) + 1)) < (max(g1, (buffer_min(out, 1) + -1)) + buffer_fold_factor(__in, 1)))));
     { let intm = allocate('intm', 2, [
         {bounds:{min:max(g, (buffer_min(out, 0) + -1)), max:min(g0, (buffer_max(out, 0) + 1))}, stride:NaN, fold_factor:9223372036854775807},
         {bounds:{min:max(g1, (buffer_min(out, 1) + -1)), max:min(g2, (buffer_max(out, 1) + 1))}, stride:NaN, fold_factor:1}

--- a/builder/test/visualize/parallel_stencils_0.html
+++ b/builder/test/visualize/parallel_stencils_0.html
@@ -330,20 +330,20 @@ function pipeline(in1, in2, out) {
   check((out != 0));
   check((buffer_rank(out) == 2));
   check((buffer_elem_size(out) == 2));
-  check(((buffer_fold_factor(out, 0) == 9223372036854775807) || (buffer_max(out, 0) < (buffer_fold_factor(out, 0) + buffer_min(out, 0)))));
-  check(((buffer_fold_factor(out, 1) == 9223372036854775807) || (buffer_max(out, 1) < (buffer_fold_factor(out, 1) + buffer_min(out, 1)))));
+  check(or_else((buffer_fold_factor(out, 0) == 9223372036854775807), (buffer_max(out, 0) < (buffer_fold_factor(out, 0) + buffer_min(out, 0)))));
+  check(or_else((buffer_fold_factor(out, 1) == 9223372036854775807), (buffer_max(out, 1) < (buffer_fold_factor(out, 1) + buffer_min(out, 1)))));
   check((buffer_min(in1, 0) < buffer_min(out, 0)));
   check((buffer_max(out, 0) < buffer_max(in1, 0)));
-  check(((buffer_fold_factor(in1, 0) == 9223372036854775807) || ((buffer_max(out, 0) + 3) <= (buffer_fold_factor(in1, 0) + buffer_min(out, 0)))));
+  check(or_else((buffer_fold_factor(in1, 0) == 9223372036854775807), ((buffer_max(out, 0) + 3) <= (buffer_fold_factor(in1, 0) + buffer_min(out, 0)))));
   check((buffer_min(in1, 1) < buffer_min(out, 1)));
   check((buffer_max(out, 1) < buffer_max(in1, 1)));
-  check(((buffer_fold_factor(in1, 1) == 9223372036854775807) || ((buffer_max(out, 1) + 3) <= (buffer_fold_factor(in1, 1) + buffer_min(out, 1)))));
+  check(or_else((buffer_fold_factor(in1, 1) == 9223372036854775807), ((buffer_max(out, 1) + 3) <= (buffer_fold_factor(in1, 1) + buffer_min(out, 1)))));
   check(((buffer_min(in2, 0) + 2) <= buffer_min(out, 0)));
   check(((buffer_max(out, 0) + 2) <= buffer_max(in2, 0)));
-  check(((buffer_fold_factor(in2, 0) == 9223372036854775807) || ((buffer_max(out, 0) + 5) <= (buffer_fold_factor(in2, 0) + buffer_min(out, 0)))));
+  check(or_else((buffer_fold_factor(in2, 0) == 9223372036854775807), ((buffer_max(out, 0) + 5) <= (buffer_fold_factor(in2, 0) + buffer_min(out, 0)))));
   check(((buffer_min(in2, 1) + 2) <= buffer_min(out, 1)));
   check(((buffer_max(out, 1) + 2) <= buffer_max(in2, 1)));
-  check(((buffer_fold_factor(in2, 1) == 9223372036854775807) || ((buffer_max(out, 1) + 5) <= (buffer_fold_factor(in2, 1) + buffer_min(out, 1)))));
+  check(or_else((buffer_fold_factor(in2, 1) == 9223372036854775807), ((buffer_max(out, 1) + 5) <= (buffer_fold_factor(in2, 1) + buffer_min(out, 1)))));
   { let intm1 = allocate('intm1', 2, [
       {bounds:{min:(buffer_min(out, 0) + -1), max:(buffer_max(out, 0) + 1)}, stride:NaN, fold_factor:9223372036854775807},
       {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:NaN, fold_factor:3}

--- a/builder/test/visualize/parallel_stencils_1.html
+++ b/builder/test/visualize/parallel_stencils_1.html
@@ -330,20 +330,20 @@ function pipeline(in1, in2, out) {
   check((out != 0));
   check((buffer_rank(out) == 2));
   check((buffer_elem_size(out) == 2));
-  check(((buffer_fold_factor(out, 0) == 9223372036854775807) || (buffer_max(out, 0) < (buffer_fold_factor(out, 0) + buffer_min(out, 0)))));
-  check(((buffer_fold_factor(out, 1) == 9223372036854775807) || (buffer_max(out, 1) < (buffer_fold_factor(out, 1) + buffer_min(out, 1)))));
+  check(or_else((buffer_fold_factor(out, 0) == 9223372036854775807), (buffer_max(out, 0) < (buffer_fold_factor(out, 0) + buffer_min(out, 0)))));
+  check(or_else((buffer_fold_factor(out, 1) == 9223372036854775807), (buffer_max(out, 1) < (buffer_fold_factor(out, 1) + buffer_min(out, 1)))));
   check((buffer_min(in1, 0) < buffer_min(out, 0)));
   check((buffer_max(out, 0) < buffer_max(in1, 0)));
-  check(((buffer_fold_factor(in1, 0) == 9223372036854775807) || ((buffer_max(out, 0) + 3) <= (buffer_fold_factor(in1, 0) + buffer_min(out, 0)))));
+  check(or_else((buffer_fold_factor(in1, 0) == 9223372036854775807), ((buffer_max(out, 0) + 3) <= (buffer_fold_factor(in1, 0) + buffer_min(out, 0)))));
   check((buffer_min(in1, 1) < buffer_min(out, 1)));
   check((buffer_max(out, 1) < buffer_max(in1, 1)));
-  check(((buffer_fold_factor(in1, 1) == 9223372036854775807) || ((buffer_max(out, 1) + 3) <= (buffer_fold_factor(in1, 1) + buffer_min(out, 1)))));
+  check(or_else((buffer_fold_factor(in1, 1) == 9223372036854775807), ((buffer_max(out, 1) + 3) <= (buffer_fold_factor(in1, 1) + buffer_min(out, 1)))));
   check(((buffer_min(in2, 0) + 2) <= buffer_min(out, 0)));
   check(((buffer_max(out, 0) + 2) <= buffer_max(in2, 0)));
-  check(((buffer_fold_factor(in2, 0) == 9223372036854775807) || ((buffer_max(out, 0) + 5) <= (buffer_fold_factor(in2, 0) + buffer_min(out, 0)))));
+  check(or_else((buffer_fold_factor(in2, 0) == 9223372036854775807), ((buffer_max(out, 0) + 5) <= (buffer_fold_factor(in2, 0) + buffer_min(out, 0)))));
   check(((buffer_min(in2, 1) + 2) <= buffer_min(out, 1)));
   check(((buffer_max(out, 1) + 2) <= buffer_max(in2, 1)));
-  check(((buffer_fold_factor(in2, 1) == 9223372036854775807) || ((buffer_max(out, 1) + 5) <= (buffer_fold_factor(in2, 1) + buffer_min(out, 1)))));
+  check(or_else((buffer_fold_factor(in2, 1) == 9223372036854775807), ((buffer_max(out, 1) + 5) <= (buffer_fold_factor(in2, 1) + buffer_min(out, 1)))));
   { let intm1 = allocate('intm1', 2, [
       {bounds:{min:(buffer_min(out, 0) + -1), max:(buffer_max(out, 0) + 1)}, stride:NaN, fold_factor:9223372036854775807},
       {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:NaN, fold_factor:9223372036854775807}

--- a/builder/test/visualize/parallel_stencils_2.html
+++ b/builder/test/visualize/parallel_stencils_2.html
@@ -330,20 +330,20 @@ function pipeline(in1, in2, out) {
   check((out != 0));
   check((buffer_rank(out) == 2));
   check((buffer_elem_size(out) == 2));
-  check(((buffer_fold_factor(out, 0) == 9223372036854775807) || (buffer_max(out, 0) < (buffer_fold_factor(out, 0) + buffer_min(out, 0)))));
-  check(((buffer_fold_factor(out, 1) == 9223372036854775807) || (buffer_max(out, 1) < (buffer_fold_factor(out, 1) + buffer_min(out, 1)))));
+  check(or_else((buffer_fold_factor(out, 0) == 9223372036854775807), (buffer_max(out, 0) < (buffer_fold_factor(out, 0) + buffer_min(out, 0)))));
+  check(or_else((buffer_fold_factor(out, 1) == 9223372036854775807), (buffer_max(out, 1) < (buffer_fold_factor(out, 1) + buffer_min(out, 1)))));
   check((buffer_min(in1, 0) < buffer_min(out, 0)));
   check((buffer_max(out, 0) < buffer_max(in1, 0)));
-  check(((buffer_fold_factor(in1, 0) == 9223372036854775807) || ((buffer_max(out, 0) + 3) <= (buffer_fold_factor(in1, 0) + buffer_min(out, 0)))));
+  check(or_else((buffer_fold_factor(in1, 0) == 9223372036854775807), ((buffer_max(out, 0) + 3) <= (buffer_fold_factor(in1, 0) + buffer_min(out, 0)))));
   check((buffer_min(in1, 1) < buffer_min(out, 1)));
   check((buffer_max(out, 1) < buffer_max(in1, 1)));
-  check(((buffer_fold_factor(in1, 1) == 9223372036854775807) || ((buffer_max(out, 1) + 3) <= (buffer_fold_factor(in1, 1) + buffer_min(out, 1)))));
+  check(or_else((buffer_fold_factor(in1, 1) == 9223372036854775807), ((buffer_max(out, 1) + 3) <= (buffer_fold_factor(in1, 1) + buffer_min(out, 1)))));
   check(((buffer_min(in2, 0) + 2) <= buffer_min(out, 0)));
   check(((buffer_max(out, 0) + 2) <= buffer_max(in2, 0)));
-  check(((buffer_fold_factor(in2, 0) == 9223372036854775807) || ((buffer_max(out, 0) + 5) <= (buffer_fold_factor(in2, 0) + buffer_min(out, 0)))));
+  check(or_else((buffer_fold_factor(in2, 0) == 9223372036854775807), ((buffer_max(out, 0) + 5) <= (buffer_fold_factor(in2, 0) + buffer_min(out, 0)))));
   check(((buffer_min(in2, 1) + 2) <= buffer_min(out, 1)));
   check(((buffer_max(out, 1) + 2) <= buffer_max(in2, 1)));
-  check(((buffer_fold_factor(in2, 1) == 9223372036854775807) || ((buffer_max(out, 1) + 5) <= (buffer_fold_factor(in2, 1) + buffer_min(out, 1)))));
+  check(or_else((buffer_fold_factor(in2, 1) == 9223372036854775807), ((buffer_max(out, 1) + 5) <= (buffer_fold_factor(in2, 1) + buffer_min(out, 1)))));
   { let intm1 = allocate('intm1', 2, [
       {bounds:{min:(buffer_min(out, 0) + -1), max:(buffer_max(out, 0) + 1)}, stride:NaN, fold_factor:9223372036854775807},
       {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:NaN, fold_factor:4}

--- a/builder/test/visualize/softmax_split_0.html
+++ b/builder/test/visualize/softmax_split_0.html
@@ -327,17 +327,17 @@ function pipeline(__in, out) {
   check((out != 0));
   check((buffer_rank(out) == 2));
   check((buffer_elem_size(out) == 4));
-  check(((buffer_fold_factor(out, 0) == 9223372036854775807) || (buffer_max(out, 0) < (buffer_fold_factor(out, 0) + buffer_min(out, 0)))));
-  check(((buffer_fold_factor(out, 1) == 9223372036854775807) || (buffer_max(out, 1) < (buffer_fold_factor(out, 1) + buffer_min(out, 1)))));
+  check(or_else((buffer_fold_factor(out, 0) == 9223372036854775807), (buffer_max(out, 0) < (buffer_fold_factor(out, 0) + buffer_min(out, 0)))));
+  check(or_else((buffer_fold_factor(out, 1) == 9223372036854775807), (buffer_max(out, 1) < (buffer_fold_factor(out, 1) + buffer_min(out, 1)))));
   {
     let g = buffer_min(out, 0);
     let g0 = buffer_max(out, 0);
     check((buffer_min(__in, 0) <= min(g, g0)));
     check((max(g, g0) <= buffer_max(__in, 0)));
-    check(((buffer_fold_factor(__in, 0) == 9223372036854775807) || (abs((g - g0)) < buffer_fold_factor(__in, 0))));
+    check(or_else((buffer_fold_factor(__in, 0) == 9223372036854775807), (abs((g - g0)) < buffer_fold_factor(__in, 0))));
     check((buffer_min(__in, 1) <= buffer_min(out, 1)));
     check((buffer_max(out, 1) <= buffer_max(__in, 1)));
-    check(((buffer_fold_factor(__in, 1) == 9223372036854775807) || (buffer_max(out, 1) < (buffer_fold_factor(__in, 1) + buffer_min(out, 1)))));
+    check(or_else((buffer_fold_factor(__in, 1) == 9223372036854775807), (buffer_max(out, 1) < (buffer_fold_factor(__in, 1) + buffer_min(out, 1)))));
     { let softmax_in = allocate('softmax_in', 4, [
         {bounds:{min:min(g, g0), max:max(g, g0)}, stride:NaN, fold_factor:9223372036854775807},
         {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:NaN, fold_factor:9223372036854775807}

--- a/builder/test/visualize/softmax_split_1.html
+++ b/builder/test/visualize/softmax_split_1.html
@@ -327,17 +327,17 @@ function pipeline(__in, out) {
   check((out != 0));
   check((buffer_rank(out) == 2));
   check((buffer_elem_size(out) == 4));
-  check(((buffer_fold_factor(out, 0) == 9223372036854775807) || (buffer_max(out, 0) < (buffer_fold_factor(out, 0) + buffer_min(out, 0)))));
-  check(((buffer_fold_factor(out, 1) == 9223372036854775807) || (buffer_max(out, 1) < (buffer_fold_factor(out, 1) + buffer_min(out, 1)))));
+  check(or_else((buffer_fold_factor(out, 0) == 9223372036854775807), (buffer_max(out, 0) < (buffer_fold_factor(out, 0) + buffer_min(out, 0)))));
+  check(or_else((buffer_fold_factor(out, 1) == 9223372036854775807), (buffer_max(out, 1) < (buffer_fold_factor(out, 1) + buffer_min(out, 1)))));
   {
     let g = buffer_min(out, 0);
     let g0 = buffer_max(out, 0);
     check((buffer_min(__in, 0) <= min(g, g0)));
     check((max(g, g0) <= buffer_max(__in, 0)));
-    check(((buffer_fold_factor(__in, 0) == 9223372036854775807) || (abs((g - g0)) < buffer_fold_factor(__in, 0))));
+    check(or_else((buffer_fold_factor(__in, 0) == 9223372036854775807), (abs((g - g0)) < buffer_fold_factor(__in, 0))));
     check((buffer_min(__in, 1) <= buffer_min(out, 1)));
     check((buffer_max(out, 1) <= buffer_max(__in, 1)));
-    check(((buffer_fold_factor(__in, 1) == 9223372036854775807) || (buffer_max(out, 1) < (buffer_fold_factor(__in, 1) + buffer_min(out, 1)))));
+    check(or_else((buffer_fold_factor(__in, 1) == 9223372036854775807), (buffer_max(out, 1) < (buffer_fold_factor(__in, 1) + buffer_min(out, 1)))));
     { let softmax_in = allocate('softmax_in', 4, [
         {bounds:{min:min(g, g0), max:max(g, g0)}, stride:NaN, fold_factor:9223372036854775807},
         {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:NaN, fold_factor:1}

--- a/builder/test/visualize/softmax_split_4.html
+++ b/builder/test/visualize/softmax_split_4.html
@@ -327,17 +327,17 @@ function pipeline(__in, out) {
   check((out != 0));
   check((buffer_rank(out) == 2));
   check((buffer_elem_size(out) == 4));
-  check(((buffer_fold_factor(out, 0) == 9223372036854775807) || (buffer_max(out, 0) < (buffer_fold_factor(out, 0) + buffer_min(out, 0)))));
-  check(((buffer_fold_factor(out, 1) == 9223372036854775807) || (buffer_max(out, 1) < (buffer_fold_factor(out, 1) + buffer_min(out, 1)))));
+  check(or_else((buffer_fold_factor(out, 0) == 9223372036854775807), (buffer_max(out, 0) < (buffer_fold_factor(out, 0) + buffer_min(out, 0)))));
+  check(or_else((buffer_fold_factor(out, 1) == 9223372036854775807), (buffer_max(out, 1) < (buffer_fold_factor(out, 1) + buffer_min(out, 1)))));
   {
     let g = buffer_min(out, 0);
     let g0 = buffer_max(out, 0);
     check((buffer_min(__in, 0) <= min(g, g0)));
     check((max(g, g0) <= buffer_max(__in, 0)));
-    check(((buffer_fold_factor(__in, 0) == 9223372036854775807) || (abs((g - g0)) < buffer_fold_factor(__in, 0))));
+    check(or_else((buffer_fold_factor(__in, 0) == 9223372036854775807), (abs((g - g0)) < buffer_fold_factor(__in, 0))));
     check((buffer_min(__in, 1) <= buffer_min(out, 1)));
     check((buffer_max(out, 1) <= buffer_max(__in, 1)));
-    check(((buffer_fold_factor(__in, 1) == 9223372036854775807) || (buffer_max(out, 1) < (buffer_fold_factor(__in, 1) + buffer_min(out, 1)))));
+    check(or_else((buffer_fold_factor(__in, 1) == 9223372036854775807), (buffer_max(out, 1) < (buffer_fold_factor(__in, 1) + buffer_min(out, 1)))));
     { let softmax_in = allocate('softmax_in', 4, [
         {bounds:{min:min(g, g0), max:max(g, g0)}, stride:NaN, fold_factor:9223372036854775807},
         {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:NaN, fold_factor:4}

--- a/builder/test/visualize/stencil_chain_split_serial_split_0.html
+++ b/builder/test/visualize/stencil_chain_split_serial_split_0.html
@@ -329,14 +329,14 @@ function pipeline(__in, out) {
     check((out != 0));
     check((buffer_rank(out) == 2));
     check((buffer_elem_size(out) == 2));
-    check(((buffer_fold_factor(out, 0) == 9223372036854775807) || (buffer_max(out, 0) < (buffer_fold_factor(out, 0) + buffer_min(out, 0)))));
-    check(((buffer_fold_factor(out, 1) == 9223372036854775807) || (buffer_max(out, 1) < (buffer_fold_factor(out, 1) + buffer_min(out, 1)))));
+    check(or_else((buffer_fold_factor(out, 0) == 9223372036854775807), (buffer_max(out, 0) < (buffer_fold_factor(out, 0) + buffer_min(out, 0)))));
+    check(or_else((buffer_fold_factor(out, 1) == 9223372036854775807), (buffer_max(out, 1) < (buffer_fold_factor(out, 1) + buffer_min(out, 1)))));
     check(((buffer_min(__in, 0) + 2) <= buffer_min(out, 0)));
     check(((buffer_max(out, 0) + 2) <= buffer_max(__in, 0)));
-    check(((buffer_fold_factor(__in, 0) == 9223372036854775807) || ((buffer_max(out, 0) + 5) <= (buffer_fold_factor(__in, 0) + buffer_min(out, 0)))));
+    check(or_else((buffer_fold_factor(__in, 0) == 9223372036854775807), ((buffer_max(out, 0) + 5) <= (buffer_fold_factor(__in, 0) + buffer_min(out, 0)))));
     check(((buffer_min(__in, 1) + 2) <= buffer_min(out, 1)));
     check(((buffer_max(out, 1) + 2) <= buffer_max(__in, 1)));
-    check(((buffer_fold_factor(__in, 1) == 9223372036854775807) || ((buffer_max(out, 1) + 5) <= (buffer_fold_factor(__in, 1) + buffer_min(out, 1)))));
+    check(or_else((buffer_fold_factor(__in, 1) == 9223372036854775807), ((buffer_max(out, 1) + 5) <= (buffer_fold_factor(__in, 1) + buffer_min(out, 1)))));
     { let add_result = allocate('add_result', 2, [
         {bounds:{min:(buffer_min(out, 0) + -2), max:(buffer_max(out, 0) + 2)}, stride:NaN, fold_factor:9223372036854775807},
         {bounds:{min:(buffer_min(out, 1) + -2), max:(buffer_max(out, 1) + 2)}, stride:NaN, fold_factor:9223372036854775807}

--- a/builder/test/visualize/stencil_chain_split_serial_split_1.html
+++ b/builder/test/visualize/stencil_chain_split_serial_split_1.html
@@ -329,14 +329,14 @@ function pipeline(__in, out) {
     check((out != 0));
     check((buffer_rank(out) == 2));
     check((buffer_elem_size(out) == 2));
-    check(((buffer_fold_factor(out, 0) == 9223372036854775807) || (buffer_max(out, 0) < (buffer_fold_factor(out, 0) + buffer_min(out, 0)))));
-    check(((buffer_fold_factor(out, 1) == 9223372036854775807) || (buffer_max(out, 1) < (buffer_fold_factor(out, 1) + buffer_min(out, 1)))));
+    check(or_else((buffer_fold_factor(out, 0) == 9223372036854775807), (buffer_max(out, 0) < (buffer_fold_factor(out, 0) + buffer_min(out, 0)))));
+    check(or_else((buffer_fold_factor(out, 1) == 9223372036854775807), (buffer_max(out, 1) < (buffer_fold_factor(out, 1) + buffer_min(out, 1)))));
     check(((buffer_min(__in, 0) + 2) <= buffer_min(out, 0)));
     check(((buffer_max(out, 0) + 2) <= buffer_max(__in, 0)));
-    check(((buffer_fold_factor(__in, 0) == 9223372036854775807) || ((buffer_max(out, 0) + 5) <= (buffer_fold_factor(__in, 0) + buffer_min(out, 0)))));
+    check(or_else((buffer_fold_factor(__in, 0) == 9223372036854775807), ((buffer_max(out, 0) + 5) <= (buffer_fold_factor(__in, 0) + buffer_min(out, 0)))));
     check(((buffer_min(__in, 1) + 2) <= buffer_min(out, 1)));
     check(((buffer_max(out, 1) + 2) <= buffer_max(__in, 1)));
-    check(((buffer_fold_factor(__in, 1) == 9223372036854775807) || ((buffer_max(out, 1) + 5) <= (buffer_fold_factor(__in, 1) + buffer_min(out, 1)))));
+    check(or_else((buffer_fold_factor(__in, 1) == 9223372036854775807), ((buffer_max(out, 1) + 5) <= (buffer_fold_factor(__in, 1) + buffer_min(out, 1)))));
     { let add_result = allocate('add_result', 2, [
         {bounds:{min:(buffer_min(out, 0) + -2), max:(buffer_max(out, 0) + 2)}, stride:NaN, fold_factor:9223372036854775807},
         {bounds:{min:(buffer_min(out, 1) + -2), max:(buffer_max(out, 1) + 2)}, stride:NaN, fold_factor:3}

--- a/builder/test/visualize/stencil_chain_split_serial_split_2.html
+++ b/builder/test/visualize/stencil_chain_split_serial_split_2.html
@@ -329,14 +329,14 @@ function pipeline(__in, out) {
     check((out != 0));
     check((buffer_rank(out) == 2));
     check((buffer_elem_size(out) == 2));
-    check(((buffer_fold_factor(out, 0) == 9223372036854775807) || (buffer_max(out, 0) < (buffer_fold_factor(out, 0) + buffer_min(out, 0)))));
-    check(((buffer_fold_factor(out, 1) == 9223372036854775807) || (buffer_max(out, 1) < (buffer_fold_factor(out, 1) + buffer_min(out, 1)))));
+    check(or_else((buffer_fold_factor(out, 0) == 9223372036854775807), (buffer_max(out, 0) < (buffer_fold_factor(out, 0) + buffer_min(out, 0)))));
+    check(or_else((buffer_fold_factor(out, 1) == 9223372036854775807), (buffer_max(out, 1) < (buffer_fold_factor(out, 1) + buffer_min(out, 1)))));
     check(((buffer_min(__in, 0) + 2) <= buffer_min(out, 0)));
     check(((buffer_max(out, 0) + 2) <= buffer_max(__in, 0)));
-    check(((buffer_fold_factor(__in, 0) == 9223372036854775807) || ((buffer_max(out, 0) + 5) <= (buffer_fold_factor(__in, 0) + buffer_min(out, 0)))));
+    check(or_else((buffer_fold_factor(__in, 0) == 9223372036854775807), ((buffer_max(out, 0) + 5) <= (buffer_fold_factor(__in, 0) + buffer_min(out, 0)))));
     check(((buffer_min(__in, 1) + 2) <= buffer_min(out, 1)));
     check(((buffer_max(out, 1) + 2) <= buffer_max(__in, 1)));
-    check(((buffer_fold_factor(__in, 1) == 9223372036854775807) || ((buffer_max(out, 1) + 5) <= (buffer_fold_factor(__in, 1) + buffer_min(out, 1)))));
+    check(or_else((buffer_fold_factor(__in, 1) == 9223372036854775807), ((buffer_max(out, 1) + 5) <= (buffer_fold_factor(__in, 1) + buffer_min(out, 1)))));
     { let add_result = allocate('add_result', 2, [
         {bounds:{min:(buffer_min(out, 0) + -2), max:(buffer_max(out, 0) + 2)}, stride:NaN, fold_factor:9223372036854775807},
         {bounds:{min:(buffer_min(out, 1) + -2), max:(buffer_max(out, 1) + 2)}, stride:NaN, fold_factor:4}

--- a/builder/test/visualize/stencil_split_0.html
+++ b/builder/test/visualize/stencil_split_0.html
@@ -327,14 +327,14 @@ function pipeline(__in, out) {
   check((out != 0));
   check((buffer_rank(out) == 2));
   check((buffer_elem_size(out) == 2));
-  check(((buffer_fold_factor(out, 0) == 9223372036854775807) || (buffer_max(out, 0) < (buffer_fold_factor(out, 0) + buffer_min(out, 0)))));
-  check(((buffer_fold_factor(out, 1) == 9223372036854775807) || (buffer_max(out, 1) < (buffer_fold_factor(out, 1) + buffer_min(out, 1)))));
+  check(or_else((buffer_fold_factor(out, 0) == 9223372036854775807), (buffer_max(out, 0) < (buffer_fold_factor(out, 0) + buffer_min(out, 0)))));
+  check(or_else((buffer_fold_factor(out, 1) == 9223372036854775807), (buffer_max(out, 1) < (buffer_fold_factor(out, 1) + buffer_min(out, 1)))));
   check((buffer_min(__in, 0) < buffer_min(out, 0)));
   check((buffer_max(out, 0) < buffer_max(__in, 0)));
-  check(((buffer_fold_factor(__in, 0) == 9223372036854775807) || ((buffer_max(out, 0) + 3) <= (buffer_fold_factor(__in, 0) + buffer_min(out, 0)))));
+  check(or_else((buffer_fold_factor(__in, 0) == 9223372036854775807), ((buffer_max(out, 0) + 3) <= (buffer_fold_factor(__in, 0) + buffer_min(out, 0)))));
   check((buffer_min(__in, 1) < buffer_min(out, 1)));
   check((buffer_max(out, 1) < buffer_max(__in, 1)));
-  check(((buffer_fold_factor(__in, 1) == 9223372036854775807) || ((buffer_max(out, 1) + 3) <= (buffer_fold_factor(__in, 1) + buffer_min(out, 1)))));
+  check(or_else((buffer_fold_factor(__in, 1) == 9223372036854775807), ((buffer_max(out, 1) + 3) <= (buffer_fold_factor(__in, 1) + buffer_min(out, 1)))));
   { let intm = allocate('intm', 2, [
       {bounds:{min:(buffer_min(out, 0) + -1), max:(buffer_max(out, 0) + 1)}, stride:NaN, fold_factor:9223372036854775807},
       {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:NaN, fold_factor:9223372036854775807}

--- a/builder/test/visualize/stencil_split_1.html
+++ b/builder/test/visualize/stencil_split_1.html
@@ -327,14 +327,14 @@ function pipeline(__in, out) {
   check((out != 0));
   check((buffer_rank(out) == 2));
   check((buffer_elem_size(out) == 2));
-  check(((buffer_fold_factor(out, 0) == 9223372036854775807) || (buffer_max(out, 0) < (buffer_fold_factor(out, 0) + buffer_min(out, 0)))));
-  check(((buffer_fold_factor(out, 1) == 9223372036854775807) || (buffer_max(out, 1) < (buffer_fold_factor(out, 1) + buffer_min(out, 1)))));
+  check(or_else((buffer_fold_factor(out, 0) == 9223372036854775807), (buffer_max(out, 0) < (buffer_fold_factor(out, 0) + buffer_min(out, 0)))));
+  check(or_else((buffer_fold_factor(out, 1) == 9223372036854775807), (buffer_max(out, 1) < (buffer_fold_factor(out, 1) + buffer_min(out, 1)))));
   check((buffer_min(__in, 0) < buffer_min(out, 0)));
   check((buffer_max(out, 0) < buffer_max(__in, 0)));
-  check(((buffer_fold_factor(__in, 0) == 9223372036854775807) || ((buffer_max(out, 0) + 3) <= (buffer_fold_factor(__in, 0) + buffer_min(out, 0)))));
+  check(or_else((buffer_fold_factor(__in, 0) == 9223372036854775807), ((buffer_max(out, 0) + 3) <= (buffer_fold_factor(__in, 0) + buffer_min(out, 0)))));
   check((buffer_min(__in, 1) < buffer_min(out, 1)));
   check((buffer_max(out, 1) < buffer_max(__in, 1)));
-  check(((buffer_fold_factor(__in, 1) == 9223372036854775807) || ((buffer_max(out, 1) + 3) <= (buffer_fold_factor(__in, 1) + buffer_min(out, 1)))));
+  check(or_else((buffer_fold_factor(__in, 1) == 9223372036854775807), ((buffer_max(out, 1) + 3) <= (buffer_fold_factor(__in, 1) + buffer_min(out, 1)))));
   { let intm = allocate('intm', 2, [
       {bounds:{min:(buffer_min(out, 0) + -1), max:(buffer_max(out, 0) + 1)}, stride:NaN, fold_factor:9223372036854775807},
       {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:NaN, fold_factor:3}

--- a/builder/test/visualize/stencil_split_2.html
+++ b/builder/test/visualize/stencil_split_2.html
@@ -327,14 +327,14 @@ function pipeline(__in, out) {
   check((out != 0));
   check((buffer_rank(out) == 2));
   check((buffer_elem_size(out) == 2));
-  check(((buffer_fold_factor(out, 0) == 9223372036854775807) || (buffer_max(out, 0) < (buffer_fold_factor(out, 0) + buffer_min(out, 0)))));
-  check(((buffer_fold_factor(out, 1) == 9223372036854775807) || (buffer_max(out, 1) < (buffer_fold_factor(out, 1) + buffer_min(out, 1)))));
+  check(or_else((buffer_fold_factor(out, 0) == 9223372036854775807), (buffer_max(out, 0) < (buffer_fold_factor(out, 0) + buffer_min(out, 0)))));
+  check(or_else((buffer_fold_factor(out, 1) == 9223372036854775807), (buffer_max(out, 1) < (buffer_fold_factor(out, 1) + buffer_min(out, 1)))));
   check((buffer_min(__in, 0) < buffer_min(out, 0)));
   check((buffer_max(out, 0) < buffer_max(__in, 0)));
-  check(((buffer_fold_factor(__in, 0) == 9223372036854775807) || ((buffer_max(out, 0) + 3) <= (buffer_fold_factor(__in, 0) + buffer_min(out, 0)))));
+  check(or_else((buffer_fold_factor(__in, 0) == 9223372036854775807), ((buffer_max(out, 0) + 3) <= (buffer_fold_factor(__in, 0) + buffer_min(out, 0)))));
   check((buffer_min(__in, 1) < buffer_min(out, 1)));
   check((buffer_max(out, 1) < buffer_max(__in, 1)));
-  check(((buffer_fold_factor(__in, 1) == 9223372036854775807) || ((buffer_max(out, 1) + 3) <= (buffer_fold_factor(__in, 1) + buffer_min(out, 1)))));
+  check(or_else((buffer_fold_factor(__in, 1) == 9223372036854775807), ((buffer_max(out, 1) + 3) <= (buffer_fold_factor(__in, 1) + buffer_min(out, 1)))));
   { let intm = allocate('intm', 2, [
       {bounds:{min:(buffer_min(out, 0) + -1), max:(buffer_max(out, 0) + 1)}, stride:NaN, fold_factor:9223372036854775807},
       {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:NaN, fold_factor:4}

--- a/builder/test/visualize/stencil_split_3.html
+++ b/builder/test/visualize/stencil_split_3.html
@@ -327,14 +327,14 @@ function pipeline(__in, out) {
   check((out != 0));
   check((buffer_rank(out) == 2));
   check((buffer_elem_size(out) == 2));
-  check(((buffer_fold_factor(out, 0) == 9223372036854775807) || (buffer_max(out, 0) < (buffer_fold_factor(out, 0) + buffer_min(out, 0)))));
-  check(((buffer_fold_factor(out, 1) == 9223372036854775807) || (buffer_max(out, 1) < (buffer_fold_factor(out, 1) + buffer_min(out, 1)))));
+  check(or_else((buffer_fold_factor(out, 0) == 9223372036854775807), (buffer_max(out, 0) < (buffer_fold_factor(out, 0) + buffer_min(out, 0)))));
+  check(or_else((buffer_fold_factor(out, 1) == 9223372036854775807), (buffer_max(out, 1) < (buffer_fold_factor(out, 1) + buffer_min(out, 1)))));
   check((buffer_min(__in, 0) < buffer_min(out, 0)));
   check((buffer_max(out, 0) < buffer_max(__in, 0)));
-  check(((buffer_fold_factor(__in, 0) == 9223372036854775807) || ((buffer_max(out, 0) + 3) <= (buffer_fold_factor(__in, 0) + buffer_min(out, 0)))));
+  check(or_else((buffer_fold_factor(__in, 0) == 9223372036854775807), ((buffer_max(out, 0) + 3) <= (buffer_fold_factor(__in, 0) + buffer_min(out, 0)))));
   check((buffer_min(__in, 1) < buffer_min(out, 1)));
   check((buffer_max(out, 1) < buffer_max(__in, 1)));
-  check(((buffer_fold_factor(__in, 1) == 9223372036854775807) || ((buffer_max(out, 1) + 3) <= (buffer_fold_factor(__in, 1) + buffer_min(out, 1)))));
+  check(or_else((buffer_fold_factor(__in, 1) == 9223372036854775807), ((buffer_max(out, 1) + 3) <= (buffer_fold_factor(__in, 1) + buffer_min(out, 1)))));
   { let intm = allocate('intm', 2, [
       {bounds:{min:(buffer_min(out, 0) + -1), max:(buffer_max(out, 0) + 1)}, stride:NaN, fold_factor:9223372036854775807},
       {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:NaN, fold_factor:6}

--- a/runtime/evaluate.cc
+++ b/runtime/evaluate.cc
@@ -195,7 +195,7 @@ public:
     }
   }
 
-  index_t eval_short_circuit_op(const call* op) {
+  bool eval_short_circuit_op(const call* op) {
     for (const expr& i : op->args) {
       index_t x = eval(i);
       if (!x && op->intrinsic == intrinsic::and_then) {

--- a/runtime/expr.h
+++ b/runtime/expr.h
@@ -90,6 +90,10 @@ enum class intrinsic {
   // Common arithmetic functions.
   abs,
 
+  // These are short circuiting logical operations, unlike the && and || operators which are commutative and do not short circuit.
+  and_then,
+  or_else,
+
   // Functions with arguments (buf) that return buffer metadata.
   buffer_rank,
   buffer_elem_size,
@@ -605,6 +609,9 @@ expr align_down(expr x, expr a);
 expr align_up(expr x, expr a);
 // Expand the interval to have a min and extent aligned to a multiple of a.
 interval_expr align(interval_expr x, expr a);
+
+expr and_then(std::vector<expr> args);
+expr or_else(std::vector<expr> args);
 
 expr buffer_rank(expr buf);
 expr buffer_elem_size(expr buf);

--- a/runtime/expr_stmt.cc
+++ b/runtime/expr_stmt.cc
@@ -528,6 +528,9 @@ expr align_down(expr x, expr a) { return (x / a) * a; }
 expr align_up(expr x, expr a) { return ((x + a - 1) / a) * a; }
 interval_expr align(interval_expr x, expr a) { return {align_down(x.min, a), align_up(x.max + 1, a) - 1}; }
 
+expr and_then(std::vector<expr> args) { return call::make(intrinsic::and_then, std::move(args)); }
+expr or_else(std::vector<expr> args) { return call::make(intrinsic::or_else, std::move(args)); } 
+
 expr buffer_rank(expr buf) { return call::make(intrinsic::buffer_rank, {std::move(buf)}); }
 expr buffer_elem_size(expr buf) { return call::make(intrinsic::buffer_elem_size, {std::move(buf)}); }
 expr buffer_min(expr buf, expr dim) { return call::make(intrinsic::buffer_min, {std::move(buf), std::move(dim)}); }

--- a/runtime/print.cc
+++ b/runtime/print.cc
@@ -25,6 +25,8 @@ std::string to_string(intrinsic fn) {
   case intrinsic::negative_infinity: return "-oo";
   case intrinsic::indeterminate: return "indeterminate";
   case intrinsic::abs: return "abs";
+  case intrinsic::and_then: return "and_then";
+  case intrinsic::or_else: return "or_else";
   case intrinsic::buffer_rank: return "buffer_rank";
   case intrinsic::buffer_elem_size: return "buffer_elem_size";
   case intrinsic::buffer_size_bytes: return "buffer_size_bytes";

--- a/runtime/test/evaluate.cc
+++ b/runtime/test/evaluate.cc
@@ -39,6 +39,14 @@ TEST(evaluate, arithmetic) {
   ASSERT_EQ(evaluate(x != 5, context), 1);
 
   ASSERT_EQ(evaluate((x + 2) / 3, context), 2);
+
+  ASSERT_EQ(evaluate(and_then({expr(true), expr(true)})), true);
+  ASSERT_EQ(evaluate(and_then({expr(true), expr(false)})), false);
+  ASSERT_EQ(evaluate(and_then({expr(false), indeterminate()})), false);
+  ASSERT_EQ(evaluate(or_else({expr(true), expr(true)})), true);
+  ASSERT_EQ(evaluate(or_else({expr(false), expr(true)})), true);
+  ASSERT_EQ(evaluate(or_else({expr(false), expr(false)})), false);
+  ASSERT_EQ(evaluate(or_else({expr(true), indeterminate()})), true);
 }
 
 TEST(evaluate, call) {


### PR DESCRIPTION
Until now we were pretty sloppy about short circuiting. We rely on short circuiting to avoid integer overflow in some checks. 

#337 made simplification of logicals a lot more aggressive, and looking at the code, I'm not sure we actually got short circuiting anyways.

This PR adds `and_then` and `or_else` intrinsics that are more explicit about wanting short circuiting.