### PR TITLE
Fix deshadow slowness

### DIFF
--- a/builder/substitute.cc
+++ b/builder/substitute.cc
@@ -578,7 +578,7 @@ public:
 
         expr result = mutate_buffer_intrinsic(op->intrinsic, *buf, span<const expr>(args).subspan(1));
         if (result.defined()) {
-          set_result(result);
+          set_result(std::move(result));
           return;
         }
       }
@@ -670,7 +670,7 @@ public:
       set_result(replacement);
       return;
     } else if (replacements) {
-      std::optional<expr> r = replacements->lookup(v->sym);
+      const std::optional<expr>& r = replacements->lookup(v->sym);
       if (r && !depends_on(*r, shadowed).any()) {
         set_result(*r);
         return;

--- a/builder/substitute.h
+++ b/builder/substitute.h
@@ -13,8 +13,6 @@ bool match(const dim_expr& a, const dim_expr& b);
 const call* match_call(const expr& x, intrinsic fn, var a);
 const call* match_call(const expr& x, intrinsic fn, var a, index_t b);
 
-expr substitute(const expr& e, const symbol_map<expr>& replacements);
-stmt substitute(const stmt& s, const symbol_map<expr>& replacements);
 expr substitute(const expr& e, var target, const expr& replacement);
 stmt substitute(const stmt& s, var target, const expr& replacement);
 interval_expr substitute(const interval_expr& x, var target, const expr& replacement);

--- a/builder/test/optimizations.cc
+++ b/builder/test/optimizations.cc
@@ -54,4 +54,13 @@ TEST(optimizations, optimize_symbols) {
   }
 }
 
+TEST(optimizations, deshadow_speed) { 
+  node_context ctx = symbols;
+  stmt s = call_stmt::make(nullptr, {x}, {y}, {});
+  for (int i = 0; i < 1000; ++i) {
+    s = crop_dim::make(y, y, 0, {0, 0}, s);
+  }
+  stmt s2 = deshadow(s, ctx);
+}
+
 }  // namespace slinky

--- a/runtime/expr.h
+++ b/runtime/expr.h
@@ -9,6 +9,7 @@
 #include <cstdint>
 #include <cstdlib>
 #include <initializer_list>
+#include <map>
 #include <memory>
 #include <optional>
 #include <string>
@@ -46,6 +47,7 @@ public:
 // uniquely maps strings to var.
 class node_context {
   std::vector<std::string> sym_to_name;
+  std::map<std::string, var> name_to_sym;
 
 public:
   // Get the name of a var.

--- a/runtime/expr_stmt.cc
+++ b/runtime/expr_stmt.cc
@@ -38,7 +38,7 @@ var node_context::insert(const std::string& name) {
 var node_context::insert_unique(const std::string& prefix) {
   std::string name = prefix;
   for (std::size_t i = 0; i < sym_to_name.size(); ++i) {
-    if (!lookup(name)) break;
+    if (name_to_sym.find(name) == name_to_sym.end()) break;
     name = prefix + "#" + std::to_string(i);
   }
   return insert(name);

--- a/runtime/expr_stmt.cc
+++ b/runtime/expr_stmt.cc
@@ -31,6 +31,7 @@ var node_context::insert(const std::string& name) {
   if (!sym) {
     sym = var(sym_to_name.size());
     sym_to_name.push_back(name);
+    name_to_sym[name] = *sym;
   }
   return *sym;
 }
@@ -43,13 +44,8 @@ var node_context::insert_unique(const std::string& prefix) {
   return insert(name);
 }
 std::optional<var> node_context::lookup(const std::string& name) const {
-  // TODO: At some point we might need a better data structure than doing this linear search.
-  for (std::size_t i = 0; i < sym_to_name.size(); ++i) {
-    if (sym_to_name[i] == name) {
-      return var(i);
-    }
-  }
-  return std::nullopt;
+  auto i = name_to_sym.find(name);
+  return i != name_to_sym.end() ? std::optional<var>(i->second) : std::nullopt;
 }
 
 template <typename T>


### PR DESCRIPTION
`deshadow` was very slow due to two algorithmic complexity issues:
- The way `substitute` handled shadowing was very inefficient: tracking all shadowed variables, and checking at substitute time if a substitution should be disallowed due to shadowing. Now, we stop traversing the IR as soon as any possible substitutions become shadowed, which also avoids the expensive way we tracked shadowed variables (linear search in a vector).
- `insert_unique` used a linear search to find an unused symbol name, and a linear search to check if a symbol name was used, both are fixed.

The test added in this PR took ~3 seconds before these fixes, and now takes 150ms, where almost all the time is spent in `insert_unique`. It could be improved further, but not easily, and it's not worth doing for now.