### PR TITLE
Propagate strides to simplify aliasing of transposes

### DIFF
--- a/builder/optimizations.cc
+++ b/builder/optimizations.cc
@@ -280,7 +280,7 @@ class buffer_aliaser : public node_mutator {
         }
       }
       if (op->dims[d].stride.defined()) {
-        if (!prove_true(op->dims[d].stride == alias_dim.stride)) {
+        if (!prove_true(op->dims[d].stride == alias_dim.stride) && !prove_true(op->dims[d].stride == target_info.dims[alias.permutation[d]].stride)) {
           // This alias would violate a constraint on the stride of the buffer.
           return false;
         }

--- a/builder/pipeline.cc
+++ b/builder/pipeline.cc
@@ -674,7 +674,7 @@ class pipeline_builder {
 
       if (permutation.size() != output.dims.size()) continue;
 
-      // Propogate strides based on the permutation of dims.
+      // Propagate strides based on the permutation of dims.
       for (int ix = 0; ix < static_cast<int>(output_dims.size()); ++ix) {
         input_dims[permutation[ix]].stride = output_dims[ix].stride;
       }


### PR DESCRIPTION
This is a bit of hack, but does help to eliminate transposes in one of the test cases.