### PR TITLE
Assign unique loop vars during the IR construction

### DIFF
--- a/builder/pipeline.cc
+++ b/builder/pipeline.cc
@@ -680,7 +680,10 @@ class pipeline_builder {
       // And make the actual loop.
       expr loop_step = sanitizer_.mutate(loop.step);
       interval_expr loop_bounds = get_loop_bounds(base_f, loop);
-      body = loop::make(loop.sym(), loop.max_workers, loop_bounds, loop_step, body);
+      // Make sure that a loop variable is unique.
+      var loop_var = ctx.insert_unique(ctx.name(loop.sym()));
+      body = substitute(body, loop.sym(), loop_var);
+      body = loop::make(loop_var, loop.max_workers, loop_bounds, loop_step, body);
     }
 
     return body;

--- a/builder/pipeline.cc
+++ b/builder/pipeline.cc
@@ -681,7 +681,12 @@ class pipeline_builder {
       expr loop_step = sanitizer_.mutate(loop.step);
       interval_expr loop_bounds = get_loop_bounds(base_f, loop);
       // Make sure that a loop variable is unique.
-      var loop_var = ctx.insert_unique(ctx.name(loop.sym()));
+      std::string loop_var_name = "<";
+      if (!base_f->attrs().name.empty()) {
+        loop_var_name += (base_f->attrs().name + ".");
+      }
+      loop_var_name += ctx.name(loop.sym()) + ">";
+      var loop_var = ctx.insert_unique(loop_var_name);
       body = substitute(body, loop.sym(), loop_var);
       body = loop::make(loop_var, loop.max_workers, loop_bounds, loop_step, body);
     }

--- a/builder/pipeline.cc
+++ b/builder/pipeline.cc
@@ -681,11 +681,11 @@ class pipeline_builder {
       expr loop_step = sanitizer_.mutate(loop.step);
       interval_expr loop_bounds = get_loop_bounds(base_f, loop);
       // Make sure that a loop variable is unique.
-      std::string loop_var_name = "<";
-      if (!base_f->attrs().name.empty()) {
-        loop_var_name += (base_f->attrs().name + ".");
+      std::string loop_var_name;
+      if (base_f->outputs().size() == 1) {
+        loop_var_name = ctx.name(base_f->outputs()[0].sym()) + ".";
       }
-      loop_var_name += ctx.name(loop.sym()) + ">";
+      loop_var_name += ctx.name(loop.sym());
       var loop_var = ctx.insert_unique(loop_var_name);
       body = substitute(body, loop.sym(), loop_var);
       body = loop::make(loop_var, loop.max_workers, loop_bounds, loop_step, body);

--- a/builder/test/visualize/padded_stencil_2.html
+++ b/builder/test/visualize/padded_stencil_2.html
@@ -368,23 +368,23 @@ function pipeline(__in, out) {
         let __loop_min = (buffer_min(out, 1) + -2);
         let __loop_max = buffer_max(out, 1);
         let __loop_step = 1;
-        for(let y_0 = __loop_min; y_0 <= __loop_max; y_0 += __loop_step) {
-          { let __intm = crop_dim(intm, 1, [(y_0 + 1), (y_0 + 1)]); {
+        for(let <y> = __loop_min; <y> <= __loop_max; <y> += __loop_step) {
+          { let __intm = crop_dim(intm, 1, [(<y> + 1), (<y> + 1)]); {
             let intm = __intm;
             consume(__in);
             produce(intm);
             __event_t++;
           }}
-          { let __padded_intm = crop_dim(padded_intm, 1, [(y_0 + 1), (y_0 + 1)]); {
+          { let __padded_intm = crop_dim(padded_intm, 1, [(<y> + 1), (<y> + 1)]); {
             let padded_intm = __padded_intm;
             produce(intm);
             produce(padded_intm);
             __event_t++;
           }}
-          { let __out_y_0 = crop_dim(out, 1, [y_0, y_0]); {
-            let out_y_0 = __out_y_0;
+          { let __out_<y> = crop_dim(out, 1, [<y>, <y>]); {
+            let out_<y> = __out_<y>;
             consume(padded_intm);
-            produce(out_y_0);
+            produce(out_<y>);
             __event_t++;
           }}
         }

--- a/builder/test/visualize/padded_stencil_2.html
+++ b/builder/test/visualize/padded_stencil_2.html
@@ -368,23 +368,23 @@ function pipeline(__in, out) {
         let __loop_min = (buffer_min(out, 1) + -2);
         let __loop_max = buffer_max(out, 1);
         let __loop_step = 1;
-        for(let y = __loop_min; y <= __loop_max; y += __loop_step) {
-          { let __intm = crop_dim(intm, 1, [(y + 1), (y + 1)]); {
+        for(let y_0 = __loop_min; y_0 <= __loop_max; y_0 += __loop_step) {
+          { let __intm = crop_dim(intm, 1, [(y_0 + 1), (y_0 + 1)]); {
             let intm = __intm;
             consume(__in);
             produce(intm);
             __event_t++;
           }}
-          { let __padded_intm = crop_dim(padded_intm, 1, [(y + 1), (y + 1)]); {
+          { let __padded_intm = crop_dim(padded_intm, 1, [(y_0 + 1), (y_0 + 1)]); {
             let padded_intm = __padded_intm;
             produce(intm);
             produce(padded_intm);
             __event_t++;
           }}
-          { let __out_y = crop_dim(out, 1, [y, y]); {
-            let out_y = __out_y;
+          { let __out_y_0 = crop_dim(out, 1, [y_0, y_0]); {
+            let out_y_0 = __out_y_0;
             consume(padded_intm);
-            produce(out_y);
+            produce(out_y_0);
             __event_t++;
           }}
         }

--- a/builder/test/visualize/padded_stencil_2.html
+++ b/builder/test/visualize/padded_stencil_2.html
@@ -368,23 +368,23 @@ function pipeline(__in, out) {
         let __loop_min = (buffer_min(out, 1) + -2);
         let __loop_max = buffer_max(out, 1);
         let __loop_step = 1;
-        for(let <y> = __loop_min; <y> <= __loop_max; <y> += __loop_step) {
-          { let __intm = crop_dim(intm, 1, [(<y> + 1), (<y> + 1)]); {
+        for(let out_y = __loop_min; out_y <= __loop_max; out_y += __loop_step) {
+          { let __intm = crop_dim(intm, 1, [(out_y + 1), (out_y + 1)]); {
             let intm = __intm;
             consume(__in);
             produce(intm);
             __event_t++;
           }}
-          { let __padded_intm = crop_dim(padded_intm, 1, [(<y> + 1), (<y> + 1)]); {
+          { let __padded_intm = crop_dim(padded_intm, 1, [(out_y + 1), (out_y + 1)]); {
             let padded_intm = __padded_intm;
             produce(intm);
             produce(padded_intm);
             __event_t++;
           }}
-          { let __out_<y> = crop_dim(out, 1, [<y>, <y>]); {
-            let out_<y> = __out_<y>;
+          { let __out_out_y = crop_dim(out, 1, [out_y, out_y]); {
+            let out_out_y = __out_out_y;
             consume(padded_intm);
-            produce(out_<y>);
+            produce(out_out_y);
             __event_t++;
           }}
         }

--- a/builder/test/visualize/parallel_stencils_0.html
+++ b/builder/test/visualize/parallel_stencils_0.html
@@ -382,36 +382,36 @@ function pipeline(in1, in2, out) {
           let __loop_min = (buffer_min(out, 1) + -6);
           let __loop_max = buffer_max(out, 1);
           let __loop_step = 1;
-          for(let y_0 = __loop_min; y_0 <= __loop_max; y_0 += __loop_step) {
-            { let __intm1 = crop_dim(intm1, 1, [(y_0 + 1), (y_0 + 1)]); {
+          for(let <subtract_y> = __loop_min; <subtract_y> <= __loop_max; <subtract_y> += __loop_step) {
+            { let __intm1 = crop_dim(intm1, 1, [(<subtract_y> + 1), (<subtract_y> + 1)]); {
               let intm1 = __intm1;
               consume(in1);
               produce(intm1);
               __event_t++;
             }}
-            { let __intm3 = crop_dim(intm3, 1, [y_0, y_0]); {
+            { let __intm3 = crop_dim(intm3, 1, [<subtract_y>, <subtract_y>]); {
               let intm3 = __intm3;
               consume(intm1);
               produce(intm3);
               __event_t++;
             }}
-            { let __intm2 = crop_dim(intm2, 1, [(y_0 + 2), (y_0 + 2)]); {
+            { let __intm2 = crop_dim(intm2, 1, [(<subtract_y> + 2), (<subtract_y> + 2)]); {
               let intm2 = __intm2;
               consume(in2);
               produce(intm2);
               __event_t++;
             }}
-            { let __intm4 = crop_dim(intm4, 1, [y_0, y_0]); {
+            { let __intm4 = crop_dim(intm4, 1, [<subtract_y>, <subtract_y>]); {
               let intm4 = __intm4;
               consume(intm2);
               produce(intm4);
               __event_t++;
             }}
-            { let __out_y_0 = crop_dim(out, 1, [y_0, y_0]); {
-              let out_y_0 = __out_y_0;
+            { let __out_<subtract_y> = crop_dim(out, 1, [<subtract_y>, <subtract_y>]); {
+              let out_<subtract_y> = __out_<subtract_y>;
               consume(intm3);
               consume(intm4);
-              produce(out_y_0);
+              produce(out_<subtract_y>);
               __event_t++;
             }}
           }

--- a/builder/test/visualize/parallel_stencils_0.html
+++ b/builder/test/visualize/parallel_stencils_0.html
@@ -382,36 +382,36 @@ function pipeline(in1, in2, out) {
           let __loop_min = (buffer_min(out, 1) + -6);
           let __loop_max = buffer_max(out, 1);
           let __loop_step = 1;
-          for(let <subtract_y> = __loop_min; <subtract_y> <= __loop_max; <subtract_y> += __loop_step) {
-            { let __intm1 = crop_dim(intm1, 1, [(<subtract_y> + 1), (<subtract_y> + 1)]); {
+          for(let out_y = __loop_min; out_y <= __loop_max; out_y += __loop_step) {
+            { let __intm1 = crop_dim(intm1, 1, [(out_y + 1), (out_y + 1)]); {
               let intm1 = __intm1;
               consume(in1);
               produce(intm1);
               __event_t++;
             }}
-            { let __intm3 = crop_dim(intm3, 1, [<subtract_y>, <subtract_y>]); {
+            { let __intm3 = crop_dim(intm3, 1, [out_y, out_y]); {
               let intm3 = __intm3;
               consume(intm1);
               produce(intm3);
               __event_t++;
             }}
-            { let __intm2 = crop_dim(intm2, 1, [(<subtract_y> + 2), (<subtract_y> + 2)]); {
+            { let __intm2 = crop_dim(intm2, 1, [(out_y + 2), (out_y + 2)]); {
               let intm2 = __intm2;
               consume(in2);
               produce(intm2);
               __event_t++;
             }}
-            { let __intm4 = crop_dim(intm4, 1, [<subtract_y>, <subtract_y>]); {
+            { let __intm4 = crop_dim(intm4, 1, [out_y, out_y]); {
               let intm4 = __intm4;
               consume(intm2);
               produce(intm4);
               __event_t++;
             }}
-            { let __out_<subtract_y> = crop_dim(out, 1, [<subtract_y>, <subtract_y>]); {
-              let out_<subtract_y> = __out_<subtract_y>;
+            { let __out_out_y = crop_dim(out, 1, [out_y, out_y]); {
+              let out_out_y = __out_out_y;
               consume(intm3);
               consume(intm4);
-              produce(out_<subtract_y>);
+              produce(out_out_y);
               __event_t++;
             }}
           }

--- a/builder/test/visualize/parallel_stencils_0.html
+++ b/builder/test/visualize/parallel_stencils_0.html
@@ -382,36 +382,36 @@ function pipeline(in1, in2, out) {
           let __loop_min = (buffer_min(out, 1) + -6);
           let __loop_max = buffer_max(out, 1);
           let __loop_step = 1;
-          for(let y = __loop_min; y <= __loop_max; y += __loop_step) {
-            { let __intm1 = crop_dim(intm1, 1, [(y + 1), (y + 1)]); {
+          for(let y_0 = __loop_min; y_0 <= __loop_max; y_0 += __loop_step) {
+            { let __intm1 = crop_dim(intm1, 1, [(y_0 + 1), (y_0 + 1)]); {
               let intm1 = __intm1;
               consume(in1);
               produce(intm1);
               __event_t++;
             }}
-            { let __intm3 = crop_dim(intm3, 1, [y, y]); {
+            { let __intm3 = crop_dim(intm3, 1, [y_0, y_0]); {
               let intm3 = __intm3;
               consume(intm1);
               produce(intm3);
               __event_t++;
             }}
-            { let __intm2 = crop_dim(intm2, 1, [(y + 2), (y + 2)]); {
+            { let __intm2 = crop_dim(intm2, 1, [(y_0 + 2), (y_0 + 2)]); {
               let intm2 = __intm2;
               consume(in2);
               produce(intm2);
               __event_t++;
             }}
-            { let __intm4 = crop_dim(intm4, 1, [y, y]); {
+            { let __intm4 = crop_dim(intm4, 1, [y_0, y_0]); {
               let intm4 = __intm4;
               consume(intm2);
               produce(intm4);
               __event_t++;
             }}
-            { let __out_y = crop_dim(out, 1, [y, y]); {
-              let out_y = __out_y;
+            { let __out_y_0 = crop_dim(out, 1, [y_0, y_0]); {
+              let out_y_0 = __out_y_0;
               consume(intm3);
               consume(intm4);
-              produce(out_y);
+              produce(out_y_0);
               __event_t++;
             }}
           }

--- a/builder/test/visualize/parallel_stencils_1.html
+++ b/builder/test/visualize/parallel_stencils_1.html
@@ -385,30 +385,30 @@ function pipeline(in1, in2, out) {
           let __loop_min = (buffer_min(out, 1) + -4);
           let __loop_max = buffer_max(out, 1);
           let __loop_step = 2;
-          for(let y = __loop_min; y <= __loop_max; y += __loop_step) {
-            { let __intm3 = crop_dim(intm3, 1, [y, (y + 1)]); {
+          for(let y_2 = __loop_min; y_2 <= __loop_max; y_2 += __loop_step) {
+            { let __intm3 = crop_dim(intm3, 1, [y_2, (y_2 + 1)]); {
               let intm3 = __intm3;
               consume(intm1);
               produce(intm3);
               __event_t++;
             }}
-            { let __intm2 = crop_dim(intm2, 1, [(y + 2), (y + 3)]); {
+            { let __intm2 = crop_dim(intm2, 1, [(y_2 + 2), (y_2 + 3)]); {
               let intm2 = __intm2;
               consume(in2);
               produce(intm2);
               __event_t++;
             }}
-            { let __intm4 = crop_dim(intm4, 1, [y, (y + 1)]); {
+            { let __intm4 = crop_dim(intm4, 1, [y_2, (y_2 + 1)]); {
               let intm4 = __intm4;
               consume(intm2);
               produce(intm4);
               __event_t++;
             }}
-            { let __out_y = crop_dim(out, 1, [y, (y + 1)]); {
-              let out_y = __out_y;
+            { let __out_y_2 = crop_dim(out, 1, [y_2, (y_2 + 1)]); {
+              let out_y_2 = __out_y_2;
               consume(intm3);
               consume(intm4);
-              produce(out_y);
+              produce(out_y_2);
               __event_t++;
             }}
           }

--- a/builder/test/visualize/parallel_stencils_1.html
+++ b/builder/test/visualize/parallel_stencils_1.html
@@ -385,30 +385,30 @@ function pipeline(in1, in2, out) {
           let __loop_min = (buffer_min(out, 1) + -4);
           let __loop_max = buffer_max(out, 1);
           let __loop_step = 2;
-          for(let <subtract_y> = __loop_min; <subtract_y> <= __loop_max; <subtract_y> += __loop_step) {
-            { let __intm3 = crop_dim(intm3, 1, [<subtract_y>, (<subtract_y> + 1)]); {
+          for(let out_y = __loop_min; out_y <= __loop_max; out_y += __loop_step) {
+            { let __intm3 = crop_dim(intm3, 1, [out_y, (out_y + 1)]); {
               let intm3 = __intm3;
               consume(intm1);
               produce(intm3);
               __event_t++;
             }}
-            { let __intm2 = crop_dim(intm2, 1, [(<subtract_y> + 2), (<subtract_y> + 3)]); {
+            { let __intm2 = crop_dim(intm2, 1, [(out_y + 2), (out_y + 3)]); {
               let intm2 = __intm2;
               consume(in2);
               produce(intm2);
               __event_t++;
             }}
-            { let __intm4 = crop_dim(intm4, 1, [<subtract_y>, (<subtract_y> + 1)]); {
+            { let __intm4 = crop_dim(intm4, 1, [out_y, (out_y + 1)]); {
               let intm4 = __intm4;
               consume(intm2);
               produce(intm4);
               __event_t++;
             }}
-            { let __out_<subtract_y> = crop_dim(out, 1, [<subtract_y>, (<subtract_y> + 1)]); {
-              let out_<subtract_y> = __out_<subtract_y>;
+            { let __out_out_y = crop_dim(out, 1, [out_y, (out_y + 1)]); {
+              let out_out_y = __out_out_y;
               consume(intm3);
               consume(intm4);
-              produce(out_<subtract_y>);
+              produce(out_out_y);
               __event_t++;
             }}
           }

--- a/builder/test/visualize/parallel_stencils_1.html
+++ b/builder/test/visualize/parallel_stencils_1.html
@@ -385,30 +385,30 @@ function pipeline(in1, in2, out) {
           let __loop_min = (buffer_min(out, 1) + -4);
           let __loop_max = buffer_max(out, 1);
           let __loop_step = 2;
-          for(let y_2 = __loop_min; y_2 <= __loop_max; y_2 += __loop_step) {
-            { let __intm3 = crop_dim(intm3, 1, [y_2, (y_2 + 1)]); {
+          for(let <subtract_y> = __loop_min; <subtract_y> <= __loop_max; <subtract_y> += __loop_step) {
+            { let __intm3 = crop_dim(intm3, 1, [<subtract_y>, (<subtract_y> + 1)]); {
               let intm3 = __intm3;
               consume(intm1);
               produce(intm3);
               __event_t++;
             }}
-            { let __intm2 = crop_dim(intm2, 1, [(y_2 + 2), (y_2 + 3)]); {
+            { let __intm2 = crop_dim(intm2, 1, [(<subtract_y> + 2), (<subtract_y> + 3)]); {
               let intm2 = __intm2;
               consume(in2);
               produce(intm2);
               __event_t++;
             }}
-            { let __intm4 = crop_dim(intm4, 1, [y_2, (y_2 + 1)]); {
+            { let __intm4 = crop_dim(intm4, 1, [<subtract_y>, (<subtract_y> + 1)]); {
               let intm4 = __intm4;
               consume(intm2);
               produce(intm4);
               __event_t++;
             }}
-            { let __out_y_2 = crop_dim(out, 1, [y_2, (y_2 + 1)]); {
-              let out_y_2 = __out_y_2;
+            { let __out_<subtract_y> = crop_dim(out, 1, [<subtract_y>, (<subtract_y> + 1)]); {
+              let out_<subtract_y> = __out_<subtract_y>;
               consume(intm3);
               consume(intm4);
-              produce(out_y_2);
+              produce(out_<subtract_y>);
               __event_t++;
             }}
           }

--- a/builder/test/visualize/parallel_stencils_2.html
+++ b/builder/test/visualize/parallel_stencils_2.html
@@ -382,36 +382,36 @@ function pipeline(in1, in2, out) {
           let __loop_min = (buffer_min(out, 1) + -6);
           let __loop_max = buffer_max(out, 1);
           let __loop_step = 2;
-          for(let <subtract_y> = __loop_min; <subtract_y> <= __loop_max; <subtract_y> += __loop_step) {
-            { let __intm1 = crop_dim(intm1, 1, [(<subtract_y> + 1), (<subtract_y> + 2)]); {
+          for(let out_y = __loop_min; out_y <= __loop_max; out_y += __loop_step) {
+            { let __intm1 = crop_dim(intm1, 1, [(out_y + 1), (out_y + 2)]); {
               let intm1 = __intm1;
               consume(in1);
               produce(intm1);
               __event_t++;
             }}
-            { let __intm3 = crop_dim(intm3, 1, [<subtract_y>, (<subtract_y> + 1)]); {
+            { let __intm3 = crop_dim(intm3, 1, [out_y, (out_y + 1)]); {
               let intm3 = __intm3;
               consume(intm1);
               produce(intm3);
               __event_t++;
             }}
-            { let __intm2 = crop_dim(intm2, 1, [(<subtract_y> + 2), (<subtract_y> + 3)]); {
+            { let __intm2 = crop_dim(intm2, 1, [(out_y + 2), (out_y + 3)]); {
               let intm2 = __intm2;
               consume(in2);
               produce(intm2);
               __event_t++;
             }}
-            { let __intm4 = crop_dim(intm4, 1, [<subtract_y>, (<subtract_y> + 1)]); {
+            { let __intm4 = crop_dim(intm4, 1, [out_y, (out_y + 1)]); {
               let intm4 = __intm4;
               consume(intm2);
               produce(intm4);
               __event_t++;
             }}
-            { let __out_<subtract_y> = crop_dim(out, 1, [<subtract_y>, (<subtract_y> + 1)]); {
-              let out_<subtract_y> = __out_<subtract_y>;
+            { let __out_out_y = crop_dim(out, 1, [out_y, (out_y + 1)]); {
+              let out_out_y = __out_out_y;
               consume(intm3);
               consume(intm4);
-              produce(out_<subtract_y>);
+              produce(out_out_y);
               __event_t++;
             }}
           }

--- a/builder/test/visualize/parallel_stencils_2.html
+++ b/builder/test/visualize/parallel_stencils_2.html
@@ -382,36 +382,36 @@ function pipeline(in1, in2, out) {
           let __loop_min = (buffer_min(out, 1) + -6);
           let __loop_max = buffer_max(out, 1);
           let __loop_step = 2;
-          for(let y_2 = __loop_min; y_2 <= __loop_max; y_2 += __loop_step) {
-            { let __intm1 = crop_dim(intm1, 1, [(y_2 + 1), (y_2 + 2)]); {
+          for(let <subtract_y> = __loop_min; <subtract_y> <= __loop_max; <subtract_y> += __loop_step) {
+            { let __intm1 = crop_dim(intm1, 1, [(<subtract_y> + 1), (<subtract_y> + 2)]); {
               let intm1 = __intm1;
               consume(in1);
               produce(intm1);
               __event_t++;
             }}
-            { let __intm3 = crop_dim(intm3, 1, [y_2, (y_2 + 1)]); {
+            { let __intm3 = crop_dim(intm3, 1, [<subtract_y>, (<subtract_y> + 1)]); {
               let intm3 = __intm3;
               consume(intm1);
               produce(intm3);
               __event_t++;
             }}
-            { let __intm2 = crop_dim(intm2, 1, [(y_2 + 2), (y_2 + 3)]); {
+            { let __intm2 = crop_dim(intm2, 1, [(<subtract_y> + 2), (<subtract_y> + 3)]); {
               let intm2 = __intm2;
               consume(in2);
               produce(intm2);
               __event_t++;
             }}
-            { let __intm4 = crop_dim(intm4, 1, [y_2, (y_2 + 1)]); {
+            { let __intm4 = crop_dim(intm4, 1, [<subtract_y>, (<subtract_y> + 1)]); {
               let intm4 = __intm4;
               consume(intm2);
               produce(intm4);
               __event_t++;
             }}
-            { let __out_y_2 = crop_dim(out, 1, [y_2, (y_2 + 1)]); {
-              let out_y_2 = __out_y_2;
+            { let __out_<subtract_y> = crop_dim(out, 1, [<subtract_y>, (<subtract_y> + 1)]); {
+              let out_<subtract_y> = __out_<subtract_y>;
               consume(intm3);
               consume(intm4);
-              produce(out_y_2);
+              produce(out_<subtract_y>);
               __event_t++;
             }}
           }

--- a/builder/test/visualize/parallel_stencils_2.html
+++ b/builder/test/visualize/parallel_stencils_2.html
@@ -382,36 +382,36 @@ function pipeline(in1, in2, out) {
           let __loop_min = (buffer_min(out, 1) + -6);
           let __loop_max = buffer_max(out, 1);
           let __loop_step = 2;
-          for(let y = __loop_min; y <= __loop_max; y += __loop_step) {
-            { let __intm1 = crop_dim(intm1, 1, [(y + 1), (y + 2)]); {
+          for(let y_2 = __loop_min; y_2 <= __loop_max; y_2 += __loop_step) {
+            { let __intm1 = crop_dim(intm1, 1, [(y_2 + 1), (y_2 + 2)]); {
               let intm1 = __intm1;
               consume(in1);
               produce(intm1);
               __event_t++;
             }}
-            { let __intm3 = crop_dim(intm3, 1, [y, (y + 1)]); {
+            { let __intm3 = crop_dim(intm3, 1, [y_2, (y_2 + 1)]); {
               let intm3 = __intm3;
               consume(intm1);
               produce(intm3);
               __event_t++;
             }}
-            { let __intm2 = crop_dim(intm2, 1, [(y + 2), (y + 3)]); {
+            { let __intm2 = crop_dim(intm2, 1, [(y_2 + 2), (y_2 + 3)]); {
               let intm2 = __intm2;
               consume(in2);
               produce(intm2);
               __event_t++;
             }}
-            { let __intm4 = crop_dim(intm4, 1, [y, (y + 1)]); {
+            { let __intm4 = crop_dim(intm4, 1, [y_2, (y_2 + 1)]); {
               let intm4 = __intm4;
               consume(intm2);
               produce(intm4);
               __event_t++;
             }}
-            { let __out_y = crop_dim(out, 1, [y, (y + 1)]); {
-              let out_y = __out_y;
+            { let __out_y_2 = crop_dim(out, 1, [y_2, (y_2 + 1)]); {
+              let out_y_2 = __out_y_2;
               consume(intm3);
               consume(intm4);
-              produce(out_y);
+              produce(out_y_2);
               __event_t++;
             }}
           }

--- a/builder/test/visualize/softmax_split_1.html
+++ b/builder/test/visualize/softmax_split_1.html
@@ -380,22 +380,22 @@ function pipeline(__in, out) {
               let __loop_min = buffer_min(out, 1);
               let __loop_max = buffer_max(out, 1);
               let __loop_step = 1;
-              for(let <consumer_b> = __loop_min; <consumer_b> <= __loop_max; <consumer_b> += __loop_step) {
-                { let __softmax_in = crop_dim(softmax_in, 1, [<consumer_b>, <consumer_b>]); {
+              for(let out_b = __loop_min; out_b <= __loop_max; out_b += __loop_step) {
+                { let __softmax_in = crop_dim(softmax_in, 1, [out_b, out_b]); {
                   let softmax_in = __softmax_in;
                   consume(__in);
                   produce(softmax_in);
                   __event_t++;
                 }}
-                { let __max_in = crop_dim(max_in, 0, [<consumer_b>, <consumer_b>]); {
+                { let __max_in = crop_dim(max_in, 0, [out_b, out_b]); {
                   let max_in = __max_in;
                   consume(softmax_in);
                   produce(max_in);
                   __event_t++;
                 }}
-                { let __sum_exp_in = crop_dim(sum_exp_in, 0, [<consumer_b>, <consumer_b>]); {
+                { let __sum_exp_in = crop_dim(sum_exp_in, 0, [out_b, out_b]); {
                   let sum_exp_in = __sum_exp_in;
-                  { let __exp_in = crop_dim(exp_in, 1, [<consumer_b>, <consumer_b>]); {
+                  { let __exp_in = crop_dim(exp_in, 1, [out_b, out_b]); {
                     let exp_in = __exp_in;
                     consume(__in);
                     consume(max_in);
@@ -404,17 +404,17 @@ function pipeline(__in, out) {
                     __event_t++;
                   }}
                 }}
-                { let __softmax_out = crop_dim(softmax_out, 1, [<consumer_b>, <consumer_b>]); {
+                { let __softmax_out = crop_dim(softmax_out, 1, [out_b, out_b]); {
                   let softmax_out = __softmax_out;
                   consume(exp_in);
                   consume(sum_exp_in);
                   produce(softmax_out);
                   __event_t++;
                 }}
-                { let __out_<consumer_b> = crop_dim(out, 1, [<consumer_b>, <consumer_b>]); {
-                  let out_<consumer_b> = __out_<consumer_b>;
+                { let __out_out_b = crop_dim(out, 1, [out_b, out_b]); {
+                  let out_out_b = __out_out_b;
                   consume(softmax_out);
-                  produce(out_<consumer_b>);
+                  produce(out_out_b);
                   __event_t++;
                 }}
               }

--- a/builder/test/visualize/softmax_split_1.html
+++ b/builder/test/visualize/softmax_split_1.html
@@ -380,22 +380,22 @@ function pipeline(__in, out) {
               let __loop_min = buffer_min(out, 1);
               let __loop_max = buffer_max(out, 1);
               let __loop_step = 1;
-              for(let b = __loop_min; b <= __loop_max; b += __loop_step) {
-                { let __softmax_in = crop_dim(softmax_in, 1, [b, b]); {
+              for(let b_1 = __loop_min; b_1 <= __loop_max; b_1 += __loop_step) {
+                { let __softmax_in = crop_dim(softmax_in, 1, [b_1, b_1]); {
                   let softmax_in = __softmax_in;
                   consume(__in);
                   produce(softmax_in);
                   __event_t++;
                 }}
-                { let __max_in = crop_dim(max_in, 0, [b, b]); {
+                { let __max_in = crop_dim(max_in, 0, [b_1, b_1]); {
                   let max_in = __max_in;
                   consume(softmax_in);
                   produce(max_in);
                   __event_t++;
                 }}
-                { let __sum_exp_in = crop_dim(sum_exp_in, 0, [b, b]); {
+                { let __sum_exp_in = crop_dim(sum_exp_in, 0, [b_1, b_1]); {
                   let sum_exp_in = __sum_exp_in;
-                  { let __exp_in = crop_dim(exp_in, 1, [b, b]); {
+                  { let __exp_in = crop_dim(exp_in, 1, [b_1, b_1]); {
                     let exp_in = __exp_in;
                     consume(__in);
                     consume(max_in);
@@ -404,17 +404,17 @@ function pipeline(__in, out) {
                     __event_t++;
                   }}
                 }}
-                { let __softmax_out = crop_dim(softmax_out, 1, [b, b]); {
+                { let __softmax_out = crop_dim(softmax_out, 1, [b_1, b_1]); {
                   let softmax_out = __softmax_out;
                   consume(exp_in);
                   consume(sum_exp_in);
                   produce(softmax_out);
                   __event_t++;
                 }}
-                { let __out_b = crop_dim(out, 1, [b, b]); {
-                  let out_b = __out_b;
+                { let __out_b_1 = crop_dim(out, 1, [b_1, b_1]); {
+                  let out_b_1 = __out_b_1;
                   consume(softmax_out);
-                  produce(out_b);
+                  produce(out_b_1);
                   __event_t++;
                 }}
               }

--- a/builder/test/visualize/softmax_split_1.html
+++ b/builder/test/visualize/softmax_split_1.html
@@ -380,22 +380,22 @@ function pipeline(__in, out) {
               let __loop_min = buffer_min(out, 1);
               let __loop_max = buffer_max(out, 1);
               let __loop_step = 1;
-              for(let b_1 = __loop_min; b_1 <= __loop_max; b_1 += __loop_step) {
-                { let __softmax_in = crop_dim(softmax_in, 1, [b_1, b_1]); {
+              for(let <consumer_b> = __loop_min; <consumer_b> <= __loop_max; <consumer_b> += __loop_step) {
+                { let __softmax_in = crop_dim(softmax_in, 1, [<consumer_b>, <consumer_b>]); {
                   let softmax_in = __softmax_in;
                   consume(__in);
                   produce(softmax_in);
                   __event_t++;
                 }}
-                { let __max_in = crop_dim(max_in, 0, [b_1, b_1]); {
+                { let __max_in = crop_dim(max_in, 0, [<consumer_b>, <consumer_b>]); {
                   let max_in = __max_in;
                   consume(softmax_in);
                   produce(max_in);
                   __event_t++;
                 }}
-                { let __sum_exp_in = crop_dim(sum_exp_in, 0, [b_1, b_1]); {
+                { let __sum_exp_in = crop_dim(sum_exp_in, 0, [<consumer_b>, <consumer_b>]); {
                   let sum_exp_in = __sum_exp_in;
-                  { let __exp_in = crop_dim(exp_in, 1, [b_1, b_1]); {
+                  { let __exp_in = crop_dim(exp_in, 1, [<consumer_b>, <consumer_b>]); {
                     let exp_in = __exp_in;
                     consume(__in);
                     consume(max_in);
@@ -404,17 +404,17 @@ function pipeline(__in, out) {
                     __event_t++;
                   }}
                 }}
-                { let __softmax_out = crop_dim(softmax_out, 1, [b_1, b_1]); {
+                { let __softmax_out = crop_dim(softmax_out, 1, [<consumer_b>, <consumer_b>]); {
                   let softmax_out = __softmax_out;
                   consume(exp_in);
                   consume(sum_exp_in);
                   produce(softmax_out);
                   __event_t++;
                 }}
-                { let __out_b_1 = crop_dim(out, 1, [b_1, b_1]); {
-                  let out_b_1 = __out_b_1;
+                { let __out_<consumer_b> = crop_dim(out, 1, [<consumer_b>, <consumer_b>]); {
+                  let out_<consumer_b> = __out_<consumer_b>;
                   consume(softmax_out);
-                  produce(out_b_1);
+                  produce(out_<consumer_b>);
                   __event_t++;
                 }}
               }

--- a/builder/test/visualize/softmax_split_4.html
+++ b/builder/test/visualize/softmax_split_4.html
@@ -380,22 +380,22 @@ function pipeline(__in, out) {
               let __loop_min = buffer_min(out, 1);
               let __loop_max = buffer_max(out, 1);
               let __loop_step = 4;
-              for(let b = __loop_min; b <= __loop_max; b += __loop_step) {
-                { let __softmax_in = crop_dim(softmax_in, 1, [b, (b + 3)]); {
+              for(let b_1 = __loop_min; b_1 <= __loop_max; b_1 += __loop_step) {
+                { let __softmax_in = crop_dim(softmax_in, 1, [b_1, (b_1 + 3)]); {
                   let softmax_in = __softmax_in;
                   consume(__in);
                   produce(softmax_in);
                   __event_t++;
                 }}
-                { let __max_in = crop_dim(max_in, 0, [b, (b + 3)]); {
+                { let __max_in = crop_dim(max_in, 0, [b_1, (b_1 + 3)]); {
                   let max_in = __max_in;
                   consume(softmax_in);
                   produce(max_in);
                   __event_t++;
                 }}
-                { let __sum_exp_in = crop_dim(sum_exp_in, 0, [b, (b + 3)]); {
+                { let __sum_exp_in = crop_dim(sum_exp_in, 0, [b_1, (b_1 + 3)]); {
                   let sum_exp_in = __sum_exp_in;
-                  { let __exp_in = crop_dim(exp_in, 1, [b, (b + 3)]); {
+                  { let __exp_in = crop_dim(exp_in, 1, [b_1, (b_1 + 3)]); {
                     let exp_in = __exp_in;
                     consume(__in);
                     consume(max_in);
@@ -404,17 +404,17 @@ function pipeline(__in, out) {
                     __event_t++;
                   }}
                 }}
-                { let __softmax_out = crop_dim(softmax_out, 1, [b, (b + 3)]); {
+                { let __softmax_out = crop_dim(softmax_out, 1, [b_1, (b_1 + 3)]); {
                   let softmax_out = __softmax_out;
                   consume(exp_in);
                   consume(sum_exp_in);
                   produce(softmax_out);
                   __event_t++;
                 }}
-                { let __out_b = crop_dim(out, 1, [b, (b + 3)]); {
-                  let out_b = __out_b;
+                { let __out_b_1 = crop_dim(out, 1, [b_1, (b_1 + 3)]); {
+                  let out_b_1 = __out_b_1;
                   consume(softmax_out);
-                  produce(out_b);
+                  produce(out_b_1);
                   __event_t++;
                 }}
               }

--- a/builder/test/visualize/softmax_split_4.html
+++ b/builder/test/visualize/softmax_split_4.html
@@ -380,22 +380,22 @@ function pipeline(__in, out) {
               let __loop_min = buffer_min(out, 1);
               let __loop_max = buffer_max(out, 1);
               let __loop_step = 4;
-              for(let <consumer_b> = __loop_min; <consumer_b> <= __loop_max; <consumer_b> += __loop_step) {
-                { let __softmax_in = crop_dim(softmax_in, 1, [<consumer_b>, (<consumer_b> + 3)]); {
+              for(let out_b = __loop_min; out_b <= __loop_max; out_b += __loop_step) {
+                { let __softmax_in = crop_dim(softmax_in, 1, [out_b, (out_b + 3)]); {
                   let softmax_in = __softmax_in;
                   consume(__in);
                   produce(softmax_in);
                   __event_t++;
                 }}
-                { let __max_in = crop_dim(max_in, 0, [<consumer_b>, (<consumer_b> + 3)]); {
+                { let __max_in = crop_dim(max_in, 0, [out_b, (out_b + 3)]); {
                   let max_in = __max_in;
                   consume(softmax_in);
                   produce(max_in);
                   __event_t++;
                 }}
-                { let __sum_exp_in = crop_dim(sum_exp_in, 0, [<consumer_b>, (<consumer_b> + 3)]); {
+                { let __sum_exp_in = crop_dim(sum_exp_in, 0, [out_b, (out_b + 3)]); {
                   let sum_exp_in = __sum_exp_in;
-                  { let __exp_in = crop_dim(exp_in, 1, [<consumer_b>, (<consumer_b> + 3)]); {
+                  { let __exp_in = crop_dim(exp_in, 1, [out_b, (out_b + 3)]); {
                     let exp_in = __exp_in;
                     consume(__in);
                     consume(max_in);
@@ -404,17 +404,17 @@ function pipeline(__in, out) {
                     __event_t++;
                   }}
                 }}
-                { let __softmax_out = crop_dim(softmax_out, 1, [<consumer_b>, (<consumer_b> + 3)]); {
+                { let __softmax_out = crop_dim(softmax_out, 1, [out_b, (out_b + 3)]); {
                   let softmax_out = __softmax_out;
                   consume(exp_in);
                   consume(sum_exp_in);
                   produce(softmax_out);
                   __event_t++;
                 }}
-                { let __out_<consumer_b> = crop_dim(out, 1, [<consumer_b>, (<consumer_b> + 3)]); {
-                  let out_<consumer_b> = __out_<consumer_b>;
+                { let __out_out_b = crop_dim(out, 1, [out_b, (out_b + 3)]); {
+                  let out_out_b = __out_out_b;
                   consume(softmax_out);
-                  produce(out_<consumer_b>);
+                  produce(out_out_b);
                   __event_t++;
                 }}
               }

--- a/builder/test/visualize/softmax_split_4.html
+++ b/builder/test/visualize/softmax_split_4.html
@@ -380,22 +380,22 @@ function pipeline(__in, out) {
               let __loop_min = buffer_min(out, 1);
               let __loop_max = buffer_max(out, 1);
               let __loop_step = 4;
-              for(let b_1 = __loop_min; b_1 <= __loop_max; b_1 += __loop_step) {
-                { let __softmax_in = crop_dim(softmax_in, 1, [b_1, (b_1 + 3)]); {
+              for(let <consumer_b> = __loop_min; <consumer_b> <= __loop_max; <consumer_b> += __loop_step) {
+                { let __softmax_in = crop_dim(softmax_in, 1, [<consumer_b>, (<consumer_b> + 3)]); {
                   let softmax_in = __softmax_in;
                   consume(__in);
                   produce(softmax_in);
                   __event_t++;
                 }}
-                { let __max_in = crop_dim(max_in, 0, [b_1, (b_1 + 3)]); {
+                { let __max_in = crop_dim(max_in, 0, [<consumer_b>, (<consumer_b> + 3)]); {
                   let max_in = __max_in;
                   consume(softmax_in);
                   produce(max_in);
                   __event_t++;
                 }}
-                { let __sum_exp_in = crop_dim(sum_exp_in, 0, [b_1, (b_1 + 3)]); {
+                { let __sum_exp_in = crop_dim(sum_exp_in, 0, [<consumer_b>, (<consumer_b> + 3)]); {
                   let sum_exp_in = __sum_exp_in;
-                  { let __exp_in = crop_dim(exp_in, 1, [b_1, (b_1 + 3)]); {
+                  { let __exp_in = crop_dim(exp_in, 1, [<consumer_b>, (<consumer_b> + 3)]); {
                     let exp_in = __exp_in;
                     consume(__in);
                     consume(max_in);
@@ -404,17 +404,17 @@ function pipeline(__in, out) {
                     __event_t++;
                   }}
                 }}
-                { let __softmax_out = crop_dim(softmax_out, 1, [b_1, (b_1 + 3)]); {
+                { let __softmax_out = crop_dim(softmax_out, 1, [<consumer_b>, (<consumer_b> + 3)]); {
                   let softmax_out = __softmax_out;
                   consume(exp_in);
                   consume(sum_exp_in);
                   produce(softmax_out);
                   __event_t++;
                 }}
-                { let __out_b_1 = crop_dim(out, 1, [b_1, (b_1 + 3)]); {
-                  let out_b_1 = __out_b_1;
+                { let __out_<consumer_b> = crop_dim(out, 1, [<consumer_b>, (<consumer_b> + 3)]); {
+                  let out_<consumer_b> = __out_<consumer_b>;
                   consume(softmax_out);
-                  produce(out_b_1);
+                  produce(out_<consumer_b>);
                   __event_t++;
                 }}
               }

--- a/builder/test/visualize/stencil_chain_split_serial_split_1.html
+++ b/builder/test/visualize/stencil_chain_split_serial_split_1.html
@@ -345,7 +345,7 @@ function trace_end(x) { return 1; }
 let __trace_names = allocate('__trace_names', 1, [{bounds:[0, 0], stride:1, fold_factor:1}], true);
 function pipeline(__in, out) {
   {
-    let __trace_token = trace_begin(buffer_at(__trace_names, 37));
+    let __trace_token = trace_begin(buffer_at(__trace_names, 41));
     check(__in);
     check((buffer_rank(__in) == 2));
     check((buffer_elem_size(__in) == 2));
@@ -367,39 +367,39 @@ function pipeline(__in, out) {
           {bounds:[(buffer_min(out, 1) + -1), (buffer_max(out, 1) + 1)], stride:NaN, fold_factor:3}
         ]);
         {
-          let __trace_token = trace_begin(buffer_at(__trace_names, 17));
+          let __trace_token = trace_begin(buffer_at(__trace_names, 19));
           let __loop_min = (buffer_min(out, 1) + -4);
           let __loop_max = buffer_max(out, 1);
           let __loop_step = 1;
-          for(let y = __loop_min; y <= __loop_max; y += __loop_step) {
+          for(let y_0 = __loop_min; y_0 <= __loop_max; y_0 += __loop_step) {
             {
               let __trace_token = trace_begin(buffer_at(__trace_names, 0));
-              { let __add_result = crop_dim(add_result, 1, [(y + 2), (y + 2)]); {
+              { let __add_result = crop_dim(add_result, 1, [(y_0 + 2), (y_0 + 2)]); {
                 let add_result = __add_result;
                 {
-                  let __trace_token = trace_begin(buffer_at(__trace_names, 24));
+                  let __trace_token = trace_begin(buffer_at(__trace_names, 28));
                   consume(__in);
                   produce(add_result);
                   __event_t++;
                   check(trace_end(__trace_token));
                 }
               }}
-              { let __stencil1_result = crop_dim(stencil1_result, 1, [(y + 1), (y + 1)]); {
+              { let __stencil1_result = crop_dim(stencil1_result, 1, [(y_0 + 1), (y_0 + 1)]); {
                 let stencil1_result = __stencil1_result;
                 {
-                  let __trace_token = trace_begin(buffer_at(__trace_names, 30));
+                  let __trace_token = trace_begin(buffer_at(__trace_names, 34));
                   consume(add_result);
                   produce(stencil1_result);
                   __event_t++;
                   check(trace_end(__trace_token));
                 }
               }}
-              { let __out_y = crop_dim(out, 1, [y, y]); {
-                let out_y = __out_y;
+              { let __out_y_0 = crop_dim(out, 1, [y_0, y_0]); {
+                let out_y_0 = __out_y_0;
                 {
-                  let __trace_token = trace_begin(buffer_at(__trace_names, 30));
+                  let __trace_token = trace_begin(buffer_at(__trace_names, 34));
                   consume(stencil1_result);
-                  produce(out_y);
+                  produce(out_y_0);
                   __event_t++;
                   check(trace_end(__trace_token));
                 }

--- a/builder/test/visualize/stencil_chain_split_serial_split_1.html
+++ b/builder/test/visualize/stencil_chain_split_serial_split_1.html
@@ -345,7 +345,7 @@ function trace_end(x) { return 1; }
 let __trace_names = allocate('__trace_names', 1, [{bounds:[0, 0], stride:1, fold_factor:1}], true);
 function pipeline(__in, out) {
   {
-    let __trace_token = trace_begin(buffer_at(__trace_names, 41));
+    let __trace_token = trace_begin(buffer_at(__trace_names, 55));
     check(__in);
     check((buffer_rank(__in) == 2));
     check((buffer_elem_size(__in) == 2));
@@ -367,39 +367,39 @@ function pipeline(__in, out) {
           {bounds:[(buffer_min(out, 1) + -1), (buffer_max(out, 1) + 1)], stride:NaN, fold_factor:3}
         ]);
         {
-          let __trace_token = trace_begin(buffer_at(__trace_names, 19));
+          let __trace_token = trace_begin(buffer_at(__trace_names, 26));
           let __loop_min = (buffer_min(out, 1) + -4);
           let __loop_max = buffer_max(out, 1);
           let __loop_step = 1;
-          for(let y_0 = __loop_min; y_0 <= __loop_max; y_0 += __loop_step) {
+          for(let <sum3x3_y> = __loop_min; <sum3x3_y> <= __loop_max; <sum3x3_y> += __loop_step) {
             {
               let __trace_token = trace_begin(buffer_at(__trace_names, 0));
-              { let __add_result = crop_dim(add_result, 1, [(y_0 + 2), (y_0 + 2)]); {
+              { let __add_result = crop_dim(add_result, 1, [(<sum3x3_y> + 2), (<sum3x3_y> + 2)]); {
                 let add_result = __add_result;
                 {
-                  let __trace_token = trace_begin(buffer_at(__trace_names, 28));
+                  let __trace_token = trace_begin(buffer_at(__trace_names, 42));
                   consume(__in);
                   produce(add_result);
                   __event_t++;
                   check(trace_end(__trace_token));
                 }
               }}
-              { let __stencil1_result = crop_dim(stencil1_result, 1, [(y_0 + 1), (y_0 + 1)]); {
+              { let __stencil1_result = crop_dim(stencil1_result, 1, [(<sum3x3_y> + 1), (<sum3x3_y> + 1)]); {
                 let stencil1_result = __stencil1_result;
                 {
-                  let __trace_token = trace_begin(buffer_at(__trace_names, 34));
+                  let __trace_token = trace_begin(buffer_at(__trace_names, 48));
                   consume(add_result);
                   produce(stencil1_result);
                   __event_t++;
                   check(trace_end(__trace_token));
                 }
               }}
-              { let __out_y_0 = crop_dim(out, 1, [y_0, y_0]); {
-                let out_y_0 = __out_y_0;
+              { let __out_<sum3x3_y> = crop_dim(out, 1, [<sum3x3_y>, <sum3x3_y>]); {
+                let out_<sum3x3_y> = __out_<sum3x3_y>;
                 {
-                  let __trace_token = trace_begin(buffer_at(__trace_names, 34));
+                  let __trace_token = trace_begin(buffer_at(__trace_names, 48));
                   consume(stencil1_result);
-                  produce(out_y_0);
+                  produce(out_<sum3x3_y>);
                   __event_t++;
                   check(trace_end(__trace_token));
                 }

--- a/builder/test/visualize/stencil_chain_split_serial_split_1.html
+++ b/builder/test/visualize/stencil_chain_split_serial_split_1.html
@@ -345,7 +345,7 @@ function trace_end(x) { return 1; }
 let __trace_names = allocate('__trace_names', 1, [{bounds:[0, 0], stride:1, fold_factor:1}], true);
 function pipeline(__in, out) {
   {
-    let __trace_token = trace_begin(buffer_at(__trace_names, 55));
+    let __trace_token = trace_begin(buffer_at(__trace_names, 45));
     check(__in);
     check((buffer_rank(__in) == 2));
     check((buffer_elem_size(__in) == 2));
@@ -367,39 +367,39 @@ function pipeline(__in, out) {
           {bounds:[(buffer_min(out, 1) + -1), (buffer_max(out, 1) + 1)], stride:NaN, fold_factor:3}
         ]);
         {
-          let __trace_token = trace_begin(buffer_at(__trace_names, 26));
+          let __trace_token = trace_begin(buffer_at(__trace_names, 21));
           let __loop_min = (buffer_min(out, 1) + -4);
           let __loop_max = buffer_max(out, 1);
           let __loop_step = 1;
-          for(let <sum3x3_y> = __loop_min; <sum3x3_y> <= __loop_max; <sum3x3_y> += __loop_step) {
+          for(let out_y = __loop_min; out_y <= __loop_max; out_y += __loop_step) {
             {
               let __trace_token = trace_begin(buffer_at(__trace_names, 0));
-              { let __add_result = crop_dim(add_result, 1, [(<sum3x3_y> + 2), (<sum3x3_y> + 2)]); {
+              { let __add_result = crop_dim(add_result, 1, [(out_y + 2), (out_y + 2)]); {
                 let add_result = __add_result;
                 {
-                  let __trace_token = trace_begin(buffer_at(__trace_names, 42));
+                  let __trace_token = trace_begin(buffer_at(__trace_names, 32));
                   consume(__in);
                   produce(add_result);
                   __event_t++;
                   check(trace_end(__trace_token));
                 }
               }}
-              { let __stencil1_result = crop_dim(stencil1_result, 1, [(<sum3x3_y> + 1), (<sum3x3_y> + 1)]); {
+              { let __stencil1_result = crop_dim(stencil1_result, 1, [(out_y + 1), (out_y + 1)]); {
                 let stencil1_result = __stencil1_result;
                 {
-                  let __trace_token = trace_begin(buffer_at(__trace_names, 48));
+                  let __trace_token = trace_begin(buffer_at(__trace_names, 38));
                   consume(add_result);
                   produce(stencil1_result);
                   __event_t++;
                   check(trace_end(__trace_token));
                 }
               }}
-              { let __out_<sum3x3_y> = crop_dim(out, 1, [<sum3x3_y>, <sum3x3_y>]); {
-                let out_<sum3x3_y> = __out_<sum3x3_y>;
+              { let __out_out_y = crop_dim(out, 1, [out_y, out_y]); {
+                let out_out_y = __out_out_y;
                 {
-                  let __trace_token = trace_begin(buffer_at(__trace_names, 48));
+                  let __trace_token = trace_begin(buffer_at(__trace_names, 38));
                   consume(stencil1_result);
-                  produce(out_<sum3x3_y>);
+                  produce(out_out_y);
                   __event_t++;
                   check(trace_end(__trace_token));
                 }

--- a/builder/test/visualize/stencil_chain_split_serial_split_2.html
+++ b/builder/test/visualize/stencil_chain_split_serial_split_2.html
@@ -345,7 +345,7 @@ function trace_end(x) { return 1; }
 let __trace_names = allocate('__trace_names', 1, [{bounds:[0, 0], stride:1, fold_factor:1}], true);
 function pipeline(__in, out) {
   {
-    let __trace_token = trace_begin(buffer_at(__trace_names, 55));
+    let __trace_token = trace_begin(buffer_at(__trace_names, 45));
     check(__in);
     check((buffer_rank(__in) == 2));
     check((buffer_elem_size(__in) == 2));
@@ -367,39 +367,39 @@ function pipeline(__in, out) {
           {bounds:[(buffer_min(out, 1) + -1), (buffer_max(out, 1) + 1)], stride:NaN, fold_factor:4}
         ]);
         {
-          let __trace_token = trace_begin(buffer_at(__trace_names, 26));
+          let __trace_token = trace_begin(buffer_at(__trace_names, 21));
           let __loop_min = (buffer_min(out, 1) + -4);
           let __loop_max = buffer_max(out, 1);
           let __loop_step = 2;
-          for(let <sum3x3_y> = __loop_min; <sum3x3_y> <= __loop_max; <sum3x3_y> += __loop_step) {
+          for(let out_y = __loop_min; out_y <= __loop_max; out_y += __loop_step) {
             {
               let __trace_token = trace_begin(buffer_at(__trace_names, 0));
-              { let __add_result = crop_dim(add_result, 1, [(<sum3x3_y> + 2), (<sum3x3_y> + 3)]); {
+              { let __add_result = crop_dim(add_result, 1, [(out_y + 2), (out_y + 3)]); {
                 let add_result = __add_result;
                 {
-                  let __trace_token = trace_begin(buffer_at(__trace_names, 42));
+                  let __trace_token = trace_begin(buffer_at(__trace_names, 32));
                   consume(__in);
                   produce(add_result);
                   __event_t++;
                   check(trace_end(__trace_token));
                 }
               }}
-              { let __stencil1_result = crop_dim(stencil1_result, 1, [(<sum3x3_y> + 1), (<sum3x3_y> + 2)]); {
+              { let __stencil1_result = crop_dim(stencil1_result, 1, [(out_y + 1), (out_y + 2)]); {
                 let stencil1_result = __stencil1_result;
                 {
-                  let __trace_token = trace_begin(buffer_at(__trace_names, 48));
+                  let __trace_token = trace_begin(buffer_at(__trace_names, 38));
                   consume(add_result);
                   produce(stencil1_result);
                   __event_t++;
                   check(trace_end(__trace_token));
                 }
               }}
-              { let __out_<sum3x3_y> = crop_dim(out, 1, [<sum3x3_y>, (<sum3x3_y> + 1)]); {
-                let out_<sum3x3_y> = __out_<sum3x3_y>;
+              { let __out_out_y = crop_dim(out, 1, [out_y, (out_y + 1)]); {
+                let out_out_y = __out_out_y;
                 {
-                  let __trace_token = trace_begin(buffer_at(__trace_names, 48));
+                  let __trace_token = trace_begin(buffer_at(__trace_names, 38));
                   consume(stencil1_result);
-                  produce(out_<sum3x3_y>);
+                  produce(out_out_y);
                   __event_t++;
                   check(trace_end(__trace_token));
                 }

--- a/builder/test/visualize/stencil_chain_split_serial_split_2.html
+++ b/builder/test/visualize/stencil_chain_split_serial_split_2.html
@@ -345,7 +345,7 @@ function trace_end(x) { return 1; }
 let __trace_names = allocate('__trace_names', 1, [{bounds:[0, 0], stride:1, fold_factor:1}], true);
 function pipeline(__in, out) {
   {
-    let __trace_token = trace_begin(buffer_at(__trace_names, 41));
+    let __trace_token = trace_begin(buffer_at(__trace_names, 55));
     check(__in);
     check((buffer_rank(__in) == 2));
     check((buffer_elem_size(__in) == 2));
@@ -367,39 +367,39 @@ function pipeline(__in, out) {
           {bounds:[(buffer_min(out, 1) + -1), (buffer_max(out, 1) + 1)], stride:NaN, fold_factor:4}
         ]);
         {
-          let __trace_token = trace_begin(buffer_at(__trace_names, 19));
+          let __trace_token = trace_begin(buffer_at(__trace_names, 26));
           let __loop_min = (buffer_min(out, 1) + -4);
           let __loop_max = buffer_max(out, 1);
           let __loop_step = 2;
-          for(let y_0 = __loop_min; y_0 <= __loop_max; y_0 += __loop_step) {
+          for(let <sum3x3_y> = __loop_min; <sum3x3_y> <= __loop_max; <sum3x3_y> += __loop_step) {
             {
               let __trace_token = trace_begin(buffer_at(__trace_names, 0));
-              { let __add_result = crop_dim(add_result, 1, [(y_0 + 2), (y_0 + 3)]); {
+              { let __add_result = crop_dim(add_result, 1, [(<sum3x3_y> + 2), (<sum3x3_y> + 3)]); {
                 let add_result = __add_result;
                 {
-                  let __trace_token = trace_begin(buffer_at(__trace_names, 28));
+                  let __trace_token = trace_begin(buffer_at(__trace_names, 42));
                   consume(__in);
                   produce(add_result);
                   __event_t++;
                   check(trace_end(__trace_token));
                 }
               }}
-              { let __stencil1_result = crop_dim(stencil1_result, 1, [(y_0 + 1), (y_0 + 2)]); {
+              { let __stencil1_result = crop_dim(stencil1_result, 1, [(<sum3x3_y> + 1), (<sum3x3_y> + 2)]); {
                 let stencil1_result = __stencil1_result;
                 {
-                  let __trace_token = trace_begin(buffer_at(__trace_names, 34));
+                  let __trace_token = trace_begin(buffer_at(__trace_names, 48));
                   consume(add_result);
                   produce(stencil1_result);
                   __event_t++;
                   check(trace_end(__trace_token));
                 }
               }}
-              { let __out_y_0 = crop_dim(out, 1, [y_0, (y_0 + 1)]); {
-                let out_y_0 = __out_y_0;
+              { let __out_<sum3x3_y> = crop_dim(out, 1, [<sum3x3_y>, (<sum3x3_y> + 1)]); {
+                let out_<sum3x3_y> = __out_<sum3x3_y>;
                 {
-                  let __trace_token = trace_begin(buffer_at(__trace_names, 34));
+                  let __trace_token = trace_begin(buffer_at(__trace_names, 48));
                   consume(stencil1_result);
-                  produce(out_y_0);
+                  produce(out_<sum3x3_y>);
                   __event_t++;
                   check(trace_end(__trace_token));
                 }

--- a/builder/test/visualize/stencil_chain_split_serial_split_2.html
+++ b/builder/test/visualize/stencil_chain_split_serial_split_2.html
@@ -345,7 +345,7 @@ function trace_end(x) { return 1; }
 let __trace_names = allocate('__trace_names', 1, [{bounds:[0, 0], stride:1, fold_factor:1}], true);
 function pipeline(__in, out) {
   {
-    let __trace_token = trace_begin(buffer_at(__trace_names, 37));
+    let __trace_token = trace_begin(buffer_at(__trace_names, 41));
     check(__in);
     check((buffer_rank(__in) == 2));
     check((buffer_elem_size(__in) == 2));
@@ -367,39 +367,39 @@ function pipeline(__in, out) {
           {bounds:[(buffer_min(out, 1) + -1), (buffer_max(out, 1) + 1)], stride:NaN, fold_factor:4}
         ]);
         {
-          let __trace_token = trace_begin(buffer_at(__trace_names, 17));
+          let __trace_token = trace_begin(buffer_at(__trace_names, 19));
           let __loop_min = (buffer_min(out, 1) + -4);
           let __loop_max = buffer_max(out, 1);
           let __loop_step = 2;
-          for(let y = __loop_min; y <= __loop_max; y += __loop_step) {
+          for(let y_0 = __loop_min; y_0 <= __loop_max; y_0 += __loop_step) {
             {
               let __trace_token = trace_begin(buffer_at(__trace_names, 0));
-              { let __add_result = crop_dim(add_result, 1, [(y + 2), (y + 3)]); {
+              { let __add_result = crop_dim(add_result, 1, [(y_0 + 2), (y_0 + 3)]); {
                 let add_result = __add_result;
                 {
-                  let __trace_token = trace_begin(buffer_at(__trace_names, 24));
+                  let __trace_token = trace_begin(buffer_at(__trace_names, 28));
                   consume(__in);
                   produce(add_result);
                   __event_t++;
                   check(trace_end(__trace_token));
                 }
               }}
-              { let __stencil1_result = crop_dim(stencil1_result, 1, [(y + 1), (y + 2)]); {
+              { let __stencil1_result = crop_dim(stencil1_result, 1, [(y_0 + 1), (y_0 + 2)]); {
                 let stencil1_result = __stencil1_result;
                 {
-                  let __trace_token = trace_begin(buffer_at(__trace_names, 30));
+                  let __trace_token = trace_begin(buffer_at(__trace_names, 34));
                   consume(add_result);
                   produce(stencil1_result);
                   __event_t++;
                   check(trace_end(__trace_token));
                 }
               }}
-              { let __out_y = crop_dim(out, 1, [y, (y + 1)]); {
-                let out_y = __out_y;
+              { let __out_y_0 = crop_dim(out, 1, [y_0, (y_0 + 1)]); {
+                let out_y_0 = __out_y_0;
                 {
-                  let __trace_token = trace_begin(buffer_at(__trace_names, 30));
+                  let __trace_token = trace_begin(buffer_at(__trace_names, 34));
                   consume(stencil1_result);
-                  produce(out_y);
+                  produce(out_y_0);
                   __event_t++;
                   check(trace_end(__trace_token));
                 }

--- a/builder/test/visualize/stencil_chain_split_serial_split_3.html
+++ b/builder/test/visualize/stencil_chain_split_serial_split_3.html
@@ -345,7 +345,7 @@ function trace_end(x) { return 1; }
 let __trace_names = allocate('__trace_names', 1, [{bounds:[0, 0], stride:1, fold_factor:1}], true);
 function pipeline(__in, out) {
   {
-    let __trace_token = trace_begin(buffer_at(__trace_names, 37));
+    let __trace_token = trace_begin(buffer_at(__trace_names, 41));
     check(__in);
     check((buffer_rank(__in) == 2));
     check((buffer_elem_size(__in) == 2));
@@ -367,39 +367,39 @@ function pipeline(__in, out) {
           {bounds:[(buffer_min(out, 1) + -1), (buffer_max(out, 1) + 1)], stride:NaN, fold_factor:5}
         ]);
         {
-          let __trace_token = trace_begin(buffer_at(__trace_names, 17));
+          let __trace_token = trace_begin(buffer_at(__trace_names, 19));
           let __loop_min = (buffer_min(out, 1) + -4);
           let __loop_max = buffer_max(out, 1);
           let __loop_step = 3;
-          for(let y = __loop_min; y <= __loop_max; y += __loop_step) {
+          for(let y_0 = __loop_min; y_0 <= __loop_max; y_0 += __loop_step) {
             {
               let __trace_token = trace_begin(buffer_at(__trace_names, 0));
-              { let __add_result = crop_dim(add_result, 1, [(y + 2), (y + 4)]); {
+              { let __add_result = crop_dim(add_result, 1, [(y_0 + 2), (y_0 + 4)]); {
                 let add_result = __add_result;
                 {
-                  let __trace_token = trace_begin(buffer_at(__trace_names, 24));
+                  let __trace_token = trace_begin(buffer_at(__trace_names, 28));
                   consume(__in);
                   produce(add_result);
                   __event_t++;
                   check(trace_end(__trace_token));
                 }
               }}
-              { let __stencil1_result = crop_dim(stencil1_result, 1, [(y + 1), (y + 3)]); {
+              { let __stencil1_result = crop_dim(stencil1_result, 1, [(y_0 + 1), (y_0 + 3)]); {
                 let stencil1_result = __stencil1_result;
                 {
-                  let __trace_token = trace_begin(buffer_at(__trace_names, 30));
+                  let __trace_token = trace_begin(buffer_at(__trace_names, 34));
                   consume(add_result);
                   produce(stencil1_result);
                   __event_t++;
                   check(trace_end(__trace_token));
                 }
               }}
-              { let __out_y = crop_dim(out, 1, [y, (y + 2)]); {
-                let out_y = __out_y;
+              { let __out_y_0 = crop_dim(out, 1, [y_0, (y_0 + 2)]); {
+                let out_y_0 = __out_y_0;
                 {
-                  let __trace_token = trace_begin(buffer_at(__trace_names, 30));
+                  let __trace_token = trace_begin(buffer_at(__trace_names, 34));
                   consume(stencil1_result);
-                  produce(out_y);
+                  produce(out_y_0);
                   __event_t++;
                   check(trace_end(__trace_token));
                 }

--- a/builder/test/visualize/stencil_chain_split_serial_split_3.html
+++ b/builder/test/visualize/stencil_chain_split_serial_split_3.html
@@ -345,7 +345,7 @@ function trace_end(x) { return 1; }
 let __trace_names = allocate('__trace_names', 1, [{bounds:[0, 0], stride:1, fold_factor:1}], true);
 function pipeline(__in, out) {
   {
-    let __trace_token = trace_begin(buffer_at(__trace_names, 55));
+    let __trace_token = trace_begin(buffer_at(__trace_names, 45));
     check(__in);
     check((buffer_rank(__in) == 2));
     check((buffer_elem_size(__in) == 2));
@@ -367,39 +367,39 @@ function pipeline(__in, out) {
           {bounds:[(buffer_min(out, 1) + -1), (buffer_max(out, 1) + 1)], stride:NaN, fold_factor:5}
         ]);
         {
-          let __trace_token = trace_begin(buffer_at(__trace_names, 26));
+          let __trace_token = trace_begin(buffer_at(__trace_names, 21));
           let __loop_min = (buffer_min(out, 1) + -4);
           let __loop_max = buffer_max(out, 1);
           let __loop_step = 3;
-          for(let <sum3x3_y> = __loop_min; <sum3x3_y> <= __loop_max; <sum3x3_y> += __loop_step) {
+          for(let out_y = __loop_min; out_y <= __loop_max; out_y += __loop_step) {
             {
               let __trace_token = trace_begin(buffer_at(__trace_names, 0));
-              { let __add_result = crop_dim(add_result, 1, [(<sum3x3_y> + 2), (<sum3x3_y> + 4)]); {
+              { let __add_result = crop_dim(add_result, 1, [(out_y + 2), (out_y + 4)]); {
                 let add_result = __add_result;
                 {
-                  let __trace_token = trace_begin(buffer_at(__trace_names, 42));
+                  let __trace_token = trace_begin(buffer_at(__trace_names, 32));
                   consume(__in);
                   produce(add_result);
                   __event_t++;
                   check(trace_end(__trace_token));
                 }
               }}
-              { let __stencil1_result = crop_dim(stencil1_result, 1, [(<sum3x3_y> + 1), (<sum3x3_y> + 3)]); {
+              { let __stencil1_result = crop_dim(stencil1_result, 1, [(out_y + 1), (out_y + 3)]); {
                 let stencil1_result = __stencil1_result;
                 {
-                  let __trace_token = trace_begin(buffer_at(__trace_names, 48));
+                  let __trace_token = trace_begin(buffer_at(__trace_names, 38));
                   consume(add_result);
                   produce(stencil1_result);
                   __event_t++;
                   check(trace_end(__trace_token));
                 }
               }}
-              { let __out_<sum3x3_y> = crop_dim(out, 1, [<sum3x3_y>, (<sum3x3_y> + 2)]); {
-                let out_<sum3x3_y> = __out_<sum3x3_y>;
+              { let __out_out_y = crop_dim(out, 1, [out_y, (out_y + 2)]); {
+                let out_out_y = __out_out_y;
                 {
-                  let __trace_token = trace_begin(buffer_at(__trace_names, 48));
+                  let __trace_token = trace_begin(buffer_at(__trace_names, 38));
                   consume(stencil1_result);
-                  produce(out_<sum3x3_y>);
+                  produce(out_out_y);
                   __event_t++;
                   check(trace_end(__trace_token));
                 }

--- a/builder/test/visualize/stencil_chain_split_serial_split_3.html
+++ b/builder/test/visualize/stencil_chain_split_serial_split_3.html
@@ -345,7 +345,7 @@ function trace_end(x) { return 1; }
 let __trace_names = allocate('__trace_names', 1, [{bounds:[0, 0], stride:1, fold_factor:1}], true);
 function pipeline(__in, out) {
   {
-    let __trace_token = trace_begin(buffer_at(__trace_names, 41));
+    let __trace_token = trace_begin(buffer_at(__trace_names, 55));
     check(__in);
     check((buffer_rank(__in) == 2));
     check((buffer_elem_size(__in) == 2));
@@ -367,39 +367,39 @@ function pipeline(__in, out) {
           {bounds:[(buffer_min(out, 1) + -1), (buffer_max(out, 1) + 1)], stride:NaN, fold_factor:5}
         ]);
         {
-          let __trace_token = trace_begin(buffer_at(__trace_names, 19));
+          let __trace_token = trace_begin(buffer_at(__trace_names, 26));
           let __loop_min = (buffer_min(out, 1) + -4);
           let __loop_max = buffer_max(out, 1);
           let __loop_step = 3;
-          for(let y_0 = __loop_min; y_0 <= __loop_max; y_0 += __loop_step) {
+          for(let <sum3x3_y> = __loop_min; <sum3x3_y> <= __loop_max; <sum3x3_y> += __loop_step) {
             {
               let __trace_token = trace_begin(buffer_at(__trace_names, 0));
-              { let __add_result = crop_dim(add_result, 1, [(y_0 + 2), (y_0 + 4)]); {
+              { let __add_result = crop_dim(add_result, 1, [(<sum3x3_y> + 2), (<sum3x3_y> + 4)]); {
                 let add_result = __add_result;
                 {
-                  let __trace_token = trace_begin(buffer_at(__trace_names, 28));
+                  let __trace_token = trace_begin(buffer_at(__trace_names, 42));
                   consume(__in);
                   produce(add_result);
                   __event_t++;
                   check(trace_end(__trace_token));
                 }
               }}
-              { let __stencil1_result = crop_dim(stencil1_result, 1, [(y_0 + 1), (y_0 + 3)]); {
+              { let __stencil1_result = crop_dim(stencil1_result, 1, [(<sum3x3_y> + 1), (<sum3x3_y> + 3)]); {
                 let stencil1_result = __stencil1_result;
                 {
-                  let __trace_token = trace_begin(buffer_at(__trace_names, 34));
+                  let __trace_token = trace_begin(buffer_at(__trace_names, 48));
                   consume(add_result);
                   produce(stencil1_result);
                   __event_t++;
                   check(trace_end(__trace_token));
                 }
               }}
-              { let __out_y_0 = crop_dim(out, 1, [y_0, (y_0 + 2)]); {
-                let out_y_0 = __out_y_0;
+              { let __out_<sum3x3_y> = crop_dim(out, 1, [<sum3x3_y>, (<sum3x3_y> + 2)]); {
+                let out_<sum3x3_y> = __out_<sum3x3_y>;
                 {
-                  let __trace_token = trace_begin(buffer_at(__trace_names, 34));
+                  let __trace_token = trace_begin(buffer_at(__trace_names, 48));
                   consume(stencil1_result);
-                  produce(out_y_0);
+                  produce(out_<sum3x3_y>);
                   __event_t++;
                   check(trace_end(__trace_token));
                 }

--- a/builder/test/visualize/stencil_chain_split_serial_split_4.html
+++ b/builder/test/visualize/stencil_chain_split_serial_split_4.html
@@ -345,7 +345,7 @@ function trace_end(x) { return 1; }
 let __trace_names = allocate('__trace_names', 1, [{bounds:[0, 0], stride:1, fold_factor:1}], true);
 function pipeline(__in, out) {
   {
-    let __trace_token = trace_begin(buffer_at(__trace_names, 37));
+    let __trace_token = trace_begin(buffer_at(__trace_names, 41));
     check(__in);
     check((buffer_rank(__in) == 2));
     check((buffer_elem_size(__in) == 2));
@@ -367,39 +367,39 @@ function pipeline(__in, out) {
           {bounds:[(buffer_min(out, 1) + -1), (buffer_max(out, 1) + 1)], stride:NaN, fold_factor:6}
         ]);
         {
-          let __trace_token = trace_begin(buffer_at(__trace_names, 17));
+          let __trace_token = trace_begin(buffer_at(__trace_names, 19));
           let __loop_min = (buffer_min(out, 1) + -4);
           let __loop_max = buffer_max(out, 1);
           let __loop_step = 4;
-          for(let y = __loop_min; y <= __loop_max; y += __loop_step) {
+          for(let y_0 = __loop_min; y_0 <= __loop_max; y_0 += __loop_step) {
             {
               let __trace_token = trace_begin(buffer_at(__trace_names, 0));
-              { let __add_result = crop_dim(add_result, 1, [(y + 2), (y + 5)]); {
+              { let __add_result = crop_dim(add_result, 1, [(y_0 + 2), (y_0 + 5)]); {
                 let add_result = __add_result;
                 {
-                  let __trace_token = trace_begin(buffer_at(__trace_names, 24));
+                  let __trace_token = trace_begin(buffer_at(__trace_names, 28));
                   consume(__in);
                   produce(add_result);
                   __event_t++;
                   check(trace_end(__trace_token));
                 }
               }}
-              { let __stencil1_result = crop_dim(stencil1_result, 1, [(y + 1), (y + 4)]); {
+              { let __stencil1_result = crop_dim(stencil1_result, 1, [(y_0 + 1), (y_0 + 4)]); {
                 let stencil1_result = __stencil1_result;
                 {
-                  let __trace_token = trace_begin(buffer_at(__trace_names, 30));
+                  let __trace_token = trace_begin(buffer_at(__trace_names, 34));
                   consume(add_result);
                   produce(stencil1_result);
                   __event_t++;
                   check(trace_end(__trace_token));
                 }
               }}
-              { let __out_y = crop_dim(out, 1, [y, (y + 3)]); {
-                let out_y = __out_y;
+              { let __out_y_0 = crop_dim(out, 1, [y_0, (y_0 + 3)]); {
+                let out_y_0 = __out_y_0;
                 {
-                  let __trace_token = trace_begin(buffer_at(__trace_names, 30));
+                  let __trace_token = trace_begin(buffer_at(__trace_names, 34));
                   consume(stencil1_result);
-                  produce(out_y);
+                  produce(out_y_0);
                   __event_t++;
                   check(trace_end(__trace_token));
                 }

--- a/builder/test/visualize/stencil_chain_split_serial_split_4.html
+++ b/builder/test/visualize/stencil_chain_split_serial_split_4.html
@@ -345,7 +345,7 @@ function trace_end(x) { return 1; }
 let __trace_names = allocate('__trace_names', 1, [{bounds:[0, 0], stride:1, fold_factor:1}], true);
 function pipeline(__in, out) {
   {
-    let __trace_token = trace_begin(buffer_at(__trace_names, 55));
+    let __trace_token = trace_begin(buffer_at(__trace_names, 45));
     check(__in);
     check((buffer_rank(__in) == 2));
     check((buffer_elem_size(__in) == 2));
@@ -367,39 +367,39 @@ function pipeline(__in, out) {
           {bounds:[(buffer_min(out, 1) + -1), (buffer_max(out, 1) + 1)], stride:NaN, fold_factor:6}
         ]);
         {
-          let __trace_token = trace_begin(buffer_at(__trace_names, 26));
+          let __trace_token = trace_begin(buffer_at(__trace_names, 21));
           let __loop_min = (buffer_min(out, 1) + -4);
           let __loop_max = buffer_max(out, 1);
           let __loop_step = 4;
-          for(let <sum3x3_y> = __loop_min; <sum3x3_y> <= __loop_max; <sum3x3_y> += __loop_step) {
+          for(let out_y = __loop_min; out_y <= __loop_max; out_y += __loop_step) {
             {
               let __trace_token = trace_begin(buffer_at(__trace_names, 0));
-              { let __add_result = crop_dim(add_result, 1, [(<sum3x3_y> + 2), (<sum3x3_y> + 5)]); {
+              { let __add_result = crop_dim(add_result, 1, [(out_y + 2), (out_y + 5)]); {
                 let add_result = __add_result;
                 {
-                  let __trace_token = trace_begin(buffer_at(__trace_names, 42));
+                  let __trace_token = trace_begin(buffer_at(__trace_names, 32));
                   consume(__in);
                   produce(add_result);
                   __event_t++;
                   check(trace_end(__trace_token));
                 }
               }}
-              { let __stencil1_result = crop_dim(stencil1_result, 1, [(<sum3x3_y> + 1), (<sum3x3_y> + 4)]); {
+              { let __stencil1_result = crop_dim(stencil1_result, 1, [(out_y + 1), (out_y + 4)]); {
                 let stencil1_result = __stencil1_result;
                 {
-                  let __trace_token = trace_begin(buffer_at(__trace_names, 48));
+                  let __trace_token = trace_begin(buffer_at(__trace_names, 38));
                   consume(add_result);
                   produce(stencil1_result);
                   __event_t++;
                   check(trace_end(__trace_token));
                 }
               }}
-              { let __out_<sum3x3_y> = crop_dim(out, 1, [<sum3x3_y>, (<sum3x3_y> + 3)]); {
-                let out_<sum3x3_y> = __out_<sum3x3_y>;
+              { let __out_out_y = crop_dim(out, 1, [out_y, (out_y + 3)]); {
+                let out_out_y = __out_out_y;
                 {
-                  let __trace_token = trace_begin(buffer_at(__trace_names, 48));
+                  let __trace_token = trace_begin(buffer_at(__trace_names, 38));
                   consume(stencil1_result);
-                  produce(out_<sum3x3_y>);
+                  produce(out_out_y);
                   __event_t++;
                   check(trace_end(__trace_token));
                 }

--- a/builder/test/visualize/stencil_chain_split_serial_split_4.html
+++ b/builder/test/visualize/stencil_chain_split_serial_split_4.html
@@ -345,7 +345,7 @@ function trace_end(x) { return 1; }
 let __trace_names = allocate('__trace_names', 1, [{bounds:[0, 0], stride:1, fold_factor:1}], true);
 function pipeline(__in, out) {
   {
-    let __trace_token = trace_begin(buffer_at(__trace_names, 41));
+    let __trace_token = trace_begin(buffer_at(__trace_names, 55));
     check(__in);
     check((buffer_rank(__in) == 2));
     check((buffer_elem_size(__in) == 2));
@@ -367,39 +367,39 @@ function pipeline(__in, out) {
           {bounds:[(buffer_min(out, 1) + -1), (buffer_max(out, 1) + 1)], stride:NaN, fold_factor:6}
         ]);
         {
-          let __trace_token = trace_begin(buffer_at(__trace_names, 19));
+          let __trace_token = trace_begin(buffer_at(__trace_names, 26));
           let __loop_min = (buffer_min(out, 1) + -4);
           let __loop_max = buffer_max(out, 1);
           let __loop_step = 4;
-          for(let y_0 = __loop_min; y_0 <= __loop_max; y_0 += __loop_step) {
+          for(let <sum3x3_y> = __loop_min; <sum3x3_y> <= __loop_max; <sum3x3_y> += __loop_step) {
             {
               let __trace_token = trace_begin(buffer_at(__trace_names, 0));
-              { let __add_result = crop_dim(add_result, 1, [(y_0 + 2), (y_0 + 5)]); {
+              { let __add_result = crop_dim(add_result, 1, [(<sum3x3_y> + 2), (<sum3x3_y> + 5)]); {
                 let add_result = __add_result;
                 {
-                  let __trace_token = trace_begin(buffer_at(__trace_names, 28));
+                  let __trace_token = trace_begin(buffer_at(__trace_names, 42));
                   consume(__in);
                   produce(add_result);
                   __event_t++;
                   check(trace_end(__trace_token));
                 }
               }}
-              { let __stencil1_result = crop_dim(stencil1_result, 1, [(y_0 + 1), (y_0 + 4)]); {
+              { let __stencil1_result = crop_dim(stencil1_result, 1, [(<sum3x3_y> + 1), (<sum3x3_y> + 4)]); {
                 let stencil1_result = __stencil1_result;
                 {
-                  let __trace_token = trace_begin(buffer_at(__trace_names, 34));
+                  let __trace_token = trace_begin(buffer_at(__trace_names, 48));
                   consume(add_result);
                   produce(stencil1_result);
                   __event_t++;
                   check(trace_end(__trace_token));
                 }
               }}
-              { let __out_y_0 = crop_dim(out, 1, [y_0, (y_0 + 3)]); {
-                let out_y_0 = __out_y_0;
+              { let __out_<sum3x3_y> = crop_dim(out, 1, [<sum3x3_y>, (<sum3x3_y> + 3)]); {
+                let out_<sum3x3_y> = __out_<sum3x3_y>;
                 {
-                  let __trace_token = trace_begin(buffer_at(__trace_names, 34));
+                  let __trace_token = trace_begin(buffer_at(__trace_names, 48));
                   consume(stencil1_result);
-                  produce(out_y_0);
+                  produce(out_<sum3x3_y>);
                   __event_t++;
                   check(trace_end(__trace_token));
                 }

--- a/builder/test/visualize/stencil_split_1.html
+++ b/builder/test/visualize/stencil_split_1.html
@@ -363,17 +363,17 @@ function pipeline(__in, out) {
     let __loop_min = (buffer_min(out, 1) + -2);
     let __loop_max = buffer_max(out, 1);
     let __loop_step = 1;
-    for(let <y> = __loop_min; <y> <= __loop_max; <y> += __loop_step) {
-      { let __intm = crop_dim(intm, 1, [(<y> + 1), (<y> + 1)]); {
+    for(let out_y = __loop_min; out_y <= __loop_max; out_y += __loop_step) {
+      { let __intm = crop_dim(intm, 1, [(out_y + 1), (out_y + 1)]); {
         let intm = __intm;
         consume(__in);
         produce(intm);
         __event_t++;
       }}
-      { let __out_<y> = crop_dim(out, 1, [<y>, <y>]); {
-        let out_<y> = __out_<y>;
+      { let __out_out_y = crop_dim(out, 1, [out_y, out_y]); {
+        let out_out_y = __out_out_y;
         consume(intm);
-        produce(out_<y>);
+        produce(out_out_y);
         __event_t++;
       }}
     }

--- a/builder/test/visualize/stencil_split_1.html
+++ b/builder/test/visualize/stencil_split_1.html
@@ -363,17 +363,17 @@ function pipeline(__in, out) {
     let __loop_min = (buffer_min(out, 1) + -2);
     let __loop_max = buffer_max(out, 1);
     let __loop_step = 1;
-    for(let y_0 = __loop_min; y_0 <= __loop_max; y_0 += __loop_step) {
-      { let __intm = crop_dim(intm, 1, [(y_0 + 1), (y_0 + 1)]); {
+    for(let <y> = __loop_min; <y> <= __loop_max; <y> += __loop_step) {
+      { let __intm = crop_dim(intm, 1, [(<y> + 1), (<y> + 1)]); {
         let intm = __intm;
         consume(__in);
         produce(intm);
         __event_t++;
       }}
-      { let __out_y_0 = crop_dim(out, 1, [y_0, y_0]); {
-        let out_y_0 = __out_y_0;
+      { let __out_<y> = crop_dim(out, 1, [<y>, <y>]); {
+        let out_<y> = __out_<y>;
         consume(intm);
-        produce(out_y_0);
+        produce(out_<y>);
         __event_t++;
       }}
     }

--- a/builder/test/visualize/stencil_split_1.html
+++ b/builder/test/visualize/stencil_split_1.html
@@ -363,17 +363,17 @@ function pipeline(__in, out) {
     let __loop_min = (buffer_min(out, 1) + -2);
     let __loop_max = buffer_max(out, 1);
     let __loop_step = 1;
-    for(let y = __loop_min; y <= __loop_max; y += __loop_step) {
-      { let __intm = crop_dim(intm, 1, [(y + 1), (y + 1)]); {
+    for(let y_0 = __loop_min; y_0 <= __loop_max; y_0 += __loop_step) {
+      { let __intm = crop_dim(intm, 1, [(y_0 + 1), (y_0 + 1)]); {
         let intm = __intm;
         consume(__in);
         produce(intm);
         __event_t++;
       }}
-      { let __out_y = crop_dim(out, 1, [y, y]); {
-        let out_y = __out_y;
+      { let __out_y_0 = crop_dim(out, 1, [y_0, y_0]); {
+        let out_y_0 = __out_y_0;
         consume(intm);
-        produce(out_y);
+        produce(out_y_0);
         __event_t++;
       }}
     }

--- a/builder/test/visualize/stencil_split_2.html
+++ b/builder/test/visualize/stencil_split_2.html
@@ -363,17 +363,17 @@ function pipeline(__in, out) {
     let __loop_min = (buffer_min(out, 1) + -2);
     let __loop_max = buffer_max(out, 1);
     let __loop_step = 2;
-    for(let y_0 = __loop_min; y_0 <= __loop_max; y_0 += __loop_step) {
-      { let __intm = crop_dim(intm, 1, [(y_0 + 1), (y_0 + 2)]); {
+    for(let <y> = __loop_min; <y> <= __loop_max; <y> += __loop_step) {
+      { let __intm = crop_dim(intm, 1, [(<y> + 1), (<y> + 2)]); {
         let intm = __intm;
         consume(__in);
         produce(intm);
         __event_t++;
       }}
-      { let __out_y_0 = crop_dim(out, 1, [y_0, (y_0 + 1)]); {
-        let out_y_0 = __out_y_0;
+      { let __out_<y> = crop_dim(out, 1, [<y>, (<y> + 1)]); {
+        let out_<y> = __out_<y>;
         consume(intm);
-        produce(out_y_0);
+        produce(out_<y>);
         __event_t++;
       }}
     }

--- a/builder/test/visualize/stencil_split_2.html
+++ b/builder/test/visualize/stencil_split_2.html
@@ -363,17 +363,17 @@ function pipeline(__in, out) {
     let __loop_min = (buffer_min(out, 1) + -2);
     let __loop_max = buffer_max(out, 1);
     let __loop_step = 2;
-    for(let y = __loop_min; y <= __loop_max; y += __loop_step) {
-      { let __intm = crop_dim(intm, 1, [(y + 1), (y + 2)]); {
+    for(let y_0 = __loop_min; y_0 <= __loop_max; y_0 += __loop_step) {
+      { let __intm = crop_dim(intm, 1, [(y_0 + 1), (y_0 + 2)]); {
         let intm = __intm;
         consume(__in);
         produce(intm);
         __event_t++;
       }}
-      { let __out_y = crop_dim(out, 1, [y, (y + 1)]); {
-        let out_y = __out_y;
+      { let __out_y_0 = crop_dim(out, 1, [y_0, (y_0 + 1)]); {
+        let out_y_0 = __out_y_0;
         consume(intm);
-        produce(out_y);
+        produce(out_y_0);
         __event_t++;
       }}
     }

--- a/builder/test/visualize/stencil_split_2.html
+++ b/builder/test/visualize/stencil_split_2.html
@@ -363,17 +363,17 @@ function pipeline(__in, out) {
     let __loop_min = (buffer_min(out, 1) + -2);
     let __loop_max = buffer_max(out, 1);
     let __loop_step = 2;
-    for(let <y> = __loop_min; <y> <= __loop_max; <y> += __loop_step) {
-      { let __intm = crop_dim(intm, 1, [(<y> + 1), (<y> + 2)]); {
+    for(let out_y = __loop_min; out_y <= __loop_max; out_y += __loop_step) {
+      { let __intm = crop_dim(intm, 1, [(out_y + 1), (out_y + 2)]); {
         let intm = __intm;
         consume(__in);
         produce(intm);
         __event_t++;
       }}
-      { let __out_<y> = crop_dim(out, 1, [<y>, (<y> + 1)]); {
-        let out_<y> = __out_<y>;
+      { let __out_out_y = crop_dim(out, 1, [out_y, (out_y + 1)]); {
+        let out_out_y = __out_out_y;
         consume(intm);
-        produce(out_<y>);
+        produce(out_out_y);
         __event_t++;
       }}
     }

--- a/builder/test/visualize/stencil_split_3.html
+++ b/builder/test/visualize/stencil_split_3.html
@@ -363,17 +363,17 @@ function pipeline(__in, out) {
     let __loop_min = (buffer_min(out, 1) + -2);
     let __loop_max = buffer_max(out, 1);
     let __loop_step = 3;
-    for(let y = __loop_min; y <= __loop_max; y += __loop_step) {
-      { let __intm = crop_dim(intm, 1, [(y + 1), (y + 3)]); {
+    for(let y_0 = __loop_min; y_0 <= __loop_max; y_0 += __loop_step) {
+      { let __intm = crop_dim(intm, 1, [(y_0 + 1), (y_0 + 3)]); {
         let intm = __intm;
         consume(__in);
         produce(intm);
         __event_t++;
       }}
-      { let __out_y = crop_dim(out, 1, [y, (y + 2)]); {
-        let out_y = __out_y;
+      { let __out_y_0 = crop_dim(out, 1, [y_0, (y_0 + 2)]); {
+        let out_y_0 = __out_y_0;
         consume(intm);
-        produce(out_y);
+        produce(out_y_0);
         __event_t++;
       }}
     }

--- a/builder/test/visualize/stencil_split_3.html
+++ b/builder/test/visualize/stencil_split_3.html
@@ -363,17 +363,17 @@ function pipeline(__in, out) {
     let __loop_min = (buffer_min(out, 1) + -2);
     let __loop_max = buffer_max(out, 1);
     let __loop_step = 3;
-    for(let y_0 = __loop_min; y_0 <= __loop_max; y_0 += __loop_step) {
-      { let __intm = crop_dim(intm, 1, [(y_0 + 1), (y_0 + 3)]); {
+    for(let <y> = __loop_min; <y> <= __loop_max; <y> += __loop_step) {
+      { let __intm = crop_dim(intm, 1, [(<y> + 1), (<y> + 3)]); {
         let intm = __intm;
         consume(__in);
         produce(intm);
         __event_t++;
       }}
-      { let __out_y_0 = crop_dim(out, 1, [y_0, (y_0 + 2)]); {
-        let out_y_0 = __out_y_0;
+      { let __out_<y> = crop_dim(out, 1, [<y>, (<y> + 2)]); {
+        let out_<y> = __out_<y>;
         consume(intm);
-        produce(out_y_0);
+        produce(out_<y>);
         __event_t++;
       }}
     }

--- a/builder/test/visualize/stencil_split_3.html
+++ b/builder/test/visualize/stencil_split_3.html
@@ -363,17 +363,17 @@ function pipeline(__in, out) {
     let __loop_min = (buffer_min(out, 1) + -2);
     let __loop_max = buffer_max(out, 1);
     let __loop_step = 3;
-    for(let <y> = __loop_min; <y> <= __loop_max; <y> += __loop_step) {
-      { let __intm = crop_dim(intm, 1, [(<y> + 1), (<y> + 3)]); {
+    for(let out_y = __loop_min; out_y <= __loop_max; out_y += __loop_step) {
+      { let __intm = crop_dim(intm, 1, [(out_y + 1), (out_y + 3)]); {
         let intm = __intm;
         consume(__in);
         produce(intm);
         __event_t++;
       }}
-      { let __out_<y> = crop_dim(out, 1, [<y>, (<y> + 2)]); {
-        let out_<y> = __out_<y>;
+      { let __out_out_y = crop_dim(out, 1, [out_y, (out_y + 2)]); {
+        let out_out_y = __out_out_y;
         consume(intm);
-        produce(out_<y>);
+        produce(out_out_y);
         __event_t++;
       }}
     }


### PR DESCRIPTION
One of the internal tests was producing incorrect results because of the loop variables being mixed up.