### PR TITLE
Fix lost alignment info when modulus = 0

### DIFF
--- a/base/arithmetic.h
+++ b/base/arithmetic.h
@@ -14,9 +14,9 @@ namespace slinky {
 // and mod are taken from:
 // https://github.com/halide/Halide/blob/1a0552bb6101273a0e007782c07e8dafe9bc5366/src/CodeGen_Internal.cpp#L358-L408
 template <typename T>
-T euclidean_div(T a, T b) {
+T euclidean_div(T a, T b, T define_b_zero = 0) {
   if (b == 0) {
-    return 0;
+    return define_b_zero;
   }
   T q = a / b;
   T r = a - q * b;
@@ -33,9 +33,9 @@ T euclidean_mod_positive_modulus(T a, T b) {
 }
 
 template <typename T>
-T euclidean_mod(T a, T b) {
+T euclidean_mod(T a, T b, T define_b_zero = 0) {
   if (b == 0) {
-    return 0;
+    return define_b_zero;
   }
   T r = a % b;
   return r >= 0 ? r : (b < 0 ? r - b : r + b);

--- a/base/modulus_remainder.h
+++ b/base/modulus_remainder.h
@@ -38,7 +38,7 @@ modulus_remainder<T> operator+(const modulus_remainder<T>& a, const modulus_rema
   int64_t m = 1, r = 0;
   if (!add_with_overflow(a.remainder, b.remainder, r)) {
     m = gcd(a.modulus, b.modulus);
-    r = euclidean_mod(r, m);
+    r = m == 0 ? r : euclidean_mod(r, m);
   }
   return {m, r};
 }
@@ -48,7 +48,7 @@ modulus_remainder<T> operator-(const modulus_remainder<T>& a, const modulus_rema
   int64_t m = 1, r = 0;
   if (!sub_with_overflow(a.remainder, b.remainder, r)) {
     m = gcd(a.modulus, b.modulus);
-    r = euclidean_mod(r, m);
+    r = m == 0 ? r : euclidean_mod(r, m);
   }
   return {m, r};
 }
@@ -85,7 +85,7 @@ modulus_remainder<T> operator*(const modulus_remainder<T>& a, const modulus_rema
     // Convert them to the same modulus and multiply
     if (!mul_with_overflow(a.remainder, b.remainder, r)) {
       m = gcd(a.modulus, b.modulus);
-      r = euclidean_mod(r, m);
+      r = m == 0 ? r : euclidean_mod(r, m);
       return {m, r};
     }
   }
@@ -105,9 +105,10 @@ modulus_remainder<T> operator/(const modulus_remainder<T>& a, const modulus_rema
   // E.g. (8x + 3) / 2 -> (4x + 1)
 
   if (b.modulus == 0 && b.remainder != 0) {
-    if (euclidean_mod(a.modulus, b.remainder) == 0) {
+    if ((b.remainder == 0 ? a.modulus : euclidean_mod(a.modulus, b.remainder)) == 0) {
       int64_t m = a.modulus / b.remainder;
-      int64_t r = euclidean_mod(euclidean_div(a.remainder, b.remainder), m);
+      int64_t r = euclidean_div(a.remainder, b.remainder);
+      r = m == 0 ? r : euclidean_mod(r, m);
       return {m, r};
     }
   }
@@ -143,9 +144,9 @@ modulus_remainder<T> operator|(const modulus_remainder<T>& a, const modulus_rema
 
   modulus = gcd(diff, modulus);
 
-  int64_t ra = euclidean_mod(a.remainder, modulus);
+  int64_t ra = modulus == 0 ? a.remainder : euclidean_mod(a.remainder, modulus);
 
-  assert(ra == euclidean_mod(b.remainder, modulus));
+  assert(ra == (modulus == 0 ? b.remainder : euclidean_mod(b.remainder, modulus)));
 
   return {modulus, ra};
 }
@@ -166,7 +167,7 @@ modulus_remainder<T> operator%(const modulus_remainder<T>& a, const modulus_rema
   // 2w + 1
   int64_t modulus = gcd(a.modulus, b.modulus);
   modulus = gcd(modulus, b.remainder);
-  int64_t remainder = euclidean_mod(a.remainder, modulus);
+  int64_t remainder = modulus == 0 ? a.remainder : euclidean_mod(a.remainder, modulus);
 
   if (b.remainder == 0 && remainder != 0) {
     // b could be zero, so the result could also just be zero.

--- a/base/modulus_remainder.h
+++ b/base/modulus_remainder.h
@@ -38,7 +38,7 @@ modulus_remainder<T> operator+(const modulus_remainder<T>& a, const modulus_rema
   int64_t m = 1, r = 0;
   if (!add_with_overflow(a.remainder, b.remainder, r)) {
     m = gcd(a.modulus, b.modulus);
-    r = m == 0 ? r : euclidean_mod(r, m);
+    r = euclidean_mod(r, m, r);
   }
   return {m, r};
 }
@@ -48,7 +48,7 @@ modulus_remainder<T> operator-(const modulus_remainder<T>& a, const modulus_rema
   int64_t m = 1, r = 0;
   if (!sub_with_overflow(a.remainder, b.remainder, r)) {
     m = gcd(a.modulus, b.modulus);
-    r = m == 0 ? r : euclidean_mod(r, m);
+    r = euclidean_mod(r, m, r);
   }
   return {m, r};
 }
@@ -85,7 +85,7 @@ modulus_remainder<T> operator*(const modulus_remainder<T>& a, const modulus_rema
     // Convert them to the same modulus and multiply
     if (!mul_with_overflow(a.remainder, b.remainder, r)) {
       m = gcd(a.modulus, b.modulus);
-      r = m == 0 ? r : euclidean_mod(r, m);
+      r = euclidean_mod(r, m, r);
       return {m, r};
     }
   }
@@ -105,10 +105,10 @@ modulus_remainder<T> operator/(const modulus_remainder<T>& a, const modulus_rema
   // E.g. (8x + 3) / 2 -> (4x + 1)
 
   if (b.modulus == 0 && b.remainder != 0) {
-    if ((b.remainder == 0 ? a.modulus : euclidean_mod(a.modulus, b.remainder)) == 0) {
+    if ((euclidean_mod(a.modulus, b.remainder, a.modulus)) == 0) {
       int64_t m = a.modulus / b.remainder;
       int64_t r = euclidean_div(a.remainder, b.remainder);
-      r = m == 0 ? r : euclidean_mod(r, m);
+      r = euclidean_mod(r, m, r);
       return {m, r};
     }
   }
@@ -144,9 +144,9 @@ modulus_remainder<T> operator|(const modulus_remainder<T>& a, const modulus_rema
 
   modulus = gcd(diff, modulus);
 
-  int64_t ra = modulus == 0 ? a.remainder : euclidean_mod(a.remainder, modulus);
+  int64_t ra = euclidean_mod(a.remainder, modulus, a.remainder);
 
-  assert(ra == (modulus == 0 ? b.remainder : euclidean_mod(b.remainder, modulus)));
+  assert(ra == (euclidean_mod(b.remainder, modulus, b.remainder)));
 
   return {modulus, ra};
 }
@@ -167,7 +167,7 @@ modulus_remainder<T> operator%(const modulus_remainder<T>& a, const modulus_rema
   // 2w + 1
   int64_t modulus = gcd(a.modulus, b.modulus);
   modulus = gcd(modulus, b.remainder);
-  int64_t remainder = modulus == 0 ? a.remainder : euclidean_mod(a.remainder, modulus);
+  int64_t remainder = euclidean_mod(a.remainder, modulus, a.remainder);
 
   if (b.remainder == 0 && remainder != 0) {
     // b could be zero, so the result could also just be zero.

--- a/base/test/arithmetic_benchmark.cc
+++ b/base/test/arithmetic_benchmark.cc
@@ -15,8 +15,12 @@ void BM_binary(benchmark::State& state, Fn&& fn) {
   }
 }
 
-void BM_euclidean_div(benchmark::State& state) { BM_binary(state, euclidean_div<std::ptrdiff_t>); }
-void BM_euclidean_mod(benchmark::State& state) { BM_binary(state, euclidean_mod<std::ptrdiff_t>); }
+void BM_euclidean_div(benchmark::State& state) {
+  BM_binary(state, [](std::ptrdiff_t a, std::ptrdiff_t b) { return euclidean_div<std::ptrdiff_t>(a, b); });
+}
+void BM_euclidean_mod(benchmark::State& state) {
+  BM_binary(state, [](std::ptrdiff_t a, std::ptrdiff_t b) { return euclidean_mod<std::ptrdiff_t>(a, b); });
+}
 void BM_euclidean_mod_positive_modulus(benchmark::State& state) {
   BM_binary(state, euclidean_mod_positive_modulus<std::ptrdiff_t>);
 }

--- a/base/test/modulus_remainder.cc
+++ b/base/test/modulus_remainder.cc
@@ -6,16 +6,21 @@
 
 namespace slinky {
 
+using mod_rem = modulus_remainder<int64_t>;
+
+std::ostream& operator<<(std::ostream& os, const mod_rem& mr) {
+  return os << "(" << mr.modulus << ", " << mr.remainder << ")";
+}
+
 TEST(modulus_remainder, p) {
-  ASSERT_EQ(modulus_remainder<int64_t>(30, 3) + modulus_remainder<int64_t>(40, 2), modulus_remainder<int64_t>(10, 5));
-  ASSERT_EQ(modulus_remainder<int64_t>(6, 3) * modulus_remainder<int64_t>(4, 1), modulus_remainder<int64_t>(2, 1));
-  ASSERT_EQ(modulus_remainder<int64_t>(30, 6) | modulus_remainder<int64_t>(40, 31), modulus_remainder<int64_t>(5, 1));
-  ASSERT_EQ(modulus_remainder<int64_t>(10, 0) - modulus_remainder<int64_t>(33, 0), modulus_remainder<int64_t>(1, 0));
-  ASSERT_EQ(modulus_remainder<int64_t>(10, 0) - modulus_remainder<int64_t>(35, 0), modulus_remainder<int64_t>(5, 0));
+  ASSERT_EQ(mod_rem(0, 0) + mod_rem(0, 6), mod_rem(0, 6));
+  ASSERT_EQ(mod_rem(30, 3) + mod_rem(40, 2), mod_rem(10, 5));
+  ASSERT_EQ(mod_rem(6, 3) * mod_rem(4, 1), mod_rem(2, 1));
+  ASSERT_EQ(mod_rem(30, 6) | mod_rem(40, 31), mod_rem(5, 1));
+  ASSERT_EQ(mod_rem(10, 0) - mod_rem(33, 0), mod_rem(1, 0));
+  ASSERT_EQ(mod_rem(10, 0) - mod_rem(35, 0), mod_rem(5, 0));
   // // Check overflow
-  ASSERT_EQ(modulus_remainder<int64_t>(5045320, 4) * modulus_remainder<int64_t>(405713, 3) *
-                modulus_remainder<int64_t>(8000123, 4354),
-      modulus_remainder<int64_t>(1, 0));
+  ASSERT_EQ(mod_rem(5045320, 4) * mod_rem(405713, 3) * mod_rem(8000123, 4354), mod_rem(1, 0));
 }
 
 }  // namespace slinky

--- a/builder/simplify.cc
+++ b/builder/simplify.cc
@@ -330,9 +330,7 @@ public:
 
     void trim_bounds_using_alignment() {
       if (alignment.modulus == 0) {
-        // TODO(vksnk): for some reason this fails simplifier test for expressions
-        // with _ % -1 in them,.
-        // bounds = point(alignment.remainder);
+        bounds = point(alignment.remainder);
       } else if (alignment.modulus > 1) {
         const index_t* bounds_min = as_constant(bounds.min);
         if (bounds_min) {


### PR DESCRIPTION
The Halide version used this tricky helper function: https://github.com/halide/Halide/blob/1a7b91426b26f94eec76d4b19a9a3f04e74b7c47/src/ModulusRemainder.cpp#L13