### PR TITLE
Fix incorrect aliasing for translated copies

### DIFF
--- a/builder/optimizations.cc
+++ b/builder/optimizations.cc
@@ -280,9 +280,8 @@ class buffer_aliaser : public node_mutator {
         if (!prove_true(op->dims[d].bounds.min >= alias_dim.bounds.min) ||
             !prove_true(op->dims[d].bounds.max <= alias_dim.bounds.max)) {
           // We don't know if this target is big enough for this allocation.
-          assert(!target_info.is_input);
-          if (target_info.is_output) {
-            // We can't reallocate this output buffer.
+          if (target_info.is_input || target_info.is_output) {
+            // We can't reallocate this buffer.
             return false;
           }
         }

--- a/builder/optimizations.cc
+++ b/builder/optimizations.cc
@@ -380,6 +380,7 @@ public:
 
       // If we aliased the source and destination of a copy with no padding, the copy can be removed.
       result = remove_copy(result, op->sym, target_var);
+
       if (!alias.is_copy) {
         // This wasn't a copy, we actually did some computation in place. We can't alias another buffer to this target
         // without understanding the lifetimes more carefully.
@@ -391,6 +392,7 @@ public:
           i->do_not_alias(target_var);
         }
       }
+
       set_result(std::move(result));
       return;
     }

--- a/builder/optimizations.cc
+++ b/builder/optimizations.cc
@@ -295,7 +295,10 @@ public:
           }
           for (std::size_t d = 0; d < op->dims.size(); ++d) {
             // TODO: We may have proven this is unnecessary in alias_compatible, we can avoid this in such cases.
-            target_info->dims[d].bounds |= alias.dims[alias.permutation[d]].bounds;
+            // We need the bounds of the alias, as it exists in the target buffer. `alias.at` tells us where this alias
+            // starts.
+            target_info->dims[d].bounds |=
+                alias.at[alias.permutation[d]] + min_extent(0, alias.dims[alias.permutation[d]].bounds.extent());
           }
         } else {
           // In this case, alias_compatible must have determined that we do not need to grow the allocation.
@@ -756,7 +759,6 @@ public:
   void visit(const copy_stmt* op) override { visit_terminal(op); }
   void visit(const check* op) override { visit_terminal(op); }
   void visit(const let_stmt* op) override { visit_terminal(op); }
-
 
   // Remaining functions collect all the buffer symbols which refer the original allocate
   // symbol or its dependencies.

--- a/builder/test/context.cc
+++ b/builder/test/context.cc
@@ -5,6 +5,7 @@
 
 #include "base/chrome_trace.h"
 #include "base/thread_pool.h"
+#include "runtime/buffer.h"
 
 namespace slinky {
 
@@ -45,6 +46,16 @@ test_context::test_context() {
   free = [this](var, raw_buffer* b, void* allocation) {
     ::free(allocation);
     heap.track_free(b->size_bytes());
+  };
+
+  copy = [this](const raw_buffer& src, const raw_buffer& dst, const void* padding) {
+    ++copy_calls;
+    copy_elements += dst.elem_count();
+    slinky::copy(src, dst, padding);
+  };
+  pad = [this](const dim* in_bounds, const raw_buffer& dst, const void* padding) {
+    ++pad_calls;
+    slinky::pad(in_bounds, dst, padding);
   };
 
   thread_pool = &threads;

--- a/builder/test/context.h
+++ b/builder/test/context.h
@@ -33,6 +33,9 @@ struct memory_info {
 class test_context : public eval_context {
 public:
   memory_info heap;
+  int copy_calls = 0;
+  int copy_elements = 0;
+  int pad_calls = 0;
 
   test_context();
 };

--- a/builder/test/copy.cc
+++ b/builder/test/copy.cc
@@ -4,30 +4,12 @@
 #include <vector>
 
 #include "builder/pipeline.h"
+#include "builder/test/context.h"
 #include "builder/test/util.h"
 #include "runtime/expr.h"
 #include "runtime/pipeline.h"
 
 namespace slinky {
-
-class test_context : public eval_context {
-public:
-  int copy_calls = 0;
-  int copy_elements = 0;
-  int pad_calls = 0;
-
-  test_context() {
-    copy = [this](const raw_buffer& src, const raw_buffer& dst, const void* padding) {
-      ++copy_calls;
-      copy_elements += dst.elem_count();
-      slinky::copy(src, dst, padding);
-    };
-    pad = [this](const dim* in_bounds, const raw_buffer& dst, const void* padding) {
-      ++pad_calls;
-      slinky::pad(in_bounds, dst, padding);
-    };
-  }
-};
 
 template <typename T, std::size_t N>
 void init_random(buffer<T, N>& x) {

--- a/builder/test/copy_pipeline.cc
+++ b/builder/test/copy_pipeline.cc
@@ -51,7 +51,7 @@ TEST(flip_y, pipeline) {
   ASSERT_THAT(eval_ctx.heap.allocs, testing::UnorderedElementsAre(W * H * sizeof(char)));
 }
 
-TEST(padded_copy, pipeline) {
+TEST(padded_copy_bounds, pipeline) {
   // Make the pipeline
   node_context ctx;
 
@@ -108,9 +108,70 @@ TEST(padded_copy, pipeline) {
   ASSERT_THAT(eval_ctx.heap.allocs, testing::UnorderedElementsAre(W * H * sizeof(char)));
 }
 
-class copied_output : public testing::TestWithParam<std::tuple<int, int, int>> {};
+class padded_copy : public testing::TestWithParam<std::tuple<bool, int, int, bool>> {};
 
-auto offsets = testing::Values(0, 3);
+auto offsets = testing::Values(0);
+auto add_stage = testing::Values(false, true);
+
+INSTANTIATE_TEST_SUITE_P(offsets, padded_copy, testing::Combine(add_stage, offsets, offsets, add_stage),
+    test_params_to_string<padded_copy::ParamType>);
+
+TEST_P(padded_copy, pipeline) {
+  bool in_stage = std::get<0>(GetParam());
+  int offset_x = std::get<1>(GetParam());
+  int offset_y = std::get<2>(GetParam());
+  bool out_stage = std::get<3>(GetParam());
+
+  // Make the pipeline
+  node_context ctx;
+
+  auto in = buffer_expr::make(ctx, "in", 2, sizeof(char));
+  auto out = buffer_expr::make(ctx, "out", 2, sizeof(char));
+  auto intm = buffer_expr::make(ctx, "intm", 2, sizeof(char));
+  auto padded_intm = buffer_expr::make(ctx, "padded_intm", 2, sizeof(char));
+
+  var x(ctx, "x");
+  var y(ctx, "y");
+
+  func copy_in, copy_out;
+  if (in_stage) {
+    copy_in = func::make(copy_2d<char>, {{in, {point(x), point(y)}}}, {{intm, {x, y}}});
+  }
+  func crop =
+      func::make_copy({in_stage ? intm : in, {point(x + offset_x), point(y + offset_y)}, in->bounds()}, {out_stage ? padded_intm : out, {x, y}}, {3});
+  if (out_stage) {
+    copy_out = func::make(copy_2d<char>, {{padded_intm, {point(x), point(y)}}}, {{out, {x, y}}});
+  }
+
+  pipeline p = build_pipeline(ctx, {in}, {out});
+
+  const int W = 8;
+  const int H = 5;
+
+  // Run the pipeline.
+  buffer<char, 2> in_buf({W, H});
+  init_random(in_buf);
+
+  buffer<char, 2> out_buf({W, H});
+  out_buf.allocate();
+
+  const raw_buffer* inputs[] = {&in_buf};
+  const raw_buffer* outputs[] = {&out_buf};
+  test_context eval_ctx;
+  p.evaluate(inputs, outputs, eval_ctx);
+
+  for (int y = 0; y < H; ++y) {
+    for (int x = 0; x < W; ++x) {
+      if (0 <= x + offset_x && x + offset_x < W && 0 <= y + offset_y && y + offset_y < H) {
+        ASSERT_EQ(out_buf(x, y), in_buf(x + offset_x, y + offset_y));
+      } else {
+        ASSERT_EQ(out_buf(x, y), 3);
+      }
+    }
+  }
+}
+
+class copied_output : public testing::TestWithParam<std::tuple<int, int, int>> {};
 
 INSTANTIATE_TEST_SUITE_P(schedule, copied_output, testing::Combine(testing::Range(0, 3), offsets, offsets),
     test_params_to_string<copied_output::ParamType>);

--- a/builder/test/copy_pipeline.cc
+++ b/builder/test/copy_pipeline.cc
@@ -110,6 +110,7 @@ TEST_P(padded_copy, pipeline) {
   }
 
   ASSERT_THAT(eval_ctx.heap.allocs, testing::UnorderedElementsAre(W * H * sizeof(char)));
+  ASSERT_EQ(eval_ctx.copy_calls, 1);
 }
 
 class copied_output : public testing::TestWithParam<std::tuple<int, int, int>> {};
@@ -181,6 +182,7 @@ TEST_P(copied_output, pipeline) {
   }
 
   ASSERT_EQ(eval_ctx.heap.allocs.size(), 0);
+  ASSERT_EQ(eval_ctx.copy_calls, 0);
 }
 
 class copied_input : public testing::TestWithParam<std::tuple<int, int, int>> {};
@@ -253,6 +255,7 @@ TEST_P(copied_input, pipeline) {
   }
 
   ASSERT_EQ(eval_ctx.heap.allocs.size(), 0);
+  ASSERT_EQ(eval_ctx.copy_calls, 0);
 }
 
 class concatenated_output : public testing::TestWithParam<bool> {};
@@ -313,6 +316,7 @@ TEST_P(concatenated_output, pipeline) {
 
   if (!no_alias_buffers) {
     ASSERT_EQ(eval_ctx.heap.allocs.size(), 0);
+    ASSERT_EQ(eval_ctx.copy_calls, 0);
   }
 
   if (no_alias_buffers == true) {
@@ -384,6 +388,7 @@ TEST_P(transposed_output, pipeline) {
 
   if (is_permutation(permutation) && !no_alias_buffers) {
     ASSERT_EQ(eval_ctx.heap.allocs.size(), 0);
+    ASSERT_EQ(eval_ctx.copy_calls, 0);
   } else {
     ASSERT_EQ(eval_ctx.heap.allocs.size(), 1);
   }
@@ -442,6 +447,7 @@ TEST(stacked_output, pipeline) {
   }
 
   ASSERT_EQ(eval_ctx.heap.allocs.size(), 0);
+  ASSERT_EQ(eval_ctx.copy_calls, 0);
 
   check_replica_pipeline(define_replica_pipeline(ctx, {in1, in2}, {out}));
 }
@@ -575,6 +581,7 @@ TEST_P(broadcasted_elementwise, internal) {
 
   if (!no_alias_buffers) {
     ASSERT_EQ(eval_ctx.heap.allocs.size(), 1);
+    ASSERT_EQ(eval_ctx.copy_calls, 0);
   }
 }
 

--- a/builder/test/funcs.h
+++ b/builder/test/funcs.h
@@ -11,12 +11,8 @@ namespace slinky {
 template <typename T, std::size_t N>
 void fill_random(const buffer<T, N>& buf) {
   std::size_t flat_size = buf.size_bytes();
-  std::size_t i = 0;
-  for (; i + 3 < flat_size; i += 4) {
-    reinterpret_cast<int*>(buf.base())[i >> 2] = (rand() % 20) - 10;
-  }
-  for (; i < flat_size; ++i) {
-    reinterpret_cast<char*>(buf.base())[i] = (rand() % 20) - 10;
+  for (size_t i = 0; i < flat_size; ++i) {
+    reinterpret_cast<char*>(buf.base())[i] = (rand() & 15) - 8;
   }
 }
 

--- a/builder/test/util.h
+++ b/builder/test/util.h
@@ -1,6 +1,7 @@
 #ifndef SLINKY_BUILDER_TEST_UTIL_H
 #define SLINKY_BUILDER_TEST_UTIL_H
 
+#include <algorithm>
 #include <numeric>
 #include <string>
 
@@ -30,7 +31,9 @@ std::string test_params_to_string_impl(const T& t, std::index_sequence<Is...>) {
 template <typename T>
 std::string test_params_to_string(const testing::TestParamInfo<T>& info) {
   constexpr std::size_t n = std::tuple_size<T>();
-  return test_params_to_string_impl(info.param, std::make_index_sequence<n>());
+  std::string result = test_params_to_string_impl(info.param, std::make_index_sequence<n>());
+  std::replace(result.begin(), result.end(), '-', '_');
+  return result;
 }
 
 std::string remove_windows_newlines(std::string s);

--- a/builder/test/visualize/padded_stencil_0.html
+++ b/builder/test/visualize/padded_stencil_0.html
@@ -370,12 +370,12 @@ function pipeline(__in, out) {
         produce(intm_padded_intm);
         __event_t++;
       }}
-      { let __intm = crop_buffer(intm_padded_intm, [
+      { let __intm_1 = crop_buffer(intm_padded_intm, [
           [g, g_0],
           [g_1, g_2]
       ]); {
-        let intm = __intm;
-        produce(intm);
+        let intm_1 = __intm_1;
+        produce(intm_1);
         produce(intm_padded_intm);
         __event_t++;
       }}

--- a/builder/test/visualize/padded_stencil_1.html
+++ b/builder/test/visualize/padded_stencil_1.html
@@ -370,12 +370,12 @@ function pipeline(__in, out) {
         produce(intm_padded_intm);
         __event_t++;
       }}
-      { let __intm = crop_buffer(intm_padded_intm, [
+      { let __intm_1 = crop_buffer(intm_padded_intm, [
           [g, g_0],
           [g_1, g_2]
       ]); {
-        let intm = __intm;
-        produce(intm);
+        let intm_1 = __intm_1;
+        produce(intm_1);
         produce(intm_padded_intm);
         __event_t++;
       }}

--- a/runtime/buffer.cc
+++ b/runtime/buffer.cc
@@ -224,7 +224,6 @@ void fill(void* dst, const void* value, index_t elem_size, index_t size) {
 void copy_impl(raw_buffer& src, raw_buffer& dst, const void* padding) {
   assert(src.rank == dst.rank);
   assert(src.elem_size == dst.elem_size);
-  assert(dst.base);
   const std::size_t rank = dst.rank;
   index_t elem_size = dst.elem_size;
 
@@ -332,7 +331,6 @@ void pad(const dim* in_bounds, const raw_buffer& dst, const void* padding) {
 
 SLINKY_NO_STACK_PROTECTOR void fill(const raw_buffer& dst, const void* value) {
   assert(value);
-  assert(dst.base);
   const std::size_t rank = dst.rank;
   index_t elem_size = dst.elem_size;
 

--- a/runtime/buffer.cc
+++ b/runtime/buffer.cc
@@ -224,6 +224,7 @@ void fill(void* dst, const void* value, index_t elem_size, index_t size) {
 void copy_impl(raw_buffer& src, raw_buffer& dst, const void* padding) {
   assert(src.rank == dst.rank);
   assert(src.elem_size == dst.elem_size);
+  assert(dst.base || dst.elem_count() == 0);
   const std::size_t rank = dst.rank;
   index_t elem_size = dst.elem_size;
 
@@ -331,6 +332,7 @@ void pad(const dim* in_bounds, const raw_buffer& dst, const void* padding) {
 
 SLINKY_NO_STACK_PROTECTOR void fill(const raw_buffer& dst, const void* value) {
   assert(value);
+  assert(dst.base || dst.elem_count() == 0);
   const std::size_t rank = dst.rank;
   index_t elem_size = dst.elem_size;
 

--- a/runtime/buffer.cc
+++ b/runtime/buffer.cc
@@ -37,6 +37,8 @@ std::size_t alloc_size(std::size_t rank, std::size_t elem_size, const dim* dims)
   for (std::size_t i = 0; i < rank; ++i) {
     if (dims[i].stride() == 0) continue;
     index_t extent = alloc_extent(dims[i]);
+    assert(extent >= 0);
+    if (extent == 0) return 0;
     flat_min += (extent - 1) * std::min<index_t>(0, dims[i].stride());
     flat_max += (extent - 1) * std::max<index_t>(0, dims[i].stride());
   }

--- a/runtime/test/buffer.cc
+++ b/runtime/test/buffer.cc
@@ -160,6 +160,14 @@ TEST(buffer, buffer) {
   }
 }
 
+TEST(buffer, empty_buffer) {
+  buffer<int, 3> buf({1, 0, 2});
+
+  ASSERT_EQ(buf.rank, 3);
+
+  buf.allocate();
+}
+
 bool test_fill(int elem_size, int size) {
   buffer<void, 1> buf({size}, elem_size);
   buf.allocate();


### PR DESCRIPTION
When we tried to expand allocations to accommodate a possibly padded alias, we used the "native" coordinates for both buffers, which is incorrect if there is a translation between the aliases. This PR fixes that.

Some related notes:
- The old "replace copy with pad" logic was pretty broken, and also pointless, because pad simply called copy with an aliased buffer anyways, expecting the copy parts of the operation to be a no-op. We might want to optimize this at some point, but it's low priority for the moment.
- The asserts added in #455 were overzealous if the buffer is empty, fixed this to allow empty buffers.