### PR TITLE
Optimize and clean up buffer traversal helpers

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -9,3 +9,8 @@ common --force_pic
 common:asan --copt -fsanitize=address
 common:asan --copt -DADDRESS_SANITIZER
 common:asan --linkopt -fsanitize=address
+
+# Allow us to run with --config=asan
+common:ubsan --copt -fsanitize=undefined
+common:ubsan --copt -DUNDEFINED_BEHAVIOR_SANITIZER
+common:ubsan --linkopt -fsanitize=undefined

--- a/apps/performance.cc
+++ b/apps/performance.cc
@@ -21,8 +21,8 @@ void memcpy_workaround(void* dst, const void* src, std::size_t size) {
   for (std::size_t i = 0; i < size; i += chunk_size) {
     std::size_t size_i = std::min(size - i, chunk_size);
     memmove(dst, src, size_i);
-    dst = offset_bytes(dst, chunk_size);
-    src = offset_bytes(src, chunk_size);
+    dst = offset_bytes_non_null(dst, chunk_size);
+    src = offset_bytes_non_null(src, chunk_size);
   }
 }
 
@@ -33,8 +33,8 @@ index_t copy_2d(const buffer<const void>& in, const buffer<void>& out) {
   std::size_t size_bytes = out.dim(0).extent() * out.elem_size;
   for (index_t y = out.dim(1).begin(); y < out.dim(1).end(); ++y) {
     memcpy_workaround(dst, src, size_bytes);
-    dst = offset_bytes(dst, out.dim(1).stride());
-    src = offset_bytes(src, in.dim(1).stride());
+    dst = offset_bytes_non_null(dst, out.dim(1).stride());
+    src = offset_bytes_non_null(src, in.dim(1).stride());
   }
   return 0;
 }

--- a/base/arithmetic.h
+++ b/base/arithmetic.h
@@ -24,6 +24,12 @@ T euclidean_div(T a, T b) {
 }
 
 template <typename T>
+T euclidean_mod_positive_modulus(T a, T b) {
+  T r = a % b;
+  return r >= 0 ? r : r + b;
+}
+
+template <typename T>
 T euclidean_mod(T a, T b) {
   if (b == 0) {
     return 0;

--- a/base/arithmetic.h
+++ b/base/arithmetic.h
@@ -1,6 +1,7 @@
 #ifndef SLINKY_BASE_ARITHMETIC_H
 #define SLINKY_BASE_ARITHMETIC_H
 
+#include <cassert>
 #include <cmath>
 #include <cstddef>
 #include <limits>
@@ -25,6 +26,7 @@ T euclidean_div(T a, T b) {
 
 template <typename T>
 T euclidean_mod_positive_modulus(T a, T b) {
+  assert(b > 0);
   T r = a % b;
   return r >= 0 ? r : r + b;
 }

--- a/base/test/BUILD
+++ b/base/test/BUILD
@@ -27,3 +27,14 @@ cc_test(
     ],
     size = "small",
 )
+
+cc_test(
+    name = "arithmetic_benchmark",
+    srcs = ["arithmetic_benchmark.cc"],
+    deps = [
+        "//base",
+        "@google_benchmark//:benchmark_main",
+    ],
+    args=["--benchmark_min_time=0.1s"],
+    size = "small",
+)

--- a/base/test/arithmetic.cc
+++ b/base/test/arithmetic.cc
@@ -13,6 +13,7 @@ TEST(arithmetic, euclidean_div_mod) {
 
     ASSERT_EQ(euclidean_div(a, b), a / b);
     ASSERT_EQ(euclidean_mod(a, b), a % b);
+    ASSERT_EQ(euclidean_mod_positive_modulus(a, b), a % b);
 
     // These are the properties we want from euclidean_div/mod:
     // 1. 0 <= a % b < |b|
@@ -24,12 +25,18 @@ TEST(arithmetic, euclidean_div_mod) {
     ASSERT_LT(euclidean_mod(-a, b), std::abs(b));
     ASSERT_LT(euclidean_mod(a, -b), std::abs(b));
     ASSERT_LT(euclidean_mod(-a, -b), std::abs(b));
+    ASSERT_GE(euclidean_mod_positive_modulus(a, b), 0);
+    ASSERT_GE(euclidean_mod_positive_modulus(-a, b), 0);
+    ASSERT_LT(euclidean_mod_positive_modulus(a, b), std::abs(b));
+    ASSERT_LT(euclidean_mod_positive_modulus(-a, b), std::abs(b));
 
     // 2. (a / b) * b + a % b == a
     ASSERT_EQ(euclidean_div(a, b) * b + euclidean_mod(a, b), a);
     ASSERT_EQ(euclidean_div(-a, b) * b + euclidean_mod(-a, b), -a);
     ASSERT_EQ(euclidean_div(a, -b) * -b + euclidean_mod(a, -b), a);
     ASSERT_EQ(euclidean_div(-a, -b) * -b + euclidean_mod(-a, -b), -a);
+    ASSERT_EQ(euclidean_div(a, b) * b + euclidean_mod_positive_modulus(a, b), a);
+    ASSERT_EQ(euclidean_div(-a, b) * b + euclidean_mod_positive_modulus(-a, b), -a);
   }
 }
 

--- a/base/test/arithmetic_benchmark.cc
+++ b/base/test/arithmetic_benchmark.cc
@@ -1,0 +1,42 @@
+#include <benchmark/benchmark.h>
+
+#include "base/arithmetic.h"
+
+namespace slinky {
+
+template <typename Fn>
+void BM_binary(benchmark::State& state, Fn&& fn) {
+  std::vector<std::pair<std::ptrdiff_t, std::ptrdiff_t>> values(1000);
+  std::generate(values.begin(), values.end(), []() { return std::make_pair(rand(), rand()); });
+  while (state.KeepRunningBatch(values.size())) {
+    for (const auto& i : values) {
+      benchmark::DoNotOptimize(fn(i.first, i.second));
+    }
+  }
+}
+
+void BM_euclidean_div(benchmark::State& state) { BM_binary(state, euclidean_div<std::ptrdiff_t>); }
+void BM_euclidean_mod(benchmark::State& state) { BM_binary(state, euclidean_mod<std::ptrdiff_t>); }
+void BM_euclidean_mod_positive_modulus(benchmark::State& state) {
+  BM_binary(state, euclidean_mod_positive_modulus<std::ptrdiff_t>);
+}
+void BM_saturate_add(benchmark::State& state) { BM_binary(state, saturate_add<std::ptrdiff_t>); }
+void BM_saturate_sub(benchmark::State& state) { BM_binary(state, saturate_sub<std::ptrdiff_t>); }
+void BM_saturate_mul(benchmark::State& state) { BM_binary(state, saturate_mul<std::ptrdiff_t>); }
+void BM_saturate_div(benchmark::State& state) { BM_binary(state, saturate_div<std::ptrdiff_t>); }
+void BM_saturate_mod(benchmark::State& state) { BM_binary(state, saturate_mod<std::ptrdiff_t>); }
+void BM_gcd(benchmark::State& state) { BM_binary(state, gcd<std::ptrdiff_t>); }
+void BM_lcm(benchmark::State& state) { BM_binary(state, lcm<std::ptrdiff_t>); }
+
+BENCHMARK(BM_euclidean_div);
+BENCHMARK(BM_euclidean_mod);
+BENCHMARK(BM_euclidean_mod_positive_modulus);
+BENCHMARK(BM_saturate_add);
+BENCHMARK(BM_saturate_sub);
+BENCHMARK(BM_saturate_mul);
+BENCHMARK(BM_saturate_div);
+BENCHMARK(BM_saturate_mod);
+BENCHMARK(BM_gcd);
+BENCHMARK(BM_lcm);
+
+}  // namespace slinky

--- a/runtime/buffer.cc
+++ b/runtime/buffer.cc
@@ -203,7 +203,7 @@ void fill(void* dst, const void* value, index_t elem_size, index_t size) {
   } else {
     while (size >= elem_size) {
       memcpy(dst, value, elem_size);
-      dst = offset_bytes(dst, elem_size);
+      dst = offset_bytes_non_null(dst, elem_size);
       size -= elem_size;
     }
     // The elem_size might not divide the size if replicate_constant replicated it.
@@ -275,11 +275,11 @@ void copy_impl(raw_buffer& src, raw_buffer& dst, const void* padding) {
           if (src) {
             if (pad_before > 0) {
               fill(dst, padding, elem_size, pad_before);
-              dst = offset_bytes(dst, pad_before);
+              dst = offset_bytes_non_null(dst, pad_before);
             }
             memcpy(dst, src, size);
             if (pad_after > 0) {
-              dst = offset_bytes(dst, size);
+              dst = offset_bytes_non_null(dst, size);
               fill(dst, padding, elem_size, pad_after);
             }
           } else {
@@ -431,7 +431,7 @@ SLINKY_ALWAYS_INLINE inline bool use_folded_loop(const raw_buffer* const* bufs, 
 template <typename T>
 SLINKY_ALWAYS_INLINE inline T* increment_plan(void*& x, std::size_t n = 1) {
   T* result = reinterpret_cast<T*>(x);
-  x = offset_bytes(x, sizeof(T) * n);
+  x = offset_bytes_non_null(x, sizeof(T) * n);
   return result;
 }
 
@@ -495,7 +495,7 @@ index_t make_for_each_slice_dims_impl(
         const dim& buf_n_dim = bufs[n]->dim(d);
         if (buf_n_dim.contains(buf_dim)) {
           index_t offset = buf_n_dim.flat_offset_bytes(buf_dim.min());
-          bases[n] = offset_bytes(bases[n], offset);
+          bases[n] = offset_bytes_non_null(bases[n], offset);
         } else {
           // If we got here, we need to say the buffer is always out of bounds. If it is partially out of bounds,
           // use_folded_loop should have returned true above.

--- a/runtime/buffer.cc
+++ b/runtime/buffer.cc
@@ -383,7 +383,9 @@ SLINKY_ALWAYS_INLINE inline bool can_fuse(const raw_buffer* const* bufs, std::si
   if (base_inner.fold_factor() != dim::unfolded) {
     // One of the dimensions is folded.
     return false;
-  } else if (base_inner.stride() * base_inner.extent() != base_outer.stride()) {
+  }
+  const index_t inner_extent = base_inner.extent();
+  if (base_inner.stride() * inner_extent != base_outer.stride()) {
     // The dimensions are not contiguous in memory.
     return false;
   }
@@ -404,7 +406,7 @@ SLINKY_ALWAYS_INLINE inline bool can_fuse(const raw_buffer* const* bufs, std::si
     }
 
     const index_t outer_stride = d < static_cast<int>(bufs[n]->rank) ? bufs[n]->dim(d).stride() : 0;
-    if (inner.stride() * base_inner.extent() != outer_stride) {
+    if (inner.stride() * inner_extent != outer_stride) {
       // The dimensions are not contiguous in memory.
       return false;
     }

--- a/runtime/buffer.cc
+++ b/runtime/buffer.cc
@@ -472,7 +472,8 @@ index_t make_for_each_slice_dims_impl(
         next->extent = buf_dim.extent();
 
         const dim** next_dims = increment_plan<const dim*>(plan, bufs_size);
-        for (std::size_t n = 0; n < bufs_size; n++) {
+        next_dims[0] = &bufs[0]->dim(d);
+        for (std::size_t n = 1; n < bufs_size; n++) {
           next_dims[n] = d < static_cast<index_t>(bufs[n]->rank) ? &bufs[n]->dim(d) : &broadcast_dim;
         }
         continue;
@@ -519,7 +520,8 @@ index_t make_for_each_slice_dims_impl(
       extent = 1;
 
       index_t* strides = increment_plan<index_t>(plan, bufs_size);
-      for (std::size_t n = 0; n < bufs_size; n++) {
+      strides[0] = bufs[0]->dim(d).stride();
+      for (std::size_t n = 1; n < bufs_size; n++) {
         strides[n] = d < static_cast<index_t>(bufs[n]->rank) ? bufs[n]->dim(d).stride() : 0;
       }
     }

--- a/runtime/buffer.cc
+++ b/runtime/buffer.cc
@@ -523,7 +523,7 @@ index_t make_for_each_slice_dims_impl(
   }
   next->impl = for_each_slice_dim::call_f;
   assert(extent == 1);
-  return slice_extent;
+  return SkipContiguous ? slice_extent : 1;
 }
 
 }  // namespace

--- a/runtime/buffer.cc
+++ b/runtime/buffer.cc
@@ -440,7 +440,7 @@ void write_empty_plan(void* plan, std::size_t bufs_size) {
   for_each_slice_dim* next = increment_plan<for_each_slice_dim>(plan);
   next->impl = for_each_slice_dim::loop_linear;
   next->extent = 0;
- 
+
   // for_each_slice_impl looks ahead to the next dimension, don't leave it uninitialized.
   increment_plan<const dim*>(plan, bufs_size);
   next = increment_plan<for_each_slice_dim>(plan);
@@ -452,7 +452,8 @@ index_t make_for_each_slice_dims_impl(
     const raw_buffer* const* bufs, void** bases, std::size_t bufs_size_dynamic, void* plan_base) {
   std::size_t bufs_size = BufsSize == 0 ? bufs_size_dynamic : BufsSize;
   const auto* buf = bufs[0];
-  for (std::size_t n = 0; n < bufs_size; ++n) {
+  bases[0] = buf->base;
+  for (std::size_t n = 1; n < bufs_size; ++n) {
     bases[n] = bufs[n]->base;
   }
   void* plan = plan_base;
@@ -472,7 +473,7 @@ index_t make_for_each_slice_dims_impl(
         next->extent = buf_dim.extent();
 
         const dim** next_dims = increment_plan<const dim*>(plan, bufs_size);
-        next_dims[0] = &bufs[0]->dim(d);
+        next_dims[0] = &buf->dim(d);
         for (std::size_t n = 1; n < bufs_size; n++) {
           next_dims[n] = d < static_cast<index_t>(bufs[n]->rank) ? &bufs[n]->dim(d) : &broadcast_dim;
         }
@@ -520,7 +521,7 @@ index_t make_for_each_slice_dims_impl(
       extent = 1;
 
       index_t* strides = increment_plan<index_t>(plan, bufs_size);
-      strides[0] = bufs[0]->dim(d).stride();
+      strides[0] = buf->dim(d).stride();
       for (std::size_t n = 1; n < bufs_size; n++) {
         strides[n] = d < static_cast<index_t>(bufs[n]->rank) ? bufs[n]->dim(d).stride() : 0;
       }

--- a/runtime/buffer.h
+++ b/runtime/buffer.h
@@ -543,7 +543,8 @@ enum class fuse_type {
 };
 
 // Fuse two dimensions of a buffer.
-inline void fuse(fuse_type type, int inner, int outer, raw_buffer& buf) {
+template <fuse_type type>
+inline void fuse(int inner, int outer, raw_buffer& buf) {
   dim& id = buf.dim(inner);
   dim& od = buf.dim(outer);
   assert(can_fuse(id, od));
@@ -603,17 +604,16 @@ bool can_fuse(int inner, int outer, const raw_buffer& buf, const Bufs&... bufs) 
 }
 
 // Fuse two dimensions of all buffers.
-inline void fuse(int inner, int outer, raw_buffer& buf) { fuse(fuse_type::remove, inner, outer, buf); }
-template <typename... Bufs>
+template <fuse_type type, typename... Bufs>
 void fuse(int inner, int outer, raw_buffer& buf, Bufs&... bufs) {
-  fuse(inner, outer, buf);
-  fuse(inner, outer, bufs...);
+  fuse<type>(inner, outer, buf);
+  fuse<type>(inner, outer, bufs...);
 }
 
 template <typename... Bufs>
 SLINKY_ALWAYS_INLINE inline void attempt_fuse(int inner, int outer, raw_buffer& buf, Bufs&... bufs) {
   if (same_bounds(inner, buf, bufs...) && can_fuse(inner, outer, buf, bufs...)) {
-    fuse(inner, outer, buf, bufs...);
+    fuse<fuse_type::remove>(inner, outer, buf, bufs...);
   }
 }
 

--- a/runtime/buffer.h
+++ b/runtime/buffer.h
@@ -537,11 +537,13 @@ inline bool can_fuse(const dim& inner, const dim& outer) {
   if (outer.max() == outer.min() && outer.stride() != 0) return true;
   if (inner.fold_factor() != dim::unfolded) return false;
 
+  // Avoid asserts on overflow in extent.
+  index_t inner_extent = inner.max() - inner.min() + 1;
 #ifdef UNDEFINED_BEHAVIOR_SANITIZER
   // Some integer overflow below is harmless when multiplied by zero, but flagged by ubsan.
-  index_t next_stride = inner.stride() == 0 ? 0 : inner.stride() * inner.extent();
+  index_t next_stride = inner.stride() == 0 ? 0 : inner.stride() * inner_extent;
 #else
-  index_t next_stride = inner.stride() * inner.extent();
+  index_t next_stride = inner.stride() * inner_extent;
 #endif
   // Avoid overflow for broadcast dimensions
   if (next_stride != outer.stride()) return false;

--- a/runtime/buffer.h
+++ b/runtime/buffer.h
@@ -602,10 +602,10 @@ bool same_bounds(int d, const raw_buffer& buf0, const raw_buffer& buf1, const Bu
 }
 
 // Returns true if two dimensions of all buffers can be fused.
-inline bool can_fuse(int inner, int outer, const raw_buffer& buf) { return can_fuse(buf.dim(inner), buf.dim(outer)); }
+inline bool can_fuse(int, int) { return true; }
 template <typename... Bufs>
 bool can_fuse(int inner, int outer, const raw_buffer& buf, const Bufs&... bufs) {
-  return can_fuse(inner, outer, buf) && can_fuse(inner, outer, bufs...);
+  return can_fuse(buf.dim(inner), buf.dim(outer)) && can_fuse(inner, outer, bufs...);
 }
 
 // Fuse two dimensions of all buffers.

--- a/runtime/buffer.h
+++ b/runtime/buffer.h
@@ -759,7 +759,7 @@ void for_each_slice_impl(const std::array<void*, NumBufs>& bases, const void* pl
     const index_t* strides = read_plan<index_t>(plan, NumBufs);
     std::array<void*, NumBufs> bases_i = bases;
     // If the next step is to call f, do that eagerly here to avoid an extra call.
-    for (index_t i = 0; i < slice_dim->extent; ++i) {
+    for (index_t i = slice_dim->extent; i > 0; --i) {
       f(bases_i);
       bases_i[0] = offset_bytes_non_null(bases_i[0], strides[0]);
       // This is a critical loop, and it seems we can't trust the compiler to unroll it. These ifs are constexpr.
@@ -774,7 +774,7 @@ void for_each_slice_impl(const std::array<void*, NumBufs>& bases, const void* pl
   case for_each_slice_dim::loop_linear: {
     const index_t* strides = read_plan<index_t>(plan, NumBufs);
     std::array<void*, NumBufs> bases_i = bases;
-    for (index_t i = 0; i < slice_dim->extent; ++i) {
+    for (index_t i = slice_dim->extent; i > 0; --i) {
       for_each_slice_impl(bases_i, plan, f);
       bases_i[0] = offset_bytes_non_null(bases_i[0], strides[0]);
       for (std::size_t n = 1; n < NumBufs; n++) {

--- a/runtime/buffer.h
+++ b/runtime/buffer.h
@@ -729,15 +729,16 @@ namespace internal {
 // this memory layout with pointer arithmetic.
 struct for_each_slice_dim {
   enum {
-    call_f,       // Uses extent
-    loop_linear,  // Uses stride, extent
-    loop_folded,  // Uses dim, extent
+    loop_linear_and_call_f,  // Uses stride, extent
+    loop_linear,             // Uses stride, extent
+    loop_folded_and_call_f,  // Uses dim, extent
+    loop_folded,             // Uses dim, extent
   } impl;
   index_t extent;
 };
 
 inline std::size_t size_of_plan(std::size_t rank, std::size_t bufs) {
-  return (rank + 1) * sizeof(for_each_slice_dim) + rank * bufs * sizeof(dim*);
+  return std::max<std::size_t>(rank, 1) * (sizeof(for_each_slice_dim) + bufs * sizeof(dim*));
 }
 
 index_t make_for_each_contiguous_slice_dims(span<const raw_buffer*> bufs, void** bases, void* plan);
@@ -753,61 +754,65 @@ SLINKY_ALWAYS_INLINE inline const T* read_plan(const void*& x, std::size_t n = 1
 template <typename F, std::size_t NumBufs>
 void for_each_slice_impl(const std::array<void*, NumBufs>& bases, const void* plan, const F& f) {
   const for_each_slice_dim* slice_dim = read_plan<for_each_slice_dim>(plan);
-  if (slice_dim->impl == for_each_slice_dim::loop_linear) {
+  switch (slice_dim->impl) {
+  case for_each_slice_dim::loop_linear_and_call_f: {
     const index_t* strides = read_plan<index_t>(plan, NumBufs);
-    const for_each_slice_dim* next = reinterpret_cast<const for_each_slice_dim*>(plan);
     std::array<void*, NumBufs> bases_i = bases;
-    if (next->impl == for_each_slice_dim::call_f) {
-      // If the next step is to call f, do that eagerly here to avoid an extra call.
-      for (index_t i = 0; i < slice_dim->extent; ++i) {
-        f(bases_i);
-        bases_i[0] = offset_bytes_non_null(bases_i[0], strides[0]);
-        // This is a critical loop, and it seems we can't trust the compiler to unroll it. These ifs are constexpr.
-        if (1 < NumBufs) bases_i[1] = offset_bytes(bases_i[1], strides[1]);
-        if (2 < NumBufs) bases_i[2] = offset_bytes(bases_i[2], strides[2]);
-        for (std::size_t n = 3; n < NumBufs; n++) {
-          bases_i[n] = offset_bytes(bases_i[n], strides[n]);
-        }
-      }
-    } else {
-      for (index_t i = 0; i < slice_dim->extent; ++i) {
-        for_each_slice_impl(bases_i, plan, f);
-        bases_i[0] = offset_bytes_non_null(bases_i[0], strides[0]);
-        for (std::size_t n = 1; n < NumBufs; n++) {
-          bases_i[n] = offset_bytes(bases_i[n], strides[n]);
-        }
+    // If the next step is to call f, do that eagerly here to avoid an extra call.
+    for (index_t i = 0; i < slice_dim->extent; ++i) {
+      f(bases_i);
+      bases_i[0] = offset_bytes_non_null(bases_i[0], strides[0]);
+      // This is a critical loop, and it seems we can't trust the compiler to unroll it. These ifs are constexpr.
+      if (1 < NumBufs) bases_i[1] = offset_bytes(bases_i[1], strides[1]);
+      if (2 < NumBufs) bases_i[2] = offset_bytes(bases_i[2], strides[2]);
+      for (std::size_t n = 3; n < NumBufs; n++) {
+        bases_i[n] = offset_bytes(bases_i[n], strides[n]);
       }
     }
-  } else if (slice_dim->impl == for_each_slice_dim::loop_folded) {
+    return;
+  }
+  case for_each_slice_dim::loop_linear: {
+    const index_t* strides = read_plan<index_t>(plan, NumBufs);
+    std::array<void*, NumBufs> bases_i = bases;
+    for (index_t i = 0; i < slice_dim->extent; ++i) {
+      for_each_slice_impl(bases_i, plan, f);
+      bases_i[0] = offset_bytes_non_null(bases_i[0], strides[0]);
+      for (std::size_t n = 1; n < NumBufs; n++) {
+        bases_i[n] = offset_bytes(bases_i[n], strides[n]);
+      }
+    }
+    return;
+  }
+  case for_each_slice_dim::loop_folded_and_call_f: {
     dim* const* dims = read_plan<dim*>(plan, NumBufs);
-    // TODO: If any buffer if folded in a given dimension, we just take the slow path
-    // that handles either folded or unfolded for *all* the buffers in that dimension.
-    // It's possible we could special-case and improve the situation somewhat if we
-    // see common cases (eg main buffer never folded and one 'other' buffer that is folded).
     index_t begin = dims[0]->begin();
     index_t end = begin + slice_dim->extent;
-    const for_each_slice_dim* next = reinterpret_cast<const for_each_slice_dim*>(plan);
     std::array<void*, NumBufs> bases_i;
-    if (next->impl == for_each_slice_dim::call_f) {
-      // If the next step is to call f, do that eagerly here to avoid an extra call.
-      for (index_t i = begin; i < end; ++i) {
-        bases_i[0] = offset_bytes_non_null(bases[0], dims[0]->flat_offset_bytes(i));
-        for (std::size_t n = 1; n < NumBufs; n++) {
-          bases_i[n] = dims[n]->contains(i) ? offset_bytes(bases[n], dims[n]->flat_offset_bytes(i)) : nullptr;
-        }
-        f(bases_i);
+    // If the next step is to call f, do that eagerly here to avoid an extra call.
+    for (index_t i = begin; i < end; ++i) {
+      bases_i[0] = offset_bytes_non_null(bases[0], dims[0]->flat_offset_bytes(i));
+      for (std::size_t n = 1; n < NumBufs; n++) {
+        bases_i[n] = dims[n]->contains(i) ? offset_bytes(bases[n], dims[n]->flat_offset_bytes(i)) : nullptr;
       }
-    } else {
-      for (index_t i = begin; i < end; ++i) {
-        bases_i[0] = offset_bytes_non_null(bases[0], dims[0]->flat_offset_bytes(i));
-        for (std::size_t n = 1; n < NumBufs; n++) {
-          bases_i[n] = dims[n]->contains(i) ? offset_bytes(bases[n], dims[n]->flat_offset_bytes(i)) : nullptr;
-        }
-        for_each_slice_impl(bases_i, plan, f);
-      }
+      f(bases_i);
     }
-  } else {
-    f(bases);
+    return;
+  }
+  default: {
+    assert(slice_dim->impl == for_each_slice_dim::loop_folded);
+    dim* const* dims = read_plan<dim*>(plan, NumBufs);
+    index_t begin = dims[0]->begin();
+    index_t end = begin + slice_dim->extent;
+    std::array<void*, NumBufs> bases_i;
+    for (index_t i = begin; i < end; ++i) {
+      bases_i[0] = offset_bytes_non_null(bases[0], dims[0]->flat_offset_bytes(i));
+      for (std::size_t n = 1; n < NumBufs; n++) {
+        bases_i[n] = dims[n]->contains(i) ? offset_bytes(bases[n], dims[n]->flat_offset_bytes(i)) : nullptr;
+      }
+      for_each_slice_impl(bases_i, plan, f);
+    }
+    return;
+  }
   }
 }
 

--- a/runtime/buffer.h
+++ b/runtime/buffer.h
@@ -101,14 +101,10 @@ public:
 
   std::ptrdiff_t flat_offset_bytes(index_t i) const {
     assert(contains(i));
-    if (stride() == 0) {
-      // We shouldn't need this special case, but it avoids sanitizer false positives on some of the arithmetic below.
-      return 0;
-    }
     if (fold_factor() == unfolded) {
       return (i - min()) * stride();
     } else {
-      return euclidean_mod(i - min(), fold_factor()) * stride();
+      return euclidean_mod_positive_modulus(i - min(), fold_factor()) * stride();
     }
   }
 

--- a/runtime/buffer.h
+++ b/runtime/buffer.h
@@ -874,7 +874,8 @@ SLINKY_NO_STACK_PROTECTOR void for_each_contiguous_slice(const Buf& buf, const F
 // sliced at the same indices as `buf`.  If the other buffers are out of bounds for a slice, the corresponding argument
 // to the callback will be `nullptr`.
 template <typename F, typename... Bufs>
-void for_each_slice(std::size_t slice_rank, const raw_buffer& buf, const F& f, const Bufs&... bufs) {
+SLINKY_NO_STACK_PROTECTOR void for_each_slice(
+    std::size_t slice_rank, const raw_buffer& buf, const F& f, const Bufs&... bufs) {
   constexpr std::size_t BufsSize = sizeof...(Bufs) + 1;
   std::array<const raw_buffer*, BufsSize> buf_ptrs;
   // Remove the sliced dimensions from the bufs.
@@ -911,7 +912,7 @@ void for_each_slice(std::size_t slice_rank, const raw_buffer& buf, const F& f, c
 // Call `f` with a pointer to each element of `buf`, and pointers to the same corresponding elements of `bufs`, or
 // `nullptr` if `buf` is out of bounds of `bufs`.
 template <typename F, typename Buf, typename... Bufs>
-void for_each_element(const F& f, const Buf& buf, const Bufs&... bufs) {
+SLINKY_NO_STACK_PROTECTOR void for_each_element(const F& f, const Buf& buf, const Bufs&... bufs) {
   constexpr std::size_t BufsSize = sizeof...(Bufs) + 1;
   std::array<const raw_buffer*, BufsSize> buf_ptrs = {&buf, &bufs...};
 

--- a/runtime/buffer.h
+++ b/runtime/buffer.h
@@ -713,19 +713,15 @@ namespace internal {
 //
 // struct loop_desc {
 //   for_each_slice_dim loop;
-//   dim_or_stride[buffer_count];
+//   union {
+//     dim* dim;
+//     index_t stride;
+//   } dim_or_stride[buffer_count];
 // };
 // loop_desc loops[rank];
 //
 // We don't actually have this struct, because buffer_count needs to be a runtime variable, but we can emulate
 // this memory layout with pointer arithmetic.
-union dim_or_stride {
-  // For loop_folded to call flat_offset_bytes
-  const slinky::dim* dim;
-  // For loop_linear to offset the base.
-  index_t stride;
-};
-
 struct for_each_slice_dim {
   enum {
     call_f,       // Uses extent
@@ -736,7 +732,7 @@ struct for_each_slice_dim {
 };
 
 inline std::size_t size_of_plan(std::size_t rank, std::size_t bufs) {
-  return (rank + 1) * sizeof(for_each_slice_dim) + rank * bufs * sizeof(dim_or_stride);
+  return (rank + 1) * sizeof(for_each_slice_dim) + rank * bufs * sizeof(dim*);
 }
 
 index_t make_for_each_contiguous_slice_dims(span<const raw_buffer*> bufs, void** bases, void* plan);

--- a/runtime/evaluate.cc
+++ b/runtime/evaluate.cc
@@ -251,7 +251,7 @@ public:
       if (op->args[d + 1].defined()) {
         index_t at = eval(op->args[d + 1]);
         if (result && buf->dims[d].contains(at)) {
-          result = offset_bytes(result, buf->dims[d].flat_offset_bytes(at));
+          result = offset_bytes_non_null(result, buf->dims[d].flat_offset_bytes(at));
         } else {
           result = nullptr;
         }
@@ -665,7 +665,7 @@ public:
         if (buffer->base) {
           index_t at_d = eval(op->at[d]);
           if (buffer->dims[d].contains(at_d)) {
-            buffer->base = offset_bytes(buffer->base, buffer->dims[d].flat_offset_bytes(at_d));
+            buffer->base = offset_bytes_non_null(buffer->base, buffer->dims[d].flat_offset_bytes(at_d));
           } else {
             buffer->base = nullptr;
           }
@@ -701,7 +701,7 @@ public:
     if (buffer->base) {
       index_t at = eval(op->at);
       if (old_dims[op->dim].contains(at)) {
-        buffer->base = offset_bytes(buffer->base, old_dims[op->dim].flat_offset_bytes(at));
+        buffer->base = offset_bytes_non_null(buffer->base, old_dims[op->dim].flat_offset_bytes(at));
       } else {
         buffer->base = nullptr;
       }


### PR DESCRIPTION
This is a bunch of small optimizations/cleanups, and a few bigger things:
- The "for each" loops are now defined by flags (linear, folded) and (call f, don't call f).
- Instead of inlining the loops into the branch that decides which kind of loop/call to make, inline the decision into the loops.
- Add fast path for slice of one dimension.