### PR TITLE
Don't lift loop invariants from the middle of a loop.

### DIFF
--- a/builder/test/simplify/simplify.cc
+++ b/builder/test/simplify/simplify.cc
@@ -223,8 +223,8 @@ TEST(simplify, licm) {
   // A call in the middle of the loop does not depend on the loop, but does depend on the first call.
   ASSERT_THAT(simplify(make_loop_x(block::make(
                   {make_crop_x(b1, 0, make_call(b0, b1)), make_call(b1, b2), make_crop_x(b3, 0, make_call(b0, b3))}))),
-      matches(block::make({make_loop_x(make_crop_x(b1, 0, make_call(b0, b1))), make_call(b1, b2),
-          make_loop_x(make_crop_x(b3, 0, make_call(b0, b3)))})));
+      matches(make_loop_x(block::make(
+          {make_crop_x(b1, 0, make_call(b0, b1)), make_call(b1, b2), make_crop_x(b3, 0, make_call(b0, b3))}))));
   // A nested loop.
   ASSERT_THAT(simplify(make_loop_y(make_crop_y(
                   b2, 1, make_loop_x(block::make({make_call(b0, b1), make_crop_x(b2, 0, make_call(b0, b2))}))))),


### PR DESCRIPTION
This is almost safe, but storage folding makes it not so.