### PR TITLE
Handle fix_buffer_races as part of optimize_symbols

### DIFF
--- a/builder/optimizations.h
+++ b/builder/optimizations.h
@@ -19,10 +19,6 @@ stmt implement_copy(const copy_stmt* c, node_context& ctx);
 // Replace every `copy_stmt` with the result of `implement_copy`
 stmt implement_copies(const stmt& s, node_context& ctx);
 
-// We can't modify buffers allocated outside parallel loops inside parallel loops. To avoid this, this mutation will
-// insert `clone_buffer` operations that clone buffers inside parallel loops.
-stmt fix_buffer_races(const stmt& s);
-
 // Find allocate nodes and try to insert free into them.
 stmt insert_early_free(const stmt& s);
 

--- a/builder/pipeline.cc
+++ b/builder/pipeline.cc
@@ -959,8 +959,6 @@ stmt build_pipeline(node_context& ctx, const std::vector<buffer_expr_ptr>& input
 
   result = optimize_symbols(result, ctx);
 
-  result = fix_buffer_races(result);
-
   result = insert_early_free(result);
 
   if (options.trace) {

--- a/builder/test/visualize/padded_stencil_2.html
+++ b/builder/test/visualize/padded_stencil_2.html
@@ -385,10 +385,10 @@ function pipeline(__in, out) {
                   produce(padded_intm);
                   __event_t++;
                 }}
-                { let __out = crop_dim(out, 1, [y, y]); {
-                  let out = __out;
+                { let __out_y = crop_dim(out, 1, [y, y]); {
+                  let out_y = __out_y;
                   consume(padded_intm_uncropped);
-                  produce(out);
+                  produce(out_y);
                   __event_t++;
                 }}
               }

--- a/builder/test/visualize/parallel_stencils_0.html
+++ b/builder/test/visualize/parallel_stencils_0.html
@@ -411,11 +411,11 @@ function pipeline(in1, in2, out) {
                       produce(intm4);
                       __event_t++;
                     }}
-                    { let __out = crop_dim(out, 1, [y, y]); {
-                      let out = __out;
+                    { let __out_y = crop_dim(out, 1, [y, y]); {
+                      let out_y = __out_y;
                       consume(intm3_uncropped);
                       consume(intm4_uncropped);
-                      produce(out);
+                      produce(out_y);
                       __event_t++;
                     }}
                   }

--- a/builder/test/visualize/parallel_stencils_1.html
+++ b/builder/test/visualize/parallel_stencils_1.html
@@ -407,11 +407,11 @@ function pipeline(in1, in2, out) {
                     produce(intm4);
                     __event_t++;
                   }}
-                  { let __out = crop_dim(out, 1, [y, (y + 1)]); {
-                    let out = __out;
+                  { let __out_y = crop_dim(out, 1, [y, (y + 1)]); {
+                    let out_y = __out_y;
                     consume(intm3_uncropped);
                     consume(intm4_uncropped);
-                    produce(out);
+                    produce(out_y);
                     __event_t++;
                   }}
                 }

--- a/builder/test/visualize/parallel_stencils_2.html
+++ b/builder/test/visualize/parallel_stencils_2.html
@@ -411,11 +411,11 @@ function pipeline(in1, in2, out) {
                       produce(intm4);
                       __event_t++;
                     }}
-                    { let __out = crop_dim(out, 1, [y, (y + 1)]); {
-                      let out = __out;
+                    { let __out_y = crop_dim(out, 1, [y, (y + 1)]); {
+                      let out_y = __out_y;
                       consume(intm3_uncropped);
                       consume(intm4_uncropped);
-                      produce(out);
+                      produce(out_y);
                       __event_t++;
                     }}
                   }

--- a/builder/test/visualize/softmax_split_1.html
+++ b/builder/test/visualize/softmax_split_1.html
@@ -416,10 +416,10 @@ function pipeline(__in, out) {
                             produce(softmax_out);
                             __event_t++;
                           }}
-                          { let __out = crop_dim(out, 1, [b, b]); {
-                            let out = __out;
+                          { let __out_b = crop_dim(out, 1, [b, b]); {
+                            let out_b = __out_b;
                             consume(softmax_out_uncropped);
-                            produce(out);
+                            produce(out_b);
                             __event_t++;
                           }}
                         }

--- a/builder/test/visualize/softmax_split_4.html
+++ b/builder/test/visualize/softmax_split_4.html
@@ -416,10 +416,10 @@ function pipeline(__in, out) {
                             produce(softmax_out);
                             __event_t++;
                           }}
-                          { let __out = crop_dim(out, 1, [b, (b + 3)]); {
-                            let out = __out;
+                          { let __out_b = crop_dim(out, 1, [b, (b + 3)]); {
+                            let out_b = __out_b;
                             consume(softmax_out_uncropped);
-                            produce(out);
+                            produce(out_b);
                             __event_t++;
                           }}
                         }

--- a/builder/test/visualize/stencil_chain_split_serial_split_1.html
+++ b/builder/test/visualize/stencil_chain_split_serial_split_1.html
@@ -396,12 +396,12 @@ function pipeline(__in, out) {
                       check(trace_end(__trace_token));
                     }
                   }}
-                  { let __out = crop_dim(out, 1, [y, y]); {
-                    let out = __out;
+                  { let __out_y = crop_dim(out, 1, [y, y]); {
+                    let out_y = __out_y;
                     {
                       let __trace_token = trace_begin(buffer_at(__trace_names, 30));
                       consume(stencil1_result_uncropped);
-                      produce(out);
+                      produce(out_y);
                       __event_t++;
                       check(trace_end(__trace_token));
                     }

--- a/builder/test/visualize/stencil_chain_split_serial_split_2.html
+++ b/builder/test/visualize/stencil_chain_split_serial_split_2.html
@@ -396,12 +396,12 @@ function pipeline(__in, out) {
                       check(trace_end(__trace_token));
                     }
                   }}
-                  { let __out = crop_dim(out, 1, [y, (y + 1)]); {
-                    let out = __out;
+                  { let __out_y = crop_dim(out, 1, [y, (y + 1)]); {
+                    let out_y = __out_y;
                     {
                       let __trace_token = trace_begin(buffer_at(__trace_names, 30));
                       consume(stencil1_result_uncropped);
-                      produce(out);
+                      produce(out_y);
                       __event_t++;
                       check(trace_end(__trace_token));
                     }

--- a/builder/test/visualize/stencil_chain_split_serial_split_3.html
+++ b/builder/test/visualize/stencil_chain_split_serial_split_3.html
@@ -396,12 +396,12 @@ function pipeline(__in, out) {
                       check(trace_end(__trace_token));
                     }
                   }}
-                  { let __out = crop_dim(out, 1, [y, (y + 2)]); {
-                    let out = __out;
+                  { let __out_y = crop_dim(out, 1, [y, (y + 2)]); {
+                    let out_y = __out_y;
                     {
                       let __trace_token = trace_begin(buffer_at(__trace_names, 30));
                       consume(stencil1_result_uncropped);
-                      produce(out);
+                      produce(out_y);
                       __event_t++;
                       check(trace_end(__trace_token));
                     }

--- a/builder/test/visualize/stencil_chain_split_serial_split_4.html
+++ b/builder/test/visualize/stencil_chain_split_serial_split_4.html
@@ -396,12 +396,12 @@ function pipeline(__in, out) {
                       check(trace_end(__trace_token));
                     }
                   }}
-                  { let __out = crop_dim(out, 1, [y, (y + 3)]); {
-                    let out = __out;
+                  { let __out_y = crop_dim(out, 1, [y, (y + 3)]); {
+                    let out_y = __out_y;
                     {
                       let __trace_token = trace_begin(buffer_at(__trace_names, 30));
                       consume(stencil1_result_uncropped);
-                      produce(out);
+                      produce(out_y);
                       __event_t++;
                       check(trace_end(__trace_token));
                     }

--- a/builder/test/visualize/stencil_split_1.html
+++ b/builder/test/visualize/stencil_split_1.html
@@ -371,10 +371,10 @@ function pipeline(__in, out) {
           produce(intm);
           __event_t++;
         }}
-        { let __out = crop_dim(out, 1, [y, y]); {
-          let out = __out;
+        { let __out_y = crop_dim(out, 1, [y, y]); {
+          let out_y = __out_y;
           consume(intm_uncropped);
-          produce(out);
+          produce(out_y);
           __event_t++;
         }}
       }

--- a/builder/test/visualize/stencil_split_2.html
+++ b/builder/test/visualize/stencil_split_2.html
@@ -371,10 +371,10 @@ function pipeline(__in, out) {
           produce(intm);
           __event_t++;
         }}
-        { let __out = crop_dim(out, 1, [y, (y + 1)]); {
-          let out = __out;
+        { let __out_y = crop_dim(out, 1, [y, (y + 1)]); {
+          let out_y = __out_y;
           consume(intm_uncropped);
-          produce(out);
+          produce(out_y);
           __event_t++;
         }}
       }

--- a/builder/test/visualize/stencil_split_3.html
+++ b/builder/test/visualize/stencil_split_3.html
@@ -371,10 +371,10 @@ function pipeline(__in, out) {
           produce(intm);
           __event_t++;
         }}
-        { let __out = crop_dim(out, 1, [y, (y + 2)]); {
-          let out = __out;
+        { let __out_y = crop_dim(out, 1, [y, (y + 2)]); {
+          let out_y = __out_y;
           consume(intm_uncropped);
-          produce(out);
+          produce(out_y);
           __event_t++;
         }}
       }


### PR DESCRIPTION
This avoids creating huge numbers of clone_buffer ops when we can just use a non-shadowing buffer mutator instead, and just less stuff to have in the code to think about.