### PR TITLE
Fix fold factors getting clobbered by a different loop

### DIFF
--- a/builder/slide_and_fold_storage.cc
+++ b/builder/slide_and_fold_storage.cc
@@ -419,9 +419,6 @@ public:
         loop_info& loop = loops[loop_index];
         loop.add_synchronization();
 
-        // We don't want to use the bounds of the loop we are sliding over here.
-        auto ignore_loop_bounds = set_value_in_scope(*loop.expr_bounds, loop.sym, interval_expr::all());
-
         expr loop_var = variable::make(loop.sym);
         if (!fold_factors[output]) continue;
         for (int d = 0; d < static_cast<int>(fold_factors[output]->size()); ++d) {

--- a/builder/slide_and_fold_storage.cc
+++ b/builder/slide_and_fold_storage.cc
@@ -419,8 +419,9 @@ public:
         loop_info& loop = loops[loop_index];
         loop.add_synchronization();
 
-        expr loop_var = variable::make(loop.sym);
         if (!fold_factors[output]) continue;
+
+        expr loop_var = variable::make(loop.sym);
         for (int d = 0; d < static_cast<int>(fold_factors[output]->size()); ++d) {
           if ((*fold_factors[output])[d].loop != loop_index) {
             // This is a fold factor for a different loop.

--- a/builder/slide_and_fold_storage.cc
+++ b/builder/slide_and_fold_storage.cc
@@ -425,6 +425,11 @@ public:
         expr loop_var = variable::make(loop.sym);
         if (!fold_factors[output]) continue;
         for (int d = 0; d < static_cast<int>(fold_factors[output]->size()); ++d) {
+          if ((*fold_factors[output])[d].loop != loop_index) {
+            // This is a fold factor for a different loop.
+            continue;
+          }
+
           expr fold_factor = (*fold_factors[output])[d].factor;
           expr overlap = (*fold_factors[output])[d].overlap;
           if (!is_finite(fold_factor)) {

--- a/builder/test/softmax.cc
+++ b/builder/test/softmax.cc
@@ -217,8 +217,7 @@ TEST_P(softmax, pipeline) {
     const int exp_in_allocation = split_b * D;
     const int max_in_allocation = split_b;
     const int softmax_in_allocation = split_b * D;
-    // This one is a bit odd, not sure why max is needed.
-    const int softmax_out_allocation = split_b * (split_c == 0 ? D : std::max(split_b, split_c));
+    const int softmax_out_allocation = split_b * (split_c == 0 ? D : split_c);
     int extra_memory = 0;
     if (copy_at_the_end == 2) {
       extra_memory = D * B;


### PR DESCRIPTION
Related to efforts about aliasing folded buffers. There are cases right now where the fold factors we come up with are wrong, but aliasing comes along later and aliases the buffer, so we don't see it.