### PR TITLE
Replace visitor with switch statements in `evaluate`

### DIFF
--- a/runtime/evaluate.cc
+++ b/runtime/evaluate.cc
@@ -76,6 +76,7 @@ public:
     switch (e.type()) {
     case expr_node_type::variable: return eval(static_cast<const variable*>(e.get()));
     case expr_node_type::constant: return eval(static_cast<const constant*>(e.get()));
+    case expr_node_type::call: return eval(static_cast<const call*>(e.get()));
     default: return eval_non_inlined(e);
     }
   }
@@ -85,7 +86,6 @@ public:
     case expr_node_type::let: return eval(static_cast<const let*>(e.get()));
     case expr_node_type::logical_not: return eval(static_cast<const logical_not*>(e.get()));
     case expr_node_type::select: return eval(static_cast<const class select*>(e.get()));
-    case expr_node_type::call: return eval(static_cast<const call*>(e.get()));
     default: return eval_binary(e);
     }
   }
@@ -124,11 +124,11 @@ public:
   }
 
   interval eval(const interval_expr& x) {
+    index_t min = eval(x.min);
     if (x.is_point()) {
-      index_t result = eval(x.min);
-      return {result, result};
+      return {min, min};
     } else {
-      return {eval(x.min), eval(x.max)};
+      return {min, eval(x.max)};
     }
   }
   interval eval(const interval_expr& x, interval def) {

--- a/runtime/expr.h
+++ b/runtime/expr.h
@@ -365,10 +365,17 @@ public:
   static constexpr expr_node_type static_type = expr_node_type::constant;
 };
 
+class binary_op : public base_expr_node {
+public:
+  expr a, b;
+
+  binary_op(expr_node_type type) : base_expr_node(type) {}
+};
+
 #define DECLARE_BINARY_OP(op, c)                                                                                       \
-  class op : public expr_node<class op> {                                                                              \
+  class op : public binary_op {                                                                                        \
   public:                                                                                                              \
-    expr a, b;                                                                                                         \
+    op() : binary_op(static_type) {}                                                                                   \
     void accept(expr_visitor* v) const override;                                                                       \
     static expr make(expr a, expr b);                                                                                  \
     static constexpr expr_node_type static_type = expr_node_type::op;                                                  \


### PR DESCRIPTION
This is a pretty big speedup, and is a step towards eliminating stack usage in `evaluate`.

Fixes #2

```
Benchmark                             Time             CPU      Time Old      Time New       CPU Old       CPU New
------------------------------------------------------------------------------------------------------------------
BM_call                            -0.4684         -0.4684        489570        260266        489571        260266
BM_let/1                           -0.0445         -0.0445       1112999       1063439       1113001       1063437
BM_let/2                           +0.0264         +0.0264       1334519       1369738       1334523       1369737
BM_let/3                           +0.0562         +0.0562       1592467       1681900       1592470       1681902
BM_block/2                         -0.3149         -0.3149       1293333        886041       1293335        886042
BM_block/4                         -0.3732         -0.3732       2224448       1394233       2224431       1394235
BM_block/8                         -0.4160         -0.4160       4094076       2390901       4094084       2390906
BM_block/16                        -0.4344         -0.4344       7936863       4488788       7936798       4488759
BM_crop_dim/0                      -0.3181         -0.3181        993844        677674        993846        677672
BM_crop_dim/1                      -0.1553         -0.1553       1483432       1252982       1483435       1252983
BM_crop_buffer/0                   +0.0893         +0.0893       1531298       1668014       1531300       1668018
BM_crop_buffer/1                   +0.0482         +0.0482       2111869       2213594       2111872       2213599
BM_slice_dim/0                     -0.2479         -0.2479       1010480        759981       1010476        759982
BM_slice_dim/1                     -0.1409         -0.1409       1464585       1258213       1464589       1258203
BM_slice_buffer/0                  -0.1179         -0.1179       1118563        986685       1118566        986687
BM_slice_buffer/1                  -0.0288         -0.0288       1529474       1485442       1529478       1485437
BM_allocate                        +0.0842         +0.0842       1716300       1860814       1716304       1860817
BM_make_buffer                     +0.1194         +0.1194       1857030       2078769       1857034       2078773
BM_buffer_metadata                 -0.2491         -0.2491       9650317       7246825       9650333       7246833
BM_parallel_loop/1                 -0.4689         -0.4689        489139        259778        489135        259773
BM_parallel_loop/2                 -0.0855         -0.0860       4125895       3773281       4108274       3755039
BM_parallel_loop/4                 +0.0468         +0.0465       5422738       5676562       5385600       5636176
BM_parallel_loop/8                 +0.0015         +0.0016       5578530       5587175       5445800       5454694
BM_parallel_loop/16                -0.0187         -0.0170       4704008       4615904       4427646       4352441
BM_semaphores/1                    +0.4096         +0.4100      20361509      28701882      20336904      28675054
BM_semaphores/2                    -0.6515         -0.5727     356336526     124165990     183473343      78397864
BM_semaphores/4                    -0.2511         -0.1812      49487745      37059936      23440344      19193218
BM_semaphores/8                    -0.0109         -0.0088      37695762      37286588      20393900      20215154
BM_semaphores/16                   -0.0118         -0.0119      41314776      40826259      27540615      27213089
OVERALL_GEOMEAN                    -0.1690         -0.1605             0             0             0             0
```