### PR TITLE
Fix bazelrc copts being different between build, run, test

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,17 +1,11 @@
 common --enable_bzlmod
-build --action_env=BAZEL_CXXOPTS="-std=c++17:-fstrict-aliasing:-Wall:-Wsuggest-override"
-build --copt=-fdiagnostics-color=always
-run --copt=-fdiagnostics-color=always
-test --copt=-fdiagnostics-color=always
-build --copt=-g --strip=never
-run --copt=-g --strip=never
-test --copt=-g --strip=never
+common --action_env=BAZEL_CXXOPTS="-std=c++17:-fstrict-aliasing:-Wall:-Wsuggest-override"
+common --copt=-fdiagnostics-color=always
+common --copt=-g --strip=never
 # Without --force_pic, bazel compiles a lot of cc files twice, if they are used by PIC and non-PIC targets.
-build --force_pic
-run --force_pic
-test --force_pic
+common --force_pic
 
 # Allow us to run with --config=asan
-build:asan --copt -fsanitize=address
-build:asan --copt -DADDRESS_SANITIZER
-build:asan --linkopt -fsanitize=address
+common:asan --copt -fsanitize=address
+common:asan --copt -DADDRESS_SANITIZER
+common:asan --linkopt -fsanitize=address


### PR DESCRIPTION
Currently, our bazelrc causes a recompile when switching between `bazel run` and `bazel test`, which is a bit annoying. This is also just a nice cleanup to not duplicate all our options 3x.