### PR TITLE
Skip simplifying buffer_at arg if the dim is folded

### DIFF
--- a/builder/optimizations.cc
+++ b/builder/optimizations.cc
@@ -302,9 +302,10 @@ class buffer_aliaser : public node_mutator {
           // The fold factor of this allocation does not evenly divide the target fold factor.
           // TODO: We could increase the fold factor like we do the bounds.
           return false;
+        } else if (!prove_true((target_info.dims[alias.permutation[d]].bounds.min % target_fold_factor) == (op->dims[d].bounds.min % op->dims[d].fold_factor))) {
+          // The mins of folded buffers are not aligned.
+          return false;
         }
-        // It's surprising we don't need to check the mins are aligned here. I have tried very hard to write a test that
-        // fails without such a check, but I cannot.
       }
     }
     return true;
@@ -342,6 +343,7 @@ public:
       var alloc_var = target_var;
       std::optional<buffer_info>& target_info = buffers[target_var];
       assert(target_info);
+
       if (!alias_compatible(op, alias, target_var, *target_info)) {
         continue;
       }

--- a/builder/simplify.cc
+++ b/builder/simplify.cc
@@ -729,7 +729,10 @@ public:
           }
         } else if (op->intrinsic == intrinsic::buffer_at) {
           for (int d = 0; d < static_cast<int>(std::min(info->dims.size(), args.size() - 1)); ++d) {
-            if (prove_true(args[d + 1] == info->dims[d].bounds.min) && !info->dims[d].fold_factor.defined()) {
+            if (!info->dims[d].fold_factor.defined() && prove_true(args[d + 1] == info->dims[d].bounds.min)) {
+              // This argument is equal to the default value, and we know it is in bounds.
+              args[d + 1] = expr();
+            } else if (info->dims[d].fold_factor.defined() && prove_true(args[d + 1] == 0)) {
               // This argument is equal to the default value, and we know it is in bounds.
               args[d + 1] = expr();
             }

--- a/builder/simplify.cc
+++ b/builder/simplify.cc
@@ -729,7 +729,7 @@ public:
           }
         } else if (op->intrinsic == intrinsic::buffer_at) {
           for (int d = 0; d < static_cast<int>(std::min(info->dims.size(), args.size() - 1)); ++d) {
-            if (prove_true(args[d + 1] == info->dims[d].bounds.min)) {
+            if (prove_true(args[d + 1] == info->dims[d].bounds.min) && !info->dims[d].fold_factor.defined()) {
               // This argument is equal to the default value, and we know it is in bounds.
               args[d + 1] = expr();
             }

--- a/builder/test/copy_pipeline.cc
+++ b/builder/test/copy_pipeline.cc
@@ -483,10 +483,10 @@ TEST_P(broadcasted_elementwise, input) {
       ASSERT_EQ(out_buf(x, y), in1_buf(x, y) - in2_buf(i));
     }
   }
-
-  if (!no_alias_buffers) {
-    ASSERT_EQ(eval_ctx.heap.allocs.size(), 0);
-  }
+  // TODO(vksnk): doesn't fold because mins of the folded buffers are not aligned.
+  // if (!no_alias_buffers ) {
+  //   ASSERT_EQ(eval_ctx.heap.allocs.size(), 0);
+  // }
 }
 
 TEST_P(broadcasted_elementwise, internal) {

--- a/builder/test/pipeline.cc
+++ b/builder/test/pipeline.cc
@@ -1044,7 +1044,7 @@ TEST_P(padded_stencil_separable, pipeline) {
   ASSERT_EQ(stencil_xs, W * (H + 2));
   ASSERT_EQ(stencil_ys, W * H);
 
-  if (split_y > 0) {
+  if (split_y == 1) {
     const index_t intm_size = W * split_y * sizeof(short);
     const index_t padded_intm_t_size = (W + 2) * split_y * sizeof(short);
     const index_t stencil_intm_size = W * split_y * sizeof(short);
@@ -1059,7 +1059,7 @@ TEST_P(padded_stencil_separable, pipeline) {
       ASSERT_THAT(eval_ctx.heap.allocs,
           testing::UnorderedElementsAre(intm_size, padded_intm_t_size, stencil_intm_size, padded_intm_size));
     }
-  } else {
+  } else if (split_y == 0) {
     const index_t intm_size = W * H * sizeof(short);
     const index_t padded_intm_t_size = (W + 2) * (H + 2) * sizeof(short);
     const index_t stencil_intm_size = W * (H + 2) * sizeof(short);
@@ -1073,6 +1073,8 @@ TEST_P(padded_stencil_separable, pipeline) {
       ASSERT_THAT(eval_ctx.heap.allocs,
           testing::UnorderedElementsAre(intm_size, padded_intm_t_size, stencil_intm_size, padded_intm_size));
     }
+  } else if (split_y == 2) {
+    // TODO(vksnk): aliasing is not happening with split_y == 2, because of the misagligned mins of the folded buffers.
   }
 }
 


### PR DESCRIPTION
This simplification assumes that the base is aligned with the min, but it's not the case for folded dims.