### PR TITLE
Try comparing bounds to values when simplifying `min` and `max`

### DIFF
--- a/builder/simplify.cc
+++ b/builder/simplify.cc
@@ -350,9 +350,13 @@ public:
     expr result = simplify(op, a, b);
     if (!result.same_as(op)) {
       mutate_and_set_result(result);
-    } else if (prove_constant_true(simplify(static_cast<const less_equal*>(nullptr), a_bounds.max, b_bounds.min))) {
+    } else if (prove_constant_true(simplify(static_cast<const less_equal*>(nullptr), a, b_bounds.min) ||
+                                   simplify(static_cast<const less_equal*>(nullptr), a_bounds.max, b) ||
+                                   simplify(static_cast<const less_equal*>(nullptr), a_bounds.max, b_bounds.min))) {
       set_result(std::move(a), std::move(a_bounds));
-    } else if (prove_constant_true(simplify(static_cast<const less_equal*>(nullptr), b_bounds.max, a_bounds.min))) {
+    } else if (prove_constant_true(simplify(static_cast<const less_equal*>(nullptr), b, a_bounds.min) ||
+                                   simplify(static_cast<const less_equal*>(nullptr), b_bounds.max, a) ||
+                                   simplify(static_cast<const less_equal*>(nullptr), b_bounds.max, a_bounds.min))) {
       set_result(std::move(b), std::move(b_bounds));
     } else {
       set_result(result, bounds_of(op, std::move(a_bounds), std::move(b_bounds)));
@@ -372,9 +376,13 @@ public:
     expr result = simplify(op, a, b);
     if (!result.same_as(op)) {
       mutate_and_set_result(result);
-    } else if (prove_constant_true(simplify(static_cast<const less_equal*>(nullptr), a_bounds.max, b_bounds.min))) {
+    } else if (prove_constant_true(simplify(static_cast<const less_equal*>(nullptr), a, b_bounds.min) ||
+                                   simplify(static_cast<const less_equal*>(nullptr), a_bounds.max, b) ||
+                                   simplify(static_cast<const less_equal*>(nullptr), a_bounds.max, b_bounds.min))) {
       set_result(std::move(b), std::move(b_bounds));
-    } else if (prove_constant_true(simplify(static_cast<const less_equal*>(nullptr), b_bounds.max, a_bounds.min))) {
+    } else if (prove_constant_true(simplify(static_cast<const less_equal*>(nullptr), b, a_bounds.min) ||
+                                   simplify(static_cast<const less_equal*>(nullptr), b_bounds.max, a) ||
+                                   simplify(static_cast<const less_equal*>(nullptr), b_bounds.max, a_bounds.min))) {
       set_result(std::move(a), std::move(a_bounds));
     } else {
       set_result(result, bounds_of(op, std::move(a_bounds), std::move(b_bounds)));

--- a/builder/simplify.cc
+++ b/builder/simplify.cc
@@ -347,18 +347,16 @@ public:
       set_result(expr(), interval_expr());
       return;
     }
-
-    expr result = simplify(op, a, b);
-    if (!result.same_as(op)) {
-      mutate_and_set_result(result);
-    } else if (prove_constant_true(simplify(static_cast<const less_equal*>(nullptr), a, b_bounds.min) ||
-                                   simplify(static_cast<const less_equal*>(nullptr), a_bounds.max, b) ||
-                                   simplify(static_cast<const less_equal*>(nullptr), a_bounds.max, b_bounds.min))) {
+    
+    if (prove_constant_true(simplify(static_cast<const less_equal*>(nullptr), a, b_bounds.min) ||
+                            simplify(static_cast<const less_equal*>(nullptr), a_bounds.max, b) ||
+                            simplify(static_cast<const less_equal*>(nullptr), a_bounds.max, b_bounds.min))) {
       if (T::static_type == expr_node_type::min) {
         set_result(std::move(a), std::move(a_bounds));
       } else {
         set_result(std::move(b), std::move(b_bounds));
       }
+      return;
     } else if (prove_constant_true(simplify(static_cast<const less_equal*>(nullptr), b, a_bounds.min) ||
                                    simplify(static_cast<const less_equal*>(nullptr), b_bounds.max, a) ||
                                    simplify(static_cast<const less_equal*>(nullptr), b_bounds.max, a_bounds.min))) {
@@ -367,6 +365,12 @@ public:
       } else {
         set_result(std::move(a), std::move(a_bounds));
       }
+      return;
+    }
+
+    expr result = simplify(op, a, b);
+    if (!result.same_as(op)) {
+      mutate_and_set_result(result);
     } else {
       set_result(result, bounds_of(op, std::move(a_bounds), std::move(b_bounds)));
     }

--- a/builder/simplify.cc
+++ b/builder/simplify.cc
@@ -467,14 +467,16 @@ public:
       x = substitute_true(x, l->b);
     } else if (const logical_not* l = c.as<logical_not>()) {
       x = substitute_false(x, l->a);
-    } else if (const equal* e = c.as<equal>()) {
+    } else if (is_boolean(c) && !as_constant(c)) {
+      x = substitute(x, c, true);
+    }
+    // Do this separately because we might be able to substitute c and one side of an equals too.
+    if (const equal* e = c.as<equal>()) {
       if (e->b.as<constant>()) {
         x = substitute(x, e->a, e->b);
       } else if (e->a.as<constant>()) {
         x = substitute(x, e->b, e->a);
       }
-    } else if (is_boolean(c) && !as_constant(c)) {
-      x = substitute(x, c, true);
     }
     return x;
   }
@@ -487,14 +489,16 @@ public:
       x = substitute_false(x, l->b);
     } else if (const logical_not* l = c.as<logical_not>()) {
       x = substitute_true(x, l->a);
-    } else if (const not_equal* e = c.as<not_equal>()) {
+    } else if (is_boolean(c) && !as_constant(c)) {
+      x = substitute(x, c, false);
+    }
+    // Do this separately because we might be able to substitute c and one side of an equals too.
+    if (const not_equal* e = c.as<not_equal>()) {
       if (e->b.as<constant>()) {
         x = substitute(x, e->a, e->b);
       } else if (e->a.as<constant>()) {
         x = substitute(x, e->b, e->a);
       }
-    } else if (is_boolean(c) && !as_constant(c)) {
-      x = substitute(x, c, false);
     }
     return x;
   }

--- a/builder/test/simplify/simplify.cc
+++ b/builder/test/simplify/simplify.cc
@@ -278,7 +278,7 @@ TEST(simplify, bounds) {
   ASSERT_THAT(simplify(loop::make(x, loop::serial, min_extent(x, z), z, check::make(y))), matches(check::make(y)));
 
   // Tricky case because want to use the bounds of x but the value of y.
-  symbol_map<interval_expr> xy_bounds = {{x, {0, y}}, {y, {0, 5}}};
+  symbol_map<interval_expr> xy_bounds = {{x, {0, y}}, {y, {z, w}}};
   ASSERT_THAT(simplify(min(x, y + 1), xy_bounds), matches(x));
 }
 

--- a/builder/test/simplify/simplify.cc
+++ b/builder/test/simplify/simplify.cc
@@ -276,6 +276,10 @@ TEST(simplify, bounds) {
 
   ASSERT_THAT(simplify(loop::make(x, loop::serial, bounds(y - 2, z), 2, check::make(y - 2 <= x))), matches(stmt()));
   ASSERT_THAT(simplify(loop::make(x, loop::serial, min_extent(x, z), z, check::make(y))), matches(check::make(y)));
+
+  // Tricky case because want to use the bounds of x but the value of y.
+  symbol_map<interval_expr> xy_bounds = {{x, {0, y}}, {y, {0, 5}}};
+  ASSERT_THAT(simplify(min(x, y + 1), xy_bounds), matches(x));
 }
 
 TEST(simplify, buffer_bounds) {

--- a/builder/test/simplify/simplify.cc
+++ b/builder/test/simplify/simplify.cc
@@ -186,6 +186,7 @@ TEST(simplify, basic) {
   ASSERT_THAT(simplify(min(select(x, 0, y) + 4, select(x, expr(), min(y, 113) + 4))),
       matches(select(x, expr(), min(y, 113) + 4)));
 
+  ASSERT_THAT(simplify(select(expr(x) == y, z, select(expr(x) == y, 2, w))), matches(select(expr(x) == y, z, w)));
   ASSERT_THAT(simplify(select(x == 1, 0, max(abs(x), 1) + -1)), matches(max(abs(x), 1) + -1));
   ASSERT_THAT(simplify(select(x != 1, max(abs(x), 1), 1)), matches(max(abs(x), 1)));
 

--- a/builder/test/simplify/simplify.cc
+++ b/builder/test/simplify/simplify.cc
@@ -186,6 +186,9 @@ TEST(simplify, basic) {
   ASSERT_THAT(simplify(min(select(x, 0, y) + 4, select(x, expr(), min(y, 113) + 4))),
       matches(select(x, expr(), min(y, 113) + 4)));
 
+  ASSERT_THAT(simplify(select(x == 1, 0, max(abs(x), 1) + -1)), matches(max(abs(x), 1) + -1));
+  ASSERT_THAT(simplify(select(x != 1, max(abs(x), 1), 1)), matches(max(abs(x), 1)));
+
   ASSERT_THAT(simplify(crop_dim::make(y, x, 1, {expr(), expr()}, call_stmt::make(nullptr, {}, {y}, {}))),
       matches(call_stmt::make(nullptr, {}, {x}, {})));
   ASSERT_THAT(simplify(crop_buffer::make(y, x, {}, call_stmt::make(nullptr, {}, {y}, {}))),


### PR DESCRIPTION
This is pretty expensive, but it is necessary to simplify some kinds of expressions. See the test for a simple example.