### PR TITLE
Simplifier improvements

### DIFF
--- a/builder/rewrite.h
+++ b/builder/rewrite.h
@@ -40,26 +40,35 @@ SLINKY_ALWAYS_INLINE inline bool match(index_t p, const expr& x, match_context&)
 SLINKY_ALWAYS_INLINE inline index_t substitute(index_t p, const match_context&) { return p; }
 
 template <typename T>
-struct pattern_type {
-  static constexpr expr_node_type value = T::type;
+struct pattern_info {
+  static constexpr expr_node_type type = T::type;
+  static constexpr bool is_canonical = true;
 };
 template <>
-struct pattern_type<std::int32_t> {
-  static constexpr expr_node_type value = expr_node_type::constant;
+struct pattern_info<std::int32_t> {
+  static constexpr expr_node_type type = expr_node_type::constant;
+  static constexpr bool is_canonical = true;
 };
 template <>
-struct pattern_type<std::int64_t> {
-  static constexpr expr_node_type value = expr_node_type::constant;
+struct pattern_info<std::int64_t> {
+  static constexpr expr_node_type type = expr_node_type::constant;
+  static constexpr bool is_canonical = true;
 };
 template <>
-struct pattern_type<bool> {
-  static constexpr expr_node_type value = expr_node_type::constant;
+struct pattern_info<bool> {
+  static constexpr expr_node_type type = expr_node_type::constant;
+  static constexpr bool is_canonical = true;
 };
 
 class pattern_expr {
 public:
-  static constexpr expr_node_type type = expr_node_type::none;
   const expr& e;
+};
+
+template<>
+struct pattern_info<pattern_expr> {
+  static constexpr expr_node_type type = expr_node_type::none;
+  static constexpr bool is_canonical = true;
 };
 
 inline std::ostream& operator<<(std::ostream& os, const pattern_expr& e) { return os << e.e; }
@@ -141,19 +150,22 @@ inline index_t match_context::matched(const pattern_constant<N>& p, index_t def)
 template <typename T, typename A, typename B>
 class pattern_binary {
 public:
-  static constexpr expr_node_type type = T::static_type;
   A a;
   B b;
+};
 
-  static_assert(!T::commutative || !should_commute(pattern_type<A>::value, pattern_type<B>::value));
+template <typename T, typename A, typename B>
+struct pattern_info<pattern_binary<T, A, B>> {
+  static constexpr expr_node_type type = T::static_type;
+  static constexpr bool is_canonical = !T::commutative || !should_commute(pattern_info<A>::type, pattern_info<B>::type);
 };
 
 template <typename T, typename A, typename B>
 bool match_binary(const pattern_binary<T, A, B>& p, const expr& a, const expr& b, match_context& ctx) {
   int this_bit = -1;
   if (T::commutative) {
-    constexpr expr_node_type ta = pattern_type<A>::value;
-    constexpr expr_node_type tb = pattern_type<B>::value;
+    constexpr expr_node_type ta = pattern_info<A>::type;
+    constexpr expr_node_type tb = pattern_info<B>::type;
     if (ta == expr_node_type::none || tb == expr_node_type::none || ta == tb) {
       // This is a commutative operation and we can't canonicalize the ordering.
       // Remember which bit in the variant index is ours, and increment the bit for the next commutative node.
@@ -355,6 +367,12 @@ public:
 };
 
 template <typename T>
+struct pattern_info<replacement_eval<T>> {
+  static constexpr expr_node_type type = expr_node_type::constant;
+  static constexpr bool is_canonical = true;
+};
+
+template <typename T>
 index_t substitute(const replacement_eval<T>& r, const match_context& ctx) {
   return substitute(r.a, ctx);
 }
@@ -466,6 +484,8 @@ auto eval(const T& x) {
 
 template <typename Pattern, typename T>
 bool match_any_variant(const Pattern& p, const T& x, match_context& ctx) {
+  static_assert(pattern_info<Pattern>::is_canonical);
+
   // We'll find out how many variant bits we have when we try to match.
   // This can grow if we fail early due to a commutative variant that doesn't match near the root
   // of the expression, so we track the max we've seen.
@@ -502,6 +522,8 @@ public:
 
   template <typename Pattern, typename Replacement>
   bool rewrite(const Pattern& p, const Replacement& r) {
+    static_assert(pattern_info<Replacement>::is_canonical);
+
     match_context ctx;
     if (!match_any_variant(p, x, ctx)) return false;
 
@@ -511,6 +533,8 @@ public:
 
   template <typename Pattern, typename Replacement, typename Predicate>
   bool rewrite(const Pattern& p, const Replacement& r, const Predicate& pr) {
+    static_assert(pattern_info<Replacement>::is_canonical);
+
     match_context ctx;
     if (!match_any_variant(p, x, ctx)) return false;
 

--- a/builder/simplify_exprs.cc
+++ b/builder/simplify_exprs.cc
@@ -102,15 +102,15 @@ expr simplify(const class min* op, expr a, expr b) {
       r.rewrite(min(c0 - x, c1), c0 - max(x, eval(c0 - c1))) ||
     
       // https://github.com/halide/Halide/blob/7994e7030976f9fcd321a4d1d5f76f4582e01905/src/Simplify_Min.cpp#L276-L311
-      r.rewrite(min(x * c0, c1), min(x, eval(c1 / c0)) * c0, eval(c0 > 0) && eval(c1 % c0 == 0)) ||
-      r.rewrite(min(x * c0, c1), max(x, eval(c1 / c0)) * c0, eval(c0 < 0) && eval(c1 % c0 == 0)) ||
+      r.rewrite(min(x * c0, c1), min(x, eval(c1 / c0)) * c0, eval(c0 > 0 && c1 % c0 == 0)) ||
+      r.rewrite(min(x * c0, c1), max(x, eval(c1 / c0)) * c0, eval(c0 < 0 && c1 % c0 == 0)) ||
 
-      r.rewrite(min(x * c0, y * c1), min(x, y * eval(c1 / c0)) * c0, eval(c0 > 0) && eval(c1 % c0 == 0)) ||
-      r.rewrite(min(x * c0, y * c1), max(x, y * eval(c1 / c0)) * c0, eval(c0 < 0) && eval(c1 % c0 == 0)) ||
-      r.rewrite(min(x * c0, y * c1), min(y, x * eval(c0 / c1)) * c1, eval(c1 > 0) && eval(c0 % c1 == 0)) ||
-      r.rewrite(min(x * c0, y * c1), max(y, x * eval(c0 / c1)) * c1, eval(c1 < 0) && eval(c0 % c1 == 0)) ||
-      r.rewrite(min(y * c0 + c1, x * c0), min(x, y + eval(c1 / c0)) * c0, eval(c0 > 0) && eval(c1 % c0 == 0)) ||
-      r.rewrite(min(y * c0 + c1, x * c0), max(x, y + eval(c1 / c0)) * c0, eval(c0 < 0) && eval(c1 % c0 == 0)) ||
+      r.rewrite(min(x * c0, y * c1), min(x, y * eval(c1 / c0)) * c0, eval(c0 > 0 && c1 % c0 == 0)) ||
+      r.rewrite(min(x * c0, y * c1), max(x, y * eval(c1 / c0)) * c0, eval(c0 < 0 && c1 % c0 == 0)) ||
+      r.rewrite(min(x * c0, y * c1), min(y, x * eval(c0 / c1)) * c1, eval(c1 > 0 && c0 % c1 == 0)) ||
+      r.rewrite(min(x * c0, y * c1), max(y, x * eval(c0 / c1)) * c1, eval(c1 < 0 && c0 % c1 == 0)) ||
+      r.rewrite(min(y * c0 + c1, x * c0), min(x, y + eval(c1 / c0)) * c0, eval(c0 > 0 && c1 % c0 == 0)) ||
+      r.rewrite(min(y * c0 + c1, x * c0), max(x, y + eval(c1 / c0)) * c0, eval(c0 < 0 && c1 % c0 == 0)) ||
 
       r.rewrite(min(x / c0, y / c0), min(x, y) / c0, eval(c0 > 0)) ||
       r.rewrite(min(x / c0, y / c0), max(x, y) / c0, eval(c0 < 0)) ||
@@ -121,25 +121,25 @@ expr simplify(const class min* op, expr a, expr b) {
       r.rewrite(min(y / c0 + c1, x / c0), min(x, y + eval(c1 * c0)) / c0, eval(c0 > 0)) ||
       r.rewrite(min(y / c0 + c1, x / c0), max(x, y + eval(c1 * c0)) / c0, eval(c0 < 0)) ||
 
-      r.rewrite(min(((x + c2) / c3) * c4, (x + c0) / c1), (x + c0) / c1, eval(c0 + c3 - c1 <= c2) && eval(c1 > 0) && eval(c3 > 0) && eval(c1 * c4 == c3)) ||
-      r.rewrite(min(((x + c2) / c3) * c4, (x + c0) / c1), ((x + c2) / c3) * c4, eval(c2 <= c0) && eval(c1 > 0) && eval(c3 > 0) && eval(c1 * c4 == c3)) ||
-      r.rewrite(min(((x + c2) / c3) * c4, x / c1), x/c1, eval(c3 - c1 <= c2) && eval(c1 > 0) && eval(c3 > 0) && eval(c1 * c4 == c3)) ||
-      r.rewrite(min(((x + c2) / c3) * c4, x / c1), ((x + c2) / c3) * c4, eval(c2 <= 0) && eval(c1 > 0) && eval(c3 > 0) && eval(c1 * c4 == c3)) ||
-      r.rewrite(min((x / c3) * c4, (x + c0) / c1), (x + c0) / c1, eval(c0 + c3 - c1 <= 0) && eval(c1 > 0) && eval(c3 > 0) && eval(c1 * c4 == c3)) ||
-      r.rewrite(min((x / c3) * c4, (x + c0) / c1), (x / c3) * c4, eval(0 <= c0) && eval(c1 > 0) && eval(c3 > 0) && eval(c1 * c4 == c3)) ||
-      r.rewrite(min(x / c1 + c0, (x / c3) * c4), (x / c3) * c4, eval(c0 > 0) && eval(c1 > 0) && eval(c3 > 0) && eval(c1 * c4 == c3)) ||
-      r.rewrite(min((x / c3) * c4, x / c1), (x / c3) * c4, eval(c1 > 0) && eval(c3 > 0) && eval(c1 * c4 == c3)) ||
+      r.rewrite(min(((x + c2) / c3) * c4, (x + c0) / c1), (x + c0) / c1, eval(c0 + c3 - c1 <= c2 && c1 > 0 && c3 > 0 && c1 * c4 == c3)) ||
+      r.rewrite(min(((x + c2) / c3) * c4, (x + c0) / c1), ((x + c2) / c3) * c4, eval(c2 <= c0 && c1 > 0 && c3 > 0 && c1 * c4 == c3)) ||
+      r.rewrite(min(((x + c2) / c3) * c4, x / c1), x/c1, eval(c3 - c1 <= c2 && c1 > 0 && c3 > 0 && c1 * c4 == c3)) ||
+      r.rewrite(min(((x + c2) / c3) * c4, x / c1), ((x + c2) / c3) * c4, eval(c2 <= 0 && c1 > 0 && c3 > 0 && c1 * c4 == c3)) ||
+      r.rewrite(min((x / c3) * c4, (x + c0) / c1), (x + c0) / c1, eval(c0 + c3 - c1 <= 0 && c1 > 0 && c3 > 0 && c1 * c4 == c3)) ||
+      r.rewrite(min((x / c3) * c4, (x + c0) / c1), (x / c3) * c4, eval(0 <= c0 && c1 > 0 && c3 > 0 && c1 * c4 == c3)) ||
+      r.rewrite(min(x / c1 + c0, (x / c3) * c4), (x / c3) * c4, eval(c0 > 0 && c1 > 0 && c3 > 0 && c1 * c4 == c3)) ||
+      r.rewrite(min((x / c3) * c4, x / c1), (x / c3) * c4, eval(c1 > 0 && c3 > 0 && c1 * c4 == c3)) ||
 
       // https://github.com/halide/Halide/blob/f4c78317887b6df4d2486e1f81e81f9012943f0f/src/Simplify_Min.cpp#L115-L129
       // Compare x to a stair-step function in x
-      r.rewrite(min(x, ((x + c0) / c1) * c1 + c2), x, eval(c1 > 0) && eval(c0 + c2 >= c1 - 1)) ||
-      r.rewrite(min(x, ((x + c0) / c1) * c1 + c2), ((x + c0) / c1) * c1 + c2, eval(c1 > 0) && eval(c0 + c2 <= 0)) ||
-      r.rewrite(min((x / c1) * c1 + c2, (x / c0) * c0), (x / c0) * c0, eval(c1 > 0) && eval(c2 >= c1) && eval(c0 != 0)) ||
+      r.rewrite(min(x, ((x + c0) / c1) * c1 + c2), x, eval(c1 > 0 && c0 + c2 >= c1 - 1)) ||
+      r.rewrite(min(x, ((x + c0) / c1) * c1 + c2), ((x + c0) / c1) * c1 + c2, eval(c1 > 0 && c0 + c2 <= 0)) ||
+      r.rewrite(min((x / c1) * c1 + c2, (x / c0) * c0), (x / c0) * c0, eval(c1 > 0 && c2 >= c1 && c0 != 0)) ||
       // Special cases where c0 or c2 is zero
-      r.rewrite(min(x, (x / c1) * c1 + c2), x, eval(c1 > 0) && eval(c2 >= c1 - 1)) ||
-      r.rewrite(min(x, ((x + c0) / c1) * c1), x, eval(c1 > 0) && eval(c0 >= c1 - 1)) ||
-      r.rewrite(min(x, (x / c1) * c1 + c2), (x / c1) * c1 + c2, eval(c1 > 0) && eval(c2 <= 0)) ||
-      r.rewrite(min(x, ((x + c0) / c1) * c1), ((x + c0) / c1) * c1, eval(c1 > 0) && eval(c0 <= 0)) ||
+      r.rewrite(min(x, (x / c1) * c1 + c2), x, eval(c1 > 0 && c2 >= c1 - 1)) ||
+      r.rewrite(min(x, ((x + c0) / c1) * c1), x, eval(c1 > 0 && c0 >= c1 - 1)) ||
+      r.rewrite(min(x, (x / c1) * c1 + c2), (x / c1) * c1 + c2, eval(c1 > 0 && c2 <= 0)) ||
+      r.rewrite(min(x, ((x + c0) / c1) * c1), ((x + c0) / c1) * c1, eval(c1 > 0 && c0 <= 0)) ||
 
       r.rewrite(min(x, (x / c0) * c0), (x / c0) * c0, eval(c0 > 0)) ||
 
@@ -227,15 +227,15 @@ expr simplify(const class max* op, expr a, expr b) {
       r.rewrite(max(c0 - x, c1), c0 - min(x, eval(c0 - c1))) ||
 
       // https://github.com/halide/Halide/blob/7994e7030976f9fcd321a4d1d5f76f4582e01905/src/Simplify_Max.cpp#L271-L300
-      r.rewrite(max(x * c0, c1), max(x, eval(c1 / c0)) * c0, eval(c0 > 0) && eval(c1 % c0 == 0)) ||
-      r.rewrite(max(x * c0, c1), min(x, eval(c1 / c0)) * c0, eval(c0 < 0) && eval(c1 % c0 == 0)) ||
+      r.rewrite(max(x * c0, c1), max(x, eval(c1 / c0)) * c0, eval(c0 > 0 && c1 % c0 == 0)) ||
+      r.rewrite(max(x * c0, c1), min(x, eval(c1 / c0)) * c0, eval(c0 < 0 && c1 % c0 == 0)) ||
 
-      r.rewrite(max(x * c0, y * c1), max(x, y * eval(c1 / c0)) * c0, eval(c0 > 0) && eval(c1 % c0 == 0)) ||
-      r.rewrite(max(x * c0, y * c1), min(x, y * eval(c1 / c0)) * c0, eval(c0 < 0) && eval(c1 % c0 == 0)) ||
-      r.rewrite(max(x * c0, y * c1), max(y, x * eval(c0 / c1)) * c1, eval(c1 > 0) && eval(c0 % c1 == 0)) ||
-      r.rewrite(max(x * c0, y * c1), min(y, x * eval(c0 / c1)) * c1, eval(c1 < 0) && eval(c0 % c1 == 0)) ||
-      r.rewrite(max(y * c0 + c1, x * c0), max(x, y + eval(c1 / c0)) * c0, eval(c0 > 0) && eval(c1 % c0 == 0)) ||
-      r.rewrite(max(y * c0 + c1, x * c0), min(x, y + eval(c1 / c0)) * c0, eval(c0 < 0) && eval(c1 % c0 == 0)) ||
+      r.rewrite(max(x * c0, y * c1), max(x, y * eval(c1 / c0)) * c0, eval(c0 > 0 && c1 % c0 == 0)) ||
+      r.rewrite(max(x * c0, y * c1), min(x, y * eval(c1 / c0)) * c0, eval(c0 < 0 && c1 % c0 == 0)) ||
+      r.rewrite(max(x * c0, y * c1), max(y, x * eval(c0 / c1)) * c1, eval(c1 > 0 && c0 % c1 == 0)) ||
+      r.rewrite(max(x * c0, y * c1), min(y, x * eval(c0 / c1)) * c1, eval(c1 < 0 && c0 % c1 == 0)) ||
+      r.rewrite(max(y * c0 + c1, x * c0), max(x, y + eval(c1 / c0)) * c0, eval(c0 > 0 && c1 % c0 == 0)) ||
+      r.rewrite(max(y * c0 + c1, x * c0), min(x, y + eval(c1 / c0)) * c0, eval(c0 < 0 && c1 % c0 == 0)) ||
 
       r.rewrite(max(x / c0, y / c0), max(x, y) / c0, eval(c0 > 0)) ||
       r.rewrite(max(x / c0, y / c0), min(x, y) / c0, eval(c0 < 0)) ||
@@ -246,25 +246,25 @@ expr simplify(const class max* op, expr a, expr b) {
       r.rewrite(max(y / c0 + c1, x / c0), max(x, y + eval(c1 * c0)) / c0, eval(c0 > 0)) ||
       r.rewrite(max(y / c0 + c1, x / c0), min(x, y + eval(c1 * c0)) / c0, eval(c0 < 0)) ||
  
-      r.rewrite(max(((x + c2) / c3) * c4, (x + c0) / c1), (x + c0) / c1, eval(c2 <= c0) && eval(c1 > 0) && eval(c3 > 0) && eval(c1 * c4 == c3)) ||
-      r.rewrite(max(((x + c2) / c3) * c4, (x + c0) / c1), ((x + c2) / c3) * c4, eval(c0 + c3 - c1 <= c2) && eval(c1 > 0) && eval(c3 > 0) && eval(c1 * c4 == c3)) ||
-      r.rewrite(max(((x + c2) / c3) * c4, x / c1), x/c1, eval(c2 <= 0) && eval(c1 > 0) && eval(c3 > 0) && eval(c1 * c4 == c3)) ||
-      r.rewrite(max(((x + c2) / c3) * c4, x / c1), ((x + c2) / c3) * c4, eval(c3 - c1 <= c2) && eval(c1 > 0) && eval(c3 > 0) && eval(c1 * c4 == c3)) ||
-      r.rewrite(max((x / c3) * c4, (x + c0) / c1), (x + c0) / c1, eval(0 <= c0) && eval(c1 > 0) && eval(c3 > 0) && eval(c1 * c4 == c3)) ||
-      r.rewrite(max((x / c3) * c4, (x + c0) / c1), (x / c3) * c4, eval(c0 + c3 - c1 <= 0) && eval(c1 > 0) && eval(c3 > 0) && eval(c1 * c4 == c3)) ||
-      r.rewrite(max(x / c1 + c0, (x / c3) * c4), x / c1 + c0, eval(c0 > 0) && eval(c1 > 0) && eval(c3 > 0) && eval(c1 * c4 == c3)) ||
-      r.rewrite(max((x / c3) * c4, x / c1), x / c1, eval(c1 > 0) && eval(c3 > 0) && eval(c1 * c4 == c3)) ||
+      r.rewrite(max(((x + c2) / c3) * c4, (x + c0) / c1), (x + c0) / c1, eval(c2 <= c0 && c1 > 0 && c3 > 0 && c1 * c4 == c3)) ||
+      r.rewrite(max(((x + c2) / c3) * c4, (x + c0) / c1), ((x + c2) / c3) * c4, eval(c0 + c3 - c1 <= c2 && c1 > 0 && c3 > 0 && c1 * c4 == c3)) ||
+      r.rewrite(max(((x + c2) / c3) * c4, x / c1), x/c1, eval(c2 <= 0 && c1 > 0 && c3 > 0 && c1 * c4 == c3)) ||
+      r.rewrite(max(((x + c2) / c3) * c4, x / c1), ((x + c2) / c3) * c4, eval(c3 - c1 <= c2 && c1 > 0 && c3 > 0 && c1 * c4 == c3)) ||
+      r.rewrite(max((x / c3) * c4, (x + c0) / c1), (x + c0) / c1, eval(0 <= c0 && c1 > 0 && c3 > 0 && c1 * c4 == c3)) ||
+      r.rewrite(max((x / c3) * c4, (x + c0) / c1), (x / c3) * c4, eval(c0 + c3 - c1 <= 0 && c1 > 0 && c3 > 0 && c1 * c4 == c3)) ||
+      r.rewrite(max(x / c1 + c0, (x / c3) * c4), x / c1 + c0, eval(c0 > 0 && c1 > 0 && c3 > 0 && c1 * c4 == c3)) ||
+      r.rewrite(max((x / c3) * c4, x / c1), x / c1, eval(c1 > 0 && c3 > 0 && c1 * c4 == c3)) ||
     
       // https://github.com/halide/Halide/blob/f4c78317887b6df4d2486e1f81e81f9012943f0f/src/Simplify_Max.cpp#L115-L129
       // Compare x to a stair-step function in x
-      r.rewrite(max(x, ((x + c0) / c1) * c1 + c2), ((x + c0) / c1) * c1 + c2, eval(c1 > 0) && eval(c0 + c2 >= c1 - 1)) ||
-      r.rewrite(max(x, ((x + c0) / c1) * c1 + c2), x, eval(c1 > 0) && eval(c0 + c2 <= 0)) ||
-      r.rewrite(max((x / c1) * c1 + c2, (x / c0) * c0), (x / c1) * c1 + c2, eval(c2 >= c1) && eval(c1 > 0) && eval(c0 != 0)) ||
+      r.rewrite(max(x, ((x + c0) / c1) * c1 + c2), ((x + c0) / c1) * c1 + c2, eval(c1 > 0 && c0 + c2 >= c1 - 1)) ||
+      r.rewrite(max(x, ((x + c0) / c1) * c1 + c2), x, eval(c1 > 0 && c0 + c2 <= 0)) ||
+      r.rewrite(max((x / c1) * c1 + c2, (x / c0) * c0), (x / c1) * c1 + c2, eval(c2 >= c1 && c1 > 0 && c0 != 0)) ||
       // Special cases where c0 or c2 is zero
-      r.rewrite(max(x, (x / c1) * c1 + c2), (x / c1) * c1 + c2, eval(c1 > 0) && eval(c2 >= c1 - 1)) ||
-      r.rewrite(max(x, ((x + c0) / c1) * c1), ((x + c0) / c1) * c1, eval(c1 > 0) && eval(c0 >= c1 - 1)) ||
-      r.rewrite(max(x, (x / c1) * c1 + c2), x, eval(c1 > 0) && eval(c2 <= 0)) ||
-      r.rewrite(max(x, ((x + c0) / c1) * c1), x, eval(c1 > 0) && eval(c0 <= 0)) ||
+      r.rewrite(max(x, (x / c1) * c1 + c2), (x / c1) * c1 + c2, eval(c1 > 0 && c2 >= c1 - 1)) ||
+      r.rewrite(max(x, ((x + c0) / c1) * c1), ((x + c0) / c1) * c1, eval(c1 > 0 && c0 >= c1 - 1)) ||
+      r.rewrite(max(x, (x / c1) * c1 + c2), x, eval(c1 > 0 && c2 <= 0)) ||
+      r.rewrite(max(x, ((x + c0) / c1) * c1), x, eval(c1 > 0 && c0 <= 0)) ||
 
       r.rewrite(max(x, (x / c0) * c0), x, eval(c0 > 0)) ||
 
@@ -497,14 +497,14 @@ expr simplify(const div* op, expr a, expr b) {
       r.rewrite(x / -1, -x) ||
       r.rewrite(x / x, x != 0) ||
 
-      r.rewrite((y + x / c0) / c1, (x + y * c0) / eval(c0 * c1), eval(c0 > 0) && eval(c1 > 0)) ||
-      r.rewrite((x / c0) / c1, x / eval(c0 * c1), eval(c0 > 0) && eval(c1 > 0)) ||
-      r.rewrite((x * c0) / c1, x * eval(c0 / c1), eval(c1 > 0) && eval(c0 % c1 == 0)) ||
+      r.rewrite((y + x / c0) / c1, (x + y * c0) / eval(c0 * c1), eval(c0 > 0 && c1 > 0)) ||
+      r.rewrite((x / c0) / c1, x / eval(c0 * c1), eval(c0 > 0 && c1 > 0)) ||
+      r.rewrite((x * c0) / c1, x * eval(c0 / c1), eval(c1 > 0 && c0 % c1 == 0)) ||
 
       r.rewrite((x + y * c0) / c1, y * eval(c0 / c1) + x / c1, eval(c0 % c1 == 0)) ||
       r.rewrite((x + c0) / c1, x / c1 + eval(c0 / c1), eval(c0 % c1 == 0)) ||
-      r.rewrite((y * c0 - x) / c1, y * eval(c0 / c1) + (-x / c1), eval(c0 % c1 == 0) && eval(c0 != 0)) ||
-      r.rewrite((c0 - x) / c1, (-x / c1) + eval(c0 / c1), eval(c0 % c1 == 0) && eval(c0 != 0)) ||
+      r.rewrite((y * c0 - x) / c1, y * eval(c0 / c1) + (-x / c1), eval(c0 % c1 == 0 && c0 != 0)) ||
+      r.rewrite((c0 - x) / c1, (-x / c1) + eval(c0 / c1), eval(c0 % c1 == 0 && c0 != 0)) ||
       false) {
     return r.result;
   }
@@ -595,24 +595,24 @@ expr simplify(const less* op, expr a, expr b) {
       r.rewrite(y + (x / c0) * c0 < x, y < x % c0, eval(c0 > 0)) ||
       r.rewrite((x / c0) * c0 < x, 0 < x % c0, eval(c0 > 0)) ||
 
-      r.rewrite(x % c0 < c1, true, eval(c0 > 0) && eval(c0 <= c1)) ||
-      r.rewrite(x % c0 < c1, false, eval(c0 > 0) && eval(c1 <= 0)) ||
-      r.rewrite(x % c0 < c1, x % c0 != c1, eval(c0 > 0) && eval(c1 >= c0 - 1)) ||
-      r.rewrite(c0 < x % c1, true, eval(c1 > 0) && eval(c0 < 0)) ||
-      r.rewrite(c0 < x % c1, false, eval(c1 > 0) && eval(c0 >= c1 - 1)) ||
-      r.rewrite(c0 < x % c1, x % c1 != 0, eval(c1 > 0) && eval(c0 <= 0)) ||
+      r.rewrite(x % c0 < c1, true, eval(c0 > 0 && c0 <= c1)) ||
+      r.rewrite(x % c0 < c1, false, eval(c0 > 0 && c1 <= 0)) ||
+      r.rewrite(x % c0 < c1, x % c0 != c1, eval(c0 > 0 && c1 >= c0 - 1)) ||
+      r.rewrite(c0 < x % c1, true, eval(c1 > 0 && c0 < 0)) ||
+      r.rewrite(c0 < x % c1, false, eval(c1 > 0 && c0 >= c1 - 1)) ||
+      r.rewrite(c0 < x % c1, x % c1 != 0, eval(c1 > 0 && c0 <= 0)) ||
     
       // These rules taken from
       // https://github.com/halide/Halide/blob/e9f8b041f63a1a337ce3be0b07de5a1cfa6f2f65/src/Simplify_LT.cpp#L399-L407
       // Cancel a division
-      r.rewrite((x + c1) / c0 < (x + c2) / c0, false, eval(c0 > 0) && eval(c1 >= c2)) ||
-      r.rewrite((x + c1) / c0 < (x + c2) / c0, true, eval(c0 > 0) && eval(c1 <= c2 - c0)) ||
+      r.rewrite((x + c1) / c0 < (x + c2) / c0, false, eval(c0 > 0 && c1 >= c2)) ||
+      r.rewrite((x + c1) / c0 < (x + c2) / c0, true, eval(c0 > 0 && c1 <= c2 - c0)) ||
       // c1 == 0
-      r.rewrite(x / c0 < (x + c2) / c0, false, eval(c0 > 0) && eval(0 >= c2)) ||
-      r.rewrite(x / c0 < (x + c2) / c0, true, eval(c0 > 0) && eval(0 <= c2 - c0)) ||
+      r.rewrite(x / c0 < (x + c2) / c0, false, eval(c0 > 0 && 0 >= c2)) ||
+      r.rewrite(x / c0 < (x + c2) / c0, true, eval(c0 > 0 && 0 <= c2 - c0)) ||
       // c2 == 0
-      r.rewrite((x + c1) / c0 < x / c0, false, eval(c0 > 0) && eval(c1 >= 0)) ||
-      r.rewrite((x + c1) / c0 < x / c0, true, eval(c0 > 0) && eval(c1 <= 0 - c0)) ||
+      r.rewrite((x + c1) / c0 < x / c0, false, eval(c0 > 0 && c1 >= 0)) ||
+      r.rewrite((x + c1) / c0 < x / c0, true, eval(c0 > 0 && c1 <= 0 - c0)) ||
 
       // TODO: These aren't fully simplified, the above rules can be applied to the rewritten result.
       // If we ever added a c2 < 0 version of the above, these would need to be duplicated as well.
@@ -775,7 +775,7 @@ expr simplify(const equal* op, expr a, expr b) {
       r.rewrite(x == z + (x / c0) * c0, z == x % c0, eval(c0 > 0)) ||
       r.rewrite(x == (x / c0) * c0, x % c0 == 0, eval(c0 > 0)) ||
     
-      r.rewrite(x % c0 == c1, false, (eval(c1 > c0) || eval(c0 < 0)) && eval(c0 > 0)) ||
+      r.rewrite(x % c0 == c1, false, eval(c0 > 0 && (c1 > c0 || c1 < 0))) ||
       false) {
     return r.result;
   }

--- a/builder/simplify_exprs.cc
+++ b/builder/simplify_exprs.cc
@@ -775,7 +775,7 @@ expr simplify(const equal* op, expr a, expr b) {
       r.rewrite(x == z + (x / c0) * c0, z == x % c0, eval(c0 > 0)) ||
       r.rewrite(x == (x / c0) * c0, x % c0 == 0, eval(c0 > 0)) ||
     
-      r.rewrite(x % c0 == c1, false, eval(c0 > 0 && (c1 > c0 || c1 < 0))) ||
+      r.rewrite(x % c0 == c1, false, eval(c0 > 0 && (c1 >= c0 || c1 < 0))) ||
       false) {
     return r.result;
   }

--- a/builder/simplify_exprs.cc
+++ b/builder/simplify_exprs.cc
@@ -580,14 +580,10 @@ expr simplify(const less* op, expr a, expr b) {
       r.rewrite(x + c0 < y, x < y + eval(-c0)) ||
       r.rewrite(c0 < x + c1, eval(c0 - c1) < x) ||
 
-      r.rewrite(x < (x / c0) * c0 + c1, true, eval(c0 > 0) && eval(c1 >= c0 - 1)) ||
-      r.rewrite(x < (x / c0) * c0 + c1, false, eval(c0 > 0) && eval(c1 <= 0)) ||
-      r.rewrite(x + c1 < (x / c0) * c0, true, eval(c0 > 0) && eval(c1 <= -c0 + 1)) ||
-      r.rewrite(x + c1 < (x / c0) * c0, false, eval(c0 > 0) && eval(c1 >= 0)) ||
+      r.rewrite(x < (x / c0) * c0 + c1, true, eval(c0 > 0) && eval(c1 >= c0)) ||
+      r.rewrite(x < (x / c0) * c0 + c1, false, eval(c0 > 0) && eval(c1 < 0)) ||
       r.rewrite((x / c0) * c0 < x + c1, true, eval(c0 > 0) && eval(c1 > 0)) ||
-      r.rewrite((x / c0) * c0 < x + c1, false, eval(c0 > 0) && eval(-c1 >= c0 - 1)) ||
-      r.rewrite((x / c0) * c0 + c1 < x, true, eval(c0 > 0) && eval(c1 < 0)) ||
-      r.rewrite((x / c0) * c0 + c1 < x, false, eval(c0 > 0) && eval(c1 >= c0 - 1)) ||
+      r.rewrite((x / c0) * c0 < x + c1, false, eval(c0 > 0) && eval(c1 < -c0)) ||
       r.rewrite(x < (x / c0) * c0, false, eval(c0 > 0)) ||
       r.rewrite((x / c0) * c0 < x, x % c0 != 0, eval(c0 > 0)) ||
     

--- a/builder/test/simplify.cc
+++ b/builder/test/simplify.cc
@@ -145,6 +145,11 @@ TEST(simplify, basic) {
   ASSERT_THAT(simplify(max(x && y, 0)), matches(x && y));
   ASSERT_THAT(simplify(min(!x, 1)), matches(!x));
   ASSERT_THAT(simplify(max(x == y, 1)), matches(1));
+
+  ASSERT_THAT(simplify((y / 4) * 4 <= y - 4), matches(false));
+  ASSERT_THAT(simplify((y / 4) * 4 <= y - 3), matches((y / 4) * 4 + 3 <= y));
+  ASSERT_THAT(simplify((y / 4) * 4 <= y - 1), matches(y % 4 != 0));
+  ASSERT_THAT(simplify((y / 4) * 4 <= y), matches(true));
 }
 
 TEST(simplify, let) {

--- a/builder/test/simplify.cc
+++ b/builder/test/simplify.cc
@@ -146,10 +146,14 @@ TEST(simplify, basic) {
   ASSERT_THAT(simplify(min(!x, 1)), matches(!x));
   ASSERT_THAT(simplify(max(x == y, 1)), matches(1));
 
+  ASSERT_THAT(simplify(0 <= x % 4), matches(true));
+  ASSERT_THAT(simplify(4 <= x % 4), matches(false));
   ASSERT_THAT(simplify((y / 4) * 4 <= y - 4), matches(false));
-  ASSERT_THAT(simplify((y / 4) * 4 <= y - 3), matches((y / 4) * 4 + 3 <= y));
+  ASSERT_THAT(simplify((y / 4) * 4 <= y - 3), matches(3 == y % 4));
   ASSERT_THAT(simplify((y / 4) * 4 <= y - 1), matches(y % 4 != 0));
   ASSERT_THAT(simplify((y / 4) * 4 <= y), matches(true));
+
+  ASSERT_THAT(simplify(x % -4 <= 1), matches(x % -4 <= 1));
 }
 
 TEST(simplify, let) {


### PR DESCRIPTION
- Add ability to print patterns, makes it much easier to debug simplify issues.
- Fix bad rules (fixes #354, fixes #335).
- Rework mod rules to be more explicit about changing comparison -> mod, and then simplify the mod.
- Don't require evaluated constant expressions to be canonical, and remove a hack workaround for this.
- Remove buffers from fuzz tester, they are annoying and don't add much now that we don't have rules for these.