### PR TITLE
Strengthen LICM

### DIFF
--- a/builder/simplify.cc
+++ b/builder/simplify.cc
@@ -935,6 +935,7 @@ public:
       // This LICM is more aggressive than the typical compiler. Because we can freely add or remove loops around calls,
       // if we find a loop invariant stmt that consumes a loop variant stmt, we can try to force the loop varying stmt
       // to be loop invariant, and remove both from the loop.
+      // These accumulate results in reverse order.
       std::vector<stmt> result;
       std::vector<stmt> loop_body;
       loop_body.reserve(b->stmts.size());

--- a/builder/simplify.cc
+++ b/builder/simplify.cc
@@ -856,6 +856,56 @@ public:
     }
   }
 
+  // Substitute expr() in for loop_var only in crop bounds within s, and only if those crop bounds do not crop a folded
+  // dimension.
+  stmt remove_loop_var_in_crop_bounds(const stmt& s, var loop_var) {
+    class m : public node_mutator {
+      symbol_map<buffer_info>& buffers;
+      var loop_var;
+
+    public:
+      m(symbol_map<buffer_info>& buffers, var loop_var) : buffers(buffers), loop_var(loop_var) {}
+
+      interval_expr mutate_crop_bounds(var src, int dim, const interval_expr& bounds) {
+        std::optional<buffer_info>& src_info = buffers[src];
+        if (!src_info || dim >= static_cast<int>(src_info->dims.size())) {
+          // We don't know about this buffer or dimension, it might be folded.
+          return bounds;
+        }
+        if (src_info->dims[dim].fold_factor.defined() && !is_constant(src_info->dims[dim].fold_factor, dim::unfolded)) {
+          // This dimension is folded, don't drop crops.
+          return bounds;
+        }
+        return substitute(bounds, loop_var, expr());
+      }
+
+      void visit(const crop_dim* op) override {
+        interval_expr bounds = mutate_crop_bounds(op->src, op->dim, op->bounds);
+        stmt body = mutate(op->body);
+        if (!bounds.same_as(op->bounds) || !body.same_as(op->body)) {
+          set_result(crop_dim::make(op->sym, op->src, op->dim, std::move(bounds), std::move(body)));
+        } else {
+          set_result(op);
+        }
+      }
+      void visit(const crop_buffer* op) override {
+        box_expr bounds(op->bounds.size());
+        bool changed = false;
+        for (std::size_t d = 0; d < op->bounds.size(); ++d) {
+          bounds[d] = mutate_crop_bounds(op->src, d, op->bounds[d]);
+          changed = changed || !bounds[d].same_as(op->bounds[d]);
+        }
+        stmt body = mutate(op->body);
+        if (changed || !body.same_as(op->body)) {
+          set_result(crop_buffer::make(op->sym, op->src, std::move(bounds), std::move(body)));
+        } else {
+          set_result(op);
+        }
+      }
+    };
+    return m(buffers, loop_var).mutate(s);
+  }
+
   void visit(const loop* op) override {
     interval_expr bounds = mutate(op->bounds);
     expr step = mutate(op->step);
@@ -882,33 +932,64 @@ public:
       return;
     } else if (const block* b = body.as<block>()) {
       scoped_trace trace("licm");
-      // Put the stmts that actually depend on the loop inside the loop.
+      // This LICM is more aggressive than the typical compiler. Because we can freely add or remove loops around calls,
+      // if we find a loop invariant stmt that consumes a loop variant stmt, we can try to force the loop varying stmt
+      // to be loop invariant, and remove both from the loop.
       std::vector<stmt> result;
       std::vector<stmt> loop_body;
-      std::set<var> produced_by_loop;
       loop_body.reserve(b->stmts.size());
-      for (const stmt& i : b->stmts) {
-        if (!depends_on(i, op->sym).any()) {
-          // This stmt does not depend on the loop variable. Find out which buffers are consumed by it.
-          std::set<var> consumed_by_i;
-          buffers_accessed_via_aliases(i, /*consumed=*/true, consumed_by_i);
 
-          if (empty_intersection(consumed_by_i, produced_by_loop)) {
-            // This doesn't depend on the loop and doesn't consume anything produced in the loop, lift it out.
-            if (i.defined()) result.push_back(i);
-          } else {
-            // This stmt consumes something produced by the loop we have so far, we can't lift it out of the loop.
-            buffers_accessed_via_aliases(i, /*consumed=*/false, produced_by_loop);
-            loop_body.push_back(i);
-          }
+      // Find out if i produces something consumed by a loop invariant.
+      for (auto ri = b->stmts.rbegin(); ri != b->stmts.rend(); ++ri) {
+        stmt i = *ri;
+
+        if (!depends_on(i, op->sym).var) {
+          // i is loop invariant. Add it to the lifted result.
+          result.push_back(std::move(i));
         } else {
-          // This stmt depends on the loop.
-          buffers_accessed_via_aliases(i, /*consumed=*/false, produced_by_loop);
-          loop_body.push_back(i);
+          // i depends on the loop. We are effectively reordering result ahead of i, we need to make sure we can do
+          // that.
+          std::set<var> produced_by_i;
+          buffers_accessed_via_aliases(i, /*consumed=*/false, produced_by_i);
+
+          // The loop invariants might depend on i. If so, we need to figure out what to do.
+          for (auto j = result.begin(); j != result.end();) {
+            std::set<var> consumed_by_j;
+            buffers_accessed_via_aliases(*j, /*consumed=*/true, consumed_by_j);
+
+            if (empty_intersection(produced_by_i, consumed_by_j)) {
+              // This loop invariant is independent of i.
+              ++j;
+              continue;
+            }
+
+            // j depends on i, so j is not loop invariant. Can we make i loop invariant? We can if we can delete the
+            // references to the loop variable.
+            stmt i_lifted = remove_loop_var_in_crop_bounds(i, op->sym);
+            if (!depends_on(i_lifted, op->sym).var) {
+              // We made i loop invariant, add it to the loop invariant result before it is used.
+              ++j;
+              result.insert(j, mutate(i_lifted));
+              i = stmt();
+              break;
+            } else {
+              // We can't delete the references to the loop variable here, so j is not loop invariant. Put it back in
+              // the loop.
+              loop_body.push_back(*j);
+              j = result.erase(j);
+            }
+          }
+
+          if (i.defined()) {
+            // We didn't lift i, put it in the loop.
+            loop_body.push_back(std::move(i));
+          }
         }
       }
       if (!result.empty()) {
         // We found something to lift out of the loop.
+        std::reverse(result.begin(), result.end());
+        std::reverse(loop_body.begin(), loop_body.end());
         result.push_back(mutate(loop::make(op->sym, op->max_workers, bounds, step, block::make(std::move(loop_body)))));
         set_result(block::make(std::move(result)));
         return;

--- a/builder/test/simplify/simplify.cc
+++ b/builder/test/simplify/simplify.cc
@@ -286,20 +286,34 @@ TEST(simplify, licm) {
       }))));
   // A call in the middle of the loop does not depend on the loop, but does depend on the first call, and we know that
   // the first call doesn't write a folded buffer.
-  ASSERT_THAT(simplify(allocate::make(b1, memory_type::heap, 1, {{{x, y}, 1, dim::unfolded}},
+  ASSERT_THAT(simplify(allocate::make(b1, memory_type::heap, 1, {{{0, 10}, 1, dim::unfolded}},
                   make_loop_x(block::make({
                       make_crop_x(b1, 0, make_call(b0, b1)),
                       make_call(b1, b2),
                       make_crop_x(b3, 0, make_call(b0, b3)),
                   })))),
       matches(block::make({
-          allocate::make(b1, memory_type::heap, 1, {{{x, y}, 1, expr()}},
+          allocate::make(b1, memory_type::heap, 1, {{{0, 10}, 1, expr()}},
               block::make({
                   make_call(b0, b1),
                   make_call(b1, b2),
               })),
           make_loop_x(make_crop_x(b3, 0, make_call(b0, b3))),
       })));
+  // A call at the end of the loop does not depend on the loop, but each call depends on the previous, and the first
+  // call writes a folded buffer.
+  ASSERT_THAT(simplify(allocate::make(b1, memory_type::heap, 1, {{{0, 10}, 1, dim::unfolded}},
+                  make_loop_x(block::make({
+                      make_crop_x(b1, 0, make_call(b0, b1)),
+                      make_crop_x(b2, 0, make_call(b1, b2)),
+                      make_call(b2, b3),
+                  })))),
+      matches(allocate::make(b1, memory_type::heap, 1, {{{0, 10}, 1, expr()}},
+          make_loop_x(block::make({
+              make_crop_x(b1, 0, make_call(b0, b1)),
+              make_crop_x(b2, 0, make_call(b1, b2)),
+              make_call(b2, b3),
+          })))));
   // A call at the end of the loop that is loop invariant.
   ASSERT_THAT(simplify(make_loop_x(block::make({
                   make_crop_x(b1, 0, make_call(b0, b1)),

--- a/builder/test/simplify/simplify.cc
+++ b/builder/test/simplify/simplify.cc
@@ -315,7 +315,7 @@ TEST(simplify, licm) {
               make_crop_x(b2, 0, make_call(b1, b2)),
               make_call(b2, b3),
           })))));
-  // Same as above, but with another loop invariant stmt
+  // Same as above, but with another loop invariant stmt that does get lifted.
   ASSERT_THAT(simplify(allocate::make(b1, memory_type::heap, 1, {{{0, 10}, 1, dim::unfolded}},
                   make_loop_x(block::make({
                       make_crop_x(b1, 0, make_call(b0, b1)),

--- a/builder/test/simplify/simplify.cc
+++ b/builder/test/simplify/simplify.cc
@@ -32,6 +32,7 @@ var b0(symbols, "b0");
 var b1(symbols, "b1");
 var b2(symbols, "b2");
 var b3(symbols, "b3");
+var b4(symbols, "b4");
 
 MATCHER_P(matches, x, "") { return match(arg, x); }
 
@@ -314,6 +315,23 @@ TEST(simplify, licm) {
               make_crop_x(b2, 0, make_call(b1, b2)),
               make_call(b2, b3),
           })))));
+  // Same as above, but with another loop invariant stmt
+  ASSERT_THAT(simplify(allocate::make(b1, memory_type::heap, 1, {{{0, 10}, 1, dim::unfolded}},
+                  make_loop_x(block::make({
+                      make_crop_x(b1, 0, make_call(b0, b1)),
+                      make_crop_x(b2, 0, make_call(b1, b2)),
+                      make_call(b0, b4),
+                      make_call(b2, b3),
+                  })))),
+      matches(block::make({
+          make_call(b0, b4),
+          allocate::make(b1, memory_type::heap, 1, {{{0, 10}, 1, expr()}},
+              make_loop_x(block::make({
+                  make_crop_x(b1, 0, make_call(b0, b1)),
+                  make_crop_x(b2, 0, make_call(b1, b2)),
+                  make_call(b2, b3),
+              }))),
+      })));
   // A call at the end of the loop that is loop invariant.
   ASSERT_THAT(simplify(make_loop_x(block::make({
                   make_crop_x(b1, 0, make_call(b0, b1)),


### PR DESCRIPTION
This PR makes LICM stronger, by allowing it to make non-loop-invariant stmts loop invariant when it is safe to do so. It works by replacing the loop variable with `expr()` only in crop bounds, and only if those crops are not cropping a folded dimension. If there are other uses of the loop variable (e.g. in a slice), the stmt will not be made to be loop invariant.

This seems like a hack, but this kind of simplification has gotten us really far already...