### PR TITLE
Add tracing to `build_pipeline` and its callees

### DIFF
--- a/base/chrome_trace.cc
+++ b/base/chrome_trace.cc
@@ -2,6 +2,7 @@
 
 #include <chrono>
 #include <cstdint>
+#include <fstream>
 #include <thread>
 
 namespace slinky {
@@ -27,5 +28,19 @@ void chrome_trace::write_event(const char* name, const char* cat, char type) {
 
 void chrome_trace::begin(const char* name) { write_event(name, "stmt", 'B'); }
 void chrome_trace::end(const char* name) { write_event(name, "stmt", 'E'); }
+
+chrome_trace* chrome_trace::global() { 
+  static std::unique_ptr<std::ofstream> file;
+  static std::unique_ptr<chrome_trace> trace;
+  if (!trace) {
+    const char* path = getenv("SLINKY_TRACE");
+    if (path) {
+      std::cout << "Tracing to: " << path << std::endl;
+      file = std::make_unique<std::ofstream>(path);
+      trace = std::make_unique<chrome_trace>(*file);
+    }
+  }
+  return trace.get();
+}
 
 }  // namespace slinky

--- a/base/chrome_trace.h
+++ b/base/chrome_trace.h
@@ -28,7 +28,8 @@ public:
   void begin(const char* name);
   void end(const char* name);
 
-  // Return the global instance of tracing, or nullptr if none.
+  // Return the global instance of tracing, or nullptr if none. Trace files will be written to the path in the
+  // `SLINKY_TRACE` environment variable.
   static chrome_trace* global();
 };
 

--- a/base/chrome_trace.h
+++ b/base/chrome_trace.h
@@ -1,13 +1,13 @@
 #ifndef SLINKY_BASE_CHROME_TRACE_H
 #define SLINKY_BASE_CHROME_TRACE_H
 
-#include <iostream>
 #include <chrono>
+#include <iostream>
 #include <mutex>
 #include <string>
 
 namespace slinky {
- 
+
 // A minimal wrapper for generating chrome trace files:
 // https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU
 class chrome_trace {
@@ -27,6 +27,29 @@ public:
 
   void begin(const char* name);
   void end(const char* name);
+
+  // Return the global instance of tracing, or nullptr if none.
+  static chrome_trace* global();
+};
+
+// Call `chrome_trace::begin` upon construction, and `chrome_trace::end` upon destruction.
+class scoped_trace {
+  chrome_trace* trace;
+  const char* name;
+
+public:
+  scoped_trace(chrome_trace* trace, const char* name) : trace(trace), name(name) {
+    if (trace) {
+      trace->begin(name);
+    }
+  }
+  scoped_trace(const char* name) : scoped_trace(chrome_trace::global(), name) {}
+
+  ~scoped_trace() {
+    if (trace) {
+      trace->end(name);
+    }
+  }
 };
 
 }  // namespace slinky

--- a/builder/BUILD
+++ b/builder/BUILD
@@ -29,6 +29,7 @@ cc_library(
     ],
     deps = [
         "//base",
+        "//base:chrome_trace",
         "//runtime",
     ],
     visibility = ["//visibility:public"],

--- a/builder/optimizations.cc
+++ b/builder/optimizations.cc
@@ -11,6 +11,7 @@
 #include <utility>
 #include <vector>
 
+#include "base/chrome_trace.h"
 #include "builder/node_mutator.h"
 #include "builder/simplify.h"
 #include "builder/substitute.h"
@@ -600,6 +601,7 @@ public:
 
 stmt alias_buffers(const stmt& s, node_context& ctx, const std::vector<buffer_expr_ptr>& inputs,
     const std::vector<buffer_expr_ptr>& outputs) {
+  scoped_trace trace("alias_buffers");
   return buffer_aliaser(ctx, inputs, outputs).mutate(s);
 }
 
@@ -680,6 +682,7 @@ stmt implement_copy(const copy_stmt* op, node_context& ctx) {
 }
 
 stmt implement_copies(const stmt& s, node_context& ctx) {
+  scoped_trace trace("implement_copies");
   return recursive_mutate<copy_stmt>(s, [&](const copy_stmt* op) { return implement_copy(op, ctx); });
 }
 
@@ -738,7 +741,10 @@ public:
 
 }  // namespace
 
-stmt fix_buffer_races(const stmt& s) { return race_condition_fixer().mutate(s); }
+stmt fix_buffer_races(const stmt& s) {
+  scoped_trace trace("fix_buffer_races");
+  return race_condition_fixer().mutate(s);
+}
 
 namespace {
 
@@ -854,7 +860,10 @@ public:
 
 }  // namespace
 
-stmt insert_early_free(const stmt& s) { return early_free_inserter().mutate(s); }
+stmt insert_early_free(const stmt& s) {
+  scoped_trace trace("insert_early_free");
+  return early_free_inserter().mutate(s);
+}
 
 namespace {
 
@@ -973,7 +982,13 @@ public:
 
 }  // namespace
 
-stmt deshadow(const stmt& s, node_context& ctx) { return deshadower(ctx).mutate(s); }
-stmt optimize_symbols(const stmt& s, node_context& ctx) { return reuse_shadows().mutate(s); }
+stmt deshadow(const stmt& s, node_context& ctx) {
+  scoped_trace trace("deshadow");
+  return deshadower(ctx).mutate(s);
+}
+stmt optimize_symbols(const stmt& s, node_context& ctx) {
+  scoped_trace trace("optimize_symbols");
+  return reuse_shadows().mutate(s);
+}
 
 }  // namespace slinky

--- a/builder/pipeline.cc
+++ b/builder/pipeline.cc
@@ -13,6 +13,7 @@
 #include <utility>
 #include <vector>
 
+#include "base/chrome_trace.h"
 #include "builder/node_mutator.h"
 #include "builder/optimizations.h"
 #include "builder/simplify.h"
@@ -926,6 +927,7 @@ stmt inject_traces(const stmt& s, node_context& ctx, std::set<buffer_expr_ptr>& 
 
 stmt build_pipeline(node_context& ctx, const std::vector<buffer_expr_ptr>& inputs,
     const std::vector<buffer_expr_ptr>& outputs, std::set<buffer_expr_ptr>& constants, const build_options& options) {
+  scoped_trace trace("build_pipeline");
   const node_context* old_context = set_default_print_context(&ctx);
 
   pipeline_builder builder(ctx, inputs, outputs, constants);

--- a/builder/simplify.cc
+++ b/builder/simplify.cc
@@ -55,6 +55,7 @@ class simplifier : public node_mutator {
   void set_result(stmt s, interval_expr) { set_result(std::move(s)); }
 
 public:
+  simplifier() {}
   simplifier(const bounds_map& expr_bounds) : expr_bounds(expr_bounds) {}
 
   expr mutate(const expr& e, interval_expr* bounds) {
@@ -123,6 +124,7 @@ public:
   }
 
   std::optional<bool> attempt_to_prove(const expr& e) {
+    scoped_trace trace("attempt_to_prove");
     interval_expr bounds;
     mutate(boolean(e), &bounds);
     if (prove_constant_true(bounds.min)) {
@@ -1325,19 +1327,16 @@ expr constant_lower_bound(const expr& x) { return constant_bound(/*sign=*/-1).mu
 expr constant_upper_bound(const expr& x) { return constant_bound(/*sign=*/1).mutate(x); }
 
 std::optional<bool> attempt_to_prove(const expr& condition, const bounds_map& expr_bounds) {
-  scoped_trace trace("attempt_to_prove");
   simplifier s(expr_bounds);
   return s.attempt_to_prove(condition);
 }
 
 bool prove_true(const expr& condition, const bounds_map& expr_bounds) {
-  scoped_trace trace("prove_true");
   simplifier s(expr_bounds);
   return s.prove_true(condition);
 }
 
 bool prove_false(const expr& condition, const bounds_map& expr_bounds) {
-  scoped_trace trace("prove_false");
   simplifier s(expr_bounds);
   return s.prove_false(condition);
 }

--- a/builder/simplify.cc
+++ b/builder/simplify.cc
@@ -1095,6 +1095,7 @@ interval_expr simplify(const interval_expr& e, const bounds_map& bounds) {
 }
 
 interval_expr bounds_of(const expr& x, const bounds_map& expr_bounds) {
+  scoped_trace trace("bounds_of");
   simplifier s(expr_bounds);
   interval_expr bounds;
   s.mutate(x, &bounds);
@@ -1105,13 +1106,12 @@ interval_expr bounds_of(const interval_expr& x, const bounds_map& expr_bounds) {
   if (x.is_point()) {
     return bounds_of(x.min, expr_bounds);
   } else {
-    interval_expr bounds_of_min = bounds_of(x.min, expr_bounds);
-    interval_expr bounds_of_max = bounds_of(x.max, expr_bounds);
-
-    return {
-        simplify(static_cast<const class min*>(nullptr), bounds_of_min.min, bounds_of_max.min),
-        simplify(static_cast<const class max*>(nullptr), bounds_of_min.max, bounds_of_max.max),
-    };
+    scoped_trace trace("bounds_of");
+    simplifier s(expr_bounds);
+    interval_expr bounds_of_min, bounds_of_max;
+    s.mutate(x.min, &bounds_of_min);
+    s.mutate(x.max, &bounds_of_max);
+    return s.mutate(bounds_of_min | bounds_of_max);
   }
 }
 

--- a/builder/simplify_exprs.cc
+++ b/builder/simplify_exprs.cc
@@ -304,13 +304,10 @@ expr simplify(const class logical_not* op, expr a) {
 }
 
 expr simplify(const class select* op, expr c, expr t, expr f) {
-  std::optional<bool> const_c = attempt_to_prove(c);
-  if (const_c) {
-    if (*const_c) {
-      return op->true_value;
-    } else {
-      return op->false_value;
-    }
+  if (is_true(c)) {
+    return t;
+  } else if (is_false(c)) {
+    return f;
   }
 
   auto r = make_rewriter(select(pattern_expr{c}, pattern_expr{t}, pattern_expr{f}));

--- a/builder/substitute.cc
+++ b/builder/substitute.cc
@@ -7,6 +7,7 @@
 #include <utility>
 #include <vector>
 
+#include "base/chrome_trace.h"
 #include "builder/node_mutator.h"
 #include "runtime/depends_on.h"
 #include "runtime/expr.h"
@@ -717,12 +718,16 @@ T substitute_bounds_impl(T op, var buffer, const box_expr& bounds) {
 }  // namespace
 
 expr substitute(const expr& e, const symbol_map<expr>& replacements) { return substitutor(replacements).mutate(e); }
-stmt substitute(const stmt& s, const symbol_map<expr>& replacements) { return substitutor(replacements).mutate(s); }
+stmt substitute(const stmt& s, const symbol_map<expr>& replacements) {
+  scoped_trace trace("substitute");
+  return substitutor(replacements).mutate(s);
+}
 
 expr substitute(const expr& e, var target, const expr& replacement) {
   return substitutor(target, replacement).mutate(e);
 }
 stmt substitute(const stmt& s, var target, const expr& replacement) {
+  scoped_trace trace("substitute");
   return substitutor(target, replacement).mutate(s);
 }
 interval_expr substitute(const interval_expr& x, var target, const expr& replacement) {
@@ -738,6 +743,7 @@ expr substitute(const expr& e, const expr& target, const expr& replacement) {
   return substitutor(subs).mutate(e);
 }
 stmt substitute(const stmt& s, const expr& target, const expr& replacement) {
+  scoped_trace trace("substitute");
   std::pair<expr, expr> subs[] = {{target, replacement}};
   return substitutor(subs).mutate(s);
 }


### PR DESCRIPTION
This shows that `where_true` is a big problem and why the softmax tests are so slow. It also revealed an inappropriate use of `attempt_to_prove`