### PR TITLE
Thread pool improvements

### DIFF
--- a/base/chrome_trace.cc
+++ b/base/chrome_trace.cc
@@ -91,16 +91,11 @@ void chrome_trace::begin(const char* name) { write_event(name, "slinky", 'B'); }
 void chrome_trace::end(const char* name) { write_event(name, "slinky", 'E'); }
 
 chrome_trace* chrome_trace::global() {
-  static std::unique_ptr<std::ofstream> file;
-  static std::unique_ptr<chrome_trace> trace;
-  if (!trace) {
-    const char* path = getenv("SLINKY_TRACE");
-    if (path) {
-      std::cout << "Tracing to: " << path << std::endl;
-      file = std::make_unique<std::ofstream>(path);
-      trace = std::make_unique<chrome_trace>(*file);
-    }
-  }
+  static const char* path = getenv("SLINKY_TRACE");
+  if (!path) return nullptr;
+
+  static auto file = std::make_unique<std::ofstream>(path);
+  static auto trace = std::make_unique<chrome_trace>(*file);
   return trace.get();
 }
 

--- a/base/test/BUILD
+++ b/base/test/BUILD
@@ -48,3 +48,15 @@ cc_test(
     args=["--benchmark_min_time=0.1s"],
     size = "small",
 )
+
+
+cc_test(
+    name = "thread_pool_benchmark",
+    srcs = ["thread_pool_benchmark.cc"],
+    deps = [
+        "//base:thread_pool",
+        "@google_benchmark//:benchmark_main",
+    ],
+    args=["--benchmark_min_time=0.1s"],
+    size = "small",
+)

--- a/base/test/thread_pool_benchmark.cc
+++ b/base/test/thread_pool_benchmark.cc
@@ -1,0 +1,61 @@
+#include <benchmark/benchmark.h>
+
+#include <atomic>
+#include <vector>
+
+#include "base/thread_pool.h"
+
+namespace slinky {
+
+constexpr int cache_line_size = 64;
+
+struct unshared {
+  alignas(cache_line_size) int value;
+};
+
+void BM_parallel_for_overhead(benchmark::State& state) {
+  const int workers = state.range(0);
+  thread_pool_impl t(workers - 1);
+
+  std::vector<unshared> values(workers);
+  while (state.KeepRunningBatch(workers)) {
+    t.parallel_for(workers, [&](int i) { values[i].value++; });
+  }
+}
+
+BENCHMARK(BM_parallel_for_overhead)->Arg(2)->Arg(4)->Arg(8);
+
+void BM_parallel_for(benchmark::State& state) {
+  const int workers = state.range(0);
+  thread_pool_impl t(workers - 1);
+
+  const int n = 1000000;
+
+  std::vector<unshared> values(workers);
+  while (state.KeepRunningBatch(values.size())) {
+    t.parallel_for(n, [&](int i) { values[i % workers].value++; });
+  }
+}
+
+BENCHMARK(BM_parallel_for)->Arg(2)->Arg(4)->Arg(8);
+
+void BM_parallel_for_nested(benchmark::State& state) {
+  const int workers = state.range(0);
+  thread_pool_impl t(workers - 1);
+
+  const int n = 1000;
+
+  std::vector<unshared> values(workers * workers);
+  while (state.KeepRunningBatch(values.size())) {
+    t.parallel_for(n, [&](int i) { 
+      t.parallel_for(n, [&](int j) { 
+        values[(i % workers) * workers + j % workers].value++; 
+      });
+    });
+  }
+}
+
+BENCHMARK(BM_parallel_for_nested)->Arg(2)->Arg(4)->Arg(8);
+
+
+}  // namespace slinky

--- a/base/thread_pool.cc
+++ b/base/thread_pool.cc
@@ -30,11 +30,11 @@ thread_pool_impl::~thread_pool_impl() {
 
 namespace {
 
-thread_local std::vector<const void*> task_stack;
+thread_local std::vector<thread_pool::task_id> task_stack;
 
 }  // namespace
 
-const void* thread_pool_impl::dequeue(task& t) {
+thread_pool::task_id thread_pool_impl::dequeue(task& t) {
   for (auto i = task_queue_.begin(); i != task_queue_.end(); ++i) {
     const task_id id = std::get<2>(*i);
     if (id != unique_task_id && std::find(task_stack.begin(), task_stack.end(), id) != task_stack.end()) {

--- a/base/thread_pool.cc
+++ b/base/thread_pool.cc
@@ -49,7 +49,7 @@ bool thread_pool_impl::dequeue(task& t, std::vector<thread_pool_impl::task_id>& 
 }
 
 void thread_pool_impl::wait_for(const thread_pool::predicate& condition, std::condition_variable& cv) {
-  thread_local std::vector<std::size_t> task_stack;
+  thread_local std::vector<task_id> task_stack;
 
   // We want to spin a few times before letting the OS take over.
   const int spin_count = 1000;

--- a/base/thread_pool.h
+++ b/base/thread_pool.h
@@ -16,6 +16,8 @@ namespace slinky {
 // It is not directly used by anything except for testing.
 class thread_pool {
 public:
+  using task_id = const void*;
+  static const task_id unique_task_id;
   using task = std::function<void()>;
   using predicate = std::function<bool()>;
 
@@ -23,10 +25,10 @@ public:
 
   // Enqueues `n` copies of task `t` on the thread pool queue. This guarantees that `t` will not
   // be run recursively on the same thread while in `wait_for`.
-  virtual void enqueue(int n, const task& t) = 0;
-  virtual void enqueue(task t) = 0;
+  virtual void enqueue(int n, task t, const task_id id = unique_task_id) = 0;
+  virtual void enqueue(task t, const task_id id = unique_task_id) = 0;
   // Run the task on the current thread, and prevents tasks enqueued by `enqueue` from running recursively.
-  virtual void run(const task& t) = 0;
+  virtual void run(const task& t, const task_id id = unique_task_id) = 0;
   // Waits for `condition` to become true. While waiting, executes tasks on the queue.
   // The condition is executed atomically.
   virtual void wait_for(const predicate& condition) = 0;
@@ -62,11 +64,11 @@ public:
     };
     int workers = std::min<int>(max_workers, std::min<std::size_t>(thread_count() + 1, n));
     if (workers > 1) {
-      enqueue(workers - 1, worker);
+      enqueue(workers - 1, worker, state.get());
     }
     // Running the worker here guarantees forward progress on the loop even if no threads in the thread pool are
     // available.
-    run(worker);
+    run(worker, state.get());
     // While the loop still isn't done, work on other tasks.
     wait_for([&]() { return state->done >= n; });
   }
@@ -76,8 +78,6 @@ public:
 // It is not directly used by anything except for testing.
 class thread_pool_impl : public thread_pool {
 private:
-  using task_id = const void*;
-
   std::vector<std::thread> workers_;
   std::atomic<bool> stop_;
 
@@ -104,9 +104,9 @@ public:
 
   int thread_count() const override { return workers_.size(); }
 
-  void enqueue(int n, const task& t) override;
-  void enqueue(task t) override;
-  void run(const task& t) override;
+  void enqueue(int n, task t, const task_id id) override;
+  void enqueue(task t, const task_id id) override;
+  void run(const task& t, const task_id id) override;
   void wait_for(const predicate& condition) override { wait_for(condition, cv_helper_); }
   void atomic_call(const task& t) override;
 };

--- a/base/thread_pool.h
+++ b/base/thread_pool.h
@@ -17,7 +17,7 @@ namespace slinky {
 class thread_pool {
 public:
   using task_id = const void*;
-  static const task_id unique_task_id;
+  static task_id unique_task_id;
   using task = std::function<void()>;
   using predicate = std::function<bool()>;
 
@@ -25,10 +25,10 @@ public:
 
   // Enqueues `n` copies of task `t` on the thread pool queue. This guarantees that `t` will not
   // be run recursively on the same thread while in `wait_for`.
-  virtual void enqueue(int n, task t, const task_id id = unique_task_id) = 0;
-  virtual void enqueue(task t, const task_id id = unique_task_id) = 0;
+  virtual void enqueue(int n, task t, task_id id = unique_task_id) = 0;
+  virtual void enqueue(task t, task_id id = unique_task_id) = 0;
   // Run the task on the current thread, and prevents tasks enqueued by `enqueue` from running recursively.
-  virtual void run(const task& t, const task_id id = unique_task_id) = 0;
+  virtual void run(const task& t, task_id id = unique_task_id) = 0;
   // Waits for `condition` to become true. While waiting, executes tasks on the queue.
   // The condition is executed atomically.
   virtual void wait_for(const predicate& condition) = 0;
@@ -104,9 +104,9 @@ public:
 
   int thread_count() const override { return workers_.size(); }
 
-  void enqueue(int n, task t, const task_id id) override;
-  void enqueue(task t, const task_id id) override;
-  void run(const task& t, const task_id id) override;
+  void enqueue(int n, task t, task_id id) override;
+  void enqueue(task t, task_id id) override;
+  void run(const task& t, task_id id) override;
   void wait_for(const predicate& condition) override { wait_for(condition, cv_helper_); }
   void atomic_call(const task& t) override;
 };


### PR DESCRIPTION
- Add some limited spinning before falling back to condition variable. This should avoid wasting much CPU, but also helps keep threads ready between tasks. Measurably improves a real workload.
- Clean up logic to avoid running the same task recursively on one thread.
- Add benchmark (not really that useful yet...)