### PR TITLE
Add typed overloads of copy/fill/pad

### DIFF
--- a/builder/test/funcs.h
+++ b/builder/test/funcs.h
@@ -30,15 +30,14 @@ void init_random(buffer<T, N>& x) {
 // TODO: We should be able to just do this with raw_buffer and not make it a template.
 template <typename T>
 index_t copy_2d(const buffer<const T>& in, const buffer<T>& out) {
-  copy(in, out, nullptr);
+  copy(in, out);
   return 0;
 }
 
 template <typename T>
 index_t zero_padded_copy(const buffer<const T>& in, const buffer<T>& out) {
   assert(in.rank == out.rank);
-  T zero = 0;
-  slinky::copy(in, out, &zero);
+  slinky::copy(in, out, static_cast<T>(0));
   return 0;
 }
 

--- a/runtime/buffer.h
+++ b/runtime/buffer.h
@@ -537,21 +537,21 @@ const buffer<NewT>& raw_buffer::cast() const {
 // If `padding` is null, `src` must contain every index that `dst` contains.
 // If `padding` is non-null, `dst` is filled with the padding when it is out of bounds of `src`.
 void copy(const raw_buffer& src, const raw_buffer& dst, const void* padding = nullptr);
-template <typename T, typename = typename std::enable_if<!std::is_pointer<T>::value>::value>
+template <typename T, typename = typename std::enable_if<!std::is_pointer<T>::value>::type>
 void copy(const raw_buffer& src, const raw_buffer& dst, const T& padding) {
   copy(src, dst, &padding);
 }
 
 // Performs only the padding operation of a copy. The region that would have been copied is unmodified.
 void pad(const dim* in_bounds, const raw_buffer& dst, const void* padding);
-template <typename T, typename = typename std::enable_if<!std::is_pointer<T>::value>::value>
+template <typename T, typename = typename std::enable_if<!std::is_pointer<T>::value>::type>
 void pad(const dim* in_bounds, const raw_buffer& dst, const T& padding) {
   pad(in_bounds, dst, &padding);
 }
 
 // Fill `dst` with `value`. `value` should point to `dst.elem_size` bytes.
 void fill(const raw_buffer& dst, const void* value);
-template <typename T, typename = typename std::enable_if<!std::is_pointer<T>::value>::value>
+template <typename T, typename = typename std::enable_if<!std::is_pointer<T>::value>::type>
 void fill(const raw_buffer& dst, const T& padding) {
   fill(dst, &padding);
 }

--- a/runtime/buffer.h
+++ b/runtime/buffer.h
@@ -536,13 +536,24 @@ const buffer<NewT>& raw_buffer::cast() const {
 // If `padding` is null, `src` must contain every index that `dst` contains.
 // If `padding` is non-null, `dst` is filled with the padding when it is out of bounds of `src`.
 void copy(const raw_buffer& src, const raw_buffer& dst, const void* padding = nullptr);
+template <typename T, typename = typename std::enable_if<!std::is_pointer<T>::value>::value>
+void copy(const raw_buffer& src, const raw_buffer& dst, const T& padding) {
+  copy(src, dst, &padding);
+}
 
 // Performs only the padding operation of a copy. The region that would have been copied is unmodified.
 void pad(const dim* in_bounds, const raw_buffer& dst, const void* padding);
+template <typename T, typename = typename std::enable_if<!std::is_pointer<T>::value>::value>
+void pad(const dim* in_bounds, const raw_buffer& dst, const T& padding) {
+  pad(in_bounds, dst, &padding);
+}
 
 // Fill `dst` with `value`. `value` should point to `dst.elem_size` bytes.
 void fill(const raw_buffer& dst, const void* value);
-
+template <typename T, typename = typename std::enable_if<!std::is_pointer<T>::value>::value>
+void fill(const raw_buffer& dst, const T& padding) {
+  fill(dst, &padding);
+}
 // Returns true if the two dimensions can be fused.
 inline bool can_fuse(const dim& inner, const dim& outer) {
   if (outer.max() == outer.min() && outer.stride() != 0) return true;

--- a/runtime/evaluate.h
+++ b/runtime/evaluate.h
@@ -32,8 +32,10 @@ public:
   // Functions implementing buffer data movement:
   // - `copy` should copy from `src` to `dst`, filling `dst` with `padding` when out of bounds of `src`.
   // - `pad` should fill the area out of bounds of `src_dims` with `padding` in `dst`.
-  std::function<void(const raw_buffer& src, const raw_buffer& dst, const void* padding)> copy = slinky::copy;
-  std::function<void(const dim* in_bounds, const raw_buffer& dst, const void* padding)> pad = slinky::pad;
+  std::function<void(const raw_buffer& src, const raw_buffer& dst, const void* padding)> copy =
+      static_cast<void (*)(const raw_buffer&, const raw_buffer&, const void*)>(slinky::copy);
+  std::function<void(const dim* in_bounds, const raw_buffer& dst, const void* padding)> pad =
+      static_cast<void (*)(const dim*, const raw_buffer&, const void*)>(slinky::pad);
 
   // Functions called every time a stmt begins or ends evaluation.
   std::function<index_t(const char*)> trace_begin;


### PR DESCRIPTION
It's a minor annoyance to have to make a variable with the fill value to take the address of, this PR solves that.