### PR TITLE
Stronger simplification of crop bounds

### DIFF
--- a/builder/simplify.cc
+++ b/builder/simplify.cc
@@ -956,7 +956,7 @@ public:
           // find a way to implement this reusing that (much more robust and complete) simplification instead of
           // expanding this logic.
           if (match(xa->b, bi->b)) {
-            // We have T(x + c0, b + c0). We can rewrite to T(x, b) + c0, and if we can eliminate the bound, the whole
+            // We have T(x + y, b + y). We can rewrite to T(x, b) + y, and if we can eliminate the bound, the whole
             // bound is redundant.
             expr removed = remove_redundant_bounds<T>(xa->a, {bi->a});
             if (!removed.same_as(xa->a)) {
@@ -964,6 +964,12 @@ public:
             }
           }
         }
+      }
+    } else if (const class select* xs = x.as<class select>()) {
+      expr t = remove_redundant_bounds<T>(xs->true_value, bounds);
+      expr f = remove_redundant_bounds<T>(xs->false_value, bounds);
+      if (!t.same_as(xs->true_value) || !f.same_as(xs->false_value)) {
+        return mutate(select(xs->condition, std::move(t), std::move(f)));
       }
     }
     return x;

--- a/builder/simplify.cc
+++ b/builder/simplify.cc
@@ -969,7 +969,7 @@ public:
       expr t = remove_redundant_bounds<T>(xs->true_value, bounds);
       expr f = remove_redundant_bounds<T>(xs->false_value, bounds);
       if (!t.same_as(xs->true_value) || !f.same_as(xs->false_value)) {
-        return mutate(select(xs->condition, std::move(t), std::move(f)));
+        return select(xs->condition, std::move(t), std::move(f));
       }
     }
     return x;

--- a/builder/test/simplify/simplify.cc
+++ b/builder/test/simplify/simplify.cc
@@ -263,23 +263,25 @@ TEST(simplify, bounds) {
 
 TEST(simplify, buffer_bounds) {
   ASSERT_THAT(
-      simplify(allocate::make(b0, memory_type::heap, 1, {{buffer_bounds(b1, 0), 4, 5}},
+      simplify(allocate::make(b0, memory_type::heap, 1, {{buffer_bounds(b1, 0)}},
           crop_dim::make(b2, b0, 0, buffer_bounds(b1, 0) & bounds(x, y), call_stmt::make(nullptr, {}, {b2}, {})))),
-      matches(allocate::make(b0, memory_type::heap, 1, {{buffer_bounds(b1, 0), 4, 5}},
+      matches(allocate::make(b0, memory_type::heap, 1, {{buffer_bounds(b1, 0)}},
           crop_dim::make(b2, b0, 0, bounds(x, y), call_stmt::make(nullptr, {}, {b2}, {})))));
 
-  ASSERT_THAT(
-      simplify(allocate::make(x, memory_type::heap, 1, {{bounds(2, 3), 4, 5}}, check::make(buffer_min(x, 0) == 2))),
+  ASSERT_THAT(simplify(allocate::make(x, memory_type::heap, 1, {{bounds(2, 3)}}, check::make(buffer_min(x, 0) == 2))),
       matches(stmt()));
-  ASSERT_THAT(simplify(allocate::make(x, memory_type::heap, 1, {{bounds(2, 3), 4, 5}},
+  ASSERT_THAT(simplify(allocate::make(x, memory_type::heap, 1, {{bounds(2, 3)}},
                   clone_buffer::make(y, x, check::make(buffer_min(y, 0) == 2)))),
       matches(stmt()));
-  ASSERT_THAT(simplify(allocate::make(x, memory_type::heap, 1, {{bounds(2, 3), 4, 5}},
+  ASSERT_THAT(simplify(allocate::make(x, memory_type::heap, 1, {{bounds(2, 3)}},
                   crop_dim::make(x, x, 0, bounds(1, 4), check::make(buffer_min(x, 0) == 2)))),
       matches(stmt()));
-  ASSERT_THAT(simplify(allocate::make(x, memory_type::heap, 1, {{bounds(y, z), 4, 5}},
+  ASSERT_THAT(simplify(allocate::make(x, memory_type::heap, 1, {{bounds(y, z)}},
                   crop_dim::make(x, x, 0, bounds(y - 1, z + 1), check::make(buffer_min(x, 0) == y && buffer_at(x))))),
-      matches(allocate::make(x, memory_type::heap, 1, {{bounds(y, z), 4, 5}}, check::make(buffer_at(x)))));
+      matches(allocate::make(x, memory_type::heap, 1, {{bounds(y, z)}}, check::make(buffer_at(x)))));
+  ASSERT_THAT(simplify(allocate::make(x, memory_type::heap, 1, {{buffer_bounds(b0, 0) + 2}},
+                  crop_dim::make(x, x, 0, bounds(expr(), min(z, buffer_max(b0, 0)) + 2), check::make(buffer_at(x))))),
+      matches(allocate::make(x, memory_type::heap, 1, {{buffer_bounds(b0, 0) + 2}}, check::make(buffer_at(x)))));
 }
 
 TEST(simplify, crop_not_needed) {

--- a/builder/test/visualize/padded_stencil_2.html
+++ b/builder/test/visualize/padded_stencil_2.html
@@ -366,7 +366,7 @@ function pipeline(__in, out) {
               let __loop_max = buffer_max(out, 1);
               let __loop_step = 1;
               for(let y = __loop_min; y <= __loop_max; y += __loop_step) {
-                { let __intm = crop_dim(intm, 1, {min:select((y <= y_min_orig), max(g_1, (y + 1)), (min(g_2, y) + 1)), max:(y + 1)}); {
+                { let __intm = crop_dim(intm, 1, {min:(select((y <= y_min_orig), y, min(g_2, y)) + 1), max:(y + 1)}); {
                   let intm = __intm;
                   consume(__in);
                   produce(intm);

--- a/builder/test/visualize/parallel_stencils_1.html
+++ b/builder/test/visualize/parallel_stencils_1.html
@@ -388,7 +388,7 @@ function pipeline(in1, in2, out) {
                     produce(intm3);
                     __event_t++;
                   }}
-                  { let __intm2 = crop_dim(intm2, 1, {min:(y + 2), max:(min((y + 1), buffer_max(out, 1)) + 2)}); {
+                  { let __intm2 = crop_dim(intm2, 1, {min:(y + 2), max:(y + 3)}); {
                     let intm2 = __intm2;
                     consume(in2);
                     produce(intm2);

--- a/builder/test/visualize/parallel_stencils_2.html
+++ b/builder/test/visualize/parallel_stencils_2.html
@@ -380,7 +380,7 @@ function pipeline(in1, in2, out) {
                   let __loop_max = buffer_max(out, 1);
                   let __loop_step = 2;
                   for(let y = __loop_min; y <= __loop_max; y += __loop_step) {
-                    { let __intm1 = crop_dim(intm1, 1, {min:(y + 1), max:(min((y + 1), buffer_max(out, 1)) + 1)}); {
+                    { let __intm1 = crop_dim(intm1, 1, {min:(y + 1), max:(y + 2)}); {
                       let intm1 = __intm1;
                       consume(in1);
                       produce(intm1);
@@ -392,7 +392,7 @@ function pipeline(in1, in2, out) {
                       produce(intm3);
                       __event_t++;
                     }}
-                    { let __intm2 = crop_dim(intm2, 1, {min:(y + 2), max:(min((y + 1), buffer_max(out, 1)) + 2)}); {
+                    { let __intm2 = crop_dim(intm2, 1, {min:(y + 2), max:(y + 3)}); {
                       let intm2 = __intm2;
                       consume(in2);
                       produce(intm2);

--- a/builder/test/visualize/stencil_chain_split_serial_split_2.html
+++ b/builder/test/visualize/stencil_chain_split_serial_split_2.html
@@ -369,7 +369,7 @@ function pipeline(__in, out) {
               for(let y = __loop_min; y <= __loop_max; y += __loop_step) {
                 {
                   let __trace_token = trace_begin(buffer_at(__trace_names, 0));
-                  { let __add_result = crop_dim(add_result, 1, {min:(y + 2), max:(min((y + 1), buffer_max(out, 1)) + 2)}); {
+                  { let __add_result = crop_dim(add_result, 1, {min:(y + 2), max:(y + 3)}); {
                     let add_result = __add_result;
                     {
                       let __trace_token = trace_begin(buffer_at(__trace_names, 24));
@@ -379,7 +379,7 @@ function pipeline(__in, out) {
                       check(trace_end(__trace_token));
                     }
                   }}
-                  { let __stencil1_result = crop_dim(stencil1_result, 1, {min:(y + 1), max:(min((y + 1), buffer_max(out, 1)) + 1)}); {
+                  { let __stencil1_result = crop_dim(stencil1_result, 1, {min:(y + 1), max:(y + 2)}); {
                     let stencil1_result = __stencil1_result;
                     {
                       let __trace_token = trace_begin(buffer_at(__trace_names, 30));

--- a/builder/test/visualize/stencil_split_2.html
+++ b/builder/test/visualize/stencil_split_2.html
@@ -358,7 +358,7 @@ function pipeline(__in, out) {
       let __loop_max = buffer_max(out, 1);
       let __loop_step = 2;
       for(let y = __loop_min; y <= __loop_max; y += __loop_step) {
-        { let __intm = crop_dim(intm, 1, {min:(y + 1), max:(min((y + 1), buffer_max(out, 1)) + 1)}); {
+        { let __intm = crop_dim(intm, 1, {min:(y + 1), max:(y + 2)}); {
           let intm = __intm;
           consume(__in);
           produce(intm);

--- a/builder/test/visualize/stencil_split_3.html
+++ b/builder/test/visualize/stencil_split_3.html
@@ -358,7 +358,7 @@ function pipeline(__in, out) {
       let __loop_max = buffer_max(out, 1);
       let __loop_step = 3;
       for(let y = __loop_min; y <= __loop_max; y += __loop_step) {
-        { let __intm = crop_dim(intm, 1, {min:(y + 1), max:(min((y + 2), buffer_max(out, 1)) + 1)}); {
+        { let __intm = crop_dim(intm, 1, {min:(y + 1), max:(y + 3)}); {
           let intm = __intm;
           consume(__in);
           produce(intm);


### PR DESCRIPTION
This attempts to simplify crops like `min(y, buffer_max(b, 0)) + 2` when the buffer being cropped has bounds `buffer_max(b, 0) + 2`, which is common in stencil pipelines.