### PR TITLE
Add iterators for buffer indices and `parallel_for` for iterators

### DIFF
--- a/base/test/thread_pool.cc
+++ b/base/test/thread_pool.cc
@@ -1,7 +1,8 @@
 #include <gtest/gtest.h>
 
 #include <cassert>
-#include <iostream>
+#include <numeric>
+#include <list>
 
 #include "base/thread_pool.h"
 
@@ -60,6 +61,38 @@ TEST(wait_for, barriers) {
   t.wait_for([&]() -> bool { return barrier2; });
 
   th.join();
+}
+
+TEST(parallel_for, sum_vector) {
+  thread_pool_impl t;
+  std::vector<int> values;
+  for (int n = 0; n < 100; ++n) {
+    std::atomic<int> count = 0;
+    std::atomic<int> sum = 0;
+    t.parallel_for(values.begin(), values.end(), [&](int i) {
+      count++;
+      sum += i;
+    });
+    ASSERT_EQ(count, n);
+    ASSERT_EQ(sum, sum_arithmetic_sequence(n));
+    values.push_back(n);
+  }
+}
+
+TEST(parallel_for, sum_list) {
+  thread_pool_impl t;
+  std::list<int> values;
+  for (int n = 0; n < 100; ++n) {
+    std::atomic<int> count = 0;
+    std::atomic<int> sum = 0;
+    t.parallel_for(values.begin(), values.end(), [&](int i) {
+      count++;
+      sum += i;
+    });
+    ASSERT_EQ(count, n);
+    ASSERT_EQ(sum, sum_arithmetic_sequence(n));
+    values.push_back(n);
+  }
 }
 
 }  // namespace slinky

--- a/runtime/buffer.cc
+++ b/runtime/buffer.cc
@@ -582,12 +582,12 @@ void make_for_each_loops(span<const raw_buffer*> bufs, void** bases, void* plan)
 
 }  // namespace internal
 
-internal::iterator_range<internal::index_iterator> index_range(const raw_buffer& buf) {
-  std::vector<index_t> min(buf.rank);
-  std::vector<index_t> max(buf.rank);
-  for (std::size_t d = 0; d < buf.rank; ++d) {
-    min[d] = buf.dim(d).min();
-    max[d] = buf.dim(d).max();
+internal::iterator_range<internal::index_iterator> index_range(const raw_buffer& buf, std::size_t min_dim) {
+  std::vector<index_t> min(buf.rank - min_dim);
+  std::vector<index_t> max(buf.rank - min_dim);
+  for (std::size_t d = min_dim; d < buf.rank; ++d) {
+    min[d - min_dim] = buf.dim(d).min();
+    max[d - min_dim] = buf.dim(d).max();
   }
   internal::index_iterator begin(min, min, max);
   std::vector<index_t> end_i = min;

--- a/runtime/buffer.cc
+++ b/runtime/buffer.cc
@@ -581,4 +581,19 @@ void make_for_each_loops(span<const raw_buffer*> bufs, void** bases, void* plan)
 }
 
 }  // namespace internal
+
+internal::iterator_range<internal::index_iterator> index_range(const raw_buffer& buf) {
+  std::vector<index_t> min(buf.rank);
+  std::vector<index_t> max(buf.rank);
+  for (std::size_t d = 0; d < buf.rank; ++d) {
+    min[d] = buf.dim(d).min();
+    max[d] = buf.dim(d).max();
+  }
+  internal::index_iterator begin(min, min, max);
+  std::vector<index_t> end_i = min;
+  end_i.back() = max.back() + 1;
+  internal::index_iterator end(std::move(end_i), std::move(min), std::move(max));
+  return {std::move(begin), std::move(end)};
+}
+
 }  // namespace slinky

--- a/runtime/buffer.h
+++ b/runtime/buffer.h
@@ -234,7 +234,6 @@ public:
   }
   bool contains() const { return true; }
 
-
   template <typename... Offsets>
   raw_buffer& translate(index_t o0, Offsets... offsets) {
     assert(sizeof...(offsets) + 1 <= rank);
@@ -309,6 +308,13 @@ public:
       }
     }
     return slice(d);
+  }
+  // Equivalent to `slice(d + i, at[i])` for i = at.size() - 1... 0
+  raw_buffer& slice(std::size_t d, span<const index_t> at) {
+    for (std::size_t i = at.size(); i > 0; --i) {
+      slice(d + i - 1, at[i - 1]);
+    }
+    return *this;
   }
 
   // Crop the buffer in dimension `d` to the bounds `[min, max]`. The bounds will be clamped to the existing bounds.
@@ -1034,6 +1040,7 @@ class index_iterator {
   std::vector<index_t> max;
 
 public:
+  index_iterator() {}
   index_iterator(std::vector<index_t> index, std::vector<index_t> min, std::vector<index_t> max)
       : index(std::move(index)), min(std::move(min)), max(std::move(max)) {}
 
@@ -1057,9 +1064,10 @@ public:
 
 }  // namespace internal
 
-// Return an iterator_range that iterators indices of a buffer. This is not an efficient way to iterate over buffers,
-// but may be useful in some circumstances, e.g. parallelism libraries based on iterators.
-internal::iterator_range<internal::index_iterator> index_range(const raw_buffer& buf);
+// Return an iterator_range that iterators indices of a buffer, starting at dimension `min_dim`. This is not an
+// efficient way to iterate over buffers, but may be useful in some circumstances, e.g. parallelism libraries based on
+// iterators.
+internal::iterator_range<internal::index_iterator> index_range(const raw_buffer& buf, std::size_t min_dim = 0);
 
 }  // namespace slinky
 

--- a/runtime/test/buffer_benchmark.cc
+++ b/runtime/test/buffer_benchmark.cc
@@ -158,6 +158,38 @@ void BM_copy_padded(benchmark::State& state) {
 BENCHMARK(BM_copy_padded)->Args({256, 4, -1});
 BENCHMARK(BM_copy_padded)->Args({64, 4, 4});
 
+void BM_copy_iterator(benchmark::State& state) {
+  std::vector<index_t> extents = state_to_vector(3, state);
+  buffer<char, 3> src;
+  buffer<char, 3> dst;
+  allocate_buffer(src, extents);
+  allocate_buffer(dst, extents);
+
+  for (auto _ : state) {
+    for (const auto& i : index_range(dst)) {
+      dst(i) = src(i);
+    }
+  }
+}
+
+BENCHMARK(BM_copy_iterator)->Args({256, 4, -1});
+BENCHMARK(BM_copy_iterator)->Args({64, 4, 4});
+
+void BM_fill_iterator(benchmark::State& state) {
+  std::vector<index_t> extents = state_to_vector(3, state);
+  buffer<char, 3> dst;
+  allocate_buffer(dst, extents);
+
+  for (auto _ : state) {
+    for (const auto& i : index_range(dst)) {
+      dst(i) = 0;
+    }
+  }
+}
+
+BENCHMARK(BM_fill_iterator)->Args({256, 4, -1});
+BENCHMARK(BM_fill_iterator)->Args({64, 4, 4});
+
 constexpr index_t slice_extent = 64;
 
 void memset_slice(index_t extent, void* base) { memset(base, 0, extent); }


### PR DESCRIPTION
This PR enables parallelizing over buffers:
- Adds `thread_pool::parallel_for(Iterator begin, Iterator end, body)`
- Adds `index_range(const raw_buffer&)` to get an object providing `begin` and `end` implementations that iterate over indices.

This also fixes a terrible bug where most of the fuzz tests for buffer actually ran with the same buffer repeatedly.