### PR TITLE
Pipeline construction improvements

### DIFF
--- a/builder/node_mutator.h
+++ b/builder/node_mutator.h
@@ -41,6 +41,14 @@ public:
     }
   }
 
+  virtual interval_expr mutate(const interval_expr& x) {
+    if (x.is_point()) {
+      return point(mutate(x.min));
+    } else {
+      return {mutate(x.min), mutate(x.max)};
+    }
+  }
+
   void visit(const variable* op) override { set_result(op); }
   void visit(const constant* op) override { set_result(op); }
 

--- a/builder/pipeline.cc
+++ b/builder/pipeline.cc
@@ -253,20 +253,12 @@ public:
       return;
     }
 
-    // Don't lift internally allocated buffer metadata expressions.
-    assert(op->args.size() >= 1 && as_variable(op->args[0]));
-    // TODO: This should be a proper API error.
-    assert(external.count(*as_variable(op->args[0])));
-
     auto i = replacements.insert(std::pair<const expr, var>(op, 0));
     if (i.second) {
       i.first->second = ctx.insert_unique("g");
     }
     set_result(variable::make(i.first->second));
   }
-
-  using node_mutator::mutate;
-  interval_expr mutate(const interval_expr& i) { return {mutate(i.min), mutate(i.max)}; }
 };
 
 bounds_map get_output_bounds(const std::vector<func::output>& outputs) {
@@ -926,8 +918,8 @@ stmt build_pipeline(node_context& ctx, const std::vector<buffer_expr_ptr>& input
   stmt result;
   result = builder.build(result, nullptr, loop_id());
   result = builder.add_input_checks(result);
-  result = builder.make_buffers(result);
   result = builder.define_sanitized_replacements(result);
+  result = builder.make_buffers(result);
 
   result = slide_and_fold_storage(result, ctx);
 

--- a/builder/pipeline.cc
+++ b/builder/pipeline.cc
@@ -41,7 +41,7 @@ buffer_expr::buffer_expr(var sym, std::size_t rank, expr elem_size)
 }
 
 buffer_expr::buffer_expr(var sym, const_raw_buffer_ptr constant_buffer)
-    : sym_(sym), elem_size_(static_cast<index_t>(constant_buffer->elem_size)), producer_(nullptr),
+    : sym_(sym), elem_size_(constant_buffer->elem_size), producer_(nullptr),
       constant_(std::move(constant_buffer)) {
   assert(constant_ != nullptr);
   dims_.reserve(constant_->rank);
@@ -59,16 +59,8 @@ buffer_expr_ptr buffer_expr::make(var sym, std::size_t rank, expr elem_size) {
   return buffer_expr_ptr(new buffer_expr(sym, rank, std::move(elem_size)));
 }
 
-buffer_expr_ptr buffer_expr::make(var sym, std::size_t rank, index_t elem_size) {
-  return make(sym, rank, expr(elem_size));
-}
-
 buffer_expr_ptr buffer_expr::make(node_context& ctx, const std::string& sym, std::size_t rank, expr elem_size) {
   return buffer_expr_ptr(new buffer_expr(ctx.insert_unique(sym), rank, std::move(elem_size)));
-}
-
-buffer_expr_ptr buffer_expr::make(node_context& ctx, const std::string& sym, std::size_t rank, index_t elem_size) {
-  return make(ctx, sym, rank, expr(elem_size));
 }
 
 buffer_expr_ptr buffer_expr::make(var sym, const_raw_buffer_ptr constant_buffer) {

--- a/builder/pipeline.h
+++ b/builder/pipeline.h
@@ -47,9 +47,7 @@ class buffer_expr : public ref_counted<buffer_expr> {
 
 public:
   static buffer_expr_ptr make(var sym, std::size_t rank, expr elem_size);
-  static buffer_expr_ptr make(var sym, std::size_t rank, index_t elem_size);
   static buffer_expr_ptr make(node_context& ctx, const std::string& sym, std::size_t rank, expr elem_size);
-  static buffer_expr_ptr make(node_context& ctx, const std::string& sym, std::size_t rank, index_t elem_size);
   // Make a constant buffer_expr. It takes ownership of the buffer from the caller.
   static buffer_expr_ptr make(var sym, const_raw_buffer_ptr constant_buffer);
   static buffer_expr_ptr make(node_context& ctx, const std::string& sym, const_raw_buffer_ptr constant_buffer);

--- a/builder/replica_pipeline.cc
+++ b/builder/replica_pipeline.cc
@@ -146,19 +146,19 @@ public:
 
     expr bep_var = variable::make(bep->sym());
     for (std::size_t d = 0; d < bep->rank(); d++) {
-      if (!match(bep->dim(d).bounds.min, buffer_min(bep_var, static_cast<index_t>(d)))) {
+      if (!match(bep->dim(d).bounds.min, buffer_min(bep_var, d))) {
         std::string e = print_expr_inlined(bep->dim(d).bounds.min);
         os_ << "  " << name << "->dim(" << d << ").min = " << e << ";\n";
       }
-      if (!match(bep->dim(d).bounds.max, buffer_max(bep_var, static_cast<index_t>(d)))) {
+      if (!match(bep->dim(d).bounds.max, buffer_max(bep_var, d))) {
         std::string e = print_expr_inlined(bep->dim(d).bounds.max);
         os_ << "  " << name << "->dim(" << d << ").max = " << e << ";\n";
       }
-      if (!match(bep->dim(d).stride, buffer_stride(bep_var, static_cast<index_t>(d)))) {
+      if (!match(bep->dim(d).stride, buffer_stride(bep_var, d))) {
         std::string e = print_expr_inlined(bep->dim(d).stride);
         os_ << "  " << name << "->dim(" << d << ").stride = " << e << ";\n";
       }
-      if (!match(bep->dim(d).fold_factor, buffer_fold_factor(bep_var, static_cast<index_t>(d)))) {
+      if (!match(bep->dim(d).fold_factor, buffer_fold_factor(bep_var, d))) {
         std::string e = print_expr_inlined(bep->dim(d).fold_factor);
         os_ << "  " << name << "->dim(" << d << ").fold_factor = " << e << ";\n";
       }

--- a/builder/simplify.cc
+++ b/builder/simplify.cc
@@ -259,8 +259,7 @@ public:
     node_mutator::set_result(mutate(e, &result_bounds));
   }
 
-  interval_expr mutate(
-      const interval_expr& x, interval_expr* min_bounds = nullptr, interval_expr* max_bounds = nullptr) {
+  interval_expr mutate(const interval_expr& x, interval_expr* min_bounds, interval_expr* max_bounds) {
     if (deep_is_point(x)) {
       expr result = mutate(x.min, min_bounds);
       if (min_bounds && max_bounds) {
@@ -273,6 +272,7 @@ public:
       return result;
     }
   }
+  interval_expr mutate(const interval_expr& x) override { return mutate(x, nullptr, nullptr); }
 
   // When we attempt to prove things about bounds, we sometimes get constant expressions, but we can't recursively
   // simplify without a high risk of infinite recursion. We can evaluate these as constants instead.

--- a/builder/simplify.cc
+++ b/builder/simplify.cc
@@ -1254,7 +1254,7 @@ public:
     changed = changed || (dims_count == 1 && std::is_same_v<T, crop_buffer>) || !body.same_as(op->body);
 
     auto make_crop = [&](const stmt& body) -> stmt {
-      if (!changed) {
+      if (!changed && body.same_as(op->body)) {
         return op;
       } else if (dims_count == 1) {
         // This crop is of one dimension, replace it with crop_dim.
@@ -1347,7 +1347,7 @@ public:
     changed = changed || (at_count == 1 && std::is_same_v<T, slice_buffer>);
 
     auto make_slice = [&](const stmt& body) -> stmt {
-      if (!changed) {
+      if (!changed && body.same_as(op)) {
         return op;
       } else if (at_count == 1) {
         // This slice is of one dimension, replace it with slice_dim.

--- a/builder/substitute.cc
+++ b/builder/substitute.cc
@@ -943,15 +943,6 @@ class slice_updater : public node_mutator {
 public:
   slice_updater(var sym, span<const int> slices) : sym(sym), slices(slices) {}
 
-  interval_expr mutate(const interval_expr& x) {
-    if (x.is_point()) {
-      return point(mutate(x.min));
-    } else {
-      return {mutate(x.min), mutate(x.max)};
-    }
-  }
-  using node_mutator::mutate;
-
   void visit(const call* op) override {
     switch (op->intrinsic) {
     case intrinsic::buffer_min:

--- a/builder/substitute.cc
+++ b/builder/substitute.cc
@@ -565,7 +565,7 @@ public:
           for (std::size_t d = 0; d < buf_rank; ++d) {
             if (d + 1 >= args.size() || !args[d + 1].defined()) {
               // buffer_at has an implicit buffer_min if it is not defined.
-              expr min_args[] = {static_cast<index_t>(d)};
+              expr min_args[] = {d};
               expr min = mutate_buffer_intrinsic(intrinsic::buffer_min, *buf, min_args);
               if (min.defined()) {
                 args.resize(std::max(args.size(), d + 2));

--- a/builder/test/cannot_alias.cc
+++ b/builder/test/cannot_alias.cc
@@ -29,7 +29,7 @@ TEST_P(may_alias, transpose_input) {
 
   if (!may_alias) {
     // Our callback requires the stride to be 1 element.
-    in_t->dim(0).stride = static_cast<index_t>(sizeof(int));
+    in_t->dim(0).stride = sizeof(int);
   }
 
   var x(ctx, "x");
@@ -82,7 +82,7 @@ TEST_P(may_alias, transpose_output) {
 
   if (!may_alias) {
     // Our callback requires the stride to be 1 element.
-    out_t->dim(0).stride = static_cast<index_t>(sizeof(int));
+    out_t->dim(0).stride = sizeof(int);
   }
 
   var x(ctx, "x");

--- a/builder/test/copy.cc
+++ b/builder/test/copy.cc
@@ -796,7 +796,7 @@ TEST(reshape, copy) {
   // To be a reshape that we can optimize, we need the buffers to be dense (strides equal to the product of extents of
   // prior dimensions).
   for (auto i : {in, out}) {
-    i->dim(0).stride = static_cast<index_t>(sizeof(int));
+    i->dim(0).stride = sizeof(int);
     i->dim(1).stride = i->dim(0).stride * i->dim(0).extent();
     i->dim(2).stride = i->dim(1).stride * i->dim(1).extent();
   }
@@ -854,7 +854,7 @@ TEST(batch_reshape, copy) {
   // To be a reshape that we can optimize, we need the buffers to be dense (strides equal to the product of extents of
   // prior dimensions).
   for (auto i : {in, out}) {
-    i->dim(0).stride = static_cast<index_t>(sizeof(int));
+    i->dim(0).stride = sizeof(int);
     i->dim(1).stride = i->dim(0).stride * i->dim(0).extent();
     i->dim(2).stride = i->dim(1).stride * i->dim(1).extent();
   }

--- a/builder/test/pipeline.cc
+++ b/builder/test/pipeline.cc
@@ -900,8 +900,8 @@ TEST_P(padded_stencil_separable, pipeline) {
   auto stencil_intm = buffer_expr::make(ctx, "stencil_intm", 2, sizeof(short));
 
   if (require_dense_x) {
-    padded_intm_t->dim(0).stride = static_cast<index_t>(sizeof(short));
-    padded_intm->dim(0).stride = static_cast<index_t>(sizeof(short));
+    padded_intm_t->dim(0).stride = sizeof(short);
+    padded_intm->dim(0).stride = sizeof(short);
   }
 
   var x(ctx, "x");

--- a/runtime/expr.h
+++ b/runtime/expr.h
@@ -191,6 +191,7 @@ public:
   // Make a new constant expression.
   expr(std::int64_t x);
   expr(std::int32_t x) : expr(static_cast<std::int64_t>(x)) {}
+  expr(std::uint64_t x) : expr(static_cast<std::int64_t>(x)) {}
   expr(var sym);
 
   // Make an `expr` referencing an existing node.


### PR DESCRIPTION
- Allow using intermediate buffer bounds in the pipeline, by moving the sanitized expressions to be after constructing the allocation bounds.
- Allow constructing expr from size_t, and clean up related hacks.
- Fix a simplify bug

This adds reshape tests to copy_pipeline that use the new functionality