### PR TITLE
Fix LICM

### DIFF
--- a/builder/test/simplify/simplify.cc
+++ b/builder/test/simplify/simplify.cc
@@ -229,13 +229,12 @@ TEST(simplify, licm) {
   // A call in the middle of the loop depends on the loop.
   ASSERT_THAT(
       simplify(make_loop_x(block::make({make_call(b0, b1), make_crop_x(b2, 0, make_call(b0, b2)), make_call(b0, b3)}))),
-      matches(block::make(
-          {make_call(b0, b1), make_loop_x(block::make({make_crop_x(b2, 0, make_call(b0, b2))})), make_call(b0, b3)})));
+      matches(block::make({make_call(b0, b1), make_call(b0, b3), make_loop_x(make_crop_x(b2, 0, make_call(b0, b2)))})));
   // A call in the middle of the loop does not depend on the loop, but does depend on the first call.
   ASSERT_THAT(simplify(make_loop_x(block::make(
                   {make_crop_x(b1, 0, make_call(b0, b1)), make_call(b1, b2), make_crop_x(b3, 0, make_call(b0, b3))}))),
-      matches(block::make({make_loop_x(make_crop_x(b1, 0, make_call(b0, b1))), make_call(b1, b2),
-          make_loop_x(make_crop_x(b3, 0, make_call(b0, b3)))})));
+      matches(make_loop_x(block::make(
+          {make_crop_x(b1, 0, make_call(b0, b1)), make_call(b1, b2), make_crop_x(b3, 0, make_call(b0, b3))}))));
   // A nested loop.
   ASSERT_THAT(simplify(make_loop_y(make_crop_y(
                   b2, 1, make_loop_x(block::make({make_call(b0, b1), make_crop_x(b2, 0, make_call(b0, b2))}))))),


### PR DESCRIPTION
I noticed that the `outer_product` tests all generated the exact same body due to simplification of loops with only one statement in them. I thought a quick and interesting thing to do would be to add another stage to the pipeline, so the test covers more logic.

It turns out that `outer_product` is an interesting example of a pipeline where you get loops with a mix of loop invariant and non-loop invariant code, and the simplifier was broken in some of those cases.