### PR TITLE
Fix visualizer output (#374)

### DIFF
--- a/builder/test/visualize/padded_stencil_0.html
+++ b/builder/test/visualize/padded_stencil_0.html
@@ -173,6 +173,18 @@ function draw(mem, t) {
   window.requestAnimationFrame(function(t) { draw(mem, __current_t); });
 }
 function check(condition) {}
+function or_else(...cond) {
+  for (let d = 0; d < cond.length; ++d) {
+    if (cond[d]) return true;
+  }
+  return false;
+}
+function and_then(...cond) {
+  for (let d = 0; d < cond.length; ++d) {
+    if (!cond[d]) return false;
+  }
+  return true;
+}
 function buffer_at(b, ...at) {
   let result = b.base;
   for (let d = 0; d < at.length; ++d) {
@@ -331,16 +343,16 @@ function pipeline(__in, out) {
   check(or_else((buffer_fold_factor(out, 1) == 9223372036854775807), (buffer_max(out, 1) < (buffer_fold_factor(out, 1) + buffer_min(out, 1)))));
   {
     let g = buffer_min(__in, 0);
-    let g#1 = buffer_min(__in, 1);
-    let g#0 = buffer_max(__in, 0);
-    let g#2 = buffer_max(__in, 1);
+    let g_1 = buffer_min(__in, 1);
+    let g_0 = buffer_max(__in, 0);
+    let g_2 = buffer_max(__in, 1);
     { let intm_padded_intm = allocate('intm/padded_intm', 2, [
         {bounds:{min:(buffer_min(out, 0) + -1), max:(buffer_max(out, 0) + 1)}, stride:NaN, fold_factor:9223372036854775807},
         {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:NaN, fold_factor:9223372036854775807}
       ]);
       { let __intm_padded_intm = crop_buffer(intm_padded_intm, [
-          {min:max(g, (buffer_min(out, 0) + -1)), max:min(g#0, (buffer_max(out, 0) + 1))},
-          {min:max(g#1, (buffer_min(out, 1) + -1)), max:min(g#2, (buffer_max(out, 1) + 1))}
+          {min:max(g, (buffer_min(out, 0) + -1)), max:min(g_0, (buffer_max(out, 0) + 1))},
+          {min:max(g_1, (buffer_min(out, 1) + -1)), max:min(g_2, (buffer_max(out, 1) + 1))}
       ]); {
         let intm_padded_intm = __intm_padded_intm;
         consume(__in);
@@ -349,8 +361,8 @@ function pipeline(__in, out) {
       }}
       check((buffer_elem_size(intm_padded_intm) == 2));
       { let __intm = crop_buffer(intm_padded_intm, [
-          {min:max(g, (buffer_min(out, 0) + -1)), max:min(g#0, (buffer_max(out, 0) + 1))},
-          {min:max(g#1, (buffer_min(out, 1) + -1)), max:min(g#2, (buffer_max(out, 1) + 1))}
+          {min:max(g, (buffer_min(out, 0) + -1)), max:min(g_0, (buffer_max(out, 0) + 1))},
+          {min:max(g_1, (buffer_min(out, 1) + -1)), max:min(g_2, (buffer_max(out, 1) + 1))}
       ]); {
         let intm = __intm;
         {
@@ -360,11 +372,11 @@ function pipeline(__in, out) {
               {bounds:{min:(buffer_min(out, 0) + -1), max:(buffer_max(out, 0) + 1)}, stride:buffer_stride(intm, 0), fold_factor:buffer_fold_factor(intm, 0)},
               {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:buffer_stride(intm, 1), fold_factor:buffer_fold_factor(intm, 1)}
           ];
-          { let padded_intm#1 = make_buffer('padded_intm#1', __base, __elem_size, __dims);
-            { let __padded_intm#1 = transpose(padded_intm#1, [0, 1]); {
-              let padded_intm#1 = __padded_intm#1;
+          { let padded_intm_1 = make_buffer('padded_intm#1', __base, __elem_size, __dims);
+            { let __padded_intm_1 = transpose(padded_intm_1, [0, 1]); {
+              let padded_intm_1 = __padded_intm_1;
               produce(intm);
-              produce(padded_intm#1);
+              produce(padded_intm_1);
               __event_t++;
             }}
           }

--- a/builder/test/visualize/padded_stencil_0.html
+++ b/builder/test/visualize/padded_stencil_0.html
@@ -173,6 +173,10 @@ function draw(mem, t) {
   window.requestAnimationFrame(function(t) { draw(mem, __current_t); });
 }
 function check(condition) {}
+// TODO: or_else() + and_then() are supposed to short-circuit in order
+// to avoid integer overflow, but since each expression is evaluated
+// when passed to this function it's not really functioning as intended here.
+// Good enough for the visualizer, but not quite right.
 function or_else(...cond) {
   for (let d = 0; d < cond.length; ++d) {
     if (cond[d]) return true;

--- a/builder/test/visualize/padded_stencil_1.html
+++ b/builder/test/visualize/padded_stencil_1.html
@@ -173,6 +173,18 @@ function draw(mem, t) {
   window.requestAnimationFrame(function(t) { draw(mem, __current_t); });
 }
 function check(condition) {}
+function or_else(...cond) {
+  for (let d = 0; d < cond.length; ++d) {
+    if (cond[d]) return true;
+  }
+  return false;
+}
+function and_then(...cond) {
+  for (let d = 0; d < cond.length; ++d) {
+    if (!cond[d]) return false;
+  }
+  return true;
+}
 function buffer_at(b, ...at) {
   let result = b.base;
   for (let d = 0; d < at.length; ++d) {
@@ -331,16 +343,16 @@ function pipeline(__in, out) {
   check(or_else((buffer_fold_factor(out, 1) == 9223372036854775807), (buffer_max(out, 1) < (buffer_fold_factor(out, 1) + buffer_min(out, 1)))));
   {
     let g = buffer_min(__in, 0);
-    let g#1 = buffer_min(__in, 1);
-    let g#0 = buffer_max(__in, 0);
-    let g#2 = buffer_max(__in, 1);
+    let g_1 = buffer_min(__in, 1);
+    let g_0 = buffer_max(__in, 0);
+    let g_2 = buffer_max(__in, 1);
     { let intm_padded_intm = allocate('intm/padded_intm', 2, [
         {bounds:{min:(buffer_min(out, 0) + -1), max:(buffer_max(out, 0) + 1)}, stride:NaN, fold_factor:9223372036854775807},
         {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:NaN, fold_factor:9223372036854775807}
       ]);
       { let __intm_padded_intm = crop_buffer(intm_padded_intm, [
-          {min:max(g, (buffer_min(out, 0) + -1)), max:min(g#0, (buffer_max(out, 0) + 1))},
-          {min:max(g#1, (buffer_min(out, 1) + -1)), max:min(g#2, (buffer_max(out, 1) + 1))}
+          {min:max(g, (buffer_min(out, 0) + -1)), max:min(g_0, (buffer_max(out, 0) + 1))},
+          {min:max(g_1, (buffer_min(out, 1) + -1)), max:min(g_2, (buffer_max(out, 1) + 1))}
       ]); {
         let intm_padded_intm = __intm_padded_intm;
         consume(__in);
@@ -349,8 +361,8 @@ function pipeline(__in, out) {
       }}
       check((buffer_elem_size(intm_padded_intm) == 2));
       { let __intm = crop_buffer(intm_padded_intm, [
-          {min:max(g, (buffer_min(out, 0) + -1)), max:min(g#0, (buffer_max(out, 0) + 1))},
-          {min:max(g#1, (buffer_min(out, 1) + -1)), max:min(g#2, (buffer_max(out, 1) + 1))}
+          {min:max(g, (buffer_min(out, 0) + -1)), max:min(g_0, (buffer_max(out, 0) + 1))},
+          {min:max(g_1, (buffer_min(out, 1) + -1)), max:min(g_2, (buffer_max(out, 1) + 1))}
       ]); {
         let intm = __intm;
         {
@@ -360,11 +372,11 @@ function pipeline(__in, out) {
               {bounds:{min:(buffer_min(out, 0) + -1), max:(buffer_max(out, 0) + 1)}, stride:buffer_stride(intm, 0), fold_factor:buffer_fold_factor(intm, 0)},
               {bounds:{min:(buffer_min(out, 1) + -1), max:(buffer_max(out, 1) + 1)}, stride:buffer_stride(intm, 1), fold_factor:buffer_fold_factor(intm, 1)}
           ];
-          { let padded_intm#1 = make_buffer('padded_intm#1', __base, __elem_size, __dims);
-            { let __padded_intm#1 = transpose(padded_intm#1, [0, 1]); {
-              let padded_intm#1 = __padded_intm#1;
+          { let padded_intm_1 = make_buffer('padded_intm#1', __base, __elem_size, __dims);
+            { let __padded_intm_1 = transpose(padded_intm_1, [0, 1]); {
+              let padded_intm_1 = __padded_intm_1;
               produce(intm);
-              produce(padded_intm#1);
+              produce(padded_intm_1);
               __event_t++;
             }}
           }

--- a/builder/test/visualize/padded_stencil_1.html
+++ b/builder/test/visualize/padded_stencil_1.html
@@ -173,6 +173,10 @@ function draw(mem, t) {
   window.requestAnimationFrame(function(t) { draw(mem, __current_t); });
 }
 function check(condition) {}
+// TODO: or_else() + and_then() are supposed to short-circuit in order
+// to avoid integer overflow, but since each expression is evaluated
+// when passed to this function it's not really functioning as intended here.
+// Good enough for the visualizer, but not quite right.
 function or_else(...cond) {
   for (let d = 0; d < cond.length; ++d) {
     if (cond[d]) return true;

--- a/builder/test/visualize/padded_stencil_2.html
+++ b/builder/test/visualize/padded_stencil_2.html
@@ -173,6 +173,18 @@ function draw(mem, t) {
   window.requestAnimationFrame(function(t) { draw(mem, __current_t); });
 }
 function check(condition) {}
+function or_else(...cond) {
+  for (let d = 0; d < cond.length; ++d) {
+    if (cond[d]) return true;
+  }
+  return false;
+}
+function and_then(...cond) {
+  for (let d = 0; d < cond.length; ++d) {
+    if (!cond[d]) return false;
+  }
+  return true;
+}
 function buffer_at(b, ...at) {
   let result = b.base;
   for (let d = 0; d < at.length; ++d) {
@@ -331,12 +343,12 @@ function pipeline(__in, out) {
   check(or_else((buffer_fold_factor(out, 1) == 9223372036854775807), (buffer_max(out, 1) < (buffer_fold_factor(out, 1) + buffer_min(out, 1)))));
   {
     let g = buffer_min(__in, 0);
-    let g#1 = buffer_min(__in, 1);
-    let g#0 = buffer_max(__in, 0);
-    let g#2 = buffer_max(__in, 1);
+    let g_1 = buffer_min(__in, 1);
+    let g_0 = buffer_max(__in, 0);
+    let g_2 = buffer_max(__in, 1);
     { let intm = allocate('intm', 2, [
-        {bounds:{min:max(g, (buffer_min(out, 0) + -1)), max:min(g#0, (buffer_max(out, 0) + 1))}, stride:NaN, fold_factor:9223372036854775807},
-        {bounds:{min:max(g#1, (buffer_min(out, 1) + -1)), max:min(g#2, (buffer_max(out, 1) + 1))}, stride:NaN, fold_factor:1}
+        {bounds:{min:max(g, (buffer_min(out, 0) + -1)), max:min(g_0, (buffer_max(out, 0) + 1))}, stride:NaN, fold_factor:9223372036854775807},
+        {bounds:{min:max(g_1, (buffer_min(out, 1) + -1)), max:min(g_2, (buffer_max(out, 1) + 1))}, stride:NaN, fold_factor:1}
       ]);
       { let intm_uncropped = clone_buffer(intm);
         { let padded_intm = allocate('padded_intm', 2, [
@@ -350,7 +362,7 @@ function pipeline(__in, out) {
               let __loop_max = buffer_max(out, 1);
               let __loop_step = 1;
               for(let y = __loop_min; y <= __loop_max; y += __loop_step) {
-                { let __intm = crop_dim(intm, 1, {min:select((y <= y_min_orig), max(g#1, (y + 1)), (min(g#2, y) + 1)), max:min(g#2, (y + 1))}); {
+                { let __intm = crop_dim(intm, 1, {min:select((y <= y_min_orig), max(g_1, (y + 1)), (min(g_2, y) + 1)), max:min(g_2, (y + 1))}); {
                   let intm = __intm;
                   consume(__in);
                   produce(intm);
@@ -361,8 +373,8 @@ function pipeline(__in, out) {
                   { let __intm_uncropped = transpose(intm_uncropped, [0, 1]); {
                     let intm_uncropped = __intm_uncropped;
                     { let __intm_uncropped = crop_buffer(intm_uncropped, [
-                        {min:max(g, (buffer_min(out, 0) + -1)), max:min(g#0, (buffer_max(out, 0) + 1))},
-                        {min:max(g#1, (buffer_min(out, 1) + -1)), max:min(g#2, (buffer_max(out, 1) + 1))}
+                        {min:max(g, (buffer_min(out, 0) + -1)), max:min(g_0, (buffer_max(out, 0) + 1))},
+                        {min:max(g_1, (buffer_min(out, 1) + -1)), max:min(g_2, (buffer_max(out, 1) + 1))}
                     ]); {
                       let intm_uncropped = __intm_uncropped;
                       produce(intm_uncropped);

--- a/builder/test/visualize/padded_stencil_2.html
+++ b/builder/test/visualize/padded_stencil_2.html
@@ -173,6 +173,10 @@ function draw(mem, t) {
   window.requestAnimationFrame(function(t) { draw(mem, __current_t); });
 }
 function check(condition) {}
+// TODO: or_else() + and_then() are supposed to short-circuit in order
+// to avoid integer overflow, but since each expression is evaluated
+// when passed to this function it's not really functioning as intended here.
+// Good enough for the visualizer, but not quite right.
 function or_else(...cond) {
   for (let d = 0; d < cond.length; ++d) {
     if (cond[d]) return true;

--- a/builder/test/visualize/parallel_stencils_0.html
+++ b/builder/test/visualize/parallel_stencils_0.html
@@ -173,6 +173,18 @@ function draw(mem, t) {
   window.requestAnimationFrame(function(t) { draw(mem, __current_t); });
 }
 function check(condition) {}
+function or_else(...cond) {
+  for (let d = 0; d < cond.length; ++d) {
+    if (cond[d]) return true;
+  }
+  return false;
+}
+function and_then(...cond) {
+  for (let d = 0; d < cond.length; ++d) {
+    if (!cond[d]) return false;
+  }
+  return true;
+}
 function buffer_at(b, ...at) {
   let result = b.base;
   for (let d = 0; d < at.length; ++d) {

--- a/builder/test/visualize/parallel_stencils_0.html
+++ b/builder/test/visualize/parallel_stencils_0.html
@@ -173,6 +173,10 @@ function draw(mem, t) {
   window.requestAnimationFrame(function(t) { draw(mem, __current_t); });
 }
 function check(condition) {}
+// TODO: or_else() + and_then() are supposed to short-circuit in order
+// to avoid integer overflow, but since each expression is evaluated
+// when passed to this function it's not really functioning as intended here.
+// Good enough for the visualizer, but not quite right.
 function or_else(...cond) {
   for (let d = 0; d < cond.length; ++d) {
     if (cond[d]) return true;

--- a/builder/test/visualize/parallel_stencils_1.html
+++ b/builder/test/visualize/parallel_stencils_1.html
@@ -173,6 +173,18 @@ function draw(mem, t) {
   window.requestAnimationFrame(function(t) { draw(mem, __current_t); });
 }
 function check(condition) {}
+function or_else(...cond) {
+  for (let d = 0; d < cond.length; ++d) {
+    if (cond[d]) return true;
+  }
+  return false;
+}
+function and_then(...cond) {
+  for (let d = 0; d < cond.length; ++d) {
+    if (!cond[d]) return false;
+  }
+  return true;
+}
 function buffer_at(b, ...at) {
   let result = b.base;
   for (let d = 0; d < at.length; ++d) {

--- a/builder/test/visualize/parallel_stencils_1.html
+++ b/builder/test/visualize/parallel_stencils_1.html
@@ -173,6 +173,10 @@ function draw(mem, t) {
   window.requestAnimationFrame(function(t) { draw(mem, __current_t); });
 }
 function check(condition) {}
+// TODO: or_else() + and_then() are supposed to short-circuit in order
+// to avoid integer overflow, but since each expression is evaluated
+// when passed to this function it's not really functioning as intended here.
+// Good enough for the visualizer, but not quite right.
 function or_else(...cond) {
   for (let d = 0; d < cond.length; ++d) {
     if (cond[d]) return true;

--- a/builder/test/visualize/parallel_stencils_2.html
+++ b/builder/test/visualize/parallel_stencils_2.html
@@ -173,6 +173,18 @@ function draw(mem, t) {
   window.requestAnimationFrame(function(t) { draw(mem, __current_t); });
 }
 function check(condition) {}
+function or_else(...cond) {
+  for (let d = 0; d < cond.length; ++d) {
+    if (cond[d]) return true;
+  }
+  return false;
+}
+function and_then(...cond) {
+  for (let d = 0; d < cond.length; ++d) {
+    if (!cond[d]) return false;
+  }
+  return true;
+}
 function buffer_at(b, ...at) {
   let result = b.base;
   for (let d = 0; d < at.length; ++d) {

--- a/builder/test/visualize/parallel_stencils_2.html
+++ b/builder/test/visualize/parallel_stencils_2.html
@@ -173,6 +173,10 @@ function draw(mem, t) {
   window.requestAnimationFrame(function(t) { draw(mem, __current_t); });
 }
 function check(condition) {}
+// TODO: or_else() + and_then() are supposed to short-circuit in order
+// to avoid integer overflow, but since each expression is evaluated
+// when passed to this function it's not really functioning as intended here.
+// Good enough for the visualizer, but not quite right.
 function or_else(...cond) {
   for (let d = 0; d < cond.length; ++d) {
     if (cond[d]) return true;

--- a/builder/test/visualize/softmax_split_0.html
+++ b/builder/test/visualize/softmax_split_0.html
@@ -173,6 +173,18 @@ function draw(mem, t) {
   window.requestAnimationFrame(function(t) { draw(mem, __current_t); });
 }
 function check(condition) {}
+function or_else(...cond) {
+  for (let d = 0; d < cond.length; ++d) {
+    if (cond[d]) return true;
+  }
+  return false;
+}
+function and_then(...cond) {
+  for (let d = 0; d < cond.length; ++d) {
+    if (!cond[d]) return false;
+  }
+  return true;
+}
 function buffer_at(b, ...at) {
   let result = b.base;
   for (let d = 0; d < at.length; ++d) {
@@ -331,13 +343,13 @@ function pipeline(__in, out) {
   check(or_else((buffer_fold_factor(out, 1) == 9223372036854775807), (buffer_max(out, 1) < (buffer_fold_factor(out, 1) + buffer_min(out, 1)))));
   {
     let g = buffer_min(out, 0);
-    let g#0 = buffer_max(out, 0);
-    check((buffer_min(__in, 0) <= min(g, g#0)));
-    check((max(g, g#0) <= buffer_max(__in, 0)));
+    let g_0 = buffer_max(out, 0);
+    check((buffer_min(__in, 0) <= min(g, g_0)));
+    check((max(g, g_0) <= buffer_max(__in, 0)));
     check((buffer_min(__in, 1) <= buffer_min(out, 1)));
     check((buffer_max(out, 1) <= buffer_max(__in, 1)));
     { let softmax_in = allocate('softmax_in', 4, [
-        {bounds:{min:min(g, g#0), max:max(g, g#0)}, stride:NaN, fold_factor:9223372036854775807},
+        {bounds:{min:min(g, g_0), max:max(g, g_0)}, stride:NaN, fold_factor:9223372036854775807},
         {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:NaN, fold_factor:9223372036854775807}
       ]);
       consume(__in);
@@ -355,7 +367,7 @@ function pipeline(__in, out) {
           ]);
           { let sum_exp_in_uncropped = clone_buffer(sum_exp_in);
             { let exp_in = allocate('exp_in', 4, [
-                {bounds:{min:min(g, g#0), max:max(g, g#0)}, stride:NaN, fold_factor:9223372036854775807},
+                {bounds:{min:min(g, g_0), max:max(g, g_0)}, stride:NaN, fold_factor:9223372036854775807},
                 {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:NaN, fold_factor:9223372036854775807}
               ]);
               consume(__in);

--- a/builder/test/visualize/softmax_split_0.html
+++ b/builder/test/visualize/softmax_split_0.html
@@ -173,6 +173,10 @@ function draw(mem, t) {
   window.requestAnimationFrame(function(t) { draw(mem, __current_t); });
 }
 function check(condition) {}
+// TODO: or_else() + and_then() are supposed to short-circuit in order
+// to avoid integer overflow, but since each expression is evaluated
+// when passed to this function it's not really functioning as intended here.
+// Good enough for the visualizer, but not quite right.
 function or_else(...cond) {
   for (let d = 0; d < cond.length; ++d) {
     if (cond[d]) return true;

--- a/builder/test/visualize/softmax_split_1.html
+++ b/builder/test/visualize/softmax_split_1.html
@@ -173,6 +173,18 @@ function draw(mem, t) {
   window.requestAnimationFrame(function(t) { draw(mem, __current_t); });
 }
 function check(condition) {}
+function or_else(...cond) {
+  for (let d = 0; d < cond.length; ++d) {
+    if (cond[d]) return true;
+  }
+  return false;
+}
+function and_then(...cond) {
+  for (let d = 0; d < cond.length; ++d) {
+    if (!cond[d]) return false;
+  }
+  return true;
+}
 function buffer_at(b, ...at) {
   let result = b.base;
   for (let d = 0; d < at.length; ++d) {
@@ -331,13 +343,13 @@ function pipeline(__in, out) {
   check(or_else((buffer_fold_factor(out, 1) == 9223372036854775807), (buffer_max(out, 1) < (buffer_fold_factor(out, 1) + buffer_min(out, 1)))));
   {
     let g = buffer_min(out, 0);
-    let g#0 = buffer_max(out, 0);
-    check((buffer_min(__in, 0) <= min(g, g#0)));
-    check((max(g, g#0) <= buffer_max(__in, 0)));
+    let g_0 = buffer_max(out, 0);
+    check((buffer_min(__in, 0) <= min(g, g_0)));
+    check((max(g, g_0) <= buffer_max(__in, 0)));
     check((buffer_min(__in, 1) <= buffer_min(out, 1)));
     check((buffer_max(out, 1) <= buffer_max(__in, 1)));
     { let softmax_in = allocate('softmax_in', 4, [
-        {bounds:{min:min(g, g#0), max:max(g, g#0)}, stride:NaN, fold_factor:9223372036854775807},
+        {bounds:{min:min(g, g_0), max:max(g, g_0)}, stride:NaN, fold_factor:9223372036854775807},
         {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:NaN, fold_factor:1}
       ]);
       { let softmax_in_uncropped = clone_buffer(softmax_in);
@@ -350,7 +362,7 @@ function pipeline(__in, out) {
               ]);
               { let sum_exp_in_uncropped = clone_buffer(sum_exp_in);
                 { let exp_in = allocate('exp_in', 4, [
-                    {bounds:{min:min(g, g#0), max:max(g, g#0)}, stride:NaN, fold_factor:9223372036854775807},
+                    {bounds:{min:min(g, g_0), max:max(g, g_0)}, stride:NaN, fold_factor:9223372036854775807},
                     {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:NaN, fold_factor:1}
                   ]);
                   { let exp_in_uncropped = clone_buffer(exp_in);

--- a/builder/test/visualize/softmax_split_1.html
+++ b/builder/test/visualize/softmax_split_1.html
@@ -173,6 +173,10 @@ function draw(mem, t) {
   window.requestAnimationFrame(function(t) { draw(mem, __current_t); });
 }
 function check(condition) {}
+// TODO: or_else() + and_then() are supposed to short-circuit in order
+// to avoid integer overflow, but since each expression is evaluated
+// when passed to this function it's not really functioning as intended here.
+// Good enough for the visualizer, but not quite right.
 function or_else(...cond) {
   for (let d = 0; d < cond.length; ++d) {
     if (cond[d]) return true;

--- a/builder/test/visualize/softmax_split_4.html
+++ b/builder/test/visualize/softmax_split_4.html
@@ -173,6 +173,18 @@ function draw(mem, t) {
   window.requestAnimationFrame(function(t) { draw(mem, __current_t); });
 }
 function check(condition) {}
+function or_else(...cond) {
+  for (let d = 0; d < cond.length; ++d) {
+    if (cond[d]) return true;
+  }
+  return false;
+}
+function and_then(...cond) {
+  for (let d = 0; d < cond.length; ++d) {
+    if (!cond[d]) return false;
+  }
+  return true;
+}
 function buffer_at(b, ...at) {
   let result = b.base;
   for (let d = 0; d < at.length; ++d) {
@@ -331,13 +343,13 @@ function pipeline(__in, out) {
   check(or_else((buffer_fold_factor(out, 1) == 9223372036854775807), (buffer_max(out, 1) < (buffer_fold_factor(out, 1) + buffer_min(out, 1)))));
   {
     let g = buffer_min(out, 0);
-    let g#0 = buffer_max(out, 0);
-    check((buffer_min(__in, 0) <= min(g, g#0)));
-    check((max(g, g#0) <= buffer_max(__in, 0)));
+    let g_0 = buffer_max(out, 0);
+    check((buffer_min(__in, 0) <= min(g, g_0)));
+    check((max(g, g_0) <= buffer_max(__in, 0)));
     check((buffer_min(__in, 1) <= buffer_min(out, 1)));
     check((buffer_max(out, 1) <= buffer_max(__in, 1)));
     { let softmax_in = allocate('softmax_in', 4, [
-        {bounds:{min:min(g, g#0), max:max(g, g#0)}, stride:NaN, fold_factor:9223372036854775807},
+        {bounds:{min:min(g, g_0), max:max(g, g_0)}, stride:NaN, fold_factor:9223372036854775807},
         {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:NaN, fold_factor:4}
       ]);
       { let softmax_in_uncropped = clone_buffer(softmax_in);
@@ -350,7 +362,7 @@ function pipeline(__in, out) {
               ]);
               { let sum_exp_in_uncropped = clone_buffer(sum_exp_in);
                 { let exp_in = allocate('exp_in', 4, [
-                    {bounds:{min:min(g, g#0), max:max(g, g#0)}, stride:NaN, fold_factor:9223372036854775807},
+                    {bounds:{min:min(g, g_0), max:max(g, g_0)}, stride:NaN, fold_factor:9223372036854775807},
                     {bounds:{min:buffer_min(out, 1), max:buffer_max(out, 1)}, stride:NaN, fold_factor:4}
                   ]);
                   { let exp_in_uncropped = clone_buffer(exp_in);

--- a/builder/test/visualize/softmax_split_4.html
+++ b/builder/test/visualize/softmax_split_4.html
@@ -173,6 +173,10 @@ function draw(mem, t) {
   window.requestAnimationFrame(function(t) { draw(mem, __current_t); });
 }
 function check(condition) {}
+// TODO: or_else() + and_then() are supposed to short-circuit in order
+// to avoid integer overflow, but since each expression is evaluated
+// when passed to this function it's not really functioning as intended here.
+// Good enough for the visualizer, but not quite right.
 function or_else(...cond) {
   for (let d = 0; d < cond.length; ++d) {
     if (cond[d]) return true;

--- a/builder/test/visualize/stencil_chain_split_serial_split_0.html
+++ b/builder/test/visualize/stencil_chain_split_serial_split_0.html
@@ -173,6 +173,18 @@ function draw(mem, t) {
   window.requestAnimationFrame(function(t) { draw(mem, __current_t); });
 }
 function check(condition) {}
+function or_else(...cond) {
+  for (let d = 0; d < cond.length; ++d) {
+    if (cond[d]) return true;
+  }
+  return false;
+}
+function and_then(...cond) {
+  for (let d = 0; d < cond.length; ++d) {
+    if (!cond[d]) return false;
+  }
+  return true;
+}
 function buffer_at(b, ...at) {
   let result = b.base;
   for (let d = 0; d < at.length; ++d) {

--- a/builder/test/visualize/stencil_chain_split_serial_split_0.html
+++ b/builder/test/visualize/stencil_chain_split_serial_split_0.html
@@ -173,6 +173,10 @@ function draw(mem, t) {
   window.requestAnimationFrame(function(t) { draw(mem, __current_t); });
 }
 function check(condition) {}
+// TODO: or_else() + and_then() are supposed to short-circuit in order
+// to avoid integer overflow, but since each expression is evaluated
+// when passed to this function it's not really functioning as intended here.
+// Good enough for the visualizer, but not quite right.
 function or_else(...cond) {
   for (let d = 0; d < cond.length; ++d) {
     if (cond[d]) return true;

--- a/builder/test/visualize/stencil_chain_split_serial_split_1.html
+++ b/builder/test/visualize/stencil_chain_split_serial_split_1.html
@@ -173,6 +173,18 @@ function draw(mem, t) {
   window.requestAnimationFrame(function(t) { draw(mem, __current_t); });
 }
 function check(condition) {}
+function or_else(...cond) {
+  for (let d = 0; d < cond.length; ++d) {
+    if (cond[d]) return true;
+  }
+  return false;
+}
+function and_then(...cond) {
+  for (let d = 0; d < cond.length; ++d) {
+    if (!cond[d]) return false;
+  }
+  return true;
+}
 function buffer_at(b, ...at) {
   let result = b.base;
   for (let d = 0; d < at.length; ++d) {

--- a/builder/test/visualize/stencil_chain_split_serial_split_1.html
+++ b/builder/test/visualize/stencil_chain_split_serial_split_1.html
@@ -173,6 +173,10 @@ function draw(mem, t) {
   window.requestAnimationFrame(function(t) { draw(mem, __current_t); });
 }
 function check(condition) {}
+// TODO: or_else() + and_then() are supposed to short-circuit in order
+// to avoid integer overflow, but since each expression is evaluated
+// when passed to this function it's not really functioning as intended here.
+// Good enough for the visualizer, but not quite right.
 function or_else(...cond) {
   for (let d = 0; d < cond.length; ++d) {
     if (cond[d]) return true;

--- a/builder/test/visualize/stencil_chain_split_serial_split_2.html
+++ b/builder/test/visualize/stencil_chain_split_serial_split_2.html
@@ -173,6 +173,18 @@ function draw(mem, t) {
   window.requestAnimationFrame(function(t) { draw(mem, __current_t); });
 }
 function check(condition) {}
+function or_else(...cond) {
+  for (let d = 0; d < cond.length; ++d) {
+    if (cond[d]) return true;
+  }
+  return false;
+}
+function and_then(...cond) {
+  for (let d = 0; d < cond.length; ++d) {
+    if (!cond[d]) return false;
+  }
+  return true;
+}
 function buffer_at(b, ...at) {
   let result = b.base;
   for (let d = 0; d < at.length; ++d) {

--- a/builder/test/visualize/stencil_chain_split_serial_split_2.html
+++ b/builder/test/visualize/stencil_chain_split_serial_split_2.html
@@ -173,6 +173,10 @@ function draw(mem, t) {
   window.requestAnimationFrame(function(t) { draw(mem, __current_t); });
 }
 function check(condition) {}
+// TODO: or_else() + and_then() are supposed to short-circuit in order
+// to avoid integer overflow, but since each expression is evaluated
+// when passed to this function it's not really functioning as intended here.
+// Good enough for the visualizer, but not quite right.
 function or_else(...cond) {
   for (let d = 0; d < cond.length; ++d) {
     if (cond[d]) return true;

--- a/builder/test/visualize/stencil_split_0.html
+++ b/builder/test/visualize/stencil_split_0.html
@@ -173,6 +173,18 @@ function draw(mem, t) {
   window.requestAnimationFrame(function(t) { draw(mem, __current_t); });
 }
 function check(condition) {}
+function or_else(...cond) {
+  for (let d = 0; d < cond.length; ++d) {
+    if (cond[d]) return true;
+  }
+  return false;
+}
+function and_then(...cond) {
+  for (let d = 0; d < cond.length; ++d) {
+    if (!cond[d]) return false;
+  }
+  return true;
+}
 function buffer_at(b, ...at) {
   let result = b.base;
   for (let d = 0; d < at.length; ++d) {

--- a/builder/test/visualize/stencil_split_0.html
+++ b/builder/test/visualize/stencil_split_0.html
@@ -173,6 +173,10 @@ function draw(mem, t) {
   window.requestAnimationFrame(function(t) { draw(mem, __current_t); });
 }
 function check(condition) {}
+// TODO: or_else() + and_then() are supposed to short-circuit in order
+// to avoid integer overflow, but since each expression is evaluated
+// when passed to this function it's not really functioning as intended here.
+// Good enough for the visualizer, but not quite right.
 function or_else(...cond) {
   for (let d = 0; d < cond.length; ++d) {
     if (cond[d]) return true;

--- a/builder/test/visualize/stencil_split_1.html
+++ b/builder/test/visualize/stencil_split_1.html
@@ -173,6 +173,18 @@ function draw(mem, t) {
   window.requestAnimationFrame(function(t) { draw(mem, __current_t); });
 }
 function check(condition) {}
+function or_else(...cond) {
+  for (let d = 0; d < cond.length; ++d) {
+    if (cond[d]) return true;
+  }
+  return false;
+}
+function and_then(...cond) {
+  for (let d = 0; d < cond.length; ++d) {
+    if (!cond[d]) return false;
+  }
+  return true;
+}
 function buffer_at(b, ...at) {
   let result = b.base;
   for (let d = 0; d < at.length; ++d) {

--- a/builder/test/visualize/stencil_split_1.html
+++ b/builder/test/visualize/stencil_split_1.html
@@ -173,6 +173,10 @@ function draw(mem, t) {
   window.requestAnimationFrame(function(t) { draw(mem, __current_t); });
 }
 function check(condition) {}
+// TODO: or_else() + and_then() are supposed to short-circuit in order
+// to avoid integer overflow, but since each expression is evaluated
+// when passed to this function it's not really functioning as intended here.
+// Good enough for the visualizer, but not quite right.
 function or_else(...cond) {
   for (let d = 0; d < cond.length; ++d) {
     if (cond[d]) return true;

--- a/builder/test/visualize/stencil_split_2.html
+++ b/builder/test/visualize/stencil_split_2.html
@@ -173,6 +173,18 @@ function draw(mem, t) {
   window.requestAnimationFrame(function(t) { draw(mem, __current_t); });
 }
 function check(condition) {}
+function or_else(...cond) {
+  for (let d = 0; d < cond.length; ++d) {
+    if (cond[d]) return true;
+  }
+  return false;
+}
+function and_then(...cond) {
+  for (let d = 0; d < cond.length; ++d) {
+    if (!cond[d]) return false;
+  }
+  return true;
+}
 function buffer_at(b, ...at) {
   let result = b.base;
   for (let d = 0; d < at.length; ++d) {

--- a/builder/test/visualize/stencil_split_2.html
+++ b/builder/test/visualize/stencil_split_2.html
@@ -173,6 +173,10 @@ function draw(mem, t) {
   window.requestAnimationFrame(function(t) { draw(mem, __current_t); });
 }
 function check(condition) {}
+// TODO: or_else() + and_then() are supposed to short-circuit in order
+// to avoid integer overflow, but since each expression is evaluated
+// when passed to this function it's not really functioning as intended here.
+// Good enough for the visualizer, but not quite right.
 function or_else(...cond) {
   for (let d = 0; d < cond.length; ++d) {
     if (cond[d]) return true;

--- a/builder/test/visualize/stencil_split_3.html
+++ b/builder/test/visualize/stencil_split_3.html
@@ -173,6 +173,18 @@ function draw(mem, t) {
   window.requestAnimationFrame(function(t) { draw(mem, __current_t); });
 }
 function check(condition) {}
+function or_else(...cond) {
+  for (let d = 0; d < cond.length; ++d) {
+    if (cond[d]) return true;
+  }
+  return false;
+}
+function and_then(...cond) {
+  for (let d = 0; d < cond.length; ++d) {
+    if (!cond[d]) return false;
+  }
+  return true;
+}
 function buffer_at(b, ...at) {
   let result = b.base;
   for (let d = 0; d < at.length; ++d) {

--- a/builder/test/visualize/stencil_split_3.html
+++ b/builder/test/visualize/stencil_split_3.html
@@ -173,6 +173,10 @@ function draw(mem, t) {
   window.requestAnimationFrame(function(t) { draw(mem, __current_t); });
 }
 function check(condition) {}
+// TODO: or_else() + and_then() are supposed to short-circuit in order
+// to avoid integer overflow, but since each expression is evaluated
+// when passed to this function it's not really functioning as intended here.
+// Good enough for the visualizer, but not quite right.
 function or_else(...cond) {
   for (let d = 0; d < cond.length; ++d) {
     if (cond[d]) return true;

--- a/runtime/visualize.cc
+++ b/runtime/visualize.cc
@@ -43,6 +43,7 @@ public:
   std::string sanitize(std::string s) {
     std::replace(s.begin(), s.end(), '.', '_');
     std::replace(s.begin(), s.end(), '/', '_');
+    std::replace(s.begin(), s.end(), '#', '_');
     if (s == "in") {
       s = "__in";
     }

--- a/runtime/visualize.cc
+++ b/runtime/visualize.cc
@@ -473,6 +473,18 @@ function draw(mem, t) {
   window.requestAnimationFrame(function(t) { draw(mem, __current_t); });
 }
 function check(condition) {}
+function or_else(...cond) {
+  for (let d = 0; d < cond.length; ++d) {
+    if (cond[d]) return true;
+  }
+  return false;
+}
+function and_then(...cond) {
+  for (let d = 0; d < cond.length; ++d) {
+    if (!cond[d]) return false;
+  }
+  return true;
+}
 function buffer_at(b, ...at) {
   let result = b.base;
   for (let d = 0; d < at.length; ++d) {

--- a/runtime/visualize.cc
+++ b/runtime/visualize.cc
@@ -473,6 +473,10 @@ function draw(mem, t) {
   window.requestAnimationFrame(function(t) { draw(mem, __current_t); });
 }
 function check(condition) {}
+// TODO: or_else() + and_then() are supposed to short-circuit in order
+// to avoid integer overflow, but since each expression is evaluated
+// when passed to this function it's not really functioning as intended here.
+// Good enough for the visualizer, but not quite right.
 function or_else(...cond) {
   for (let d = 0; d < cond.length; ++d) {
     if (cond[d]) return true;

--- a/runtime/visualize.cc
+++ b/runtime/visualize.cc
@@ -130,15 +130,12 @@ public:
   void visit(const constant* c) override { *this << c->value; }
 
   void visit(const let* l) override {
-    // TODO: this is wrong and needs attention
+    // Use a lambda to allow scoped lets within an expression
+    *this << "(() => { ";
     for (const auto& s : l->lets) {
-      *this << "(let " << s.first << " = " << s.second << "; \n";
+      *this << "let " << s.first << " = " << s.second << "; ";
     }
-    *this << l->body;
-    for (const auto& s : l->lets) {
-      (void)s;
-      *this << ")\n";
-    }
+    *this << "return " << l->body << "; })()";
   }
 
   void visit(const let_stmt* l) override {


### PR DESCRIPTION
Fixes #374; also cherry-picks the fix for nested-let-expr and saniziting `#` from #375