### PR TITLE
Refactor thread pool to make `parallel_for` more broadly available

### DIFF
--- a/base/test/BUILD
+++ b/base/test/BUILD
@@ -29,6 +29,16 @@ cc_test(
 )
 
 cc_test(
+    name = "thread_pool",
+    srcs = ["thread_pool.cc"],
+    deps = [
+        "//base:thread_pool",
+        "@googletest//:gtest_main",
+    ],
+    size = "small",
+)
+
+cc_test(
     name = "arithmetic_benchmark",
     srcs = ["arithmetic_benchmark.cc"],
     deps = [

--- a/base/test/thread_pool.cc
+++ b/base/test/thread_pool.cc
@@ -1,0 +1,65 @@
+#include <gtest/gtest.h>
+
+#include <cassert>
+#include <iostream>
+
+#include "base/thread_pool.h"
+
+namespace slinky {
+
+int sum_arithmetic_sequence(int n) { return n * (n - 1) / 2; }
+
+TEST(parallel_for, sum) {
+  thread_pool_impl t;
+  for (int n = 0; n < 100; ++n) {
+    std::atomic<int> count = 0;
+    std::atomic<int> sum = 0;
+    t.parallel_for(n, [&](int i) {
+      count++;
+      sum += i;
+    });
+    ASSERT_EQ(count, n);
+    ASSERT_EQ(sum, sum_arithmetic_sequence(n));
+  }
+}
+
+TEST(parallel_for, sum_nested) {
+  thread_pool_impl t;
+  std::atomic<int> count = 0;
+  std::atomic<int> sum = 0;
+  t.parallel_for(10, [&](int i) {
+    t.parallel_for(8, [&](int j) {
+      count++;
+      sum += j;
+    });
+  });
+  ASSERT_EQ(count, 10 * 8);
+  ASSERT_EQ(sum, 10 * sum_arithmetic_sequence(8));
+}
+
+TEST(atomic_call, sum) {
+  thread_pool_impl t;
+  int sum = 0;
+  t.parallel_for(1000, [&](int i) { t.atomic_call([&]() { sum += i; }); });
+  ASSERT_EQ(sum, sum_arithmetic_sequence(1000));
+}
+
+TEST(wait_for, barriers) {
+  thread_pool_impl t;
+  bool barrier0 = false;
+  bool barrier1 = false;
+  bool barrier2 = false;
+
+  std::thread th([&]() {
+    t.atomic_call([&]() { barrier0 = true; });
+    t.wait_for([&]() -> bool { return barrier1; });
+    t.atomic_call([&]() { barrier2 = true; });
+  });
+  t.wait_for([&]() -> bool { return barrier0; });
+  t.atomic_call([&]() { barrier1 = true; });
+  t.wait_for([&]() -> bool { return barrier2; });
+
+  th.join();
+}
+
+}  // namespace slinky

--- a/base/thread_pool.cc
+++ b/base/thread_pool.cc
@@ -8,8 +8,11 @@
 
 namespace slinky {
 
-thread_pool_impl::thread_pool_impl(int workers) : stop_(false) {
-  auto worker = [this]() { wait_for([this]() -> bool { return stop_; }, cv_worker_); };
+thread_pool_impl::thread_pool_impl(int workers, const task& init) : stop_(false) {
+  auto worker = [this, init]() {
+    if (init) init();
+    wait_for([this]() -> bool { return stop_; }, cv_worker_);
+  };
   for (int i = 0; i < workers; ++i) {
     workers_.push_back(std::thread(worker));
   }

--- a/base/thread_pool.cc
+++ b/base/thread_pool.cc
@@ -60,7 +60,7 @@ void thread_pool_impl::wait_for(const thread_pool::predicate& condition, std::co
       l.lock();
       // Notify the helper CV, helpers might be waiting for a condition that the task changed the value of.
       cv_helper_.notify_all();
-    } else if (!stop_) {
+    } else {
       cv.wait(l);
     }
   }

--- a/base/thread_pool.h
+++ b/base/thread_pool.h
@@ -118,7 +118,9 @@ private:
   bool dequeue(task& t, std::vector<task_id>& task_stack);
 
 public:
-  thread_pool_impl(int workers = 3);
+  // `workers` indicates how many worker threads the thread pool will have.
+  // `init` is a task that is run on each newly created thread.
+  thread_pool_impl(int workers = 3, const task& init = nullptr);
   ~thread_pool_impl();
 
   int thread_count() const override { return workers_.size(); }

--- a/base/thread_pool.h
+++ b/base/thread_pool.h
@@ -2,10 +2,13 @@
 #define SLINKY_BASE_THREAD_POOL_H
 
 #include <atomic>
+#include <cassert>
 #include <condition_variable>
 #include <deque>
 #include <functional>
+#include <limits>
 #include <mutex>
+#include <set>
 #include <thread>
 
 namespace slinky {
@@ -15,9 +18,86 @@ namespace slinky {
 class thread_pool {
 public:
   using task = std::function<void()>;
+  using predicate = std::function<bool()>;
+
+  virtual int thread_count() const = 0;
+
+  // Enqueues `n` copies of task `t` on the thread pool queue. This guarantees that `t` will not
+  // be run recursively on the same thread while in `wait_for`.
+  virtual void enqueue(int n, task t) = 0;
+  virtual void enqueue(task t) = 0;
+  // Waits for `condition` to become true. While waiting, executes tasks on the queue.
+  // The condition is executed atomically.
+  virtual void wait_for(const predicate& condition) = 0;
+  // Run `t` on the calling thread, but atomically w.r.t. other `atomic_call` and `wait_for` conditions.
+  virtual void atomic_call(const task& t) = 0;
+
+  template <typename Fn>
+  void parallel_for(std::size_t n, Fn&& body, int max_workers = std::numeric_limits<int>::max()) {
+    if (n == 0) {
+      return;
+    } else if (n == 1) {
+      body(0);
+      return;
+    }
+
+    struct shared_state {
+      // We track the loop progress with two variables: `i` is the next iteration to run, and `done` is the number of
+      // iterations completed. This allows us to check if the loop is done without relying on the workers actually
+      // running. If the thread pool is busy, then we might enqueue workers that never run until after the loop is
+      // done. Waiting for these to return (after doing nothing) would risk deadlock.
+      std::atomic<std::size_t> i = 0;
+      std::atomic<std::size_t> done = 0;
+
+      // Which threads are working on this loop.
+      std::set<std::thread::id> working_threads;
+      std::mutex m;
+
+      // This should be called when entering a worker. If it returns false, we are already in the call stack of a
+      // worker on this loop, and should return to work on other tasks instead.
+      bool begin_work() {
+        std::unique_lock l(m);
+        std::thread::id tid = std::this_thread::get_id();
+        return working_threads.emplace(tid).second;
+      }
+
+      void end_work() {
+        std::unique_lock l(m);
+        auto i = working_threads.find(std::this_thread::get_id());
+        assert(i != working_threads.end());
+        working_threads.erase(i);
+      }
+    };
+    auto state = std::make_shared<shared_state>();
+    // Capture n by value becuase this may run after the parallel_for call returns.
+    auto worker = [state, n, body = std::move(body)]() mutable {
+      if (!state->begin_work()) return;
+
+      while (true) {
+        std::size_t i = state->i++;
+        if (i >= n) break;
+        body(i);
+        ++state->done;
+      }
+
+      state->end_work();
+    };
+    int workers = std::min<int>(max_workers, std::min<std::size_t>(thread_count() + 1, n));
+    if (workers > 1) {
+      enqueue(workers - 1, worker);
+    }
+    worker();
+    // While the loop still isn't done, work on other tasks.
+    wait_for([&]() { return state->done >= n; });
+  }
+};
+
+// This implements a simple thread pool that maps easily to the eval_context thread pool interface.
+// It is not directly used by anything except for testing.
+class thread_pool_impl : public thread_pool {
+private:
   using task_id = std::size_t;
 
-private:
   std::vector<std::thread> workers_;
   std::atomic<bool> stop_;
 
@@ -30,20 +110,20 @@ private:
   bool dequeue(task& t, std::vector<task_id>& task_stack);
 
 public:
-  thread_pool(int workers = 3);
-  ~thread_pool();
+  thread_pool_impl(int workers = 3);
+  ~thread_pool_impl();
 
-  int thread_count() const { return workers_.size(); }
+  int thread_count() const override { return workers_.size(); }
 
   // Enqueues `n` copies of task `t` on the thread pool queue. This guarantees that `t` will not
   // be run recursively on the same thread while in `wait_for`.
-  void enqueue(int n, task t); 
-  void enqueue(task t);
+  void enqueue(int n, task t) override;
+  void enqueue(task t) override;
   // Waits for `condition` to become true. While waiting, executes tasks on the queue.
   // The condition is executed atomically.
-  void wait_for(const std::function<bool()>& condition);
+  void wait_for(const predicate& condition) override;
   // Run `t` on the calling thread, but atomically w.r.t. other `atomic_call` and `wait_for` conditions.
-  void atomic_call(const task& t);
+  void atomic_call(const task& t) override;
 };
 
 }  // namespace slinky

--- a/builder/test/context.cc
+++ b/builder/test/context.cc
@@ -35,7 +35,7 @@ void setup_tracing(eval_context& ctx, const std::string& filename) {
 }
 
 test_context::test_context() {
-  static thread_pool threads;
+  static thread_pool_impl threads;
 
   allocate = [this](var, raw_buffer* b) {
     void* allocation = b->allocate();
@@ -47,10 +47,7 @@ test_context::test_context() {
     heap.track_free(b->size_bytes());
   };
 
-  enqueue_many = [&](thread_pool::task t) { threads.enqueue(threads.thread_count(), std::move(t)); };
-  enqueue = [&](int n, thread_pool::task t) { threads.enqueue(n, std::move(t)); };
-  wait_for = [&](const std::function<bool()>& condition) { return threads.wait_for(condition); };
-  atomic_call = [&](const thread_pool::task& t) { return threads.atomic_call(t); };
+  thread_pool = &threads;
 }
 
 }  // namespace slinky

--- a/runtime/BUILD
+++ b/runtime/BUILD
@@ -26,6 +26,7 @@ cc_library(
     deps = [
         "//base",
         "//base:chrome_trace",
+        "//base:thread_pool",
     ],
     visibility = ["//visibility:public"],
 )

--- a/runtime/evaluate.h
+++ b/runtime/evaluate.h
@@ -50,6 +50,9 @@ public:
   std::function<void(index_t)> trace_end;
 
   const raw_buffer* lookup_buffer(var id) const { return reinterpret_cast<const raw_buffer*>(*lookup(id)); }
+
+  void parallel_for(index_t begin, index_t end, index_t step, std::function<void(index_t)> body,
+      int max_workers = std::numeric_limits<int>::max());
 };
 
 index_t evaluate(const expr& e, eval_context& context);

--- a/runtime/test/evaluate_benchmark.cc
+++ b/runtime/test/evaluate_benchmark.cc
@@ -200,13 +200,9 @@ void benchmark_parallel_loop(benchmark::State& state, bool synchronize) {
   }
   body = loop::make(x, workers, range(0, iterations), 1, body);
 
-  thread_pool t(workers);
-
   eval_context eval_ctx;
-  eval_ctx.enqueue_many = [&](thread_pool::task f) { t.enqueue(t.thread_count(), std::move(f)); };
-  eval_ctx.enqueue = [&](int n, thread_pool::task f) { t.enqueue(n, std::move(f)); };
-  eval_ctx.wait_for = [&](const std::function<bool()>& f) { t.wait_for(f); };
-  eval_ctx.atomic_call = [&](const thread_pool::task& f) { t.atomic_call(f); };
+  thread_pool_impl t(workers);
+  eval_ctx.thread_pool = &t;
 
   for (auto _ : state) {
     evaluate(body, eval_ctx);


### PR DESCRIPTION
I think we need to add helpers to parallelize work within callbacks. To enable working towards that, this PR refactors the thread pool to move `parallel_for` from inside `evaluate` to be a public function of `thread_pool`.

This also cleans up a bit of an annoying wart in how customizing parallelism worked through `std::function`. This may also have had some extra overhead.