### PR TITLE
Improve simplification of buffer bounds

### DIFF
--- a/base/span.h
+++ b/base/span.h
@@ -46,6 +46,15 @@ public:
   span subspan(std::size_t offset, std::size_t size) const { return span(data_ + offset, size); }
 };
 
+template <typename T>
+std::vector<T> permute(span<const int> p, const std::vector<T>& x) {
+  std::vector<T> result(p.size());
+  for (std::size_t i = 0; i < p.size(); ++i) {
+    result[i] = x[p[i]];
+  }
+  return result;
+}
+
 }  // namespace slinky
 
 #endif  // SLINKY_BASE_SPAN_H

--- a/builder/simplify.cc
+++ b/builder/simplify.cc
@@ -22,6 +22,16 @@ namespace slinky {
 
 namespace {
 
+// std::optional::operator= causes asan failures...
+template <typename T>
+void assign(std::optional<T>& dst, std::optional<T> src) {
+  if (src) {
+    dst = std::move(src);
+  } else {
+    dst = std::nullopt;
+  }
+}
+
 expr strip_boolean(expr x) {
   if (const not_equal* ne = x.as<not_equal>()) {
     if (is_zero(ne->b)) {
@@ -1021,7 +1031,7 @@ public:
 
     symbol_map<buffer_info> old_buffers = buffers;
     bounds_map old_expr_bounds = expr_bounds;
-    buffers[op->sym] = buffers[op->src];
+    assign(buffers[op->sym], buffers[op->src]);
     update_sliced_buffer_metadata(buffers, op->sym, sliced_dims);
     update_sliced_buffer_metadata(expr_bounds, op->sym, sliced_dims);
     stmt body = mutate(op->body);
@@ -1068,7 +1078,7 @@ public:
     symbol_map<buffer_info> old_buffers = buffers;
     bounds_map old_expr_bounds = expr_bounds;
     int sliced_dims[] = {op->dim};
-    buffers[op->sym] = buffers[op->src];
+    assign(buffers[op->sym], buffers[op->src]);
     update_sliced_buffer_metadata(buffers, op->sym, sliced_dims);
     update_sliced_buffer_metadata(expr_bounds, op->sym, sliced_dims);
     stmt body = mutate(op->body);

--- a/builder/simplify.cc
+++ b/builder/simplify.cc
@@ -88,6 +88,9 @@ public:
   expr mutate(const expr& e, interval_expr* bounds) {
     expr result = node_mutator::mutate(e);
     if (bounds) {
+      if (!result_bounds.is_point() && match(result_bounds.min, result_bounds.max)) {
+        result_bounds.max = result_bounds.min;
+      }
       if (bounds != &result_bounds) {
         *bounds = std::move(result_bounds);
       }

--- a/builder/simplify.cc
+++ b/builder/simplify.cc
@@ -1126,10 +1126,7 @@ public:
       }
       buffer_info new_info;
       new_info.elem_size = info->elem_size;
-      new_info.dims.resize(op->dims.size());
-      for (std::size_t i = 0; i < op->dims.size(); ++i) {
-        new_info.dims[i] = info->dims[op->dims[i]];
-      }
+      new_info.dims = permute(op->dims, info->dims);
       info = std::move(new_info);
     }
 

--- a/builder/simplify.cc
+++ b/builder/simplify.cc
@@ -487,8 +487,7 @@ public:
         if ((*bounds)[d].max.defined()) info->dims[d].bounds.max = (*bounds)[d].max;
       }
     }
-    auto set_bounds = set_value_in_scope(buffers, buf, std::move(info));
-    return mutate(body);
+    return mutate_with_buffer(std::move(body), buf, std::move(info));
   }
 
   stmt mutate_with_bounds(stmt body, var v, interval_expr bounds) {

--- a/builder/simplify.cc
+++ b/builder/simplify.cc
@@ -313,6 +313,19 @@ public:
         set_result(expr(), interval_expr());
         return;
       }
+      if (op->intrinsic == intrinsic::buffer_min || op->intrinsic == intrinsic::buffer_max) {
+        const var* buf = as_variable(op->args[0]);
+        const index_t* dim = as_constant(op->args[1]);
+        assert(buf);
+        assert(dim);
+        const std::optional<box_expr>& bounds = buffer_bounds[*buf];
+        if (bounds && *dim < static_cast<index_t>(bounds->size())) {
+          // TODO: Should we set the interval to a point that is the min or max depending on if we are buffer_min or
+          // buffer_max?
+          set_result(op, (*bounds)[*dim]);
+          return;
+        }
+      }
     }
 
     expr e = simplify(op, op->intrinsic, std::move(args));

--- a/builder/simplify.cc
+++ b/builder/simplify.cc
@@ -394,6 +394,8 @@ public:
       assert(buf);
       const std::optional<buffer_info>& info = buffers[*buf];
       if (info) {
+        // TODO: We substitute here because we can't prove things like buffer_elem_size(x) == buffer_elem_size(y) where
+        // x is a crop of y. If we can fix that, we don't need to substitute here, which seems better.
         if (op->intrinsic == intrinsic::buffer_elem_size) {
           expr value = info->elem_size;
           if (should_substitute(value) || value.as<call>()) {

--- a/builder/simplify_rules.h
+++ b/builder/simplify_rules.h
@@ -775,7 +775,9 @@ bool apply_select_rules(Fn&& apply) {
       apply(select(x, y + z, y), y + select(x, z, 0)) ||
       apply(select(x, y + z, y + w), y + select(x, z, w)) ||
       apply(select(x, z - y, w - y), select(x, z, w) - y) ||
-      
+
+      apply(select(x, select(y, z, w), select(y, u, w + c0) + c1), select(y, select(x, z, u + c1), w), eval(c0 + c1 == 0)) ||
+      apply(select(x, select(y, z, w), select(y, z + c0, u) + c1), select(y, z, select(x, w, u + c1)), eval(c0 + c1 == 0)) ||
       apply(select(x, select(y, z, w), select(y, u, w)), select(y, select(x, z, u), w)) ||
       apply(select(x, select(y, z, w), select(y, z, u)), select(y, z, select(x, w, u))) ||
       apply(select(x, false, true), !x) ||

--- a/builder/substitute.cc
+++ b/builder/substitute.cc
@@ -692,6 +692,7 @@ public:
   }
 };
 
+// TODO: These helpers are messy and maybe inefficient. We should support substituting buffers directly in substitutor.
 template <typename T>
 T substitute_bounds_impl(T op, var buffer, int dim, const interval_expr& bounds) {
   expr buf_var = variable::make(buffer);

--- a/builder/substitute.cc
+++ b/builder/substitute.cc
@@ -714,6 +714,21 @@ T substitute_bounds_impl(T op, var buffer, const box_expr& bounds) {
   return substitutor(subs).mutate(op);
 }
 
+template <typename T>
+T substitute_buffer_impl(T op, var buffer, const expr& elem_size, const std::vector<dim_expr>& dims) {
+  expr buf_var = variable::make(buffer);
+  std::vector<std::pair<expr, expr>> subs;
+  subs.reserve(dims.size() * 4 + 1);
+  subs.emplace_back(buffer_elem_size(buffer), elem_size);
+  for (index_t d = 0; d < static_cast<index_t>(dims.size()); ++d) {
+    if (dims[d].bounds.min.defined()) subs.emplace_back(buffer_min(buf_var, d), dims[d].bounds.min);
+    if (dims[d].bounds.max.defined()) subs.emplace_back(buffer_max(buf_var, d), dims[d].bounds.max);
+    if (dims[d].stride.defined()) subs.emplace_back(buffer_stride(buf_var, d), dims[d].stride);
+    if (dims[d].fold_factor.defined()) subs.emplace_back(buffer_fold_factor(buf_var, d), dims[d].fold_factor);
+  }
+  return substitutor(subs).mutate(op);
+}
+
 }  // namespace
 
 expr substitute(const expr& e, const symbol_map<expr>& replacements) { return substitutor(replacements).mutate(e); }
@@ -742,6 +757,12 @@ stmt substitute(const stmt& s, const expr& target, const expr& replacement) {
   return substitutor(subs).mutate(s);
 }
 
+expr substitute_buffer(const expr& e, var buffer, const expr& elem_size, const std::vector<dim_expr>& dims) {
+  return substitute_buffer_impl(e, buffer, elem_size, dims);
+}
+stmt substitute_buffer(const stmt& s, var buffer, const expr& elem_size, const std::vector<dim_expr>& dims) {
+  return substitute_buffer_impl(s, buffer, elem_size, dims);
+}
 expr substitute_bounds(const expr& e, var buffer, const box_expr& bounds) {
   return substitute_bounds_impl(e, buffer, bounds);
 }

--- a/builder/substitute.h
+++ b/builder/substitute.h
@@ -18,6 +18,10 @@ stmt substitute(const stmt& s, var target, const expr& replacement);
 interval_expr substitute(const interval_expr& x, var target, const expr& replacement);
 expr substitute(const expr& e, const expr& target, const expr& replacement);
 stmt substitute(const stmt& s, const expr& target, const expr& replacement);
+
+
+expr substitute_buffer(const expr& e, var buffer, const expr& elem_size, const std::vector<dim_expr>& dims);
+stmt substitute_buffer(const stmt& s, var buffer, const expr& elem_size, const std::vector<dim_expr>& dims);
 expr substitute_bounds(const expr& e, var buffer, const box_expr& bounds);
 stmt substitute_bounds(const stmt& s, var buffer, const box_expr& bounds);
 expr substitute_bounds(const expr& e, var buffer, int dim, const interval_expr& bounds);

--- a/builder/substitute.h
+++ b/builder/substitute.h
@@ -19,7 +19,8 @@ interval_expr substitute(const interval_expr& x, var target, const expr& replace
 expr substitute(const expr& e, const expr& target, const expr& replacement);
 stmt substitute(const stmt& s, const expr& target, const expr& replacement);
 
-
+// Substitute `elem_size` in for buffer_elem_size(buffer) and the other buffer metadata in `dims` for per-dimension
+// metadata.
 expr substitute_buffer(const expr& e, var buffer, const expr& elem_size, const std::vector<dim_expr>& dims);
 stmt substitute_buffer(const stmt& s, var buffer, const expr& elem_size, const std::vector<dim_expr>& dims);
 expr substitute_bounds(const expr& e, var buffer, const box_expr& bounds);

--- a/builder/test/simplify/simplify.cc
+++ b/builder/test/simplify/simplify.cc
@@ -247,7 +247,7 @@ TEST(simplify, bounds) {
       matches(stmt()));
   ASSERT_THAT(simplify(allocate::make(x, memory_type::heap, 1, {{bounds(y, z), 4, 5}},
                   crop_dim::make(x, x, 0, bounds(y - 1, z + 1), check::make(buffer_min(x, 0) == 2)))),
-      matches(allocate::make(x, memory_type::heap, 1, {{bounds(y, z), 4, 5}}, check::make(y == 2))));
+      matches(check::make(y == 2)));
 
   ASSERT_THAT(simplify(crop_dim::make(x, x, 1, {buffer_min(y, 1), buffer_max(y, 1)},
                   crop_dim::make(y, y, 1, {1, 3}, check::make(buffer_min(x, 1) == buffer_min(y, 1))))),
@@ -275,15 +275,15 @@ TEST(simplify, clone) {
 TEST(simplify, allocate) {
   // Pull statements that don't use the buffer out of allocate nodes.
   ASSERT_THAT(simplify(allocate::make(x, memory_type::heap, 1, {{bounds(2, 3), 4, 5}},
-                  block::make({check::make(y), check::make(x), check::make(z)}))),
+                  block::make({check::make(y), check::make(buffer_at(x)), check::make(z)}))),
       matches(block::make({check::make(y),
-          allocate::make(x, memory_type::heap, 1, {{bounds(2, 3), 4, 5}}, check::make(x)), check::make(z)})));
+          allocate::make(x, memory_type::heap, 1, {{bounds(2, 3), 4, 5}}, check::make(buffer_at(x))), check::make(z)})));
 
   // Make sure clone_buffer doesn't hide uses of buffers or bounds.
   ASSERT_THAT(simplify(allocate::make(x, memory_type::heap, 1, {{bounds(2, 3), 4, 5}},
-                  block::make({check::make(y), clone_buffer::make(w, x, check::make(w)), check::make(z)}))),
+                  block::make({check::make(y), clone_buffer::make(w, x, check::make(buffer_at(w))), check::make(z)}))),
       matches(block::make({check::make(y),
-          allocate::make(x, memory_type::heap, 1, {{bounds(2, 3), 4, 5}}, check::make(x)), check::make(z)})));
+          allocate::make(x, memory_type::heap, 1, {{bounds(2, 3), 4, 5}}, check::make(buffer_at(x))), check::make(z)})));
 }
 
 TEST(simplify, make_buffer) {

--- a/builder/test/simplify/simplify.cc
+++ b/builder/test/simplify/simplify.cc
@@ -372,6 +372,15 @@ TEST(simplify, make_buffer) {
       matches(transpose::make(b1, b0, {0, 2}, body)));
 }
 
+TEST(simplify, transpose) {
+  ASSERT_THAT(simplify(transpose::make(
+                  b1, b0, {2, 1, 0}, transpose::make(b2, b1, {2, 1, 0}, call_stmt::make(nullptr, {}, {b2}, {})))),
+      matches(transpose::make(b2, b0, {0, 1, 2}, call_stmt::make(nullptr, {}, {b2}, {}))));
+  ASSERT_THAT(simplify(transpose::make(
+                  b1, b0, {3, 2, 1}, transpose::make(b2, b1, {1, 0}, call_stmt::make(nullptr, {}, {b2}, {})))),
+      matches(transpose::make(b2, b0, {2, 3}, call_stmt::make(nullptr, {}, {b2}, {}))));
+}
+
 TEST(simplify, bounds_of) {
   // Test bounds_of by testing expressions of up to two operands, and setting the
   // bounds of the two operands to all possible cases of overlap. This approach

--- a/builder/test/simplify/simplify.cc
+++ b/builder/test/simplify/simplify.cc
@@ -252,6 +252,12 @@ TEST(simplify, bounds) {
 
 TEST(simplify, buffer_bounds) {
   ASSERT_THAT(
+      simplify(allocate::make(b0, memory_type::heap, 1, {{buffer_bounds(b1, 0), 4, 5}},
+          crop_dim::make(b2, b0, 0, buffer_bounds(b1, 0) & bounds(x, y), call_stmt::make(nullptr, {}, {b2}, {})))),
+      matches(allocate::make(b0, memory_type::heap, 1, {{buffer_bounds(b1, 0), 4, 5}},
+          crop_dim::make(b2, b0, 0, bounds(x, y), call_stmt::make(nullptr, {}, {b2}, {})))));
+
+  ASSERT_THAT(
       simplify(allocate::make(x, memory_type::heap, 1, {{bounds(2, 3), 4, 5}}, check::make(buffer_min(x, 0) == 2))),
       matches(stmt()));
   ASSERT_THAT(simplify(allocate::make(x, memory_type::heap, 1, {{bounds(2, 3), 4, 5}},

--- a/builder/test/simplify/simplify.cc
+++ b/builder/test/simplify/simplify.cc
@@ -263,10 +263,6 @@ TEST(simplify, buffer_bounds) {
   ASSERT_THAT(simplify(allocate::make(x, memory_type::heap, 1, {{bounds(y, z), 4, 5}},
                   crop_dim::make(x, x, 0, bounds(y - 1, z + 1), check::make(buffer_min(x, 0) == y && buffer_at(x))))),
       matches(allocate::make(x, memory_type::heap, 1, {{bounds(y, z), 4, 5}}, check::make(buffer_at(x)))));
-
-  ASSERT_THAT(simplify(crop_dim::make(x, x, 1, {buffer_min(y, 1), buffer_max(y, 1)},
-                  crop_dim::make(y, y, 1, {1, 3}, check::make(buffer_min(x, 1) == buffer_min(y, 1))))),
-      matches(check::make(max(1, buffer_min(y, 1)) == max(buffer_min(y, 1), buffer_min(x, 1)))));
 }
 
 TEST(simplify, crop_not_needed) {

--- a/builder/test/simplify/simplify.cc
+++ b/builder/test/simplify/simplify.cc
@@ -244,6 +244,8 @@ TEST(simplify, bounds) {
   ASSERT_THAT(simplify(min(x, y), {{x, {y + 1, z}}}), matches(y));
   ASSERT_THAT(simplify(min(x, y), {{x, {y + abs(w), z}}}), matches(y));
 
+  ASSERT_THAT(simplify(expr(x) == y, {{x, {y, y}}}), matches(true));
+
   ASSERT_THAT(simplify(loop::make(x, loop::serial, bounds(y - 2, z), 2, check::make(y - 2 <= x))), matches(stmt()));
   ASSERT_THAT(simplify(loop::make(x, loop::serial, min_extent(x, z), z, check::make(y))), matches(check::make(y)));
 }

--- a/builder/test/simplify/simplify.cc
+++ b/builder/test/simplify/simplify.cc
@@ -233,9 +233,22 @@ TEST(simplify, licm) {
 }
 
 TEST(simplify, bounds) {
+  ASSERT_THAT(simplify(min(x, y), {{x, {y, z}}}), matches(y));
+  ASSERT_THAT(simplify(max(x, y), {{x, {y, z}}}), matches(x));
+  ASSERT_THAT(simplify(min(x, z), {{x, {y, z}}}), matches(x));
+  ASSERT_THAT(simplify(max(x, z), {{x, {y, z}}}), matches(z));
+  ASSERT_THAT(simplify(min(x + 1, y), {{x, {y, z}}}), matches(y));
+  ASSERT_THAT(simplify(min(x, y - 1), {{x, {y, z}}}), matches(y + -1));
+  ASSERT_THAT(simplify(max(x + 2, y), {{x, {y, z}}}), matches(x + 2));
+  ASSERT_THAT(simplify(max(x, y - 2), {{x, {y, z}}}), matches(x));
+  ASSERT_THAT(simplify(min(x, y), {{x, {y + 1, z}}}), matches(y));
+  ASSERT_THAT(simplify(min(x, y), {{x, {y + abs(w), z}}}), matches(y));
+
   ASSERT_THAT(simplify(loop::make(x, loop::serial, bounds(y - 2, z), 2, check::make(y - 2 <= x))), matches(stmt()));
   ASSERT_THAT(simplify(loop::make(x, loop::serial, min_extent(x, z), z, check::make(y))), matches(check::make(y)));
+}
 
+TEST(simplify, buffer_bounds) {
   ASSERT_THAT(
       simplify(allocate::make(x, memory_type::heap, 1, {{bounds(2, 3), 4, 5}}, check::make(buffer_min(x, 0) == 2))),
       matches(stmt()));

--- a/builder/test/util.h
+++ b/builder/test/util.h
@@ -37,15 +37,6 @@ std::string remove_windows_newlines(std::string s);
 
 std::string read_entire_file(const std::string& pathname);
 
-template <typename T>
-std::vector<T> permute(span<const int> p, const std::vector<T>& x) {
-  std::vector<T> result(p.size());
-  for (std::size_t i = 0; i < p.size(); ++i) {
-    result[i] = x[p[i]];
-  }
-  return result;
-}
-
 inline bool is_permutation(span<const int> p) {
   std::vector<int> unpermuted(p.size());
   std::iota(unpermuted.begin(), unpermuted.end(), 0);

--- a/builder/test/visualize/padded_stencil_0.html
+++ b/builder/test/visualize/padded_stencil_0.html
@@ -347,25 +347,14 @@ function pipeline(__in, out) {
         produce(intm_padded_intm);
         __event_t++;
       }}
-      check((buffer_elem_size(intm_padded_intm) == 2));
       { let __intm = crop_buffer(intm_padded_intm, [
           {min:max(g, (buffer_min(out, 0) + -1)), max:min(g#0, (buffer_max(out, 0) + 1))},
           {min:max(g#1, (buffer_min(out, 1) + -1)), max:min(g#2, (buffer_max(out, 1) + 1))}
       ]); {
         let intm = __intm;
-        {
-          let __base = buffer_at(intm_padded_intm);
-          let __elem_size = buffer_elem_size(intm);
-          let __dims = [
-              {bounds:{min:buffer_min(intm_padded_intm, 0), max:buffer_max(intm_padded_intm, 0)}, stride:buffer_stride(intm, 0), fold_factor:buffer_fold_factor(intm, 0)},
-              {bounds:{min:buffer_min(intm_padded_intm, 1), max:buffer_max(intm_padded_intm, 1)}, stride:buffer_stride(intm, 1), fold_factor:buffer_fold_factor(intm, 1)}
-          ];
-          { let padded_intm#1 = make_buffer('padded_intm#1', __base, __elem_size, __dims);
-            produce(intm);
-            produce(padded_intm#1);
-            __event_t++;
-          }
-        }
+        produce(intm);
+        produce(intm_padded_intm);
+        __event_t++;
       }}
       consume(intm_padded_intm);
       produce(out);

--- a/builder/test/visualize/padded_stencil_0.html
+++ b/builder/test/visualize/padded_stencil_0.html
@@ -321,10 +321,10 @@ function trace_begin(x) { return x; }
 function trace_end(x) { return 1; }
 let __trace_names = allocate('__trace_names', 1, [{bounds:{min:0, max:0}, stride:1, fold_factor:1}], true);
 function pipeline(__in, out) {
-  check((__in != 0));
+  check(__in);
   check((buffer_rank(__in) == 2));
   check((buffer_elem_size(__in) == 2));
-  check((out != 0));
+  check(out);
   check((buffer_rank(out) == 2));
   check((buffer_elem_size(out) == 2));
   check(or_else((buffer_fold_factor(out, 0) == 9223372036854775807), (buffer_max(out, 0) < (buffer_fold_factor(out, 0) + buffer_min(out, 0)))));

--- a/builder/test/visualize/padded_stencil_0.html
+++ b/builder/test/visualize/padded_stencil_0.html
@@ -339,8 +339,8 @@ function pipeline(__in, out) {
         {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:NaN, fold_factor:9223372036854775807}
       ]);
       { let __intm_padded_intm = crop_buffer(intm_padded_intm, [
-          {min:max(g, (buffer_min(out, 0) + -1)), max:min(g#0, (buffer_max(out, 0) + 1))},
-          {min:max(g#1, (buffer_min(out, 1) + -1)), max:min(g#2, (buffer_max(out, 1) + 1))}
+          {min:g, max:g#0},
+          {min:g#1, max:g#2}
       ]); {
         let intm_padded_intm = __intm_padded_intm;
         consume(__in);
@@ -348,8 +348,8 @@ function pipeline(__in, out) {
         __event_t++;
       }}
       { let __intm = crop_buffer(intm_padded_intm, [
-          {min:max(g, (buffer_min(out, 0) + -1)), max:min(g#0, (buffer_max(out, 0) + 1))},
-          {min:max(g#1, (buffer_min(out, 1) + -1)), max:min(g#2, (buffer_max(out, 1) + 1))}
+          {min:g, max:g#0},
+          {min:g#1, max:g#2}
       ]); {
         let intm = __intm;
         produce(intm);

--- a/builder/test/visualize/padded_stencil_0.html
+++ b/builder/test/visualize/padded_stencil_0.html
@@ -361,21 +361,15 @@ function pipeline(__in, out) {
               {bounds:{min:buffer_min(intm_padded_intm, 1), max:buffer_max(intm_padded_intm, 1)}, stride:buffer_stride(intm, 1), fold_factor:buffer_fold_factor(intm, 1)}
           ];
           { let padded_intm#1 = make_buffer('padded_intm#1', __base, __elem_size, __dims);
-            { let __padded_intm#1 = transpose(padded_intm#1, [0, 1]); {
-              let padded_intm#1 = __padded_intm#1;
-              produce(intm);
-              produce(padded_intm#1);
-              __event_t++;
-            }}
+            produce(intm);
+            produce(padded_intm#1);
+            __event_t++;
           }
         }
       }}
-      { let __intm_padded_intm = transpose(intm_padded_intm, [0, 1]); {
-        let intm_padded_intm = __intm_padded_intm;
-        consume(intm_padded_intm);
-        produce(out);
-        __event_t++;
-      }}
+      consume(intm_padded_intm);
+      produce(out);
+      __event_t++;
       free(intm_padded_intm);
     }
   }

--- a/builder/test/visualize/padded_stencil_0.html
+++ b/builder/test/visualize/padded_stencil_0.html
@@ -354,11 +354,11 @@ function pipeline(__in, out) {
       ]); {
         let intm = __intm;
         {
-          let __base = buffer_at(intm_padded_intm, (buffer_min(out, 0) + -1), (buffer_min(out, 1) + -1));
+          let __base = buffer_at(intm_padded_intm);
           let __elem_size = buffer_elem_size(intm);
           let __dims = [
-              {bounds:{min:(buffer_min(out, 0) + -1), max:(buffer_max(out, 0) + 1)}, stride:buffer_stride(intm, 0), fold_factor:buffer_fold_factor(intm, 0)},
-              {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:buffer_stride(intm, 1), fold_factor:buffer_fold_factor(intm, 1)}
+              {bounds:{min:buffer_min(intm_padded_intm, 0), max:buffer_max(intm_padded_intm, 0)}, stride:buffer_stride(intm, 0), fold_factor:buffer_fold_factor(intm, 0)},
+              {bounds:{min:buffer_min(intm_padded_intm, 1), max:buffer_max(intm_padded_intm, 1)}, stride:buffer_stride(intm, 1), fold_factor:buffer_fold_factor(intm, 1)}
           ];
           { let padded_intm#1 = make_buffer('padded_intm#1', __base, __elem_size, __dims);
             { let __padded_intm#1 = transpose(padded_intm#1, [0, 1]); {

--- a/builder/test/visualize/padded_stencil_1.html
+++ b/builder/test/visualize/padded_stencil_1.html
@@ -347,25 +347,14 @@ function pipeline(__in, out) {
         produce(intm_padded_intm);
         __event_t++;
       }}
-      check((buffer_elem_size(intm_padded_intm) == 2));
       { let __intm = crop_buffer(intm_padded_intm, [
           {min:max(g, (buffer_min(out, 0) + -1)), max:min(g#0, (buffer_max(out, 0) + 1))},
           {min:max(g#1, (buffer_min(out, 1) + -1)), max:min(g#2, (buffer_max(out, 1) + 1))}
       ]); {
         let intm = __intm;
-        {
-          let __base = buffer_at(intm_padded_intm);
-          let __elem_size = buffer_elem_size(intm);
-          let __dims = [
-              {bounds:{min:buffer_min(intm_padded_intm, 0), max:buffer_max(intm_padded_intm, 0)}, stride:buffer_stride(intm, 0), fold_factor:buffer_fold_factor(intm, 0)},
-              {bounds:{min:buffer_min(intm_padded_intm, 1), max:buffer_max(intm_padded_intm, 1)}, stride:buffer_stride(intm, 1), fold_factor:buffer_fold_factor(intm, 1)}
-          ];
-          { let padded_intm#1 = make_buffer('padded_intm#1', __base, __elem_size, __dims);
-            produce(intm);
-            produce(padded_intm#1);
-            __event_t++;
-          }
-        }
+        produce(intm);
+        produce(intm_padded_intm);
+        __event_t++;
       }}
       consume(intm_padded_intm);
       produce(out);

--- a/builder/test/visualize/padded_stencil_1.html
+++ b/builder/test/visualize/padded_stencil_1.html
@@ -321,10 +321,10 @@ function trace_begin(x) { return x; }
 function trace_end(x) { return 1; }
 let __trace_names = allocate('__trace_names', 1, [{bounds:{min:0, max:0}, stride:1, fold_factor:1}], true);
 function pipeline(__in, out) {
-  check((__in != 0));
+  check(__in);
   check((buffer_rank(__in) == 2));
   check((buffer_elem_size(__in) == 2));
-  check((out != 0));
+  check(out);
   check((buffer_rank(out) == 2));
   check((buffer_elem_size(out) == 2));
   check(or_else((buffer_fold_factor(out, 0) == 9223372036854775807), (buffer_max(out, 0) < (buffer_fold_factor(out, 0) + buffer_min(out, 0)))));

--- a/builder/test/visualize/padded_stencil_1.html
+++ b/builder/test/visualize/padded_stencil_1.html
@@ -339,8 +339,8 @@ function pipeline(__in, out) {
         {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:NaN, fold_factor:9223372036854775807}
       ]);
       { let __intm_padded_intm = crop_buffer(intm_padded_intm, [
-          {min:max(g, (buffer_min(out, 0) + -1)), max:min(g#0, (buffer_max(out, 0) + 1))},
-          {min:max(g#1, (buffer_min(out, 1) + -1)), max:min(g#2, (buffer_max(out, 1) + 1))}
+          {min:g, max:g#0},
+          {min:g#1, max:g#2}
       ]); {
         let intm_padded_intm = __intm_padded_intm;
         consume(__in);
@@ -348,8 +348,8 @@ function pipeline(__in, out) {
         __event_t++;
       }}
       { let __intm = crop_buffer(intm_padded_intm, [
-          {min:max(g, (buffer_min(out, 0) + -1)), max:min(g#0, (buffer_max(out, 0) + 1))},
-          {min:max(g#1, (buffer_min(out, 1) + -1)), max:min(g#2, (buffer_max(out, 1) + 1))}
+          {min:g, max:g#0},
+          {min:g#1, max:g#2}
       ]); {
         let intm = __intm;
         produce(intm);

--- a/builder/test/visualize/padded_stencil_1.html
+++ b/builder/test/visualize/padded_stencil_1.html
@@ -361,21 +361,15 @@ function pipeline(__in, out) {
               {bounds:{min:buffer_min(intm_padded_intm, 1), max:buffer_max(intm_padded_intm, 1)}, stride:buffer_stride(intm, 1), fold_factor:buffer_fold_factor(intm, 1)}
           ];
           { let padded_intm#1 = make_buffer('padded_intm#1', __base, __elem_size, __dims);
-            { let __padded_intm#1 = transpose(padded_intm#1, [0, 1]); {
-              let padded_intm#1 = __padded_intm#1;
-              produce(intm);
-              produce(padded_intm#1);
-              __event_t++;
-            }}
+            produce(intm);
+            produce(padded_intm#1);
+            __event_t++;
           }
         }
       }}
-      { let __intm_padded_intm = transpose(intm_padded_intm, [0, 1]); {
-        let intm_padded_intm = __intm_padded_intm;
-        consume(intm_padded_intm);
-        produce(out);
-        __event_t++;
-      }}
+      consume(intm_padded_intm);
+      produce(out);
+      __event_t++;
       free(intm_padded_intm);
     }
   }

--- a/builder/test/visualize/padded_stencil_1.html
+++ b/builder/test/visualize/padded_stencil_1.html
@@ -354,11 +354,11 @@ function pipeline(__in, out) {
       ]); {
         let intm = __intm;
         {
-          let __base = buffer_at(intm_padded_intm, (buffer_min(out, 0) + -1), (buffer_min(out, 1) + -1));
+          let __base = buffer_at(intm_padded_intm);
           let __elem_size = buffer_elem_size(intm);
           let __dims = [
-              {bounds:{min:(buffer_min(out, 0) + -1), max:(buffer_max(out, 0) + 1)}, stride:buffer_stride(intm, 0), fold_factor:buffer_fold_factor(intm, 0)},
-              {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:buffer_stride(intm, 1), fold_factor:buffer_fold_factor(intm, 1)}
+              {bounds:{min:buffer_min(intm_padded_intm, 0), max:buffer_max(intm_padded_intm, 0)}, stride:buffer_stride(intm, 0), fold_factor:buffer_fold_factor(intm, 0)},
+              {bounds:{min:buffer_min(intm_padded_intm, 1), max:buffer_max(intm_padded_intm, 1)}, stride:buffer_stride(intm, 1), fold_factor:buffer_fold_factor(intm, 1)}
           ];
           { let padded_intm#1 = make_buffer('padded_intm#1', __base, __elem_size, __dims);
             { let __padded_intm#1 = transpose(padded_intm#1, [0, 1]); {

--- a/builder/test/visualize/padded_stencil_2.html
+++ b/builder/test/visualize/padded_stencil_2.html
@@ -350,10 +350,7 @@ function pipeline(__in, out) {
               let __loop_max = buffer_max(out, 1);
               let __loop_step = 1;
               for(let y = __loop_min; y <= __loop_max; y += __loop_step) {
-                { let __intm = crop_buffer(intm, [
-                    {min:max(g, (buffer_min(out, 0) + -1)), max:min(g#0, (buffer_max(out, 0) + 1))},
-                    {min:select((y <= y_min_orig), max(g#1, (y + 1)), (min(g#2, y) + 1)), max:min(g#2, (y + 1))}
-                ]); {
+                { let __intm = crop_dim(intm, 1, {min:max(g#1, (max((buffer_min(out, 1) + -2), select((y <= y_min_orig), y, min(g#2, y))) + 1)), max:min(g#2, (y + 1))}); {
                   let intm = __intm;
                   consume(__in);
                   produce(intm);

--- a/builder/test/visualize/padded_stencil_2.html
+++ b/builder/test/visualize/padded_stencil_2.html
@@ -358,12 +358,9 @@ function pipeline(__in, out) {
                 }}
                 { let __padded_intm = crop_dim(padded_intm, 1, {min:(y + 1), max:(y + 1)}); {
                   let padded_intm = __padded_intm;
-                  { let __intm_uncropped = transpose(intm_uncropped, [0, 1]); {
-                    let intm_uncropped = __intm_uncropped;
-                    produce(intm_uncropped);
-                    produce(padded_intm);
-                    __event_t++;
-                  }}
+                  produce(intm_uncropped);
+                  produce(padded_intm);
+                  __event_t++;
                 }}
                 { let __out = crop_dim(out, 1, {min:y, max:y}); {
                   let out = __out;

--- a/builder/test/visualize/padded_stencil_2.html
+++ b/builder/test/visualize/padded_stencil_2.html
@@ -350,7 +350,7 @@ function pipeline(__in, out) {
               let __loop_max = buffer_max(out, 1);
               let __loop_step = 1;
               for(let y = __loop_min; y <= __loop_max; y += __loop_step) {
-                { let __intm = crop_dim(intm, 1, {min:select((y <= y_min_orig), max(g#1, (y + 1)), (min(g#2, y) + 1)), max:min(g#2, (y + 1))}); {
+                { let __intm = crop_dim(intm, 1, {min:select((y <= y_min_orig), max(g#1, (y + 1)), (min(g#2, y) + 1)), max:(y + 1)}); {
                   let intm = __intm;
                   consume(__in);
                   produce(intm);

--- a/builder/test/visualize/padded_stencil_2.html
+++ b/builder/test/visualize/padded_stencil_2.html
@@ -321,10 +321,10 @@ function trace_begin(x) { return x; }
 function trace_end(x) { return 1; }
 let __trace_names = allocate('__trace_names', 1, [{bounds:{min:0, max:0}, stride:1, fold_factor:1}], true);
 function pipeline(__in, out) {
-  check((__in != 0));
+  check(__in);
   check((buffer_rank(__in) == 2));
   check((buffer_elem_size(__in) == 2));
-  check((out != 0));
+  check(out);
   check((buffer_rank(out) == 2));
   check((buffer_elem_size(out) == 2));
   check(or_else((buffer_fold_factor(out, 0) == 9223372036854775807), (buffer_max(out, 0) < (buffer_fold_factor(out, 0) + buffer_min(out, 0)))));

--- a/builder/test/visualize/padded_stencil_2.html
+++ b/builder/test/visualize/padded_stencil_2.html
@@ -350,7 +350,10 @@ function pipeline(__in, out) {
               let __loop_max = buffer_max(out, 1);
               let __loop_step = 1;
               for(let y = __loop_min; y <= __loop_max; y += __loop_step) {
-                { let __intm = crop_dim(intm, 1, {min:select((y <= y_min_orig), max(g#1, (y + 1)), (min(g#2, y) + 1)), max:min(g#2, (y + 1))}); {
+                { let __intm = crop_buffer(intm, [
+                    {min:max(g, (buffer_min(out, 0) + -1)), max:min(g#0, (buffer_max(out, 0) + 1))},
+                    {min:select((y <= y_min_orig), max(g#1, (y + 1)), (min(g#2, y) + 1)), max:min(g#2, (y + 1))}
+                ]); {
                   let intm = __intm;
                   consume(__in);
                   produce(intm);
@@ -360,15 +363,9 @@ function pipeline(__in, out) {
                   let padded_intm = __padded_intm;
                   { let __intm_uncropped = transpose(intm_uncropped, [0, 1]); {
                     let intm_uncropped = __intm_uncropped;
-                    { let __intm_uncropped = crop_buffer(intm_uncropped, [
-                        {min:max(g, (buffer_min(out, 0) + -1)), max:min(g#0, (buffer_max(out, 0) + 1))},
-                        {min:max(g#1, (buffer_min(out, 1) + -1)), max:min(g#2, (buffer_max(out, 1) + 1))}
-                    ]); {
-                      let intm_uncropped = __intm_uncropped;
-                      produce(intm_uncropped);
-                      produce(padded_intm);
-                      __event_t++;
-                    }}
+                    produce(intm_uncropped);
+                    produce(padded_intm);
+                    __event_t++;
                   }}
                 }}
                 { let __out = crop_dim(out, 1, {min:y, max:y}); {

--- a/builder/test/visualize/padded_stencil_2.html
+++ b/builder/test/visualize/padded_stencil_2.html
@@ -350,7 +350,7 @@ function pipeline(__in, out) {
               let __loop_max = buffer_max(out, 1);
               let __loop_step = 1;
               for(let y = __loop_min; y <= __loop_max; y += __loop_step) {
-                { let __intm = crop_dim(intm, 1, {min:max(g#1, (max((buffer_min(out, 1) + -2), select((y <= y_min_orig), y, min(g#2, y))) + 1)), max:min(g#2, (y + 1))}); {
+                { let __intm = crop_dim(intm, 1, {min:select((y <= y_min_orig), max(g#1, (y + 1)), (min(g#2, y) + 1)), max:min(g#2, (y + 1))}); {
                   let intm = __intm;
                   consume(__in);
                   produce(intm);

--- a/builder/test/visualize/parallel_stencils_0.html
+++ b/builder/test/visualize/parallel_stencils_0.html
@@ -364,25 +364,25 @@ function pipeline(in1, in2, out) {
                   let __loop_max = buffer_max(out, 1);
                   let __loop_step = 1;
                   for(let y = __loop_min; y <= __loop_max; y += __loop_step) {
-                    { let __intm1 = crop_dim(intm1, 1, {min:(max(y, (buffer_min(out, 1) + -2)) + 1), max:(y + 1)}); {
+                    { let __intm1 = crop_dim(intm1, 1, {min:(y + 1), max:(y + 1)}); {
                       let intm1 = __intm1;
                       consume(in1);
                       produce(intm1);
                       __event_t++;
                     }}
-                    { let __intm3 = crop_dim(intm3, 1, {min:max(y, buffer_min(out, 1)), max:y}); {
+                    { let __intm3 = crop_dim(intm3, 1, {min:y, max:y}); {
                       let intm3 = __intm3;
                       consume(intm1_uncropped);
                       produce(intm3);
                       __event_t++;
                     }}
-                    { let __intm2 = crop_dim(intm2, 1, {min:(max(y, (buffer_min(out, 1) + -4)) + 2), max:(y + 2)}); {
+                    { let __intm2 = crop_dim(intm2, 1, {min:(y + 2), max:(y + 2)}); {
                       let intm2 = __intm2;
                       consume(in2);
                       produce(intm2);
                       __event_t++;
                     }}
-                    { let __intm4 = crop_dim(intm4, 1, {min:max(y, buffer_min(out, 1)), max:y}); {
+                    { let __intm4 = crop_dim(intm4, 1, {min:y, max:y}); {
                       let intm4 = __intm4;
                       consume(intm2_uncropped);
                       produce(intm4);

--- a/builder/test/visualize/parallel_stencils_0.html
+++ b/builder/test/visualize/parallel_stencils_0.html
@@ -321,13 +321,13 @@ function trace_begin(x) { return x; }
 function trace_end(x) { return 1; }
 let __trace_names = allocate('__trace_names', 1, [{bounds:{min:0, max:0}, stride:1, fold_factor:1}], true);
 function pipeline(in1, in2, out) {
-  check((in1 != 0));
+  check(in1);
   check((buffer_rank(in1) == 2));
   check((buffer_elem_size(in1) == 2));
-  check((in2 != 0));
+  check(in2);
   check((buffer_rank(in2) == 2));
   check((buffer_elem_size(in2) == 2));
-  check((out != 0));
+  check(out);
   check((buffer_rank(out) == 2));
   check((buffer_elem_size(out) == 2));
   check(or_else((buffer_fold_factor(out, 0) == 9223372036854775807), (buffer_max(out, 0) < (buffer_fold_factor(out, 0) + buffer_min(out, 0)))));

--- a/builder/test/visualize/parallel_stencils_0.html
+++ b/builder/test/visualize/parallel_stencils_0.html
@@ -364,25 +364,25 @@ function pipeline(in1, in2, out) {
                   let __loop_max = buffer_max(out, 1);
                   let __loop_step = 1;
                   for(let y = __loop_min; y <= __loop_max; y += __loop_step) {
-                    { let __intm1 = crop_dim(intm1, 1, {min:(y + 1), max:(y + 1)}); {
+                    { let __intm1 = crop_dim(intm1, 1, {min:(max(y, (buffer_min(out, 1) + -2)) + 1), max:(y + 1)}); {
                       let intm1 = __intm1;
                       consume(in1);
                       produce(intm1);
                       __event_t++;
                     }}
-                    { let __intm3 = crop_dim(intm3, 1, {min:y, max:y}); {
+                    { let __intm3 = crop_dim(intm3, 1, {min:max(y, buffer_min(out, 1)), max:y}); {
                       let intm3 = __intm3;
                       consume(intm1_uncropped);
                       produce(intm3);
                       __event_t++;
                     }}
-                    { let __intm2 = crop_dim(intm2, 1, {min:(y + 2), max:(y + 2)}); {
+                    { let __intm2 = crop_dim(intm2, 1, {min:(max(y, (buffer_min(out, 1) + -4)) + 2), max:(y + 2)}); {
                       let intm2 = __intm2;
                       consume(in2);
                       produce(intm2);
                       __event_t++;
                     }}
-                    { let __intm4 = crop_dim(intm4, 1, {min:y, max:y}); {
+                    { let __intm4 = crop_dim(intm4, 1, {min:max(y, buffer_min(out, 1)), max:y}); {
                       let intm4 = __intm4;
                       consume(intm2_uncropped);
                       produce(intm4);

--- a/builder/test/visualize/parallel_stencils_1.html
+++ b/builder/test/visualize/parallel_stencils_1.html
@@ -366,19 +366,11 @@ function pipeline(in1, in2, out) {
                 let __loop_max = buffer_max(out, 1);
                 let __loop_step = 2;
                 for(let y = __loop_min; y <= __loop_max; y += __loop_step) {
-                  { let __intm3 = crop_dim(intm3, 1, {min:max(y, buffer_min(out, 1)), max:min((y + 1), buffer_max(out, 1))}); {
+                  { let __intm3 = crop_dim(intm3, 1, {min:y, max:min((y + 1), buffer_max(out, 1))}); {
                     let intm3 = __intm3;
-                    let __loop_min = y;
-                    let __loop_max = min((y + 1), buffer_max(out, 1));
-                    let __loop_step = 1;
-                    for(let y_y = __loop_min; y_y <= __loop_max; y_y += __loop_step) {
-                      { let __intm3 = crop_dim(intm3, 1, {min:max(y_y, buffer_min(out, 1)), max:y_y}); {
-                        let intm3 = __intm3;
-                        consume(intm1);
-                        produce(intm3);
-                        __event_t++;
-                      }}
-                    }
+                    consume(intm1);
+                    produce(intm3);
+                    __event_t++;
                   }}
                   { let __intm2 = crop_dim(intm2, 1, {min:(y + 2), max:(min((y + 1), buffer_max(out, 1)) + 2)}); {
                     let intm2 = __intm2;
@@ -386,7 +378,7 @@ function pipeline(in1, in2, out) {
                     produce(intm2);
                     __event_t++;
                   }}
-                  { let __intm4 = crop_dim(intm4, 1, {min:max(y, buffer_min(out, 1)), max:min((y + 1), buffer_max(out, 1))}); {
+                  { let __intm4 = crop_dim(intm4, 1, {min:y, max:min((y + 1), buffer_max(out, 1))}); {
                     let intm4 = __intm4;
                     consume(intm2_uncropped);
                     produce(intm4);

--- a/builder/test/visualize/parallel_stencils_1.html
+++ b/builder/test/visualize/parallel_stencils_1.html
@@ -368,9 +368,17 @@ function pipeline(in1, in2, out) {
                 for(let y = __loop_min; y <= __loop_max; y += __loop_step) {
                   { let __intm3 = crop_dim(intm3, 1, {min:y, max:min((y + 1), buffer_max(out, 1))}); {
                     let intm3 = __intm3;
-                    consume(intm1);
-                    produce(intm3);
-                    __event_t++;
+                    let __loop_min = y;
+                    let __loop_max = min((y + 1), buffer_max(out, 1));
+                    let __loop_step = 1;
+                    for(let y_y = __loop_min; y_y <= __loop_max; y_y += __loop_step) {
+                      { let __intm3 = crop_dim(intm3, 1, {min:y_y, max:min(y_y, min((y + 1), buffer_max(out, 1)))}); {
+                        let intm3 = __intm3;
+                        consume(intm1);
+                        produce(intm3);
+                        __event_t++;
+                      }}
+                    }
                   }}
                   { let __intm2 = crop_dim(intm2, 1, {min:(y + 2), max:(min((y + 1), buffer_max(out, 1)) + 2)}); {
                     let intm2 = __intm2;

--- a/builder/test/visualize/parallel_stencils_1.html
+++ b/builder/test/visualize/parallel_stencils_1.html
@@ -366,13 +366,13 @@ function pipeline(in1, in2, out) {
                 let __loop_max = buffer_max(out, 1);
                 let __loop_step = 2;
                 for(let y = __loop_min; y <= __loop_max; y += __loop_step) {
-                  { let __intm3 = crop_dim(intm3, 1, {min:y, max:min((y + 1), buffer_max(out, 1))}); {
+                  { let __intm3 = crop_dim(intm3, 1, {min:max(y, buffer_min(out, 1)), max:min((y + 1), buffer_max(out, 1))}); {
                     let intm3 = __intm3;
                     let __loop_min = buffer_min(intm3, 1);
                     let __loop_max = buffer_max(intm3, 1);
                     let __loop_step = 1;
                     for(let y_y = __loop_min; y_y <= __loop_max; y_y += __loop_step) {
-                      { let __intm3 = crop_dim(intm3, 1, {min:y_y, max:min(y_y, min((y + 1), buffer_max(out, 1)))}); {
+                      { let __intm3 = crop_dim(intm3, 1, {min:max(y_y, buffer_min(out, 1)), max:min(y_y, buffer_max(out, 1))}); {
                         let intm3 = __intm3;
                         consume(intm1);
                         produce(intm3);
@@ -386,13 +386,13 @@ function pipeline(in1, in2, out) {
                     produce(intm2);
                     __event_t++;
                   }}
-                  { let __intm4 = crop_dim(intm4, 1, {min:y, max:min((y + 1), buffer_max(out, 1))}); {
+                  { let __intm4 = crop_dim(intm4, 1, {min:max(y, buffer_min(out, 1)), max:min((y + 1), buffer_max(out, 1))}); {
                     let intm4 = __intm4;
                     let __loop_min = buffer_min(intm4, 1);
                     let __loop_max = buffer_max(intm4, 1);
                     let __loop_step = 2;
                     for(let y_y#0 = __loop_min; y_y#0 <= __loop_max; y_y#0 += __loop_step) {
-                      { let __intm4 = crop_dim(intm4, 1, {min:y_y#0, max:min((min(y, y_y#0) + 1), buffer_max(out, 1))}); {
+                      { let __intm4 = crop_dim(intm4, 1, {min:max(y_y#0, buffer_min(out, 1)), max:min((y_y#0 + 1), buffer_max(out, 1))}); {
                         let intm4 = __intm4;
                         consume(intm2_uncropped);
                         produce(intm4);

--- a/builder/test/visualize/parallel_stencils_1.html
+++ b/builder/test/visualize/parallel_stencils_1.html
@@ -321,13 +321,13 @@ function trace_begin(x) { return x; }
 function trace_end(x) { return 1; }
 let __trace_names = allocate('__trace_names', 1, [{bounds:{min:0, max:0}, stride:1, fold_factor:1}], true);
 function pipeline(in1, in2, out) {
-  check((in1 != 0));
+  check(in1);
   check((buffer_rank(in1) == 2));
   check((buffer_elem_size(in1) == 2));
-  check((in2 != 0));
+  check(in2);
   check((buffer_rank(in2) == 2));
   check((buffer_elem_size(in2) == 2));
-  check((out != 0));
+  check(out);
   check((buffer_rank(out) == 2));
   check((buffer_elem_size(out) == 2));
   check(or_else((buffer_fold_factor(out, 0) == 9223372036854775807), (buffer_max(out, 0) < (buffer_fold_factor(out, 0) + buffer_min(out, 0)))));

--- a/builder/test/visualize/parallel_stencils_1.html
+++ b/builder/test/visualize/parallel_stencils_1.html
@@ -368,9 +368,17 @@ function pipeline(in1, in2, out) {
                 for(let y = __loop_min; y <= __loop_max; y += __loop_step) {
                   { let __intm3 = crop_dim(intm3, 1, {min:y, max:min((y + 1), buffer_max(out, 1))}); {
                     let intm3 = __intm3;
-                    consume(intm1);
-                    produce(intm3);
-                    __event_t++;
+                    let __loop_min = buffer_min(intm3, 1);
+                    let __loop_max = buffer_max(intm3, 1);
+                    let __loop_step = 1;
+                    for(let y_y = __loop_min; y_y <= __loop_max; y_y += __loop_step) {
+                      { let __intm3 = crop_dim(intm3, 1, {min:y_y, max:min(y_y, min((y + 1), buffer_max(out, 1)))}); {
+                        let intm3 = __intm3;
+                        consume(intm1);
+                        produce(intm3);
+                        __event_t++;
+                      }}
+                    }
                   }}
                   { let __intm2 = crop_dim(intm2, 1, {min:(y + 2), max:(min((y + 1), buffer_max(out, 1)) + 2)}); {
                     let intm2 = __intm2;
@@ -380,9 +388,17 @@ function pipeline(in1, in2, out) {
                   }}
                   { let __intm4 = crop_dim(intm4, 1, {min:y, max:min((y + 1), buffer_max(out, 1))}); {
                     let intm4 = __intm4;
-                    consume(intm2_uncropped);
-                    produce(intm4);
-                    __event_t++;
+                    let __loop_min = buffer_min(intm4, 1);
+                    let __loop_max = buffer_max(intm4, 1);
+                    let __loop_step = 2;
+                    for(let y_y#0 = __loop_min; y_y#0 <= __loop_max; y_y#0 += __loop_step) {
+                      { let __intm4 = crop_dim(intm4, 1, {min:y_y#0, max:min((min(y, y_y#0) + 1), buffer_max(out, 1))}); {
+                        let intm4 = __intm4;
+                        consume(intm2_uncropped);
+                        produce(intm4);
+                        __event_t++;
+                      }}
+                    }
                   }}
                   { let __out = crop_dim(out, 1, {min:y, max:(y + 1)}); {
                     let out = __out;

--- a/builder/test/visualize/parallel_stencils_1.html
+++ b/builder/test/visualize/parallel_stencils_1.html
@@ -368,11 +368,11 @@ function pipeline(in1, in2, out) {
                 for(let y = __loop_min; y <= __loop_max; y += __loop_step) {
                   { let __intm3 = crop_dim(intm3, 1, {min:max(y, buffer_min(out, 1)), max:min((y + 1), buffer_max(out, 1))}); {
                     let intm3 = __intm3;
-                    let __loop_min = buffer_min(intm3, 1);
-                    let __loop_max = buffer_max(intm3, 1);
+                    let __loop_min = y;
+                    let __loop_max = min((y + 1), buffer_max(out, 1));
                     let __loop_step = 1;
                     for(let y_y = __loop_min; y_y <= __loop_max; y_y += __loop_step) {
-                      { let __intm3 = crop_dim(intm3, 1, {min:max(y_y, buffer_min(out, 1)), max:min(y_y, buffer_max(out, 1))}); {
+                      { let __intm3 = crop_dim(intm3, 1, {min:max(y_y, buffer_min(out, 1)), max:y_y}); {
                         let intm3 = __intm3;
                         consume(intm1);
                         produce(intm3);
@@ -388,17 +388,9 @@ function pipeline(in1, in2, out) {
                   }}
                   { let __intm4 = crop_dim(intm4, 1, {min:max(y, buffer_min(out, 1)), max:min((y + 1), buffer_max(out, 1))}); {
                     let intm4 = __intm4;
-                    let __loop_min = buffer_min(intm4, 1);
-                    let __loop_max = buffer_max(intm4, 1);
-                    let __loop_step = 2;
-                    for(let y_y#0 = __loop_min; y_y#0 <= __loop_max; y_y#0 += __loop_step) {
-                      { let __intm4 = crop_dim(intm4, 1, {min:max(y_y#0, buffer_min(out, 1)), max:min((y_y#0 + 1), buffer_max(out, 1))}); {
-                        let intm4 = __intm4;
-                        consume(intm2_uncropped);
-                        produce(intm4);
-                        __event_t++;
-                      }}
-                    }
+                    consume(intm2_uncropped);
+                    produce(intm4);
+                    __event_t++;
                   }}
                   { let __out = crop_dim(out, 1, {min:y, max:(y + 1)}); {
                     let out = __out;

--- a/builder/test/visualize/parallel_stencils_1.html
+++ b/builder/test/visualize/parallel_stencils_1.html
@@ -366,19 +366,11 @@ function pipeline(in1, in2, out) {
                 let __loop_max = buffer_max(out, 1);
                 let __loop_step = 2;
                 for(let y = __loop_min; y <= __loop_max; y += __loop_step) {
-                  { let __intm3 = crop_dim(intm3, 1, {min:y, max:min((y + 1), buffer_max(out, 1))}); {
+                  { let __intm3 = crop_dim(intm3, 1, {min:y, max:(y + 1)}); {
                     let intm3 = __intm3;
-                    let __loop_min = y;
-                    let __loop_max = min((y + 1), buffer_max(out, 1));
-                    let __loop_step = 1;
-                    for(let y_y = __loop_min; y_y <= __loop_max; y_y += __loop_step) {
-                      { let __intm3 = crop_dim(intm3, 1, {min:y_y, max:min(y_y, min((y + 1), buffer_max(out, 1)))}); {
-                        let intm3 = __intm3;
-                        consume(intm1);
-                        produce(intm3);
-                        __event_t++;
-                      }}
-                    }
+                    consume(intm1);
+                    produce(intm3);
+                    __event_t++;
                   }}
                   { let __intm2 = crop_dim(intm2, 1, {min:(y + 2), max:(min((y + 1), buffer_max(out, 1)) + 2)}); {
                     let intm2 = __intm2;
@@ -386,7 +378,7 @@ function pipeline(in1, in2, out) {
                     produce(intm2);
                     __event_t++;
                   }}
-                  { let __intm4 = crop_dim(intm4, 1, {min:y, max:min((y + 1), buffer_max(out, 1))}); {
+                  { let __intm4 = crop_dim(intm4, 1, {min:y, max:(y + 1)}); {
                     let intm4 = __intm4;
                     consume(intm2_uncropped);
                     produce(intm4);

--- a/builder/test/visualize/parallel_stencils_2.html
+++ b/builder/test/visualize/parallel_stencils_2.html
@@ -370,7 +370,7 @@ function pipeline(in1, in2, out) {
                       produce(intm1);
                       __event_t++;
                     }}
-                    { let __intm3 = crop_dim(intm3, 1, {min:y, max:min((y + 1), buffer_max(out, 1))}); {
+                    { let __intm3 = crop_dim(intm3, 1, {min:y, max:(y + 1)}); {
                       let intm3 = __intm3;
                       consume(intm1_uncropped);
                       produce(intm3);
@@ -382,7 +382,7 @@ function pipeline(in1, in2, out) {
                       produce(intm2);
                       __event_t++;
                     }}
-                    { let __intm4 = crop_dim(intm4, 1, {min:y, max:min((y + 1), buffer_max(out, 1))}); {
+                    { let __intm4 = crop_dim(intm4, 1, {min:y, max:(y + 1)}); {
                       let intm4 = __intm4;
                       consume(intm2_uncropped);
                       produce(intm4);

--- a/builder/test/visualize/parallel_stencils_2.html
+++ b/builder/test/visualize/parallel_stencils_2.html
@@ -364,25 +364,25 @@ function pipeline(in1, in2, out) {
                   let __loop_max = buffer_max(out, 1);
                   let __loop_step = 2;
                   for(let y = __loop_min; y <= __loop_max; y += __loop_step) {
-                    { let __intm1 = crop_dim(intm1, 1, {min:(max((y + 2), buffer_min(out, 1)) + -1), max:(min((y + 1), buffer_max(out, 1)) + 1)}); {
+                    { let __intm1 = crop_dim(intm1, 1, {min:(y + 1), max:(min((y + 1), buffer_max(out, 1)) + 1)}); {
                       let intm1 = __intm1;
                       consume(in1);
                       produce(intm1);
                       __event_t++;
                     }}
-                    { let __intm3 = crop_dim(intm3, 1, {min:max(y, buffer_min(out, 1)), max:min((y + 1), buffer_max(out, 1))}); {
+                    { let __intm3 = crop_dim(intm3, 1, {min:y, max:min((y + 1), buffer_max(out, 1))}); {
                       let intm3 = __intm3;
                       consume(intm1_uncropped);
                       produce(intm3);
                       __event_t++;
                     }}
-                    { let __intm2 = crop_dim(intm2, 1, {min:(max((y + 4), buffer_min(out, 1)) + -2), max:(min((y + 1), buffer_max(out, 1)) + 2)}); {
+                    { let __intm2 = crop_dim(intm2, 1, {min:(y + 2), max:(min((y + 1), buffer_max(out, 1)) + 2)}); {
                       let intm2 = __intm2;
                       consume(in2);
                       produce(intm2);
                       __event_t++;
                     }}
-                    { let __intm4 = crop_dim(intm4, 1, {min:max(y, buffer_min(out, 1)), max:min((y + 1), buffer_max(out, 1))}); {
+                    { let __intm4 = crop_dim(intm4, 1, {min:y, max:min((y + 1), buffer_max(out, 1))}); {
                       let intm4 = __intm4;
                       consume(intm2_uncropped);
                       produce(intm4);

--- a/builder/test/visualize/parallel_stencils_2.html
+++ b/builder/test/visualize/parallel_stencils_2.html
@@ -364,25 +364,25 @@ function pipeline(in1, in2, out) {
                   let __loop_max = buffer_max(out, 1);
                   let __loop_step = 2;
                   for(let y = __loop_min; y <= __loop_max; y += __loop_step) {
-                    { let __intm1 = crop_dim(intm1, 1, {min:(y + 1), max:(min((y + 1), buffer_max(out, 1)) + 1)}); {
+                    { let __intm1 = crop_dim(intm1, 1, {min:(max((y + 2), buffer_min(out, 1)) + -1), max:(min((y + 1), buffer_max(out, 1)) + 1)}); {
                       let intm1 = __intm1;
                       consume(in1);
                       produce(intm1);
                       __event_t++;
                     }}
-                    { let __intm3 = crop_dim(intm3, 1, {min:y, max:min((y + 1), buffer_max(out, 1))}); {
+                    { let __intm3 = crop_dim(intm3, 1, {min:max(y, buffer_min(out, 1)), max:min((y + 1), buffer_max(out, 1))}); {
                       let intm3 = __intm3;
                       consume(intm1_uncropped);
                       produce(intm3);
                       __event_t++;
                     }}
-                    { let __intm2 = crop_dim(intm2, 1, {min:(y + 2), max:(min((y + 1), buffer_max(out, 1)) + 2)}); {
+                    { let __intm2 = crop_dim(intm2, 1, {min:(max((y + 4), buffer_min(out, 1)) + -2), max:(min((y + 1), buffer_max(out, 1)) + 2)}); {
                       let intm2 = __intm2;
                       consume(in2);
                       produce(intm2);
                       __event_t++;
                     }}
-                    { let __intm4 = crop_dim(intm4, 1, {min:y, max:min((y + 1), buffer_max(out, 1))}); {
+                    { let __intm4 = crop_dim(intm4, 1, {min:max(y, buffer_min(out, 1)), max:min((y + 1), buffer_max(out, 1))}); {
                       let intm4 = __intm4;
                       consume(intm2_uncropped);
                       produce(intm4);

--- a/builder/test/visualize/parallel_stencils_2.html
+++ b/builder/test/visualize/parallel_stencils_2.html
@@ -321,13 +321,13 @@ function trace_begin(x) { return x; }
 function trace_end(x) { return 1; }
 let __trace_names = allocate('__trace_names', 1, [{bounds:{min:0, max:0}, stride:1, fold_factor:1}], true);
 function pipeline(in1, in2, out) {
-  check((in1 != 0));
+  check(in1);
   check((buffer_rank(in1) == 2));
   check((buffer_elem_size(in1) == 2));
-  check((in2 != 0));
+  check(in2);
   check((buffer_rank(in2) == 2));
   check((buffer_elem_size(in2) == 2));
-  check((out != 0));
+  check(out);
   check((buffer_rank(out) == 2));
   check((buffer_elem_size(out) == 2));
   check(or_else((buffer_fold_factor(out, 0) == 9223372036854775807), (buffer_max(out, 0) < (buffer_fold_factor(out, 0) + buffer_min(out, 0)))));

--- a/builder/test/visualize/softmax_split_0.html
+++ b/builder/test/visualize/softmax_split_0.html
@@ -321,10 +321,10 @@ function trace_begin(x) { return x; }
 function trace_end(x) { return 1; }
 let __trace_names = allocate('__trace_names', 1, [{bounds:{min:0, max:0}, stride:1, fold_factor:1}], true);
 function pipeline(__in, out) {
-  check((__in != 0));
+  check(__in);
   check((buffer_rank(__in) == 2));
   check((buffer_elem_size(__in) == 4));
-  check((out != 0));
+  check(out);
   check((buffer_rank(out) == 2));
   check((buffer_elem_size(out) == 4));
   check(or_else((buffer_fold_factor(out, 0) == 9223372036854775807), (buffer_max(out, 0) < (buffer_fold_factor(out, 0) + buffer_min(out, 0)))));

--- a/builder/test/visualize/softmax_split_1.html
+++ b/builder/test/visualize/softmax_split_1.html
@@ -363,11 +363,20 @@ function pipeline(__in, out) {
                         let __loop_max = buffer_max(out, 1);
                         let __loop_step = 1;
                         for(let b = __loop_min; b <= __loop_max; b += __loop_step) {
-                          { let __softmax_in = crop_dim(softmax_in, 1, {min:b, max:b}); {
+                          { let __softmax_in = crop_buffer(softmax_in, [
+                              {min:min(g, g#0), max:max(g, g#0)},
+                              {min:b, max:b}
+                          ]); {
                             let softmax_in = __softmax_in;
-                            consume(__in);
-                            produce(softmax_in);
-                            __event_t++;
+                            {
+                              let b_b = buffer_min(softmax_in, 1);
+                              { let __softmax_in = crop_dim(softmax_in, 1, {min:NaN, max:min(b_b, b)}); {
+                                let softmax_in = __softmax_in;
+                                consume(__in);
+                                produce(softmax_in);
+                                __event_t++;
+                              }}
+                            }
                           }}
                           { let __max_in = crop_dim(max_in, 0, {min:b, max:b}); {
                             let max_in = __max_in;
@@ -377,7 +386,10 @@ function pipeline(__in, out) {
                           }}
                           { let __sum_exp_in = crop_dim(sum_exp_in, 0, {min:b, max:b}); {
                             let sum_exp_in = __sum_exp_in;
-                            { let __exp_in = crop_dim(exp_in, 1, {min:b, max:b}); {
+                            { let __exp_in = crop_buffer(exp_in, [
+                                {min:min(g, g#0), max:max(g, g#0)},
+                                {min:b, max:b}
+                            ]); {
                               let exp_in = __exp_in;
                               consume(__in);
                               consume(max_in_uncropped);

--- a/builder/test/visualize/softmax_split_1.html
+++ b/builder/test/visualize/softmax_split_1.html
@@ -321,10 +321,10 @@ function trace_begin(x) { return x; }
 function trace_end(x) { return 1; }
 let __trace_names = allocate('__trace_names', 1, [{bounds:{min:0, max:0}, stride:1, fold_factor:1}], true);
 function pipeline(__in, out) {
-  check((__in != 0));
+  check(__in);
   check((buffer_rank(__in) == 2));
   check((buffer_elem_size(__in) == 4));
-  check((out != 0));
+  check(out);
   check((buffer_rank(out) == 2));
   check((buffer_elem_size(out) == 4));
   check(or_else((buffer_fold_factor(out, 0) == 9223372036854775807), (buffer_max(out, 0) < (buffer_fold_factor(out, 0) + buffer_min(out, 0)))));

--- a/builder/test/visualize/softmax_split_1.html
+++ b/builder/test/visualize/softmax_split_1.html
@@ -365,17 +365,9 @@ function pipeline(__in, out) {
                         for(let b = __loop_min; b <= __loop_max; b += __loop_step) {
                           { let __softmax_in = crop_dim(softmax_in, 1, {min:b, max:b}); {
                             let softmax_in = __softmax_in;
-                            let __loop_min = buffer_min(softmax_in, 1);
-                            let __loop_max = buffer_max(softmax_in, 1);
-                            let __loop_step = 1;
-                            for(let b_b = __loop_min; b_b <= __loop_max; b_b += __loop_step) {
-                              { let __softmax_in = crop_dim(softmax_in, 1, {min:max(b_b, buffer_min(out, 1)), max:min(b_b, buffer_max(out, 1))}); {
-                                let softmax_in = __softmax_in;
-                                consume(__in);
-                                produce(softmax_in);
-                                __event_t++;
-                              }}
-                            }
+                            consume(__in);
+                            produce(softmax_in);
+                            __event_t++;
                           }}
                           { let __max_in = crop_dim(max_in, 0, {min:b, max:b}); {
                             let max_in = __max_in;

--- a/builder/test/visualize/softmax_split_1.html
+++ b/builder/test/visualize/softmax_split_1.html
@@ -365,9 +365,17 @@ function pipeline(__in, out) {
                         for(let b = __loop_min; b <= __loop_max; b += __loop_step) {
                           { let __softmax_in = crop_dim(softmax_in, 1, {min:b, max:b}); {
                             let softmax_in = __softmax_in;
-                            consume(__in);
-                            produce(softmax_in);
-                            __event_t++;
+                            let __loop_min = max(b, buffer_min(max_in, 0));
+                            let __loop_max = min(b, buffer_max(max_in, 0));
+                            let __loop_step = 1;
+                            for(let b = __loop_min; b <= __loop_max; b += __loop_step) {
+                              { let __softmax_in = crop_dim(softmax_in, 1, {min:NaN, max:min(b, buffer_max(out, 1))}); {
+                                let softmax_in = __softmax_in;
+                                consume(__in);
+                                produce(softmax_in);
+                                __event_t++;
+                              }}
+                            }
                           }}
                           { let __max_in = crop_dim(max_in, 0, {min:b, max:b}); {
                             let max_in = __max_in;

--- a/builder/test/visualize/softmax_split_1.html
+++ b/builder/test/visualize/softmax_split_1.html
@@ -363,14 +363,13 @@ function pipeline(__in, out) {
                         let __loop_max = buffer_max(out, 1);
                         let __loop_step = 1;
                         for(let b = __loop_min; b <= __loop_max; b += __loop_step) {
-                          { let __softmax_in = crop_buffer(softmax_in, [
-                              {min:min(g, g#0), max:max(g, g#0)},
-                              {min:b, max:b}
-                          ]); {
+                          { let __softmax_in = crop_dim(softmax_in, 1, {min:b, max:b}); {
                             let softmax_in = __softmax_in;
-                            {
-                              let b_b = buffer_min(softmax_in, 1);
-                              { let __softmax_in = crop_dim(softmax_in, 1, {min:NaN, max:min(b_b, b)}); {
+                            let __loop_min = buffer_min(softmax_in, 1);
+                            let __loop_max = buffer_max(softmax_in, 1);
+                            let __loop_step = 1;
+                            for(let b_b = __loop_min; b_b <= __loop_max; b_b += __loop_step) {
+                              { let __softmax_in = crop_dim(softmax_in, 1, {min:max(b_b, buffer_min(out, 1)), max:min(b_b, buffer_max(out, 1))}); {
                                 let softmax_in = __softmax_in;
                                 consume(__in);
                                 produce(softmax_in);
@@ -386,10 +385,7 @@ function pipeline(__in, out) {
                           }}
                           { let __sum_exp_in = crop_dim(sum_exp_in, 0, {min:b, max:b}); {
                             let sum_exp_in = __sum_exp_in;
-                            { let __exp_in = crop_buffer(exp_in, [
-                                {min:min(g, g#0), max:max(g, g#0)},
-                                {min:b, max:b}
-                            ]); {
+                            { let __exp_in = crop_dim(exp_in, 1, {min:b, max:b}); {
                               let exp_in = __exp_in;
                               consume(__in);
                               consume(max_in_uncropped);

--- a/builder/test/visualize/softmax_split_1.html
+++ b/builder/test/visualize/softmax_split_1.html
@@ -365,17 +365,9 @@ function pipeline(__in, out) {
                         for(let b = __loop_min; b <= __loop_max; b += __loop_step) {
                           { let __softmax_in = crop_dim(softmax_in, 1, {min:b, max:b}); {
                             let softmax_in = __softmax_in;
-                            let __loop_min = max(b, buffer_min(max_in, 0));
-                            let __loop_max = min(b, buffer_max(max_in, 0));
-                            let __loop_step = 1;
-                            for(let b = __loop_min; b <= __loop_max; b += __loop_step) {
-                              { let __softmax_in = crop_dim(softmax_in, 1, {min:NaN, max:min(b, buffer_max(out, 1))}); {
-                                let softmax_in = __softmax_in;
-                                consume(__in);
-                                produce(softmax_in);
-                                __event_t++;
-                              }}
-                            }
+                            consume(__in);
+                            produce(softmax_in);
+                            __event_t++;
                           }}
                           { let __max_in = crop_dim(max_in, 0, {min:b, max:b}); {
                             let max_in = __max_in;

--- a/builder/test/visualize/softmax_split_4.html
+++ b/builder/test/visualize/softmax_split_4.html
@@ -321,10 +321,10 @@ function trace_begin(x) { return x; }
 function trace_end(x) { return 1; }
 let __trace_names = allocate('__trace_names', 1, [{bounds:{min:0, max:0}, stride:1, fold_factor:1}], true);
 function pipeline(__in, out) {
-  check((__in != 0));
+  check(__in);
   check((buffer_rank(__in) == 2));
   check((buffer_elem_size(__in) == 4));
-  check((out != 0));
+  check(out);
   check((buffer_rank(out) == 2));
   check((buffer_elem_size(out) == 4));
   check(or_else((buffer_fold_factor(out, 0) == 9223372036854775807), (buffer_max(out, 0) < (buffer_fold_factor(out, 0) + buffer_min(out, 0)))));

--- a/builder/test/visualize/softmax_split_4.html
+++ b/builder/test/visualize/softmax_split_4.html
@@ -363,14 +363,22 @@ function pipeline(__in, out) {
                         let __loop_max = buffer_max(out, 1);
                         let __loop_step = 4;
                         for(let b = __loop_min; b <= __loop_max; b += __loop_step) {
-                          { let __softmax_in = crop_dim(softmax_in, 1, {min:b, max:min((b + 3), buffer_max(out, 1))}); {
+                          { let __softmax_in = crop_buffer(softmax_in, [
+                              {min:min(g, g#0), max:max(g, g#0)},
+                              {min:b, max:min((b + 3), buffer_max(out, 1))}
+                          ]); {
                             let softmax_in = __softmax_in;
-                            { let __softmax_in = crop_dim(softmax_in, 1, {min:b, max:min((b + 3), buffer_max(out, 1))}); {
-                              let softmax_in = __softmax_in;
-                              consume(__in);
-                              produce(softmax_in);
-                              __event_t++;
-                            }}
+                            let __loop_min = buffer_min(softmax_in, 1);
+                            let __loop_max = buffer_max(softmax_in, 1);
+                            let __loop_step = 4;
+                            for(let b_b = __loop_min; b_b <= __loop_max; b_b += __loop_step) {
+                              { let __softmax_in = crop_dim(softmax_in, 1, {min:b_b, max:min((min(b, b_b) + 3), buffer_max(out, 1))}); {
+                                let softmax_in = __softmax_in;
+                                consume(__in);
+                                produce(softmax_in);
+                                __event_t++;
+                              }}
+                            }
                           }}
                           { let __max_in = crop_dim(max_in, 0, {min:b, max:min((b + 3), buffer_max(out, 1))}); {
                             let max_in = __max_in;
@@ -380,7 +388,10 @@ function pipeline(__in, out) {
                           }}
                           { let __sum_exp_in = crop_dim(sum_exp_in, 0, {min:b, max:min((b + 3), buffer_max(out, 1))}); {
                             let sum_exp_in = __sum_exp_in;
-                            { let __exp_in = crop_dim(exp_in, 1, {min:b, max:min((b + 3), buffer_max(out, 1))}); {
+                            { let __exp_in = crop_buffer(exp_in, [
+                                {min:min(g, g#0), max:max(g, g#0)},
+                                {min:b, max:min((b + 3), buffer_max(out, 1))}
+                            ]); {
                               let exp_in = __exp_in;
                               consume(__in);
                               consume(max_in_uncropped);

--- a/builder/test/visualize/softmax_split_4.html
+++ b/builder/test/visualize/softmax_split_4.html
@@ -363,21 +363,21 @@ function pipeline(__in, out) {
                         let __loop_max = buffer_max(out, 1);
                         let __loop_step = 4;
                         for(let b = __loop_min; b <= __loop_max; b += __loop_step) {
-                          { let __softmax_in = crop_dim(softmax_in, 1, {min:b, max:min((b + 3), buffer_max(out, 1))}); {
+                          { let __softmax_in = crop_dim(softmax_in, 1, {min:b, max:(b + 3)}); {
                             let softmax_in = __softmax_in;
                             consume(__in);
                             produce(softmax_in);
                             __event_t++;
                           }}
-                          { let __max_in = crop_dim(max_in, 0, {min:b, max:min((b + 3), buffer_max(out, 1))}); {
+                          { let __max_in = crop_dim(max_in, 0, {min:b, max:(b + 3)}); {
                             let max_in = __max_in;
                             consume(softmax_in_uncropped);
                             produce(max_in);
                             __event_t++;
                           }}
-                          { let __sum_exp_in = crop_dim(sum_exp_in, 0, {min:b, max:min((b + 3), buffer_max(out, 1))}); {
+                          { let __sum_exp_in = crop_dim(sum_exp_in, 0, {min:b, max:(b + 3)}); {
                             let sum_exp_in = __sum_exp_in;
-                            { let __exp_in = crop_dim(exp_in, 1, {min:b, max:min((b + 3), buffer_max(out, 1))}); {
+                            { let __exp_in = crop_dim(exp_in, 1, {min:b, max:(b + 3)}); {
                               let exp_in = __exp_in;
                               consume(__in);
                               consume(max_in_uncropped);
@@ -386,7 +386,7 @@ function pipeline(__in, out) {
                               __event_t++;
                             }}
                           }}
-                          { let __softmax_out = crop_dim(softmax_out, 1, {min:b, max:min((b + 3), buffer_max(out, 1))}); {
+                          { let __softmax_out = crop_dim(softmax_out, 1, {min:b, max:(b + 3)}); {
                             let softmax_out = __softmax_out;
                             consume(exp_in_uncropped);
                             consume(sum_exp_in_uncropped);

--- a/builder/test/visualize/softmax_split_4.html
+++ b/builder/test/visualize/softmax_split_4.html
@@ -363,16 +363,13 @@ function pipeline(__in, out) {
                         let __loop_max = buffer_max(out, 1);
                         let __loop_step = 4;
                         for(let b = __loop_min; b <= __loop_max; b += __loop_step) {
-                          { let __softmax_in = crop_buffer(softmax_in, [
-                              {min:min(g, g#0), max:max(g, g#0)},
-                              {min:b, max:min((b + 3), buffer_max(out, 1))}
-                          ]); {
+                          { let __softmax_in = crop_dim(softmax_in, 1, {min:b, max:min((b + 3), buffer_max(out, 1))}); {
                             let softmax_in = __softmax_in;
                             let __loop_min = buffer_min(softmax_in, 1);
                             let __loop_max = buffer_max(softmax_in, 1);
                             let __loop_step = 4;
                             for(let b_b = __loop_min; b_b <= __loop_max; b_b += __loop_step) {
-                              { let __softmax_in = crop_dim(softmax_in, 1, {min:b_b, max:min((min(b, b_b) + 3), buffer_max(out, 1))}); {
+                              { let __softmax_in = crop_dim(softmax_in, 1, {min:max(b_b, buffer_min(out, 1)), max:min((b_b + 3), buffer_max(out, 1))}); {
                                 let softmax_in = __softmax_in;
                                 consume(__in);
                                 produce(softmax_in);
@@ -388,10 +385,7 @@ function pipeline(__in, out) {
                           }}
                           { let __sum_exp_in = crop_dim(sum_exp_in, 0, {min:b, max:min((b + 3), buffer_max(out, 1))}); {
                             let sum_exp_in = __sum_exp_in;
-                            { let __exp_in = crop_buffer(exp_in, [
-                                {min:min(g, g#0), max:max(g, g#0)},
-                                {min:b, max:min((b + 3), buffer_max(out, 1))}
-                            ]); {
+                            { let __exp_in = crop_dim(exp_in, 1, {min:b, max:min((b + 3), buffer_max(out, 1))}); {
                               let exp_in = __exp_in;
                               consume(__in);
                               consume(max_in_uncropped);

--- a/builder/test/visualize/softmax_split_4.html
+++ b/builder/test/visualize/softmax_split_4.html
@@ -365,17 +365,9 @@ function pipeline(__in, out) {
                         for(let b = __loop_min; b <= __loop_max; b += __loop_step) {
                           { let __softmax_in = crop_dim(softmax_in, 1, {min:b, max:min((b + 3), buffer_max(out, 1))}); {
                             let softmax_in = __softmax_in;
-                            let __loop_min = buffer_min(softmax_in, 1);
-                            let __loop_max = buffer_max(softmax_in, 1);
-                            let __loop_step = 4;
-                            for(let b_b = __loop_min; b_b <= __loop_max; b_b += __loop_step) {
-                              { let __softmax_in = crop_dim(softmax_in, 1, {min:max(b_b, buffer_min(out, 1)), max:min((b_b + 3), buffer_max(out, 1))}); {
-                                let softmax_in = __softmax_in;
-                                consume(__in);
-                                produce(softmax_in);
-                                __event_t++;
-                              }}
-                            }
+                            consume(__in);
+                            produce(softmax_in);
+                            __event_t++;
                           }}
                           { let __max_in = crop_dim(max_in, 0, {min:b, max:min((b + 3), buffer_max(out, 1))}); {
                             let max_in = __max_in;

--- a/builder/test/visualize/stencil_chain_split_serial_split_0.html
+++ b/builder/test/visualize/stencil_chain_split_serial_split_0.html
@@ -323,10 +323,10 @@ let __trace_names = allocate('__trace_names', 1, [{bounds:{min:0, max:0}, stride
 function pipeline(__in, out) {
   {
     let __trace_token = trace_begin(buffer_at(__trace_names, 13));
-    check((__in != 0));
+    check(__in);
     check((buffer_rank(__in) == 2));
     check((buffer_elem_size(__in) == 2));
-    check((out != 0));
+    check(out);
     check((buffer_rank(out) == 2));
     check((buffer_elem_size(out) == 2));
     check(or_else((buffer_fold_factor(out, 0) == 9223372036854775807), (buffer_max(out, 0) < (buffer_fold_factor(out, 0) + buffer_min(out, 0)))));

--- a/builder/test/visualize/stencil_chain_split_serial_split_0.html
+++ b/builder/test/visualize/stencil_chain_split_serial_split_0.html
@@ -331,10 +331,10 @@ function pipeline(__in, out) {
     check((buffer_elem_size(out) == 2));
     check(or_else((buffer_fold_factor(out, 0) == 9223372036854775807), (buffer_max(out, 0) < (buffer_fold_factor(out, 0) + buffer_min(out, 0)))));
     check(or_else((buffer_fold_factor(out, 1) == 9223372036854775807), (buffer_max(out, 1) < (buffer_fold_factor(out, 1) + buffer_min(out, 1)))));
-    check(((buffer_min(__in, 0) + 2) <= buffer_min(out, 0)));
-    check(((buffer_max(out, 0) + 2) <= buffer_max(__in, 0)));
-    check(((buffer_min(__in, 1) + 2) <= buffer_min(out, 1)));
-    check(((buffer_max(out, 1) + 2) <= buffer_max(__in, 1)));
+    check((buffer_min(__in, 0) < (buffer_min(out, 0) + -1)));
+    check((buffer_max(out, 0) < (buffer_max(__in, 0) + -1)));
+    check((buffer_min(__in, 1) < (buffer_min(out, 1) + -1)));
+    check((buffer_max(out, 1) < (buffer_max(__in, 1) + -1)));
     { let add_result = allocate('add_result', 2, [
         {bounds:{min:(buffer_min(out, 0) + -2), max:(buffer_max(out, 0) + 2)}, stride:NaN, fold_factor:9223372036854775807},
         {bounds:{min:(buffer_min(out, 1) + -2), max:(buffer_max(out, 1) + 2)}, stride:NaN, fold_factor:9223372036854775807}

--- a/builder/test/visualize/stencil_chain_split_serial_split_1.html
+++ b/builder/test/visualize/stencil_chain_split_serial_split_1.html
@@ -323,10 +323,10 @@ let __trace_names = allocate('__trace_names', 1, [{bounds:{min:0, max:0}, stride
 function pipeline(__in, out) {
   {
     let __trace_token = trace_begin(buffer_at(__trace_names, 37));
-    check((__in != 0));
+    check(__in);
     check((buffer_rank(__in) == 2));
     check((buffer_elem_size(__in) == 2));
-    check((out != 0));
+    check(out);
     check((buffer_rank(out) == 2));
     check((buffer_elem_size(out) == 2));
     check(or_else((buffer_fold_factor(out, 0) == 9223372036854775807), (buffer_max(out, 0) < (buffer_fold_factor(out, 0) + buffer_min(out, 0)))));

--- a/builder/test/visualize/stencil_chain_split_serial_split_1.html
+++ b/builder/test/visualize/stencil_chain_split_serial_split_1.html
@@ -331,10 +331,10 @@ function pipeline(__in, out) {
     check((buffer_elem_size(out) == 2));
     check(or_else((buffer_fold_factor(out, 0) == 9223372036854775807), (buffer_max(out, 0) < (buffer_fold_factor(out, 0) + buffer_min(out, 0)))));
     check(or_else((buffer_fold_factor(out, 1) == 9223372036854775807), (buffer_max(out, 1) < (buffer_fold_factor(out, 1) + buffer_min(out, 1)))));
-    check(((buffer_min(__in, 0) + 2) <= buffer_min(out, 0)));
-    check(((buffer_max(out, 0) + 2) <= buffer_max(__in, 0)));
-    check(((buffer_min(__in, 1) + 2) <= buffer_min(out, 1)));
-    check(((buffer_max(out, 1) + 2) <= buffer_max(__in, 1)));
+    check((buffer_min(__in, 0) < (buffer_min(out, 0) + -1)));
+    check((buffer_max(out, 0) < (buffer_max(__in, 0) + -1)));
+    check((buffer_min(__in, 1) < (buffer_min(out, 1) + -1)));
+    check((buffer_max(out, 1) < (buffer_max(__in, 1) + -1)));
     { let add_result = allocate('add_result', 2, [
         {bounds:{min:(buffer_min(out, 0) + -2), max:(buffer_max(out, 0) + 2)}, stride:NaN, fold_factor:9223372036854775807},
         {bounds:{min:(buffer_min(out, 1) + -2), max:(buffer_max(out, 1) + 2)}, stride:NaN, fold_factor:3}

--- a/builder/test/visualize/stencil_chain_split_serial_split_1.html
+++ b/builder/test/visualize/stencil_chain_split_serial_split_1.html
@@ -363,7 +363,7 @@ function pipeline(__in, out) {
                       check(trace_end(__trace_token));
                     }
                   }}
-                  { let __stencil1_result = crop_dim(stencil1_result, 1, {min:(y + 1), max:(y + 1)}); {
+                  { let __stencil1_result = crop_dim(stencil1_result, 1, {min:(max(y, (buffer_min(out, 1) + -2)) + 1), max:(y + 1)}); {
                     let stencil1_result = __stencil1_result;
                     {
                       let __trace_token = trace_begin(buffer_at(__trace_names, 30));

--- a/builder/test/visualize/stencil_chain_split_serial_split_1.html
+++ b/builder/test/visualize/stencil_chain_split_serial_split_1.html
@@ -363,7 +363,7 @@ function pipeline(__in, out) {
                       check(trace_end(__trace_token));
                     }
                   }}
-                  { let __stencil1_result = crop_dim(stencil1_result, 1, {min:(max(y, (buffer_min(out, 1) + -2)) + 1), max:(y + 1)}); {
+                  { let __stencil1_result = crop_dim(stencil1_result, 1, {min:(y + 1), max:(y + 1)}); {
                     let stencil1_result = __stencil1_result;
                     {
                       let __trace_token = trace_begin(buffer_at(__trace_names, 30));

--- a/builder/test/visualize/stencil_chain_split_serial_split_2.html
+++ b/builder/test/visualize/stencil_chain_split_serial_split_2.html
@@ -331,10 +331,10 @@ function pipeline(__in, out) {
     check((buffer_elem_size(out) == 2));
     check(or_else((buffer_fold_factor(out, 0) == 9223372036854775807), (buffer_max(out, 0) < (buffer_fold_factor(out, 0) + buffer_min(out, 0)))));
     check(or_else((buffer_fold_factor(out, 1) == 9223372036854775807), (buffer_max(out, 1) < (buffer_fold_factor(out, 1) + buffer_min(out, 1)))));
-    check(((buffer_min(__in, 0) + 2) <= buffer_min(out, 0)));
-    check(((buffer_max(out, 0) + 2) <= buffer_max(__in, 0)));
-    check(((buffer_min(__in, 1) + 2) <= buffer_min(out, 1)));
-    check(((buffer_max(out, 1) + 2) <= buffer_max(__in, 1)));
+    check((buffer_min(__in, 0) < (buffer_min(out, 0) + -1)));
+    check((buffer_max(out, 0) < (buffer_max(__in, 0) + -1)));
+    check((buffer_min(__in, 1) < (buffer_min(out, 1) + -1)));
+    check((buffer_max(out, 1) < (buffer_max(__in, 1) + -1)));
     { let add_result = allocate('add_result', 2, [
         {bounds:{min:(buffer_min(out, 0) + -2), max:(buffer_max(out, 0) + 2)}, stride:NaN, fold_factor:9223372036854775807},
         {bounds:{min:(buffer_min(out, 1) + -2), max:(buffer_max(out, 1) + 2)}, stride:NaN, fold_factor:4}

--- a/builder/test/visualize/stencil_chain_split_serial_split_2.html
+++ b/builder/test/visualize/stencil_chain_split_serial_split_2.html
@@ -323,10 +323,10 @@ let __trace_names = allocate('__trace_names', 1, [{bounds:{min:0, max:0}, stride
 function pipeline(__in, out) {
   {
     let __trace_token = trace_begin(buffer_at(__trace_names, 37));
-    check((__in != 0));
+    check(__in);
     check((buffer_rank(__in) == 2));
     check((buffer_elem_size(__in) == 2));
-    check((out != 0));
+    check(out);
     check((buffer_rank(out) == 2));
     check((buffer_elem_size(out) == 2));
     check(or_else((buffer_fold_factor(out, 0) == 9223372036854775807), (buffer_max(out, 0) < (buffer_fold_factor(out, 0) + buffer_min(out, 0)))));

--- a/builder/test/visualize/stencil_chain_split_serial_split_2.html
+++ b/builder/test/visualize/stencil_chain_split_serial_split_2.html
@@ -363,7 +363,7 @@ function pipeline(__in, out) {
                       check(trace_end(__trace_token));
                     }
                   }}
-                  { let __stencil1_result = crop_dim(stencil1_result, 1, {min:(y + 1), max:(min((y + 1), buffer_max(out, 1)) + 1)}); {
+                  { let __stencil1_result = crop_dim(stencil1_result, 1, {min:(max(y, (buffer_min(out, 1) + -2)) + 1), max:(min((y + 1), buffer_max(out, 1)) + 1)}); {
                     let stencil1_result = __stencil1_result;
                     {
                       let __trace_token = trace_begin(buffer_at(__trace_names, 30));

--- a/builder/test/visualize/stencil_chain_split_serial_split_2.html
+++ b/builder/test/visualize/stencil_chain_split_serial_split_2.html
@@ -363,7 +363,7 @@ function pipeline(__in, out) {
                       check(trace_end(__trace_token));
                     }
                   }}
-                  { let __stencil1_result = crop_dim(stencil1_result, 1, {min:(max(y, (buffer_min(out, 1) + -2)) + 1), max:(min((y + 1), buffer_max(out, 1)) + 1)}); {
+                  { let __stencil1_result = crop_dim(stencil1_result, 1, {min:(y + 1), max:(min((y + 1), buffer_max(out, 1)) + 1)}); {
                     let stencil1_result = __stencil1_result;
                     {
                       let __trace_token = trace_begin(buffer_at(__trace_names, 30));

--- a/builder/test/visualize/stencil_split_0.html
+++ b/builder/test/visualize/stencil_split_0.html
@@ -321,10 +321,10 @@ function trace_begin(x) { return x; }
 function trace_end(x) { return 1; }
 let __trace_names = allocate('__trace_names', 1, [{bounds:{min:0, max:0}, stride:1, fold_factor:1}], true);
 function pipeline(__in, out) {
-  check((__in != 0));
+  check(__in);
   check((buffer_rank(__in) == 2));
   check((buffer_elem_size(__in) == 2));
-  check((out != 0));
+  check(out);
   check((buffer_rank(out) == 2));
   check((buffer_elem_size(out) == 2));
   check(or_else((buffer_fold_factor(out, 0) == 9223372036854775807), (buffer_max(out, 0) < (buffer_fold_factor(out, 0) + buffer_min(out, 0)))));

--- a/builder/test/visualize/stencil_split_1.html
+++ b/builder/test/visualize/stencil_split_1.html
@@ -321,10 +321,10 @@ function trace_begin(x) { return x; }
 function trace_end(x) { return 1; }
 let __trace_names = allocate('__trace_names', 1, [{bounds:{min:0, max:0}, stride:1, fold_factor:1}], true);
 function pipeline(__in, out) {
-  check((__in != 0));
+  check(__in);
   check((buffer_rank(__in) == 2));
   check((buffer_elem_size(__in) == 2));
-  check((out != 0));
+  check(out);
   check((buffer_rank(out) == 2));
   check((buffer_elem_size(out) == 2));
   check(or_else((buffer_fold_factor(out, 0) == 9223372036854775807), (buffer_max(out, 0) < (buffer_fold_factor(out, 0) + buffer_min(out, 0)))));

--- a/builder/test/visualize/stencil_split_2.html
+++ b/builder/test/visualize/stencil_split_2.html
@@ -321,10 +321,10 @@ function trace_begin(x) { return x; }
 function trace_end(x) { return 1; }
 let __trace_names = allocate('__trace_names', 1, [{bounds:{min:0, max:0}, stride:1, fold_factor:1}], true);
 function pipeline(__in, out) {
-  check((__in != 0));
+  check(__in);
   check((buffer_rank(__in) == 2));
   check((buffer_elem_size(__in) == 2));
-  check((out != 0));
+  check(out);
   check((buffer_rank(out) == 2));
   check((buffer_elem_size(out) == 2));
   check(or_else((buffer_fold_factor(out, 0) == 9223372036854775807), (buffer_max(out, 0) < (buffer_fold_factor(out, 0) + buffer_min(out, 0)))));

--- a/builder/test/visualize/stencil_split_3.html
+++ b/builder/test/visualize/stencil_split_3.html
@@ -321,10 +321,10 @@ function trace_begin(x) { return x; }
 function trace_end(x) { return 1; }
 let __trace_names = allocate('__trace_names', 1, [{bounds:{min:0, max:0}, stride:1, fold_factor:1}], true);
 function pipeline(__in, out) {
-  check((__in != 0));
+  check(__in);
   check((buffer_rank(__in) == 2));
   check((buffer_elem_size(__in) == 2));
-  check((out != 0));
+  check(out);
   check((buffer_rank(out) == 2));
   check((buffer_elem_size(out) == 2));
   check(or_else((buffer_fold_factor(out, 0) == 9223372036854775807), (buffer_max(out, 0) < (buffer_fold_factor(out, 0) + buffer_min(out, 0)))));

--- a/runtime/depends_on.cc
+++ b/runtime/depends_on.cc
@@ -50,7 +50,12 @@ public:
       if (op->args[0].defined()) {
         const var* buf = as_variable(op->args[0]);
         assert(buf);
-        update_deps(*buf, [](depends_on_result& deps) { deps.buffer_meta = true; });
+        update_deps(*buf, [fn = op->intrinsic](depends_on_result& deps) {
+          deps.buffer_meta = true;
+          if (fn == intrinsic::buffer_at) {
+            deps.buffer_base = true;
+          }
+        });
 
         for (std::size_t i = 1; i < op->args.size(); ++i) {
           if (op->args[i].defined()) op->args[i].accept(this);

--- a/runtime/depends_on.h
+++ b/runtime/depends_on.h
@@ -17,11 +17,13 @@ struct depends_on_result {
   // True if the buffer is used as a copy source or destination, respectively.
   bool buffer_src = false;
   bool buffer_dst = false;
+  // True if the buffer's base pointer is read.
+  bool buffer_base = false;
 
   // True if the buffer metadata is read.
   bool buffer_meta = false;
 
-  bool buffer_data() const { return buffer_input || buffer_output || buffer_src || buffer_dst; }
+  bool buffer_data() const { return buffer_input || buffer_output || buffer_src || buffer_dst || buffer_base; }
   bool buffer() const { return buffer_data() || buffer_meta; }
 
   bool any() const { return var || buffer(); }

--- a/runtime/expr_stmt.cc
+++ b/runtime/expr_stmt.cc
@@ -618,7 +618,7 @@ bool is_finite(const expr& x) {
 }
 
 expr boolean(const expr& x) {
-  if (is_boolean(x)) {
+  if (!x.defined() || is_boolean(x)) {
     return x;
   } else if (const index_t* c = as_constant(x)) {
     return *c != 0;
@@ -690,8 +690,8 @@ namespace {
 
 template <typename T>
 void visit_binary(recursive_node_visitor* _this, const T* op) {
-  op->a.accept(_this);
-  op->b.accept(_this);
+  if (op->a.defined()) op->a.accept(_this);
+  if (op->b.defined()) op->b.accept(_this);
 }
 
 }  // namespace
@@ -709,11 +709,13 @@ void recursive_node_visitor::visit(const less* op) { visit_binary(this, op); }
 void recursive_node_visitor::visit(const less_equal* op) { visit_binary(this, op); }
 void recursive_node_visitor::visit(const logical_and* op) { visit_binary(this, op); }
 void recursive_node_visitor::visit(const logical_or* op) { visit_binary(this, op); }
-void recursive_node_visitor::visit(const logical_not* op) { op->a.accept(this); }
+void recursive_node_visitor::visit(const logical_not* op) {
+  if (op->a.defined()) op->a.accept(this);
+}
 void recursive_node_visitor::visit(const class select* op) {
-  op->condition.accept(this);
-  op->true_value.accept(this);
-  op->false_value.accept(this);
+  if (op->condition.defined()) op->condition.accept(this);
+  if (op->true_value.defined()) op->true_value.accept(this);
+  if (op->false_value.defined()) op->false_value.accept(this);
 }
 void recursive_node_visitor::visit(const call* op) {
   for (const expr& i : op->args) {
@@ -723,13 +725,13 @@ void recursive_node_visitor::visit(const call* op) {
 
 void recursive_node_visitor::visit(const let_stmt* op) {
   for (const auto& p : op->lets) {
-    p.second.accept(this);
+    if (p.second.defined()) p.second.accept(this);
   }
   if (op->body.defined()) op->body.accept(this);
 }
 void recursive_node_visitor::visit(const block* op) {
   for (const auto& s : op->stmts) {
-    s.accept(this);
+    if (s.defined()) s.accept(this);
   }
 }
 void recursive_node_visitor::visit(const loop* op) {

--- a/runtime/test/depends_on.cc
+++ b/runtime/test/depends_on.cc
@@ -22,6 +22,7 @@ bool operator==(const depends_on_result& l, const depends_on_result& r) {
   if (l.buffer_output != r.buffer_output) return false;
   if (l.buffer_src != r.buffer_src) return false;
   if (l.buffer_dst != r.buffer_dst) return false;
+  if (l.buffer_base != r.buffer_base) return false;
   if (l.buffer_meta != r.buffer_meta) return false;
   return true;
 }
@@ -32,6 +33,7 @@ std::ostream& operator<<(std::ostream& os, const depends_on_result& r) {
   os << ", .buffer_output = " << r.buffer_output;
   os << ", .buffer_src = " << r.buffer_src;
   os << ", .buffer_dst = " << r.buffer_dst;
+  os << ", .buffer_base = " << r.buffer_base;
   os << ", .buffer_meta = " << r.buffer_meta;
   os << "}";
   return os;
@@ -40,6 +42,7 @@ std::ostream& operator<<(std::ostream& os, const depends_on_result& r) {
 TEST(depends_on, basic) {
   ASSERT_EQ(depends_on(x + y, x), (depends_on_result{.var = true}));
   ASSERT_EQ(depends_on(x + x, x), (depends_on_result{.var = true}));
+  ASSERT_EQ(depends_on(buffer_at(x), x), (depends_on_result{.buffer_base = true, .buffer_meta = true}));
 
   stmt loop_x = loop::make(x, loop::serial, {y, z}, 1, check::make(x && z));
   ASSERT_EQ(depends_on(loop_x, x), depends_on_result{});


### PR DESCRIPTION
This PR attempts to simplify things more strongly using existing buffer information:
- Try to rewrite more `make_buffer` ops to be `crop_buffer`/`transpose`/etc. where possible.
- Simplify crop bounds more strongly. This fixes some recent regressions.

