### PR TITLE
Revert "Fixes for compiling Slinky under Emscripten"

### DIFF
--- a/runtime/buffer.h
+++ b/runtime/buffer.h
@@ -16,9 +16,6 @@ namespace slinky {
 #ifdef __APPLE__
 using index_t = std::int64_t;
 static_assert(sizeof(index_t) == sizeof(std::size_t));
-#elif defined __EMSCRIPTEN__
-using index_t = std::int64_t;
-// Note that size_t and ptrdiff_t are sizeof(int32_t) under Emscripten
 #else
 using index_t = std::ptrdiff_t;
 #endif

--- a/runtime/expr.h
+++ b/runtime/expr.h
@@ -195,9 +195,6 @@ public:
   expr(std::int64_t x);
   expr(std::int32_t x) : expr(static_cast<std::int64_t>(x)) {}
   expr(std::uint64_t x) : expr(static_cast<std::int64_t>(x)) {}
-#ifdef __EMSCRIPTEN__
-  expr(std::size_t x) : expr(static_cast<std::int64_t>(x)) {}
-#endif
   expr(var sym);
 
   // Make an `expr` referencing an existing node.


### PR DESCRIPTION
Reverts dsharlet/slinky#475 -- change was misguided and incomplete.