### PR TITLE
Use ASSERT_THAT container checks for allocation asserts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,8 +32,6 @@ jobs:
 
       - name: Setup Cpp
         uses: aminya/setup-cpp@v1
-        with:
-          compiler: llvm
 
       - name: Build and test
         run: bazel test --test_output=errors ...

--- a/builder/test/cannot_alias.cc
+++ b/builder/test/cannot_alias.cc
@@ -66,7 +66,7 @@ TEST_P(may_alias, transpose_input) {
     }
   }
 
-  ASSERT_EQ(eval_ctx.heap.total_count, may_alias ? 0 : 1);
+  ASSERT_EQ(eval_ctx.heap.allocs.size(), may_alias ? 0 : 1);
 }
 
 TEST_P(may_alias, transpose_output) {
@@ -119,7 +119,7 @@ TEST_P(may_alias, transpose_output) {
     }
   }
 
-  ASSERT_EQ(eval_ctx.heap.total_count, may_alias ? 0 : 1);
+  ASSERT_EQ(eval_ctx.heap.allocs.size(), may_alias ? 0 : 1);
 }
 
 TEST_P(may_alias, aligned) {
@@ -170,8 +170,8 @@ TEST_P(may_alias, aligned) {
 
   // TODO: This test actually currently requires that the input and output are aligned, so it can alias.
   // I think there should be a similar pipeline where this would not be true, and in that case it should not alias.
-  // ASSERT_EQ(eval_ctx.heap.total_count, may_alias ? 0 : 1);
-  ASSERT_EQ(eval_ctx.heap.total_count, 0);
+  // ASSERT_EQ(eval_ctx.heap.allocs.size(), may_alias ? 0 : 1);
+  ASSERT_EQ(eval_ctx.heap.allocs.size(), 0);
 }
 
 TEST_P(may_alias, same_bounds) {
@@ -226,8 +226,8 @@ TEST_P(may_alias, same_bounds) {
 
   // TODO: This test actually currently requires that the input and output bounds are the same, so it can alias.
   // I think there should be a similar pipeline where this would not be true, and in that case it should not alias.
-  // ASSERT_EQ(eval_ctx.heap.total_count, may_alias ? 0 : 1);
-  ASSERT_EQ(eval_ctx.heap.total_count, 0);
+  // ASSERT_EQ(eval_ctx.heap.allocs.size(), may_alias ? 0 : 1);
+  ASSERT_EQ(eval_ctx.heap.allocs.size(), 0);
 }
 
 TEST_P(may_alias, unfolded) {
@@ -277,7 +277,7 @@ TEST_P(may_alias, unfolded) {
     }
   }
 
-  ASSERT_EQ(eval_ctx.heap.total_count, may_alias ? 0 : 1);
+  ASSERT_EQ(eval_ctx.heap.allocs.size(), may_alias ? 0 : 1);
 }
 
 }  // namespace slinky

--- a/builder/test/context.h
+++ b/builder/test/context.h
@@ -1,7 +1,9 @@
 #ifndef SLINKY_BUILDER_TEST_CONTEXT_H
 #define SLINKY_BUILDER_TEST_CONTEXT_H
 
+#include <mutex>
 #include <string>
+#include <vector>
 
 #include "runtime/evaluate.h"
 
@@ -12,14 +14,14 @@ void setup_tracing(eval_context& ctx, const std::string& filename);
 struct memory_info {
   std::atomic<index_t> live_count = 0;
   std::atomic<index_t> live_size = 0;
-  std::atomic<index_t> total_count = 0;
-  std::atomic<index_t> total_size = 0;
+  std::mutex m;
+  std::vector<index_t> allocs;
 
   void track_allocate(index_t size) {
     live_count += 1;
     live_size += size;
-    total_count += 1;
-    total_size += size;
+    std::unique_lock l(m);
+    allocs.push_back(size);
   }
 
   void track_free(index_t size) {

--- a/builder/test/copy_pipeline.cc
+++ b/builder/test/copy_pipeline.cc
@@ -1,4 +1,5 @@
 #include <gtest/gtest.h>
+#include <gmock/gmock.h>
 
 #include "base/test/bazel_util.h"
 #include "builder/pipeline.h"
@@ -57,8 +58,8 @@ TEST(flip_y, pipeline) {
     }
   }
 
-  ASSERT_EQ(eval_ctx.heap.total_size, W * H * sizeof(char));
-  ASSERT_EQ(eval_ctx.heap.total_count, 1);
+  ASSERT_THAT(eval_ctx.heap.allocs, testing::UnorderedElementsAre(W * H * sizeof(char)));
+  ASSERT_EQ(eval_ctx.heap.allocs.size(), 1);
 }
 
 TEST(padded_copy, pipeline) {
@@ -115,8 +116,8 @@ TEST(padded_copy, pipeline) {
     }
   }
 
-  ASSERT_EQ(eval_ctx.heap.total_size, W * H * sizeof(char));
-  ASSERT_EQ(eval_ctx.heap.total_count, 1);
+  ASSERT_THAT(eval_ctx.heap.allocs, testing::UnorderedElementsAre(W * H * sizeof(char)));
+  ASSERT_EQ(eval_ctx.heap.allocs.size(), 1);
 }
 
 class copied_output : public testing::TestWithParam<std::tuple<int, int, int>> {};
@@ -189,7 +190,7 @@ TEST_P(copied_output, pipeline) {
     }
   }
 
-  ASSERT_EQ(eval_ctx.heap.total_count, 0);
+  ASSERT_EQ(eval_ctx.heap.allocs.size(), 0);
 }
 
 class copied_input : public testing::TestWithParam<std::tuple<int, int, int>> {};
@@ -256,7 +257,7 @@ TEST_P(copied_input, pipeline) {
     }
   }
 
-  ASSERT_EQ(eval_ctx.heap.total_count, 0);
+  ASSERT_EQ(eval_ctx.heap.allocs.size(), 0);
 }
 
 class concatenated_result : public testing::TestWithParam<bool> {};
@@ -311,7 +312,7 @@ TEST_P(concatenated_result, pipeline) {
   }
 
   if (!no_alias_buffers) {
-    ASSERT_EQ(eval_ctx.heap.total_count, 0);
+    ASSERT_EQ(eval_ctx.heap.allocs.size(), 0);
   }
 
   if (no_alias_buffers == true) {
@@ -376,9 +377,9 @@ TEST_P(transposed_result, pipeline) {
   }
 
   if (is_permutation(permutation) && !no_alias_buffers) {
-    ASSERT_EQ(eval_ctx.heap.total_count, 0);
+    ASSERT_EQ(eval_ctx.heap.allocs.size(), 0);
   } else {
-    ASSERT_EQ(eval_ctx.heap.total_count, 1);
+    ASSERT_EQ(eval_ctx.heap.allocs.size(), 1);
   }
 }
 
@@ -428,7 +429,7 @@ TEST(stacked_result, pipeline) {
     }
   }
 
-  ASSERT_EQ(eval_ctx.heap.total_count, 0);
+  ASSERT_EQ(eval_ctx.heap.allocs.size(), 0);
 
   check_replica_pipeline(define_replica_pipeline(ctx, {in1, in2}, {out}));
 }
@@ -496,7 +497,7 @@ TEST_P(broadcasted_elementwise, input) {
   }
 
   if (!no_alias_buffers) {
-    ASSERT_EQ(eval_ctx.heap.total_count, 0);
+    ASSERT_EQ(eval_ctx.heap.allocs.size(), 0);
   }
 }
 
@@ -561,7 +562,7 @@ TEST_P(broadcasted_elementwise, internal) {
   }
 
   if (!no_alias_buffers) {
-    ASSERT_EQ(eval_ctx.heap.total_count, 1);
+    ASSERT_EQ(eval_ctx.heap.allocs.size(), 1);
   }
 }
 

--- a/builder/test/copy_pipeline.cc
+++ b/builder/test/copy_pipeline.cc
@@ -59,7 +59,6 @@ TEST(flip_y, pipeline) {
   }
 
   ASSERT_THAT(eval_ctx.heap.allocs, testing::UnorderedElementsAre(W * H * sizeof(char)));
-  ASSERT_EQ(eval_ctx.heap.allocs.size(), 1);
 }
 
 TEST(padded_copy, pipeline) {
@@ -117,7 +116,6 @@ TEST(padded_copy, pipeline) {
   }
 
   ASSERT_THAT(eval_ctx.heap.allocs, testing::UnorderedElementsAre(W * H * sizeof(char)));
-  ASSERT_EQ(eval_ctx.heap.allocs.size(), 1);
 }
 
 class copied_output : public testing::TestWithParam<std::tuple<int, int, int>> {};

--- a/builder/test/pipeline.cc
+++ b/builder/test/pipeline.cc
@@ -395,8 +395,9 @@ TEST_P(stencil, pipeline) {
     const int parallel_extra = max_workers != loop::serial ? split : 0;
     const int intm_size = (W + 2) * align_up(split + parallel_extra + 2, split) * sizeof(short);
     ASSERT_THAT(eval_ctx.heap.allocs, testing::UnorderedElementsAre(intm_size));
+  } else {
+    ASSERT_EQ(eval_ctx.heap.allocs.size(), 1);
   }
-  ASSERT_EQ(eval_ctx.heap.allocs.size(), 1);
 
   // Also visualize this pipeline.
   if (max_workers == loop::serial && split_intermediate == 0) {
@@ -472,7 +473,6 @@ TEST_P(slide_2d, pipeline) {
   }
 
   ASSERT_THAT(eval_ctx.heap.allocs, testing::UnorderedElementsAre((W + 2) * 3 * sizeof(short)));
-  ASSERT_EQ(eval_ctx.heap.allocs.size(), 1);
   ASSERT_EQ(add_count, (W + 2) * (H + 2));
 }
 
@@ -785,8 +785,8 @@ TEST(unrelated, pipeline) {
     ASSERT_EQ(out2_buf(i), 2 * i + 1);
   }
 
+  // intm2 aliased to out2.
   ASSERT_THAT(eval_ctx.heap.allocs, testing::UnorderedElementsAre((W1 + 2) * 4 * sizeof(short)));
-  ASSERT_EQ(eval_ctx.heap.allocs.size(), 1);  // intm2 aliased to out2.
 }
 
 class padded_stencil : public testing::TestWithParam<int> {};
@@ -855,8 +855,9 @@ TEST_P(padded_stencil, pipeline) {
   }
 
   if (schedule == 2) {
-    ASSERT_THAT(eval_ctx.heap.allocs, testing::UnorderedElementsAre(W * sizeof(short), (W + 2) * 3 * sizeof(short)));
-    ASSERT_EQ(eval_ctx.heap.allocs.size(), 2);
+    const int intm_size = W * sizeof(short);
+    const int padded_intm_size = (W + 2) * 3 * sizeof(short);
+    ASSERT_THAT(eval_ctx.heap.allocs, testing::UnorderedElementsAre(intm_size, padded_intm_size));
   } else {
     ASSERT_EQ(eval_ctx.heap.allocs.size(), 1);
   }

--- a/builder/test/pipeline.cc
+++ b/builder/test/pipeline.cc
@@ -1,3 +1,4 @@
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include <numeric>
@@ -86,7 +87,7 @@ TEST_P(trivial, pipeline) {
     ASSERT_EQ(out_buf(i), 2 * i);
   }
 
-  ASSERT_EQ(eval_ctx.heap.total_size, 0);
+  ASSERT_EQ(eval_ctx.heap.allocs.size(), 0);
 }
 
 class elementwise : public testing::TestWithParam<std::tuple<int, int, bool>> {};
@@ -154,7 +155,7 @@ TEST_P(elementwise, pipeline_1d) {
   }
 
   if (schedule_storage) {
-    ASSERT_EQ(eval_ctx.heap.total_count, 0);  // The intermediate only needs stack.
+    ASSERT_EQ(eval_ctx.heap.allocs.size(), 0);  // The intermediate only needs stack.
   }
 }
 
@@ -222,7 +223,7 @@ TEST_P(elementwise, pipeline_2d) {
   }
 
   if (schedule_storage) {
-    ASSERT_EQ(eval_ctx.heap.total_count, 0);  // The intermediate only needs stack.
+    ASSERT_EQ(eval_ctx.heap.allocs.size(), 0);  // The intermediate only needs stack.
   }
 }
 
@@ -316,7 +317,7 @@ TEST_P(matmuls, pipeline) {
   }
 
   if (split > 0 && max_workers == loop::serial) {
-    ASSERT_EQ(eval_ctx.heap.total_size, N * sizeof(int) * split);
+    ASSERT_THAT(eval_ctx.heap.allocs, testing::UnorderedElementsAre(N * sizeof(int) * split));
   }
 
   if (split == 1 && max_workers == loop::serial) {
@@ -392,9 +393,10 @@ TEST_P(stencil, pipeline) {
 
   if (split > 0) {
     const int parallel_extra = max_workers != loop::serial ? split : 0;
-    ASSERT_EQ(eval_ctx.heap.total_size, (W + 2) * align_up(split + parallel_extra + 2, split) * sizeof(short));
+    const int intm_size = (W + 2) * align_up(split + parallel_extra + 2, split) * sizeof(short);
+    ASSERT_THAT(eval_ctx.heap.allocs, testing::UnorderedElementsAre(intm_size));
   }
-  ASSERT_EQ(eval_ctx.heap.total_count, 1);
+  ASSERT_EQ(eval_ctx.heap.allocs.size(), 1);
 
   // Also visualize this pipeline.
   if (max_workers == loop::serial && split_intermediate == 0) {
@@ -469,8 +471,8 @@ TEST_P(slide_2d, pipeline) {
     }
   }
 
-  ASSERT_EQ(eval_ctx.heap.total_size, (W + 2) * 3 * sizeof(short));
-  ASSERT_EQ(eval_ctx.heap.total_count, 1);
+  ASSERT_THAT(eval_ctx.heap.allocs, testing::UnorderedElementsAre((W + 2) * 3 * sizeof(short)));
+  ASSERT_EQ(eval_ctx.heap.allocs.size(), 1);
   ASSERT_EQ(add_count, (W + 2) * (H + 2));
 }
 
@@ -553,9 +555,10 @@ TEST_P(stencil_chain, pipeline) {
     const int parallel_extra = max_workers != loop::serial ? split * 2 : 0;
     const int intm_size = (W + 2) * align_up(split + parallel_extra + 2, split) * sizeof(short);
     const int intm2_size = (W + 4) * align_up(split + parallel_extra + 2, split) * sizeof(short);
-    ASSERT_EQ(eval_ctx.heap.total_size, intm_size + intm2_size);
+    ASSERT_THAT(eval_ctx.heap.allocs, testing::UnorderedElementsAre(intm_size, intm2_size));
+  } else {
+    ASSERT_EQ(eval_ctx.heap.allocs.size(), 2);
   }
-  ASSERT_EQ(eval_ctx.heap.total_count, 2);
 
   // Also visualize this pipeline.
   if (max_workers == loop::serial) {
@@ -782,8 +785,8 @@ TEST(unrelated, pipeline) {
     ASSERT_EQ(out2_buf(i), 2 * i + 1);
   }
 
-  ASSERT_EQ(eval_ctx.heap.total_size, (W1 + 2) * 4 * sizeof(short));
-  ASSERT_EQ(eval_ctx.heap.total_count, 1);  // intm2 aliased to out2.
+  ASSERT_THAT(eval_ctx.heap.allocs, testing::UnorderedElementsAre((W1 + 2) * 4 * sizeof(short)));
+  ASSERT_EQ(eval_ctx.heap.allocs.size(), 1);  // intm2 aliased to out2.
 }
 
 class padded_stencil : public testing::TestWithParam<int> {};
@@ -852,12 +855,10 @@ TEST_P(padded_stencil, pipeline) {
   }
 
   if (schedule == 2) {
-    const index_t intm_size = W * sizeof(short);
-    const index_t padded_intm_size = (W + 2) * 3 * sizeof(short);
-    ASSERT_EQ(eval_ctx.heap.total_size, intm_size + padded_intm_size);
-    ASSERT_EQ(eval_ctx.heap.total_count, 2);
+    ASSERT_THAT(eval_ctx.heap.allocs, testing::UnorderedElementsAre(W * sizeof(short), (W + 2) * 3 * sizeof(short)));
+    ASSERT_EQ(eval_ctx.heap.allocs.size(), 2);
   } else {
-    ASSERT_EQ(eval_ctx.heap.total_count, 1);
+    ASSERT_EQ(eval_ctx.heap.allocs.size(), 1);
   }
 
   // Also visualize this pipeline.
@@ -987,12 +988,12 @@ TEST_P(padded_stencil_separable, pipeline) {
 
     if (!require_dense_x) {
       // We can't alias stencil_intm and padded_intm like we can without splitting because of fold factor constraints.
-      ASSERT_EQ(eval_ctx.heap.total_size, std::max(intm_size, padded_intm_t_size) + stencil_intm_size + padded_intm_size);
-      ASSERT_EQ(eval_ctx.heap.total_count, 3);
+      ASSERT_THAT(eval_ctx.heap.allocs,
+          testing::UnorderedElementsAre(std::max(intm_size, padded_intm_t_size), stencil_intm_size, padded_intm_size));
     } else {
       // We can't alias anything when we require the strides to be dense.
-      ASSERT_EQ(eval_ctx.heap.total_size, intm_size + padded_intm_t_size + stencil_intm_size + padded_intm_size);
-      ASSERT_EQ(eval_ctx.heap.total_count, 4);
+      ASSERT_THAT(eval_ctx.heap.allocs,
+          testing::UnorderedElementsAre(intm_size, padded_intm_t_size, stencil_intm_size, padded_intm_size));
     }
   } else {
     const index_t intm_size = W * H * sizeof(short);
@@ -1001,13 +1002,12 @@ TEST_P(padded_stencil_separable, pipeline) {
     const index_t padded_intm_size = W * (H + 2) * sizeof(short);
 
     if (!require_dense_x) {
-      ASSERT_EQ(eval_ctx.heap.total_size,
-          std::max(intm_size, padded_intm_t_size) + std::max(stencil_intm_size, padded_intm_size));
-      ASSERT_EQ(eval_ctx.heap.total_count, 2);
+      ASSERT_THAT(eval_ctx.heap.allocs,
+          testing::UnorderedElementsAre(std::max(intm_size, padded_intm_t_size), std::max(stencil_intm_size, padded_intm_size)));
     } else {
       // We can't alias anything when we require the strides to be dense.
-      ASSERT_EQ(eval_ctx.heap.total_size, intm_size + padded_intm_t_size + stencil_intm_size + padded_intm_size);
-      ASSERT_EQ(eval_ctx.heap.total_count, 4);
+      ASSERT_THAT(eval_ctx.heap.allocs,
+          testing::UnorderedElementsAre(intm_size, padded_intm_t_size, stencil_intm_size, padded_intm_size));
     }
   }
 }

--- a/builder/test/pyramid.cc
+++ b/builder/test/pyramid.cc
@@ -88,7 +88,6 @@ TEST_P(pyramid, pipeline) {
 
   const int parallel_extra = max_workers != loop::serial ? 1 : 0;
   ASSERT_THAT(eval_ctx.heap.allocs, testing::UnorderedElementsAre((W + 2) / 2 * (2 + parallel_extra) * sizeof(int)));
-  ASSERT_EQ(eval_ctx.heap.allocs.size(), 1);
 
   if (max_workers == loop::serial) {
     check_replica_pipeline(define_replica_pipeline(ctx, {in}, {out}));

--- a/builder/test/pyramid.cc
+++ b/builder/test/pyramid.cc
@@ -1,4 +1,5 @@
 #include <gtest/gtest.h>
+#include <gmock/gmock.h>
 
 #include "base/test/bazel_util.h"
 #include "builder/pipeline.h"
@@ -86,8 +87,8 @@ TEST_P(pyramid, pipeline) {
   p.evaluate(inputs, outputs, eval_ctx);
 
   const int parallel_extra = max_workers != loop::serial ? 1 : 0;
-  ASSERT_EQ(eval_ctx.heap.total_size, (W + 2) / 2 * (2 + parallel_extra) * sizeof(int));
-  ASSERT_EQ(eval_ctx.heap.total_count, 1);
+  ASSERT_THAT(eval_ctx.heap.allocs, testing::UnorderedElementsAre((W + 2) / 2 * (2 + parallel_extra) * sizeof(int)));
+  ASSERT_EQ(eval_ctx.heap.allocs.size(), 1);
 
   if (max_workers == loop::serial) {
     check_replica_pipeline(define_replica_pipeline(ctx, {in}, {out}));


### PR DESCRIPTION
Asserts of the form `ASSERT_EQ(ctx.heap.total_size, buf1_size + buf2_size + ...)` are hard to debug and maintain because it's hard to tell which buffer is wrong.

This PR changes this to use ASSERT_THAT and a matcher that lets us specify the size of each buffer we expect to find.