### PR TITLE
Allow aliasing "flat" copies

### DIFF
--- a/builder/substitute.cc
+++ b/builder/substitute.cc
@@ -852,6 +852,9 @@ public:
           return result;
         }
       }
+    } else if (fn == intrinsic::buffer_size_bytes) {
+      std::cerr << "substituting buffer_size_bytes not implemented" << std::endl;
+      std::abort();
     }
     return expr();
   }

--- a/runtime/depends_on.cc
+++ b/runtime/depends_on.cc
@@ -55,7 +55,9 @@ public:
         assert(buf);
         update_deps(*buf, [fn = op->intrinsic](depends_on_result& deps) {
           deps.buffer_meta = true;
-          if (fn == intrinsic::buffer_at) {
+          // TODO: Treating buffer_size_bytes as using the base is a hack to avoid needing to implement substituting a
+          // buffer into it.
+          if (fn == intrinsic::buffer_at || fn == intrinsic::buffer_size_bytes) {
             deps.buffer_base = true;
           }
         });

--- a/runtime/stmt.h
+++ b/runtime/stmt.h
@@ -93,7 +93,10 @@ public:
     bool allow_in_place = false;
 
     // A name for the callable. This is only a tag that is passed through slinky and used for printing, it doesn't
-    // affect any slinky logic.
+    // affect any slinky logic, *except* for if this is named `memcpy`, slinky assumes that the implementation of this
+    // callback is:
+    // assert(inputs[0]->size_bytes() == outputs[0]->size_bytes());
+    // memcpy(outputs[0]->base(), inputs[0]->base(), outputs[0]->size_bytes());
     std::string name;
   };
 


### PR DESCRIPTION
This PR is a bit of a hack to allow aliasing reshapes implemented by a callback to memcpy. It makes `memcpy` a special callback name that we recognize in aliasing.

This is a workaround for #187, which we should still try to do, but it's quite difficult.