### PR TITLE
Check if we actually cross a fold, rather than just if the dim is folded

### DIFF
--- a/runtime/buffer.cc
+++ b/runtime/buffer.cc
@@ -422,7 +422,8 @@ SLINKY_ALWAYS_INLINE inline bool can_fuse(const raw_buffer* const* bufs, std::si
 }
 
 SLINKY_ALWAYS_INLINE inline bool use_folded_loop(const raw_buffer* const* bufs, std::size_t size, int d) {
-  if (bufs[0]->dim(d).fold_factor() != dim::unfolded) {
+  const dim& buf_dim = bufs[0]->dim(d);
+  if (buf_dim.is_folded()) {
     // The main buffer is folded.
     return true;
   }
@@ -430,10 +431,10 @@ SLINKY_ALWAYS_INLINE inline bool use_folded_loop(const raw_buffer* const* bufs, 
     if (d >= static_cast<int>(bufs[i]->rank)) {
       // Broadcast dimension.
       continue;
-    } else if (bufs[i]->dim(d).fold_factor() != dim::unfolded) {
+    } else if (bufs[i]->dim(d).is_folded(buf_dim)) {
       // There's a folded buffer, we need a folded loop.
       return true;
-    } else if (!bufs[i]->dim(d).contains(bufs[0]->dim(d))) {
+    } else if (!bufs[i]->dim(d).contains(buf_dim)) {
       // One of the extra buffers is out of bounds, use a folded loop.
       return true;
     }

--- a/runtime/buffer.h
+++ b/runtime/buffer.h
@@ -126,6 +126,7 @@ public:
     if (fold_factor() == unfolded) return false;
     return euclidean_div(min, fold_factor()) != euclidean_div(max, fold_factor());
   }
+  bool is_folded(const dim& other) const { return is_folded(other.min(), other.max()); }
   bool is_folded() const { return is_folded(min(), max()); }
 };
 

--- a/runtime/test/buffer.cc
+++ b/runtime/test/buffer.cc
@@ -314,7 +314,7 @@ TEST(buffer, for_each_contiguous_slice) {
   buf.allocate();
   int slices = 0;
   for_each_contiguous_slice(buf, [&](index_t slice_extent, char* slice) {
-    memset(slice, 7, slice_extent);
+    std::fill_n(slice, slice_extent, 7);
     slices++;
   });
   ASSERT_EQ(slices, 1);
@@ -327,7 +327,7 @@ TEST(buffer, for_each_contiguous_slice_non_zero_min) {
   buf.translate(1, 2, 3);
   int slices = 0;
   for_each_contiguous_slice(buf, [&](index_t slice_extent, char* slice) {
-    memset(slice, 7, slice_extent);
+    std::fill_n(slice, slice_extent, 7);
     slices++;
   });
   ASSERT_EQ(slices, 1);
@@ -342,12 +342,21 @@ TEST(buffer, for_each_contiguous_folded) {
     buf.dim(1).set_min_extent(8, crop_extent);
     int slices = 0;
     for_each_contiguous_slice(buf, [&](index_t slice_extent, char* slice) {
-      memset(slice, 7, slice_extent);
+      std::fill_n(slice, slice_extent, 7);
       slices++;
     });
-    ASSERT_EQ(slices, crop_extent * 30);
+    ASSERT_EQ(slices, 30);
     ASSERT_TRUE(is_filled_buffer(buf, 7));
   }
+  // Also check an unaligned crop with the fold.
+  buf.dim(1).set_min_extent(6, 4);
+  int slices = 0;
+  for_each_contiguous_slice(buf, [&](index_t slice_extent, char* slice) {
+    std::fill_n(slice, slice_extent, 7);
+    slices++;
+  });
+  ASSERT_EQ(slices, 120);
+  ASSERT_TRUE(is_filled_buffer(buf, 7));
 }
 
 TEST(buffer, for_each_contiguous_slice_padded) {
@@ -355,7 +364,7 @@ TEST(buffer, for_each_contiguous_slice_padded) {
     buffer<char, 3> buf({10, 20, 30});
     buf.allocate();
     buf.dim(padded_dim).set_bounds(0, 8);
-    for_each_contiguous_slice(buf, [&](index_t slice_extent, char* slice) { memset(slice, 7, slice_extent); });
+    for_each_contiguous_slice(buf, [&](index_t slice_extent, char* slice) { std::fill_n(slice, slice_extent, 7); });
     ASSERT_TRUE(is_filled_buffer(buf, 7));
   }
 }

--- a/runtime/test/buffer.cc
+++ b/runtime/test/buffer.cc
@@ -548,15 +548,15 @@ TEST(buffer, for_each_contiguous_slice_multi_fuse_lots) {
       buf1,
       [&](index_t slice_extent, char* slice1, char* slice2, char* slice3, char* slice4, char* slice5, char* slice6,
           char* slice7, char* slice8, char* slice9) {
-        memset(slice1, 1, slice_extent);
-        memset(slice2, 2, slice_extent);
-        memset(slice3, 3, slice_extent);
-        memset(slice4, 4, slice_extent);
-        memset(slice5, 5, slice_extent);
-        memset(slice6, 6, slice_extent);
-        memset(slice7, 7, slice_extent);
-        memset(slice8, 8, slice_extent);
-        memset(slice9, 9, slice_extent);
+        std::fill_n(slice1, slice_extent, 1);
+        std::fill_n(slice2, slice_extent, 2);
+        std::fill_n(slice3, slice_extent, 3);
+        std::fill_n(slice4, slice_extent, 4);
+        std::fill_n(slice5, slice_extent, 5);
+        std::fill_n(slice6, slice_extent, 6);
+        std::fill_n(slice7, slice_extent, 7);
+        std::fill_n(slice8, slice_extent, 8);
+        std::fill_n(slice9, slice_extent, 9);
         slices++;
       },
       buf2, buf3, buf4, buf5, buf6, buf7, buf8, buf9);


### PR DESCRIPTION
This makes it so `for_each_contiguous_slice` and `for_each_element` will still use contiguous slices or linear loops for folded dimensions if the buffer doesn't cross a folded dimension.

We could do better still if we could just use n linear/contiguous chunks between the fold boundaries, but that's much harder to do.