### PR TITLE
Update loop bounds after sliding

### DIFF
--- a/builder/slide_and_fold_storage.cc
+++ b/builder/slide_and_fold_storage.cc
@@ -591,7 +591,7 @@ public:
     // we substitute current buffer bounds into loop bounds.
     substitute_bounds(loop_bounds, current_buffer_bounds());
 
-    if (body.same_as(op->body)) {
+    if (body.same_as(op->body) && loop_bounds.min.same_as(op->bounds.min) && loop_bounds.max.same_as(op->bounds.max)) {
       set_result(op);
       return;
     }

--- a/builder/slide_and_fold_storage.cc
+++ b/builder/slide_and_fold_storage.cc
@@ -82,6 +82,14 @@ std::vector<dim_expr> recursive_substitute(
   }
 }
 
+void substitute_bounds(interval_expr& bounds, const symbol_map<box_expr>& buffers) {
+  for (std::size_t i = 0; i < buffers.size(); ++i) {
+    if (!buffers[i]) continue;
+    if (bounds.min.defined()) bounds.min = substitute_bounds(bounds.min, var(i), *buffers[i]);
+    if (bounds.max.defined()) bounds.max = substitute_bounds(bounds.max, var(i), *buffers[i]);
+  }
+}
+
 void substitute_bounds(box_expr& bounds, const symbol_map<box_expr>& buffers) {
   for (std::size_t i = 0; i < buffers.size(); ++i) {
     if (!buffers[i]) continue;
@@ -579,10 +587,10 @@ public:
       body = mutate(op->body);
     }
     interval_expr loop_bounds = {loops.back().bounds.min, op->bounds.max};
-
-    if (loop_bounds.min.same_as(orig_min)) {
-      loop_bounds.min = op->bounds.min;
-    }
+    substitute_bounds(loop_bounds, current_buffer_bounds());
+    // if (loop_bounds.min.same_as(orig_min)) {
+    //   loop_bounds.min = op->bounds.min;
+    // }
 
     if (body.same_as(op->body)) {
       set_result(op);

--- a/builder/test/util.cc
+++ b/builder/test/util.cc
@@ -21,7 +21,6 @@ std::string read_entire_file(const std::string& pathname) {
 
 void check_visualize(const std::string& filename, const pipeline& p, pipeline::buffers inputs,
     pipeline::buffers outputs, const node_context* ctx) {
-  // return ;
   std::stringstream viz_stream;
   visualize(viz_stream, p, inputs, outputs, ctx);
   std::string viz = viz_stream.str();

--- a/builder/test/util.cc
+++ b/builder/test/util.cc
@@ -21,6 +21,7 @@ std::string read_entire_file(const std::string& pathname) {
 
 void check_visualize(const std::string& filename, const pipeline& p, pipeline::buffers inputs,
     pipeline::buffers outputs, const node_context* ctx) {
+  // return ;
   std::stringstream viz_stream;
   visualize(viz_stream, p, inputs, outputs, ctx);
   std::string viz = viz_stream.str();


### PR DESCRIPTION
This addresses the issue in #363.

The issue is that loop bounds may refer to buffer_min/buffer_max of some buffer which are inferred by bounds inference and are outside of the actual buffer bounds. This is a problem because the buffer_min/buffer_max will be clamped to the actual buffer bounds during evaluation (and maybe in some other places).