### PR TITLE
Various minor fixes

### DIFF
--- a/base/thread_pool.h
+++ b/base/thread_pool.h
@@ -21,6 +21,8 @@ public:
   using task = std::function<void()>;
   using predicate = std::function<bool()>;
 
+  virtual ~thread_pool() = default;
+
   virtual int thread_count() const = 0;
 
   // Enqueues `n` copies of task `t` on the thread pool queue. This guarantees that `t` will not
@@ -109,7 +111,7 @@ public:
   // `workers` indicates how many worker threads the thread pool will have.
   // `init` is a task that is run on each newly created thread.
   thread_pool_impl(int workers = 3, const task& init = nullptr);
-  ~thread_pool_impl();
+  virtual ~thread_pool_impl();
 
   int thread_count() const override { return workers_.size(); }
 

--- a/base/thread_pool.h
+++ b/base/thread_pool.h
@@ -111,7 +111,7 @@ public:
   // `workers` indicates how many worker threads the thread pool will have.
   // `init` is a task that is run on each newly created thread.
   thread_pool_impl(int workers = 3, const task& init = nullptr);
-  virtual ~thread_pool_impl();
+  ~thread_pool_impl() override;
 
   int thread_count() const override { return workers_.size(); }
 

--- a/builder/optimizations.cc
+++ b/builder/optimizations.cc
@@ -498,8 +498,8 @@ public:
           alias_info back;
           // Use the bounds of the output, but the memory layout of the input.
           back.dims.resize(rank);
-          for (size_t d = 0; d < rank; ++d) {
-            back.dims[d] = {buffer_bounds(o, (int32_t)d), buffer_stride(i, (int32_t)d), buffer_fold_factor(i, (int32_t)d)};
+          for (int d = 0; d < static_cast<int>(rank); ++d) {
+            back.dims[d] = {buffer_bounds(o, d), buffer_stride(i, d), buffer_fold_factor(i, d)};
           }
           back.at = buffer_mins(o, rank);
           back.assume_in_bounds = true;

--- a/builder/optimizations.cc
+++ b/builder/optimizations.cc
@@ -1,24 +1,27 @@
 #include "builder/optimizations.h"
 
+#include <algorithm>
 #include <cassert>
 #include <cstddef>
+#include <cstdint>
 #include <cstdlib>
 #include <map>
 #include <numeric>
 #include <optional>
 #include <set>
-#include <tuple>
 #include <utility>
 #include <vector>
 
 #include "base/chrome_trace.h"
 #include "builder/node_mutator.h"
+#include "builder/pipeline.h"
 #include "builder/simplify.h"
 #include "builder/substitute.h"
 #include "runtime/buffer.h"
 #include "runtime/depends_on.h"
 #include "runtime/evaluate.h"
 #include "runtime/expr.h"
+#include "runtime/stmt.h"
 
 namespace slinky {
 
@@ -434,7 +437,7 @@ public:
     std::vector<dim_expr> dims(rank);
     expr stride = buffer_elem_size(buf);
     for (std::size_t i = 0; i < rank; ++i) {
-      dims[i].bounds = buffer_bounds(buf, i);
+      dims[i].bounds = buffer_bounds(buf, (int32_t)i);
       dims[i].stride = stride;
       stride *= dims[i].bounds.extent();
     }
@@ -496,7 +499,7 @@ public:
           // Use the bounds of the output, but the memory layout of the input.
           back.dims.resize(rank);
           for (size_t d = 0; d < rank; ++d) {
-            back.dims[d] = {buffer_bounds(o, d), buffer_stride(i, d), buffer_fold_factor(i, d)};
+            back.dims[d] = {buffer_bounds(o, (int32_t)d), buffer_stride(i, (int32_t)d), buffer_fold_factor(i, (int32_t)d)};
           }
           back.at = buffer_mins(o, rank);
           back.assume_in_bounds = true;

--- a/builder/optimizations.cc
+++ b/builder/optimizations.cc
@@ -436,8 +436,8 @@ public:
   static std::vector<dim_expr> make_contiguous_dims(var buf, std::size_t rank) {
     std::vector<dim_expr> dims(rank);
     expr stride = buffer_elem_size(buf);
-    for (std::size_t i = 0; i < rank; ++i) {
-      dims[i].bounds = buffer_bounds(buf, (int32_t)i);
+    for (int i = 0; i < static_cast<int>(rank); ++i) {
+      dims[i].bounds = buffer_bounds(buf, i);
       dims[i].stride = stride;
       stride *= dims[i].bounds.extent();
     }

--- a/builder/substitute.cc
+++ b/builder/substitute.cc
@@ -2,7 +2,6 @@
 
 #include <cassert>
 #include <cstddef>
-#include <cstdint>
 #include <functional>
 #include <optional>
 #include <utility>

--- a/builder/substitute.cc
+++ b/builder/substitute.cc
@@ -2,6 +2,7 @@
 
 #include <cassert>
 #include <cstddef>
+#include <cstdint>
 #include <functional>
 #include <optional>
 #include <utility>
@@ -563,7 +564,7 @@ public:
         for (std::size_t d = 0; d < buf_rank; ++d) {
           if (d + 1 >= args.size() || !args[d + 1].defined()) {
             // buffer_at has an implicit buffer_min if it is not defined.
-            expr min_args[] = {d};
+            expr min_args[] = {(int32_t)d};
             expr min = mutate_buffer_intrinsic(intrinsic::buffer_min, *buf, min_args);
             if (min.defined()) {
               args.resize(std::max(args.size(), d + 2));

--- a/builder/substitute.cc
+++ b/builder/substitute.cc
@@ -564,7 +564,7 @@ public:
         for (std::size_t d = 0; d < buf_rank; ++d) {
           if (d + 1 >= args.size() || !args[d + 1].defined()) {
             // buffer_at has an implicit buffer_min if it is not defined.
-            expr min_args[] = {(int32_t)d};
+            expr min_args[] = {d};
             expr min = mutate_buffer_intrinsic(intrinsic::buffer_min, *buf, min_args);
             if (min.defined()) {
               args.resize(std::max(args.size(), d + 2));


### PR DESCRIPTION
- Classes with virtual methods need virtual dtors
- Fix ambiguous size_t -> expr conversions
- Various clang-tidy fixes re: includes