### PR TITLE
Consider both inputs and outputs as alias candidates for in-place ops

### DIFF
--- a/builder/optimizations.cc
+++ b/builder/optimizations.cc
@@ -448,22 +448,29 @@ public:
     } else if (op->attrs.allow_in_place) {
       for (var i : op->inputs) {
         std::optional<buffer_info>& input_info = buffers[i];
-        if (input_info) {
-          if (input_info->is_input) {
-            // We can't write to this buffer.
-            continue;
-          }
-          for (var o : op->outputs) {
-            alias_info a;
-            a.dims = buffer_dims(o, input_info->dims.size());
-            a.at = buffer_mins(o, input_info->dims.size());
-            // We assume that op->attrs.allow_in_place means that the input is in bounds of the entire output, and the
-            // dimensions are not permuted.
-            a.assume_in_bounds = true;
-            a.permutation.resize(input_info->dims.size());
-            std::iota(a.permutation.begin(), a.permutation.end(), 0);
-            input_info->maybe_alias(o, std::move(a));
-          }
+        if (!input_info || input_info->is_input) {
+          // We can't write to this buffer.
+          continue;
+        }
+        for (var o : op->outputs) {
+          std::optional<buffer_info>& output_info = buffers[o];
+          if (!output_info) continue;
+          
+          alias_info fwd;
+          fwd.dims = buffer_dims(o, output_info->dims.size());
+          fwd.at = buffer_mins(i, input_info->dims.size());
+          fwd.assume_in_bounds = true;
+          fwd.permutation.resize(output_info->dims.size());
+          std::iota(fwd.permutation.begin(), fwd.permutation.end(), 0);
+          input_info->maybe_alias(o, std::move(fwd));
+
+          alias_info back;
+          back.dims = buffer_dims(i, input_info->dims.size());
+          back.at = buffer_mins(o, output_info->dims.size());
+          back.assume_in_bounds = true;
+          back.permutation.resize(input_info->dims.size());
+          std::iota(back.permutation.begin(), back.permutation.end(), 0);
+          output_info->maybe_alias(i, std::move(back));
         }
       }
     }

--- a/builder/test/elementwise.cc
+++ b/builder/test/elementwise.cc
@@ -261,6 +261,8 @@ expr pow(expr x, int n) {
     return 1;
   } else if (n == 1) {
     return x;
+  } else if (n % 2 == 0) {
+    return pow(x, n / 2) * pow(x, n / 2);
   } else {
     return x * pow(x, n - 1);
   }
@@ -275,5 +277,16 @@ TEST(elementwise, exp1) { test_expr_pipeline<int, 1>(ctx, 1 + x); }
 TEST(elementwise, exp2) { test_expr_pipeline<int, 1>(ctx, 1 + x + pow(x, 2)); }
 TEST(elementwise, exp3) { test_expr_pipeline<int, 1>(ctx, 1 + x + pow(x, 2) + pow(x, 3)); }
 TEST(elementwise, exp4) { test_expr_pipeline<int, 1>(ctx, 1 + x + pow(x, 2) + pow(x, 3) + pow(x, 4)); }
+TEST(elementwise, exp8) {
+  test_expr_pipeline<int, 1>(
+      ctx, 1 + x + pow(x, 2) + pow(x, 3) + pow(x, 4) + pow(x, 5) + pow(x, 6) + pow(x, 7) + pow(x, 8));
+}
+
+TEST(elementwise, exp2_horners) { test_expr_pipeline<int, 1>(ctx, 1 + x * (1 + x)); }
+TEST(elementwise, exp3_horners) { test_expr_pipeline<int, 1>(ctx, 1 + x * (1 + x * (1 + x))); }
+TEST(elementwise, exp4_horners) { test_expr_pipeline<int, 1>(ctx, 1 + x * (1 + x * (1 + x * (1 + x)))); }
+TEST(elementwise, exp8_horners) {
+  test_expr_pipeline<int, 1>(ctx, 1 + x * (1 + x * (1 + x * (1 + x * (1 + x * (1 + x * (1 + x * (1 + x))))))));
+}
 
 }  // namespace slinky


### PR DESCRIPTION
This makes us able to alias in-place ops regardless of the allocation order.

It *seems* like this should require more safety checks, but I can't seem to construct a pipeline that does bad aliasing with this change.