### PR TITLE
Introduce SLINKY_TRIVIAL_ABI

### DIFF
--- a/base/ref_count.h
+++ b/base/ref_count.h
@@ -29,7 +29,7 @@ public:
 
 // A smart pointer to a ref_counted base.
 template <typename T>
-class ref_count {
+class SLINKY_TRIVIAL_ABI ref_count {
   T* value;
 
 public:

--- a/base/util.h
+++ b/base/util.h
@@ -7,6 +7,18 @@ namespace slinky {
 #define SLINKY_ALWAYS_INLINE __attribute__((always_inline))
 #define SLINKY_NO_INLINE __attribute__((noinline))
 
+#if !defined(__has_attribute)
+#define SLINKY_HAS_ATTRIBUTE(x) 0
+#else
+#define SLINKY_HAS_ATTRIBUTE(x) __has_attribute(x)
+#endif
+
+#if SLINKY_HAS_ATTRIBUTE(trivial_abi)
+#define SLINKY_TRIVIAL_ABI __attribute__((trivial_abi))
+#else
+#define SLINKY_TRIVIAL_ABI
+#endif
+
 #ifdef NDEBUG
 // alloca() will cause stack-smashing code to be inserted;
 // while laudable, we use alloca() in time-critical code


### PR DESCRIPTION
https://clang.llvm.org/docs/AttributeReference.html#trivial-abi 

This PR adds SLINKY_TRIVIAL_ABI and annotates ref_count with it.
The binary size (measured internally) impact: libruntime.so: 321K -> 315K, libruntime.a: 413K -> 406K