### PR TITLE
Minor changes to support viewing traces in ui.perfetto.dev

### DIFF
--- a/base/chrome_trace.cc
+++ b/base/chrome_trace.cc
@@ -16,7 +16,8 @@ std::atomic<int> next_id = 0;
 }  // namespace
 
 chrome_trace::chrome_trace(std::ostream& os) : os_(os), id_(next_id++) {
-  os_ << "[{}";
+  os_ << "[{\"name\":\"chrome_trace\",\"cat\":\"slinky\",\"ph\":\"B\",\"pid\":0,\"tid\":0,\"ts\":0}";
+  os_ << ",\n{\"name\":\"chrome_trace\",\"cat\":\"slinky\",\"ph\":\"E\",\"pid\":0,\"tid\":0,\"ts\":0}";
   t0_ = std::chrono::high_resolution_clock::now();
 }
 chrome_trace::~chrome_trace() {
@@ -35,7 +36,7 @@ void chrome_trace::write_event(const char* name, const char* cat, char type) {
   // initializer.
   thread_local std::string pid_tid_str = []() {
     std::stringstream ss;
-    ss << "\",\"pid\":0,\"tid\":" << std::this_thread::get_id();
+    ss << "\",\"pid\":0,\"tid\":\"" << std::this_thread::get_id() << "\"";
     return ss.str();
   }();
 

--- a/base/chrome_trace.cc
+++ b/base/chrome_trace.cc
@@ -34,9 +34,10 @@ void chrome_trace::write_event(const char* name, const char* cat, char type) {
 
   // The only way to convert a thread ID to a string is via operator<<, which is slow, so we do it as a thread_local
   // initializer.
+  static std::atomic<int> next_thread_id = 0;
   thread_local std::string pid_tid_str = []() {
     std::stringstream ss;
-    ss << "\",\"pid\":0,\"tid\":\"" << std::this_thread::get_id() << "\"";
+    ss << "\",\"pid\":0,\"tid\":" << next_thread_id++;
     return ss.str();
   }();
 


### PR DESCRIPTION
It was failing to load a trace file because it didn't like the empty event in the beginning. Also, for whatever reason it didn't like the long thread ids, so had to add quotes for it to be able to handle multi-threaded traces.

This is a matter of taste, but IMO ui.perfetto.dev has a better UI compared to the built-in viewer and allows to get a lot of aggregated statistics, etc, while still handling everything locally. The great benefit though is that allows uploading and sharing traces with other people which I think is extemely convinient. Example: https://ui.perfetto.dev/#!/?s=17bcbcc16c0c8d6157bae9020e0c1d5e53a00db56841169fcdb9b885ea309e5e