### PR TITLE
Don't decrease depth twice for make_random_condition

### DIFF
--- a/builder/test/simplify.cc
+++ b/builder/test/simplify.cc
@@ -536,7 +536,7 @@ public:
       case 7: return select(make_random_condition(depth - 1), a, b);
       case 8: return random_constant();
       case 9: return random_pick(vars_);
-      case 10: return make_random_condition(depth - 1);
+      case 10: return make_random_condition(depth);
       default: std::abort();
       }
     }


### PR DESCRIPTION
I think this is one of the reasons we don't hit #347 in the test.