### PR TITLE
Various portability fixes for Slinky

### DIFF
--- a/base/chrome_trace.cc
+++ b/base/chrome_trace.cc
@@ -15,9 +15,14 @@ std::atomic<int> next_id = 0;
 
 // Unfortunately, std::clock returns the CPU time for the whole process, not the current thread.
 std::clock_t clock_per_thread_us() {
+  #ifdef _MSC_VER
+  // CLOCK_THREAD_CPUTIME_ID not defined under MSVC
+  return 0;
+  #else
   timespec t;
   clock_gettime(CLOCK_THREAD_CPUTIME_ID, &t);
   return t.tv_sec * 1000000 + t.tv_nsec / 1000;
+  #endif
 }
 
 }  // namespace

--- a/base/modulus_remainder.h
+++ b/base/modulus_remainder.h
@@ -35,7 +35,7 @@ struct modulus_remainder {
 
 template <typename T>
 modulus_remainder<T> operator+(const modulus_remainder<T>& a, const modulus_remainder<T>& b) {
-  int64_t m = 1, r = 0;
+  T m = 1, r = 0;
   if (!add_with_overflow(a.remainder, b.remainder, r)) {
     m = gcd(a.modulus, b.modulus);
     r = euclidean_mod(r, m, r);
@@ -45,7 +45,7 @@ modulus_remainder<T> operator+(const modulus_remainder<T>& a, const modulus_rema
 
 template <typename T>
 modulus_remainder<T> operator-(const modulus_remainder<T>& a, const modulus_remainder<T>& b) {
-  int64_t m = 1, r = 0;
+  T m = 1, r = 0;
   if (!sub_with_overflow(a.remainder, b.remainder, r)) {
     m = gcd(a.modulus, b.modulus);
     r = euclidean_mod(r, m, r);
@@ -55,7 +55,7 @@ modulus_remainder<T> operator-(const modulus_remainder<T>& a, const modulus_rema
 
 template <typename T>
 modulus_remainder<T> operator*(const modulus_remainder<T>& a, const modulus_remainder<T>& b) {
-  int64_t m, r;
+  T m, r;
   if (a.modulus == 0) {
     // a is constant
     if (!mul_with_overflow(a.remainder, b.modulus, m) && !mul_with_overflow(a.remainder, b.remainder, r)) {
@@ -72,12 +72,12 @@ modulus_remainder<T> operator*(const modulus_remainder<T>& a, const modulus_rema
       return {m, 0};
     }
   } else if (a.remainder == 0) {
-    int64_t g = gcd(b.modulus, b.remainder);
+    T g = gcd(b.modulus, b.remainder);
     if (!mul_with_overflow(a.modulus, g, m)) {
       return {m, 0};
     }
   } else if (b.remainder == 0) {
-    int64_t g = gcd(a.modulus, a.remainder);
+    T g = gcd(a.modulus, a.remainder);
     if (!mul_with_overflow(b.modulus, g, m)) {
       return {m, 0};
     }
@@ -106,8 +106,8 @@ modulus_remainder<T> operator/(const modulus_remainder<T>& a, const modulus_rema
 
   if (b.modulus == 0 && b.remainder != 0) {
     if ((euclidean_mod(a.modulus, b.remainder, a.modulus)) == 0) {
-      int64_t m = a.modulus / b.remainder;
-      int64_t r = euclidean_div(a.remainder, b.remainder);
+      T m = a.modulus / b.remainder;
+      T r = euclidean_div(a.remainder, b.remainder);
       r = euclidean_mod(r, m, r);
       return {m, r};
     }
@@ -132,19 +132,19 @@ modulus_remainder<T> operator|(const modulus_remainder<T>& a, const modulus_rema
   }
 
   // Reduce them to the same modulus and the same remainder
-  int64_t modulus = gcd(a.modulus, b.modulus);
+  T modulus = gcd(a.modulus, b.modulus);
 
-  int64_t r;
+  T r;
   if (sub_with_overflow(a.remainder, b.remainder, r)) {
     // The modulus is not representable as an int64.
     return modulus_remainder<T>{};
   }
 
-  int64_t diff = a.remainder - b.remainder;
+  T diff = a.remainder - b.remainder;
 
   modulus = gcd(diff, modulus);
 
-  int64_t ra = euclidean_mod(a.remainder, modulus, a.remainder);
+  T ra = euclidean_mod(a.remainder, modulus, a.remainder);
 
   assert(ra == (euclidean_mod(b.remainder, modulus, b.remainder)));
 
@@ -165,9 +165,9 @@ modulus_remainder<T> operator%(const modulus_remainder<T>& a, const modulus_rema
   // (8x + 6zx + 2x) + 5 ->
   // 2(4x + 3zx + x) + 5 ->
   // 2w + 1
-  int64_t modulus = gcd(a.modulus, b.modulus);
+  T modulus = gcd(a.modulus, b.modulus);
   modulus = gcd(modulus, b.remainder);
-  int64_t remainder = euclidean_mod(a.remainder, modulus, a.remainder);
+  T remainder = euclidean_mod(a.remainder, modulus, a.remainder);
 
   if (b.remainder == 0 && remainder != 0) {
     // b could be zero, so the result could also just be zero.
@@ -184,27 +184,27 @@ modulus_remainder<T> operator%(const modulus_remainder<T>& a, const modulus_rema
 }
 
 template <typename T>
-modulus_remainder<T> operator+(const modulus_remainder<T>& a, int64_t b) {
+modulus_remainder<T> operator+(const modulus_remainder<T>& a, T b) {
   return a + modulus_remainder<T>(0, b);
 }
 
 template <typename T>
-modulus_remainder<T> operator-(const modulus_remainder<T>& a, int64_t b) {
+modulus_remainder<T> operator-(const modulus_remainder<T>& a, T b) {
   return a - modulus_remainder<T>(0, b);
 }
 
 template <typename T>
-modulus_remainder<T> operator*(const modulus_remainder<T>& a, int64_t b) {
+modulus_remainder<T> operator*(const modulus_remainder<T>& a, T b) {
   return a * modulus_remainder<T>(0, b);
 }
 
 template <typename T>
-modulus_remainder<T> operator/(const modulus_remainder<T>& a, int64_t b) {
+modulus_remainder<T> operator/(const modulus_remainder<T>& a, T b) {
   return a / modulus_remainder<T>(0, b);
 }
 
 template <typename T>
-modulus_remainder<T> operator%(const modulus_remainder<T>& a, int64_t b) {
+modulus_remainder<T> operator%(const modulus_remainder<T>& a, T b) {
   return a % modulus_remainder<T>(0, b);
 }
 

--- a/base/util.h
+++ b/base/util.h
@@ -3,7 +3,7 @@
 
 namespace slinky {
 
-#define SLINKY_ALLOCA(T, N) reinterpret_cast<T*>(alloca((N) * sizeof(T)))
+#define SLINKY_ALLOCA(T, N) reinterpret_cast<T*>(__builtin_alloca((N) * sizeof(T)))
 #define SLINKY_ALWAYS_INLINE __attribute__((always_inline))
 #define SLINKY_NO_INLINE __attribute__((noinline))
 

--- a/builder/rewrite.h
+++ b/builder/rewrite.h
@@ -65,6 +65,14 @@ struct pattern_info<bool> {
   static constexpr bool is_boolean = true;
   static constexpr bool is_canonical = true;
 };
+#ifdef __EMSCRIPTEN__
+template <>
+struct pattern_info<long> {
+  static constexpr expr_node_type type = expr_node_type::constant;
+  static constexpr bool is_boolean = false;
+  static constexpr bool is_canonical = true;
+};
+#endif
 
 class pattern_expr {
 public:

--- a/builder/simplify.cc
+++ b/builder/simplify.cc
@@ -755,9 +755,9 @@ public:
     } else {
       interval_expr result_info = bounds_of(op, std::move(a_info.bounds), std::move(b_info.bounds));
       if (prove_constant_true(result_info.min)) {
-        set_result(true, {{1, 1}, alignment_type()});
+        set_result(expr(true), {{1, 1}, alignment_type()});
       } else if (prove_constant_false(result_info.max)) {
-        set_result(false, {{0, 0}, alignment_type()});
+        set_result(expr(false), {{0, 0}, alignment_type()});
       } else {
         set_result(result, {std::move(result_info), alignment_type()});
       }
@@ -777,9 +777,9 @@ public:
     if (!a.defined()) {
       set_result(expr(), expr_info());
     } else if (prove_constant_true(info.bounds.min)) {
-      set_result(false, {{0, 0}, alignment_type()});
+      set_result(expr(false), {{0, 0}, alignment_type()});
     } else if (prove_constant_false(info.bounds.max)) {
-      set_result(true, {{1, 1}, alignment_type()});
+      set_result(expr(true), {{1, 1}, alignment_type()});
     } else {
       expr result = simplify(op, std::move(a));
       if (result.same_as(op)) {

--- a/builder/simplify.cc
+++ b/builder/simplify.cc
@@ -338,11 +338,11 @@ public:
       } else if (alignment.modulus > 1) {
         const index_t* bounds_min = as_constant(bounds.min);
         if (bounds_min) {
-          int64_t adjustment;
+          index_t adjustment;
           bool no_overflow =
               !sub_with_overflow(alignment.remainder, euclidean_mod(*bounds_min, alignment.modulus), adjustment);
           adjustment = euclidean_mod(adjustment, alignment.modulus);
-          int64_t new_min;
+          index_t new_min;
           no_overflow &= !add_with_overflow(*bounds_min, adjustment, new_min);
           if (no_overflow) {
             bounds.min = new_min;
@@ -350,11 +350,11 @@ public:
         }
         const index_t* bounds_max = as_constant(bounds.max);
         if (bounds_max) {
-          int64_t adjustment;
+          index_t adjustment;
           bool no_overflow =
               !sub_with_overflow(euclidean_mod(*bounds_max, alignment.modulus), alignment.remainder, adjustment);
           adjustment = euclidean_mod(adjustment, alignment.modulus);
-          int64_t new_max;
+          index_t new_max;
           no_overflow &= !sub_with_overflow(*bounds_max, adjustment, new_max);
           if (no_overflow) {
             bounds.max = new_max;

--- a/runtime/buffer.h
+++ b/runtime/buffer.h
@@ -13,8 +13,13 @@
 
 namespace slinky {
 
-// index_t needs to at least be as big as a pointer and must be signed
-using index_t = std::ptrdiff_t;
+// index_t needs to at least be as big as a pointer and must be signed.
+// Using ptrdiff_t or intptr_t here seems tempting, but those can
+// alias to `long` under some compilers which can cause some not so fun
+// overloading issues with expr(), so let's use std::conditional
+// instead to make it an exact alias of either int32_t or int64_t.
+using index_t =
+    std::conditional<sizeof(void*) == 4, std::int32_t, std::int64_t>::type;
 
 // Helper to offset a pointer by a number of bytes.
 template <typename T>

--- a/runtime/buffer.h
+++ b/runtime/buffer.h
@@ -13,12 +13,8 @@
 
 namespace slinky {
 
-#ifdef __APPLE__
-using index_t = std::int64_t;
-static_assert(sizeof(index_t) == sizeof(std::size_t));
-#else
+// index_t needs to at least be as big as a pointer and must be signed
 using index_t = std::ptrdiff_t;
-#endif
 
 // Helper to offset a pointer by a number of bytes.
 template <typename T>

--- a/runtime/buffer.h
+++ b/runtime/buffer.h
@@ -3,6 +3,7 @@
 
 #include <algorithm>
 #include <cassert>
+#include <cstdint>
 #include <cstdlib>
 #include <cstring>
 #include <memory>

--- a/runtime/evaluate.cc
+++ b/runtime/evaluate.cc
@@ -497,7 +497,7 @@ public:
 
     if (op->storage == memory_type::stack) {
       buffer.init_strides();
-      buffer.base = alloca(buffer.size_bytes());
+      buffer.base = __builtin_alloca(buffer.size_bytes());
       buffer.allocation = nullptr;
     } else {
       assert(op->storage == memory_type::heap);

--- a/runtime/expr.h
+++ b/runtime/expr.h
@@ -194,7 +194,12 @@ public:
   // Make a new constant expression.
   expr(std::int64_t x);
   expr(std::int32_t x) : expr(static_cast<std::int64_t>(x)) {}
+  expr(std::uint32_t x) : expr(static_cast<std::int64_t>(x)) {}
   expr(std::uint64_t x) : expr(static_cast<std::int64_t>(x)) {}
+#ifdef __EMSCRIPTEN__
+  expr(std::size_t x) : expr(static_cast<std::int64_t>(x)) {}
+  expr(long x) : expr(static_cast<std::int64_t>(x)) {}
+#endif
   expr(var sym);
 
   // Make an `expr` referencing an existing node.

--- a/runtime/expr.h
+++ b/runtime/expr.h
@@ -194,12 +194,7 @@ public:
   // Make a new constant expression.
   expr(std::int64_t x);
   expr(std::int32_t x) : expr(static_cast<std::int64_t>(x)) {}
-  expr(std::uint32_t x) : expr(static_cast<std::int64_t>(x)) {}
-  expr(std::uint64_t x) : expr(static_cast<std::int64_t>(x)) {}
-#ifdef __EMSCRIPTEN__
   expr(std::size_t x) : expr(static_cast<std::int64_t>(x)) {}
-  expr(long x) : expr(static_cast<std::int64_t>(x)) {}
-#endif
   expr(var sym);
 
   // Make an `expr` referencing an existing node.


### PR DESCRIPTION
Various fixes to improve portability to targets/compilers that we hadn't tested on (much): 
- index_t needed some love to avoid multiple issues:
  - on 32-bit systems we really want it to be a 32-bit type for efficiency; there were various templated functions that assumed it was always an int64_t that needed to use an `index_t` (or `T`) as the temporary instead
  - defining `index_t` as `ptrdiff_t` or `intptr_t` seems like the right thing but introduces pain on some compilers (eg Emscripten, AppleClang) where the result is a `long` type that is distinct from both `int32_t` and `int64_t`, making it painful to get the overloaded ctors for `expr` correct without an ugly mass of ifdefs. Instead, I chose to use `std::conditional` to make it explicitly `int32_t` or `int64_t` to dodge that particular bullet.
- expr() needs a size_t ctor; note that size_t can be a bespoke type that doesn't match uint32_t or uint64_t
- Visual C++ fixes (alloca -> __builtin_alloca; implicit bool -> expr conversion doesn't match gcc/clang in some cases, requiring explicit conversion)
