### PR TITLE
Reduce code size and speed up simplifier

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -4,6 +4,8 @@ common --copt=-fdiagnostics-color=always
 common --copt=-g --strip=never
 # Without --force_pic, bazel compiles a lot of cc files twice, if they are used by PIC and non-PIC targets.
 common --force_pic
+# Reduces code size and build time a little, and prevents accidentally relying on these features.
+common --copt=-fno-rtti --copt=-fno-exceptions
 
 # Allow us to run with --config=asan
 common:asan --copt -fsanitize=address

--- a/base/arithmetic.h
+++ b/base/arithmetic.h
@@ -14,7 +14,7 @@ namespace slinky {
 // and mod are taken from:
 // https://github.com/halide/Halide/blob/1a0552bb6101273a0e007782c07e8dafe9bc5366/src/CodeGen_Internal.cpp#L358-L408
 template <typename T>
-static T euclidean_div(T a, T b, T define_b_zero = 0) {
+T euclidean_div(T a, T b, T define_b_zero = 0) {
   if (b == 0) {
     return define_b_zero;
   }
@@ -26,14 +26,14 @@ static T euclidean_div(T a, T b, T define_b_zero = 0) {
 }
 
 template <typename T>
-static T euclidean_mod_positive_modulus(T a, T b) {
+T euclidean_mod_positive_modulus(T a, T b) {
   assert(b > 0);
   T r = a % b;
   return r >= 0 ? r : r + b;
 }
 
 template <typename T>
-static T euclidean_mod(T a, T b, T define_b_zero = 0) {
+T euclidean_mod(T a, T b, T define_b_zero = 0) {
   if (b == 0) {
     return define_b_zero;
   }
@@ -43,36 +43,36 @@ static T euclidean_mod(T a, T b, T define_b_zero = 0) {
 
 // Compute a / b, rounding down.
 template <typename T>
-static T floor_div(T a, T b) {
+T floor_div(T a, T b) {
   return euclidean_div(a, b);
 }
 
 // Compute a / b, rounding to nearest.
 template <typename T>
-static T round_div(T a, T b) {
+T round_div(T a, T b) {
   return floor_div(a + (b >> 1), b);
 }
 
 // Compute a / b, rounding upwards.
 template <typename T>
-static T ceil_div(T a, T b) {
+T ceil_div(T a, T b) {
   return floor_div(a + b - 1, b);
 }
 
 // Align x up to the next multiplie of n.
 template <typename T>
-static T align_up(T x, T n) {
+T align_up(T x, T n) {
   return ceil_div(x, n) * n;
 }
 
 // Align x down to the next multiplie of n.
 template <typename T>
-static T align_down(T x, T n) {
+T align_down(T x, T n) {
   return floor_div(x, n) * n;
 }
 
 template <typename T>
-static T saturate_add(T a, T b) {
+T saturate_add(T a, T b) {
   T result;
   if (!__builtin_add_overflow(a, b, &result)) {
     return result;
@@ -82,7 +82,7 @@ static T saturate_add(T a, T b) {
 }
 
 template <typename T>
-static T saturate_sub(T a, T b) {
+T saturate_sub(T a, T b) {
   T result;
   if (!__builtin_sub_overflow(a, b, &result)) {
     return result;
@@ -91,7 +91,7 @@ static T saturate_sub(T a, T b) {
   }
 }
 template <typename T>
-static T saturate_negate(T x) {
+T saturate_negate(T x) {
   if (x == std::numeric_limits<T>::min()) {
     return std::numeric_limits<T>::max();
   } else {
@@ -100,12 +100,12 @@ static T saturate_negate(T x) {
 }
 
 template <typename T>
-static int sign(T x) {
+int sign(T x) {
   return x >= 0 ? 1 : -1;
 }
 
 template <typename T>
-static T saturate_mul(T a, T b) {
+T saturate_mul(T a, T b) {
   T result;
   if (!__builtin_mul_overflow(a, b, &result)) {
     return result;
@@ -115,7 +115,7 @@ static T saturate_mul(T a, T b) {
 }
 
 template <typename T>
-static T saturate_div(T a, T b) {
+T saturate_div(T a, T b) {
   // This is safe from overflow unless a is max and b is -1.
   if (b == -1 && a == std::numeric_limits<T>::min()) {
     return std::numeric_limits<T>::max();
@@ -125,7 +125,7 @@ static T saturate_div(T a, T b) {
 }
 
 template <typename T>
-static T saturate_mod(T a, T b) {
+T saturate_mod(T a, T b) {
   // Can this overflow...?
   if (b == -1) {
     return 0;
@@ -135,19 +135,19 @@ static T saturate_mod(T a, T b) {
 }
 
 template <class T>
-static bool add_overflows(T a, T b) {
+bool add_overflows(T a, T b) {
   T dummy;
   return __builtin_add_overflow(a, b, &dummy);
 }
 
 template <class T>
-static bool sub_overflows(T a, T b) {
+bool sub_overflows(T a, T b) {
   T dummy;
   return __builtin_sub_overflow(a, b, &dummy);
 }
 
 template <class T>
-static bool mul_overflows(T a, T b) {
+bool mul_overflows(T a, T b) {
   T dummy;
   return __builtin_mul_overflow(a, b, &dummy);
 }
@@ -156,7 +156,7 @@ static bool mul_overflows(T a, T b) {
  * overflow. If overflow would occur, sets result to zero, and returns
  * true. Otherwise set result to the correct value, and returns false. */
 template <class T>
-static bool add_with_overflow(T a, T b, T& result) {
+bool add_with_overflow(T a, T b, T& result) {
   bool overflows = __builtin_add_overflow(a, b, &result);
   if (overflows) {
     result = 0;
@@ -165,7 +165,7 @@ static bool add_with_overflow(T a, T b, T& result) {
 }
 
 template <class T>
-static bool sub_with_overflow(T a, T b, T& result) {
+bool sub_with_overflow(T a, T b, T& result) {
   bool overflows = __builtin_sub_overflow(a, b, &result);
   if (overflows) {
     result = 0;
@@ -174,7 +174,7 @@ static bool sub_with_overflow(T a, T b, T& result) {
 }
 
 template <class T>
-static bool mul_with_overflow(T a, T b, T& result) {
+bool mul_with_overflow(T a, T b, T& result) {
   bool overflows = __builtin_mul_overflow(a, b, &result);
   if (overflows) {
     result = 0;
@@ -183,7 +183,7 @@ static bool mul_with_overflow(T a, T b, T& result) {
 }
 
 template <typename T>
-static T gcd(T a, T b) {
+T gcd(T a, T b) {
   if (a < b) {
     std::swap(a, b);
   }
@@ -196,7 +196,7 @@ static T gcd(T a, T b) {
 }
 
 template <typename T>
-static T lcm(T a, T b) {
+T lcm(T a, T b) {
   return (a * b) / gcd(a, b);
 }
 

--- a/base/arithmetic.h
+++ b/base/arithmetic.h
@@ -14,7 +14,7 @@ namespace slinky {
 // and mod are taken from:
 // https://github.com/halide/Halide/blob/1a0552bb6101273a0e007782c07e8dafe9bc5366/src/CodeGen_Internal.cpp#L358-L408
 template <typename T>
-T euclidean_div(T a, T b, T define_b_zero = 0) {
+static T euclidean_div(T a, T b, T define_b_zero = 0) {
   if (b == 0) {
     return define_b_zero;
   }
@@ -26,14 +26,14 @@ T euclidean_div(T a, T b, T define_b_zero = 0) {
 }
 
 template <typename T>
-T euclidean_mod_positive_modulus(T a, T b) {
+static T euclidean_mod_positive_modulus(T a, T b) {
   assert(b > 0);
   T r = a % b;
   return r >= 0 ? r : r + b;
 }
 
 template <typename T>
-T euclidean_mod(T a, T b, T define_b_zero = 0) {
+static T euclidean_mod(T a, T b, T define_b_zero = 0) {
   if (b == 0) {
     return define_b_zero;
   }
@@ -43,36 +43,36 @@ T euclidean_mod(T a, T b, T define_b_zero = 0) {
 
 // Compute a / b, rounding down.
 template <typename T>
-inline T floor_div(T a, T b) {
+static T floor_div(T a, T b) {
   return euclidean_div(a, b);
 }
 
 // Compute a / b, rounding to nearest.
 template <typename T>
-inline T round_div(T a, T b) {
+static T round_div(T a, T b) {
   return floor_div(a + (b >> 1), b);
 }
 
 // Compute a / b, rounding upwards.
 template <typename T>
-inline T ceil_div(T a, T b) {
+static T ceil_div(T a, T b) {
   return floor_div(a + b - 1, b);
 }
 
 // Align x up to the next multiplie of n.
 template <typename T>
-inline T align_up(T x, T n) {
+static T align_up(T x, T n) {
   return ceil_div(x, n) * n;
 }
 
 // Align x down to the next multiplie of n.
 template <typename T>
-inline T align_down(T x, T n) {
+static T align_down(T x, T n) {
   return floor_div(x, n) * n;
 }
 
 template <typename T>
-inline T saturate_add(T a, T b) {
+static T saturate_add(T a, T b) {
   T result;
   if (!__builtin_add_overflow(a, b, &result)) {
     return result;
@@ -82,7 +82,7 @@ inline T saturate_add(T a, T b) {
 }
 
 template <typename T>
-inline T saturate_sub(T a, T b) {
+static T saturate_sub(T a, T b) {
   T result;
   if (!__builtin_sub_overflow(a, b, &result)) {
     return result;
@@ -91,7 +91,7 @@ inline T saturate_sub(T a, T b) {
   }
 }
 template <typename T>
-inline T saturate_negate(T x) {
+static T saturate_negate(T x) {
   if (x == std::numeric_limits<T>::min()) {
     return std::numeric_limits<T>::max();
   } else {
@@ -100,12 +100,12 @@ inline T saturate_negate(T x) {
 }
 
 template <typename T>
-inline int sign(T x) {
+static int sign(T x) {
   return x >= 0 ? 1 : -1;
 }
 
 template <typename T>
-inline T saturate_mul(T a, T b) {
+static T saturate_mul(T a, T b) {
   T result;
   if (!__builtin_mul_overflow(a, b, &result)) {
     return result;
@@ -115,7 +115,7 @@ inline T saturate_mul(T a, T b) {
 }
 
 template <typename T>
-inline T saturate_div(T a, T b) {
+static T saturate_div(T a, T b) {
   // This is safe from overflow unless a is max and b is -1.
   if (b == -1 && a == std::numeric_limits<T>::min()) {
     return std::numeric_limits<T>::max();
@@ -125,7 +125,7 @@ inline T saturate_div(T a, T b) {
 }
 
 template <typename T>
-inline T saturate_mod(T a, T b) {
+static T saturate_mod(T a, T b) {
   // Can this overflow...?
   if (b == -1) {
     return 0;
@@ -135,19 +135,19 @@ inline T saturate_mod(T a, T b) {
 }
 
 template <class T>
-bool add_overflows(T a, T b) {
+static bool add_overflows(T a, T b) {
   T dummy;
   return __builtin_add_overflow(a, b, &dummy);
 }
 
 template <class T>
-bool sub_overflows(T a, T b) {
+static bool sub_overflows(T a, T b) {
   T dummy;
   return __builtin_sub_overflow(a, b, &dummy);
 }
 
 template <class T>
-bool mul_overflows(T a, T b) {
+static bool mul_overflows(T a, T b) {
   T dummy;
   return __builtin_mul_overflow(a, b, &dummy);
 }
@@ -156,7 +156,7 @@ bool mul_overflows(T a, T b) {
  * overflow. If overflow would occur, sets result to zero, and returns
  * true. Otherwise set result to the correct value, and returns false. */
 template <class T>
-bool add_with_overflow(T a, T b, T& result) {
+static bool add_with_overflow(T a, T b, T& result) {
   bool overflows = __builtin_add_overflow(a, b, &result);
   if (overflows) {
     result = 0;
@@ -165,7 +165,7 @@ bool add_with_overflow(T a, T b, T& result) {
 }
 
 template <class T>
-bool sub_with_overflow(T a, T b, T& result) {
+static bool sub_with_overflow(T a, T b, T& result) {
   bool overflows = __builtin_sub_overflow(a, b, &result);
   if (overflows) {
     result = 0;
@@ -174,7 +174,7 @@ bool sub_with_overflow(T a, T b, T& result) {
 }
 
 template <class T>
-bool mul_with_overflow(T a, T b, T& result) {
+static bool mul_with_overflow(T a, T b, T& result) {
   bool overflows = __builtin_mul_overflow(a, b, &result);
   if (overflows) {
     result = 0;
@@ -183,7 +183,7 @@ bool mul_with_overflow(T a, T b, T& result) {
 }
 
 template <typename T>
-inline T gcd(T a, T b) {
+static T gcd(T a, T b) {
   if (a < b) {
     std::swap(a, b);
   }
@@ -196,7 +196,7 @@ inline T gcd(T a, T b) {
 }
 
 template <typename T>
-inline T lcm(T a, T b) {
+static T lcm(T a, T b) {
   return (a * b) / gcd(a, b);
 }
 

--- a/base/chrome_trace.cc
+++ b/base/chrome_trace.cc
@@ -4,6 +4,7 @@
 #include <chrono>
 #include <cstdint>
 #include <fstream>
+#include <memory>
 
 namespace slinky {
 

--- a/base/chrome_trace.cc
+++ b/base/chrome_trace.cc
@@ -11,8 +11,6 @@ namespace slinky {
 
 namespace {
 
-std::atomic<int> next_id = 0;
-
 // Unfortunately, std::clock returns the CPU time for the whole process, not the current thread.
 std::clock_t clock_per_thread_us() {
   #ifdef _MSC_VER
@@ -27,17 +25,13 @@ std::clock_t clock_per_thread_us() {
 
 }  // namespace
 
-chrome_trace::chrome_trace(std::ostream& os) : os_(os), id_(next_id++) {
+chrome_trace::chrome_trace(std::ostream& os) : os_(os) {
   os_ << "[{\"name\":\"chrome_trace\",\"cat\":\"slinky\",\"ph\":\"B\",\"pid\":0,\"tid\":0,\"ts\":0}";
   os_ << ",\n{\"name\":\"chrome_trace\",\"cat\":\"slinky\",\"ph\":\"E\",\"pid\":0,\"tid\":0,\"ts\":0}";
   t0_ = std::chrono::high_resolution_clock::now();
   cpu_t0_ = clock_per_thread_us();
 }
 chrome_trace::~chrome_trace() {
-  // Flush any unwritten buffers.
-  for (const auto& i : buffers_) {
-    os_ << i.second;
-  }
   os_ << "]\n";
 }
 
@@ -56,40 +50,27 @@ void chrome_trace::write_event(const char* name, const char* cat, char type) {
     return ss.str();
   }();
 
-  // To avoid overhead when multiple threads are writing traces, we try to keep a pointer to the buffer for this trace
-  // object and thread cached locally.
-  thread_local int current_buffer_owner = -1;
-  thread_local std::string* buffer = nullptr;
+  thread_local std::string buffer;
 
-  if (!buffer || current_buffer_owner != id_) {
-    // We should only need to pay the cost of this lookup if multiple different chrome_trace objects are writing traces
-    // on the same thread at the same time.
-    std::unique_lock l(mtx_);
-    buffer = &buffers_[std::this_thread::get_id()];
-    current_buffer_owner = id_;
-  }
-
+  buffer.clear();
   // It would be an error to put a comma here as the first item in the output, but we put a dummy {} object at the
   // beginning of the array.
-  *buffer += ",\n{\"name\":\"";
-  *buffer += name;
-  *buffer += "\",\"cat\":\"";
-  *buffer += cat;
-  *buffer += "\",\"ph\":\"";
-  *buffer += type;
-  *buffer += pid_tid_str;
-  *buffer += ",\"ts\":";
-  *buffer += std::to_string(ts);
-  *buffer += ",\"tts\":";
-  *buffer += std::to_string(cpu_ts);
-  *buffer += '}';
+  buffer += ",\n{\"name\":\"";
+  buffer += name;
+  buffer += "\",\"cat\":\"";
+  buffer += cat;
+  buffer += "\",\"ph\":\"";
+  buffer += type;
+  buffer += pid_tid_str;
+  buffer += ",\"ts\":";
+  buffer += std::to_string(ts);
+  buffer += ",\"tts\":";
+  buffer += std::to_string(cpu_ts);
+  buffer += '}';
 
-  if (buffer->size() > 4096 * 16) {
-    // Flush our buffer.
-    std::unique_lock l(mtx_);
-    os_.write(buffer->data(), buffer->size());
-    buffer->clear();
-  }
+  // Flush our buffer.
+  std::unique_lock l(mtx_);
+  os_.write(buffer.data(), buffer.size());
 }
 
 void chrome_trace::begin(const char* name) { write_event(name, "slinky", 'B'); }

--- a/base/chrome_trace.cc
+++ b/base/chrome_trace.cc
@@ -4,8 +4,6 @@
 #include <chrono>
 #include <cstdint>
 #include <fstream>
-#include <sstream>
-#include <thread>
 
 namespace slinky {
 
@@ -13,27 +11,31 @@ namespace {
 
 // Unfortunately, std::clock returns the CPU time for the whole process, not the current thread.
 std::clock_t clock_per_thread_us() {
-  #ifdef _MSC_VER
+#ifdef _MSC_VER
   // CLOCK_THREAD_CPUTIME_ID not defined under MSVC
   return 0;
-  #else
+#else
   timespec t;
   clock_gettime(CLOCK_THREAD_CPUTIME_ID, &t);
   return t.tv_sec * 1000000 + t.tv_nsec / 1000;
-  #endif
+#endif
 }
+
+const char* message_format =
+    "%s{\"name\":\"%s\",\"cat\":\"%s\",\"ph\":\"%c\",\"pid\":0,\"tid\":%d,\"ts\":%ld,\"tts\":%ld}";
 
 }  // namespace
 
 chrome_trace::chrome_trace(std::ostream& os) : os_(os) {
-  os_ << "[{\"name\":\"chrome_trace\",\"cat\":\"slinky\",\"ph\":\"B\",\"pid\":0,\"tid\":0,\"ts\":0}";
-  os_ << ",\n{\"name\":\"chrome_trace\",\"cat\":\"slinky\",\"ph\":\"E\",\"pid\":0,\"tid\":0,\"ts\":0}";
+  char buffer[1024];
+  int size = snprintf(buffer, sizeof(buffer), message_format, "[", "chrome_trace", "slinky", 'B', 0, 0, 0);
+  os_.write(buffer, size);
+  size = snprintf(buffer, sizeof(buffer), message_format, ",\n", "chrome_trace", "slinky", 'E', 0, 0, 0);
+  os_.write(buffer, size);
   t0_ = std::chrono::high_resolution_clock::now();
   cpu_t0_ = clock_per_thread_us();
 }
-chrome_trace::~chrome_trace() {
-  os_ << "]\n";
-}
+chrome_trace::~chrome_trace() { os_ << "]\n"; }
 
 void chrome_trace::write_event(const char* name, const char* cat, char type) {
   auto t = std::chrono::high_resolution_clock::now();
@@ -41,36 +43,18 @@ void chrome_trace::write_event(const char* name, const char* cat, char type) {
   auto ts = std::chrono::duration_cast<std::chrono::microseconds>(t - t0_).count();
   std::clock_t cpu_ts = cpu_t - cpu_t0_;
 
-  // The only way to convert a thread ID to a string is via operator<<, which is slow, so we do it as a thread_local
-  // initializer.
+  // std::thread ids are super long, use our own integer id instead.
   static std::atomic<int> next_thread_id = 0;
-  thread_local std::string pid_tid_str = []() {
-    std::stringstream ss;
-    ss << "\",\"pid\":0,\"tid\":" << next_thread_id++;
-    return ss.str();
-  }();
+  thread_local int tid = next_thread_id++;
 
-  thread_local std::string buffer;
-
-  buffer.clear();
+  char buffer[1024];
   // It would be an error to put a comma here as the first item in the output, but we put a dummy {} object at the
   // beginning of the array.
-  buffer += ",\n{\"name\":\"";
-  buffer += name;
-  buffer += "\",\"cat\":\"";
-  buffer += cat;
-  buffer += "\",\"ph\":\"";
-  buffer += type;
-  buffer += pid_tid_str;
-  buffer += ",\"ts\":";
-  buffer += std::to_string(ts);
-  buffer += ",\"tts\":";
-  buffer += std::to_string(cpu_ts);
-  buffer += '}';
+  int size = snprintf(buffer, sizeof(buffer), message_format, ",\n", name, cat, type, tid, ts, cpu_ts);
 
   // Flush our buffer.
   std::unique_lock l(mtx_);
-  os_.write(buffer.data(), buffer.size());
+  os_.write(buffer, size);
 }
 
 void chrome_trace::begin(const char* name) { write_event(name, "slinky", 'B'); }

--- a/base/chrome_trace.h
+++ b/base/chrome_trace.h
@@ -4,7 +4,6 @@
 #include <chrono>
 #include <ctime>
 #include <iostream>
-#include <map>
 #include <mutex>
 #include <string>
 #include <thread>
@@ -15,9 +14,6 @@ namespace slinky {
 // https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU
 class chrome_trace {
   std::ostream& os_;
-  std::map<std::thread::id, std::string> buffers_;
-  // A unique identifier for chrome_trace instances.
-  int id_;
   std::mutex mtx_;
   using timestamp = std::chrono::high_resolution_clock::time_point;
   timestamp t0_;

--- a/base/chrome_trace.h
+++ b/base/chrome_trace.h
@@ -5,7 +5,6 @@
 #include <ctime>
 #include <iostream>
 #include <mutex>
-#include <thread>
 
 namespace slinky {
 

--- a/base/chrome_trace.h
+++ b/base/chrome_trace.h
@@ -5,7 +5,6 @@
 #include <ctime>
 #include <iostream>
 #include <mutex>
-#include <string>
 #include <thread>
 
 namespace slinky {

--- a/base/test/BUILD
+++ b/base/test/BUILD
@@ -55,7 +55,7 @@ cc_test(
         "//base",
         "@google_benchmark//:benchmark_main",
     ],
-    args=["--benchmark_min_time=0.1s"],
+    args=["--benchmark_min_time=1x"],
     size = "small",
 )
 
@@ -67,6 +67,6 @@ cc_test(
         "//base:thread_pool",
         "@google_benchmark//:benchmark_main",
     ],
-    args=["--benchmark_min_time=0.1s"],
+    args=["--benchmark_min_time=1x"],
     size = "small",
 )

--- a/base/util.h
+++ b/base/util.h
@@ -3,6 +3,10 @@
 
 namespace slinky {
 
+// Some functions are templates that are usually unique specializations, which are beneficial to inline. The compiler
+// will inline functions it knows are used only once, but it can't know this unless the functions have internal linkage.
+#define SLINKY_UNIQUE static inline
+
 #define SLINKY_ALLOCA(T, N) reinterpret_cast<T*>(__builtin_alloca((N) * sizeof(T)))
 #define SLINKY_ALWAYS_INLINE __attribute__((always_inline))
 #define SLINKY_NO_INLINE __attribute__((noinline))

--- a/builder/optimizations.cc
+++ b/builder/optimizations.cc
@@ -50,10 +50,10 @@ dim_expr select(const expr& c, dim_expr t, dim_expr f) {
 bool is_copy(var src, expr src_x, int src_d, var dst, var dst_x, int dst_d, expr& at, dim_expr& src_dim) {
   if (const class select* s = src_x.as<class select>()) {
     // The src is a select of two things that might both be copies.
-    expr at_t = at;
-    expr at_f = at;
-    dim_expr src_dim_t = src_dim;
-    dim_expr src_dim_f = src_dim;
+    expr at_t;
+    expr at_f;
+    dim_expr src_dim_t;
+    dim_expr src_dim_f;
     if (is_copy(src, s->true_value, src_d, dst, dst_x, dst_d, at_t, src_dim_t) &&
         is_copy(src, s->false_value, src_d, dst, dst_x, dst_d, at_f, src_dim_f)) {
       at = select(s->condition, at_t, at_f);

--- a/builder/rewrite.h
+++ b/builder/rewrite.h
@@ -434,10 +434,8 @@ public:
 };
 
 template <typename T>
-SLINKY_UNIQUE expr substitute(const replacement_boolean<T>& r, const match_context& ctx) {
-  expr result = substitute(r.a, ctx);
-  if (!is_boolean(result)) result = not_equal::make(std::move(result), 0);
-  return result;
+SLINKY_UNIQUE auto substitute(const replacement_boolean<T>& r, const match_context& ctx) {
+  return boolean(substitute(r.a, ctx));
 }
 
 template <typename T>

--- a/builder/rewrite.h
+++ b/builder/rewrite.h
@@ -426,7 +426,7 @@ public:
 template <typename T>
 SLINKY_UNIQUE expr substitute(const replacement_boolean<T>& r, const match_context& ctx) {
   expr result = substitute(r.a, ctx);
-  if (!is_boolean(result)) result = result != 0;
+  if (!is_boolean(result)) result = not_equal::make(std::move(result), 0);
   return result;
 }
 

--- a/builder/rewrite.h
+++ b/builder/rewrite.h
@@ -525,13 +525,13 @@ SLINKY_UNIQUE auto positive_infinity() { return pattern_call<>{intrinsic::positi
 SLINKY_UNIQUE auto negative_infinity() { return pattern_call<>{intrinsic::negative_infinity, {}}; }
 SLINKY_UNIQUE auto indeterminate() { return pattern_call<>{intrinsic::indeterminate, {}}; }
 
-template <typename T>
+template <typename T, bool = typename enable_pattern_ops<T>::type()>
 SLINKY_UNIQUE auto is_finite(const T& x) { return make_predicate(x, slinky::is_finite); }
-template <typename T>
+template <typename T, bool = typename enable_pattern_ops<T>::type()>
 SLINKY_UNIQUE auto is_constant(const T& x) { return make_predicate(x, slinky::as_constant); }
-template <typename T>
+template <typename T, bool = typename enable_pattern_ops<T>::type()>
 SLINKY_UNIQUE auto is_zero(const T& x) { return make_predicate(x, slinky::is_zero); }
-template <typename T>
+template <typename T, bool = typename enable_pattern_ops<T>::type()>
 SLINKY_UNIQUE auto is_boolean(const T& x) { return make_predicate(x, slinky::is_boolean); }
 // clang-format on
 

--- a/builder/rewrite.h
+++ b/builder/rewrite.h
@@ -101,8 +101,7 @@ public:
 template <int N>
 inline bool match(const pattern_wildcard<N>& p, const expr& x, match_context& ctx) {
   if (ctx.vars_mask & (1 << N)) {
-    // Try pointer comparison first to short circuit the full match.
-    return x.get() == ctx.vars[N] || slinky::match(x.get(), ctx.vars[N]);
+    return slinky::match(x.get(), ctx.vars[N]);
   } else {
     ctx.vars_mask |= (1 << N);
     ctx.vars[N] = x.get();

--- a/builder/simplify.cc
+++ b/builder/simplify.cc
@@ -694,7 +694,7 @@ public:
     rewrite::pattern_constant<1> c1;
 
     // It's really ugly to have rules here instead of simplify_rules, but plumbing bounds and alignment seems difficult.
-    if (op->type == expr_node_type::div) {
+    if (T::static_type == expr_node_type::div) {
       auto r = rewrite::make_rewriter(rewrite::pattern_expr{a} / rewrite::pattern_expr{b});
       // Taken from https://github.com/halide/Halide/blob/main/src/Simplify_Div.cpp#L125-L167.
       // clang-format off

--- a/builder/simplify.cc
+++ b/builder/simplify.cc
@@ -566,8 +566,8 @@ public:
     std::optional<index_t> ec = evaluate_constant(e);
     if (ec) return *ec != 0;
 
-    // This might have a constant bound we can use.
-    expr predicate = constant_lower_bound(e) > 0 || constant_upper_bound(e) < 0;
+    // e is constant true if we know it has a bounds that don't include zero.
+    expr predicate = logical_or::make(less::make(0, constant_lower_bound(e)), less::make(constant_upper_bound(e), 0));
     std::optional<index_t> result = evaluate_constant(predicate);
     return result && *result != 0;
   }
@@ -578,10 +578,10 @@ public:
     std::optional<index_t> ec = evaluate_constant(e);
     if (ec) return *ec == 0;
 
-    // This might have a constant bound we can use.
-    expr predicate = constant_lower_bound(e) == 0 && constant_upper_bound(e) == 0;
+    // e is constant false if we know its bounds are [0, 0].
+    expr predicate = logical_or::make(constant_lower_bound(e), constant_upper_bound(e));
     std::optional<index_t> result = evaluate_constant(predicate);
-    return result && *result != 0;
+    return result && *result == 0;
   }
 
   std::optional<bool> attempt_to_prove(const expr& e) {

--- a/builder/simplify_bounds.cc
+++ b/builder/simplify_bounds.cc
@@ -45,6 +45,10 @@ interval_expr bounds_of_less(const T* op, interval_expr a, interval_expr b) {
 // like ((x + c0) / c1) * c2.
 void tighten_correlated_bounds_stairs(interval_expr& bounds, const expr& a, const expr& b, int sign_b) {
   match_context lhs, rhs;
+  lhs.constants[1] = 1;
+  rhs.constants[1] = 1;
+  lhs.constants[2] = 0;
+  rhs.constants[2] = 0;
   // Match the LHS and RHS both to the form ((x + a) / b) * c
   // clang-format off
   if (!(match(lhs, ((x + c2) / c0) * c1, a, eval(c0 > 0)) ||
@@ -67,17 +71,17 @@ void tighten_correlated_bounds_stairs(interval_expr& bounds, const expr& a, cons
   }
 
   // We have a sum of two such rational expressions.
-  index_t l_c0 = *lhs.matched(c0);
-  index_t l_c1 = lhs.matched(c1, 1);
-  index_t r_c0 = *rhs.matched(c0);
-  index_t r_c1 = rhs.matched(c1, 1) * sign_b;
+  index_t l_c0 = lhs.matched(c0);
+  index_t l_c1 = lhs.matched(c1);
+  index_t r_c0 = rhs.matched(c0);
+  index_t r_c1 = rhs.matched(c1) * sign_b;
   if (l_c1 * r_c0 != -r_c1 * l_c0) {
     // The ratios of the two sides aren't the same, we can't tighten the bounds.
     return;
   }
 
-  index_t l_c2 = lhs.matched(c2, 0);
-  index_t r_c2 = rhs.matched(c2, 0);
+  index_t l_c2 = lhs.matched(c2);
+  index_t r_c2 = rhs.matched(c2);
 
   // The ratios of the two sides are equal. The value of this expression is a periodic pattern.
   // We need to search the period for the min and max.

--- a/builder/simplify_exprs.cc
+++ b/builder/simplify_exprs.cc
@@ -196,7 +196,8 @@ expr simplify(const less* op, expr a, expr b) {
 
 expr simplify(const less_equal* op, expr a, expr b) {
   // Rewrite to !(b < a) and simplify that instead.
-  expr result = simplify(static_cast<const logical_not*>(nullptr), simplify(static_cast<const less*>(nullptr), b, a));
+  expr result = simplify(static_cast<const logical_not*>(nullptr),
+      simplify(static_cast<const less*>(nullptr), std::move(b), std::move(a)));
   if (op) {
     if (const less_equal* le = result.as<less_equal>()) {
       if (le->a.same_as(op->a) && le->b.same_as(op->b)) {
@@ -230,7 +231,8 @@ expr simplify(const equal* op, expr a, expr b) {
 
 expr simplify(const not_equal* op, expr a, expr b) {
   // Rewrite to !(a == b) and simplify that instead.
-  expr result = simplify(static_cast<const logical_not*>(nullptr), simplify(static_cast<const equal*>(nullptr), a, b));
+  expr result = simplify(static_cast<const logical_not*>(nullptr),
+      simplify(static_cast<const equal*>(nullptr), std::move(a), std::move(b)));
   if (op) {
     if (const not_equal* ne = result.as<not_equal>()) {
       if (ne->a.same_as(op->a) && ne->b.same_as(op->b)) {

--- a/builder/simplify_rules.h
+++ b/builder/simplify_rules.h
@@ -70,8 +70,6 @@ bool apply_min_rules(Fn&& apply) {
       apply(min(y - z, min(x, y)), min(x, y - max(z, 0))) ||
       apply(min(y, min(x, y + z)), min(x, y + min(z, 0))) ||
       apply(min(y, min(x, y - z)), min(x, y - max(z, 0))) ||
-      apply(min(x, min(y, x + z)), min(y, min(x, x + z))) ||
-      apply(min(x, min(y, x - z)), min(y, min(x, x - z))) ||
       apply(min((y + w), min(x, (y + z))), min(x, min(y + z, y + w))) ||
       apply(min(x + z, y + z), z + min(x, y)) ||
       apply(min(x - z, y - z), min(x, y) - z) ||

--- a/builder/simplify_rules.h
+++ b/builder/simplify_rules.h
@@ -374,8 +374,8 @@ bool apply_sub_rules(Fn&& apply) {
       apply(c2 - max(x + c0, y + c1), min(eval(c2 - c0) - x, eval(c2 - c1) - y)) ||
       apply(c2 - min(x + c0, c1 - y), max(y + eval(c2 - c1), eval(c2 - c0) - x)) ||
       apply(c2 - max(x + c0, c1 - y), min(y + eval(c2 - c1), eval(c2 - c0) - x)) ||
-      apply(c2 - min(x, c1 - y), max(y, c2 - x), eval(c1 == c2)) ||
-      apply(c2 - max(x, c1 - y), min(y, c2 - x), eval(c1 == c2)) ||
+      apply(z - min(x, z - y), max(y, z - x)) ||
+      apply(z - max(x, z - y), min(y, z - x)) ||
 
       apply(min(x, y + z) - z, min(y, x - z)) ||
       apply(max(x, y + z) - z, max(y, x - z)) ||
@@ -522,12 +522,12 @@ bool apply_less_rules(Fn&& apply) {
       apply(x + y < z + (x/c0)*c0, y + x%c0 < z, eval(c0 > 0)) ||
       apply(x + y < (x/c0)*c0, y + x%c0 < 0, eval(c0 > 0)) ||
       apply(x < z + (x/c0)*c0, x%c0 < z, eval(c0 > 0)) ||
-      apply(x < (x/c0)*c0, x%c0 < 0, eval(c0 > 0)) ||
+      apply(x < (x/c0)*c0, false, eval(c0 > 0)) ||
     
       apply(y + (x/c0)*c0 < x + z, y < z + x%c0, eval(c0 > 0)) ||
       apply((x/c0)*c0 < x + z, 0 < z + x%c0, eval(c0 > 0)) ||
       apply(y + (x/c0)*c0 < x, y < x%c0, eval(c0 > 0)) ||
-      apply((x/c0)*c0 < x, 0 < x%c0, eval(c0 > 0)) ||
+      apply((x/c0)*c0 < x, boolean(x%c0), eval(c0 > 0)) ||
 
       apply(x%c0 < c1, true, eval(c0 > 0 && c0 <= c1)) ||
       apply(x%c0 < c1, false, eval(c0 > 0 && c1 <= 0)) ||
@@ -719,8 +719,6 @@ bool apply_equal_rules(Fn&& apply) {
       apply(min(x, c0) == c1, false, eval(c0 < c1)) ||
       apply(max(x, c0) == c1, x == c1, eval(c0 < c1)) ||
       apply(min(x, c0) == c1, x == c1, eval(c0 > c1)) ||
-      apply(max(x, c0) == c1, x <= c0, eval(c0 == c1)) ||
-      apply(min(x, c0) == c1, c0 <= x, eval(c0 == c1)) ||
 
       false;
 }
@@ -745,7 +743,11 @@ bool apply_logical_and_rules(Fn&& apply) {
 
       apply(x && !x, false) ||
       apply(x == y && x != y, false) ||
+      apply(x == y && x < y, false) ||
+      apply(x == y && x <= y, x == y) ||
       apply(x == y && (z && x != y), false) ||
+      apply(x != y && x < y, x < y) ||
+      apply(x != y && x <= y, x < y) ||
       apply(x != y && (z && x == y), false) ||
       apply(x == c1 && x != c0, x == c1, eval(c0 != c1)) ||
       apply(x == c0 && x == c1, false, eval(c0 != c1)) ||
@@ -781,7 +783,6 @@ bool apply_logical_and_rules(Fn&& apply) {
 
       // Above, we have rules for combinations of < and <=, or == and !=. Here, we have a mix of both.
       apply(x != c0 && x <= c1, x <= c1, eval(c0 > c1)) ||
-      apply(x != c0 && x <= c1, x < c1, eval(c0 == c1)) ||
       apply(x != c0 && x < c1, x < c1, eval(c0 > c1)) ||
       apply(x == c0 && x <= c1, x == c0, eval(c0 <= c1)) ||
       apply(x == c0 && x < c1, x == c0, eval(c0 < c1)) ||
@@ -789,7 +790,6 @@ bool apply_logical_and_rules(Fn&& apply) {
       apply(x == c0 && x < c1, false, eval(c0 >= c1)) ||
 
       apply(x != c0 && c1 <= x, c1 <= x, eval(c0 < c1)) ||
-      apply(x != c0 && c1 <= x, c1 < x, eval(c0 == c1)) ||
       apply(x != c0 && c1 < x, c1 < x, eval(c0 < c1)) ||
       apply(x == c0 && c1 <= x, x == c0, eval(c0 >= c1)) ||
       apply(x == c0 && c1 < x, x == c0, eval(c0 > c1)) ||
@@ -822,6 +822,8 @@ bool apply_logical_or_rules(Fn&& apply) {
       // https://github.com/halide/Halide/blob/e9f8b041f63a1a337ce3be0b07de5a1cfa6f2f65/src/Simplify_Or.cpp#L59-L68
       apply(x || !x, true) ||
       apply(x == y || x != y, true) ||
+      apply(x == y || x < y, x <= y) ||
+      apply(x == y || x <= y, x <= y) ||
       apply(x == y || (z || x != y), true) ||
       apply(x != y || (z || x == y), true) ||
       apply(x == c1 || x != c0, x != c0, eval(c0 != c1)) ||
@@ -859,7 +861,6 @@ bool apply_logical_or_rules(Fn&& apply) {
       apply(x != c0 || x < c1, x != c0, eval(c0 >= c1)) ||
       apply(x == c0 || x <= c1, x <= c1, eval(c0 <= c1)) ||
       apply(x == c0 || x < c1, x < c1, eval(c0 < c1)) ||
-      apply(x == c0 || x < c1, x <= c1, eval(c0 == c1)) ||
 
       apply(x != c0 || c1 <= x, true, eval(c0 >= c1)) ||
       apply(x != c0 || c1 < x, true, eval(c0 > c1)) ||
@@ -867,7 +868,6 @@ bool apply_logical_or_rules(Fn&& apply) {
       apply(x != c0 || c1 < x, x != c0, eval(c0 <= c1)) ||
       apply(x == c0 || c1 <= x, c1 <= x, eval(c0 >= c1)) ||
       apply(x == c0 || c1 < x, c1 < x, eval(c0 > c1)) ||
-      apply(x == c0 || c1 < x, c1 <= x, eval(c0 == c1)) ||
 
       // TODO: These rules are just a few of many similar possible rules. We should find a way to get at these
       // some other way.

--- a/builder/slide_and_fold_storage.cc
+++ b/builder/slide_and_fold_storage.cc
@@ -436,10 +436,8 @@ public:
     }
   }
 
-  template <typename T>
-  void visit_call_or_copy(const T* op, span<const var> inputs, span<const var> outputs) {
+  void visit_call_or_copy(span<const var> inputs, span<const var> outputs) {
     scoped_trace trace("visit_call_or_copy");
-    set_result(op);
 
     for (var input : inputs) {
       // Remove folding for an input that was folded in a more deeply nested loop than the current loop.
@@ -503,8 +501,14 @@ public:
     }
   }
 
-  void visit(const call_stmt* op) override { visit_call_or_copy(op, op->inputs, op->outputs); }
-  void visit(const copy_stmt* op) override { visit_call_or_copy(op, {&op->src, 1}, {&op->dst, 1}); }
+  void visit(const call_stmt* op) override {
+    set_result(op);
+    visit_call_or_copy(op->inputs, op->outputs);
+  }
+  void visit(const copy_stmt* op) override {
+    set_result(op);
+    visit_call_or_copy({&op->src, 1}, {&op->dst, 1});
+  }
 
   void visit(const crop_buffer* op) override {
     std::optional<box_expr> bounds = current_buffer_bounds()[op->src];

--- a/builder/substitute.cc
+++ b/builder/substitute.cc
@@ -357,7 +357,7 @@ int compare(const stmt& a, const stmt& b) {
 
 namespace {
 
-expr eval_buffer_intrinsic(intrinsic fn, const dim_expr& d) {
+const expr& eval_buffer_intrinsic(intrinsic fn, const dim_expr& d) {
   switch (fn) {
   case intrinsic::buffer_min: return d.bounds.min;
   case intrinsic::buffer_max: return d.bounds.max;

--- a/builder/substitute.cc
+++ b/builder/substitute.cc
@@ -307,6 +307,7 @@ public:
 };
 
 bool match(const expr& a, const expr& b) { return compare(a, b) == 0; }
+bool match(const base_expr_node* a, const base_expr_node* b) { return compare(a, b) == 0; }
 bool match(const stmt& a, const stmt& b) { return compare(a, b) == 0; }
 bool match(const interval_expr& a, const interval_expr& b) { return match(a.min, b.min) && match(a.max, b.max); }
 bool match(const dim_expr& a, const dim_expr& b) {

--- a/builder/substitute.cc
+++ b/builder/substitute.cc
@@ -51,7 +51,7 @@ public:
 
   bool try_match(const base_expr_node* e, const base_expr_node* op) {
     assert(match == 0);
-    if (!e && !op) {
+    if (e == op) {
     } else if (!e) {
       match = -1;
     } else if (!op) {
@@ -70,7 +70,7 @@ public:
 
   bool try_match(const base_stmt_node* s, const base_stmt_node* op) {
     assert(match == 0);
-    if (!s && !op) {
+    if (s == op) {
     } else if (!s) {
       match = -1;
     } else if (!op) {

--- a/builder/substitute.h
+++ b/builder/substitute.h
@@ -7,6 +7,7 @@
 namespace slinky {
 
 bool match(const expr& a, const expr& b);
+bool match(const base_expr_node* a, const base_expr_node* b);
 bool match(const stmt& a, const stmt& b);
 bool match(const interval_expr& a, const interval_expr& b);
 bool match(const dim_expr& a, const dim_expr& b);

--- a/builder/test/simplify/rule_tester.h
+++ b/builder/test/simplify/rule_tester.h
@@ -35,18 +35,15 @@ class rule_tester {
   expr_generator<gtest_seeded_mt19937> expr_gen_;
 
   std::array<expr, rewrite::symbol_count> exprs;
-  std::array<index_t, rewrite::constant_count> constants;
   rewrite::match_context m;
 
   void init_match_context() {
     for (std::size_t i = 0; i < m.constants.size(); ++i) {
-      constants[i] = expr_gen_.random_constant();
-      m.constants[i] = &constants[i];
+      m.constants[i] = expr_gen_.random_constant();
     }
     for (std::size_t i = 0; i < rewrite::symbol_count; ++i) {
       exprs[i] = expr_gen_.random_expr(0);
       m.vars[i] = exprs[i].get();
-      m.vars_mask |= 1 << i;
     }
   }
 

--- a/runtime/expr.h
+++ b/runtime/expr.h
@@ -294,16 +294,16 @@ struct interval_expr {
 };
 
 // Make an interval of the region [begin, end) (like python's range).
-inline interval_expr range(expr begin, expr end) { return {std::move(begin), std::move(end) - 1}; }
+interval_expr range(expr begin, expr end);
 // Make an interval of the region [min, max].
-inline interval_expr bounds(expr min, expr max) { return {std::move(min), std::move(max)}; }
+interval_expr bounds(expr min, expr max);
 // Make an interval of the region [min, min + extent).
-inline interval_expr min_extent(const expr& min, expr extent) { return {min, min + std::move(extent) - 1}; }
+interval_expr min_extent(const expr& min, expr extent);
 // Make a interval of the region [x, x].
 inline interval_expr point(expr x) { return interval_expr(std::move(x)); }
 
-inline interval_expr operator*(const expr& a, const interval_expr& b) { return b * a; }
-inline interval_expr operator+(const expr& a, const interval_expr& b) { return b + a; }
+interval_expr operator*(const expr& a, const interval_expr& b);
+interval_expr operator+(const expr& a, const interval_expr& b);
 
 expr clamp(expr x, interval_expr b);
 interval_expr select(const expr& c, interval_expr t, interval_expr f);

--- a/runtime/expr.h
+++ b/runtime/expr.h
@@ -730,11 +730,11 @@ public:
 
 template <typename T>
 scoped_value_in_symbol_map<T> set_value_in_scope(symbol_map<T>& context, var sym, T value) {
-  return scoped_value_in_symbol_map<T>(context, sym, value);
+  return scoped_value_in_symbol_map<T>(context, sym, std::move(value));
 }
 template <typename T>
 scoped_value_in_symbol_map<T> set_value_in_scope(symbol_map<T>& context, var sym, std::optional<T> value) {
-  return scoped_value_in_symbol_map<T>(context, sym, value);
+  return scoped_value_in_symbol_map<T>(context, sym, std::move(value));
 }
 
 }  // namespace slinky

--- a/runtime/expr.h
+++ b/runtime/expr.h
@@ -553,6 +553,7 @@ bool is_indeterminate(const expr& x);
 int is_infinity(const expr& x);
 bool is_finite(const expr& x);
 
+SLINKY_ALWAYS_INLINE inline index_t boolean(index_t x) { return x != 0 ? 1 : 0; }
 expr boolean(const expr& x);
 bool is_boolean(const expr& x);
 

--- a/runtime/expr.h
+++ b/runtime/expr.h
@@ -582,10 +582,10 @@ bool is_negative(const expr& x);
 bool is_non_positive(const expr& x);
 
 expr abs(expr x);
-expr align_down(expr x, expr a);
-expr align_up(expr x, expr a);
+expr align_down(expr x, const expr& a);
+expr align_up(expr x, const expr& a);
 // Expand the interval to have a min and extent aligned to a multiple of a.
-interval_expr align(interval_expr x, expr a);
+interval_expr align(interval_expr x, const expr& a);
 
 expr and_then(std::vector<expr> args);
 expr or_else(std::vector<expr> args);
@@ -594,7 +594,7 @@ expr buffer_rank(expr buf);
 expr buffer_elem_size(expr buf);
 expr buffer_min(expr buf, expr dim);
 expr buffer_max(expr buf, expr dim);
-expr buffer_extent(expr buf, expr dim);
+expr buffer_extent(const expr& buf, const expr& dim);
 expr buffer_stride(expr buf, expr dim);
 expr buffer_fold_factor(expr buf, expr dim);
 expr buffer_at(expr buf, span<const expr> at);

--- a/runtime/expr.h
+++ b/runtime/expr.h
@@ -220,28 +220,13 @@ public:
     }
   }
 
-  expr operator-() const { return 0 - *this; }
+  expr operator-() const;
 
-  expr& operator+=(const expr& r) {
-    *this = *this + r;
-    return *this;
-  }
-  expr& operator-=(const expr& r) {
-    *this = *this - r;
-    return *this;
-  }
-  expr& operator*=(const expr& r) {
-    *this = *this * r;
-    return *this;
-  }
-  expr& operator/=(const expr& r) {
-    *this = *this / r;
-    return *this;
-  }
-  expr& operator%=(const expr& r) {
-    *this = *this % r;
-    return *this;
-  }
+  expr& operator+=(const expr& r);
+  expr& operator-=(const expr& r);
+  expr& operator*=(const expr& r);
+  expr& operator/=(const expr& r);
+  expr& operator%=(const expr& r);
 };
 
 expr operator==(expr a, expr b);
@@ -283,10 +268,10 @@ struct interval_expr {
   // An interval_expr x such that x & y == y
   static const interval_expr& intersection_identity();
 
-  const expr& begin() const { return min; }
-  expr end() const { return max + 1; }
-  expr extent() const { return max - min + 1; }
-  expr empty() const { return min > max; }
+  const expr& begin() const;
+  expr end() const;
+  expr extent() const;
+  expr empty() const;
 
   interval_expr& operator*=(const expr& scale);
   interval_expr& operator/=(const expr& scale);
@@ -341,7 +326,7 @@ public:
 
   static expr make(std::vector<std::pair<var, expr>> lets, expr body);
 
-  static expr make(var sym, expr value, expr body) { return make({{sym, std::move(value)}}, std::move(body)); }
+  static expr make(var sym, expr value, expr body);
 
   static constexpr expr_node_type static_type = expr_node_type::let;
 };
@@ -594,34 +579,10 @@ const expr& negative_infinity();
 const expr& infinity(int sign = 1);
 const expr& indeterminate();
 
-inline bool is_positive(const expr& x) {
-  if (is_positive_infinity(x)) return true;
-  if (const call* c = as_intrinsic(x, intrinsic::abs)) {
-    assert(c->args.size() == 1);
-    return is_positive(c->args[0]);
-  }
-  const index_t* c = as_constant(x);
-  return c ? *c > 0 : false;
-}
-
-inline bool is_non_negative(const expr& x) {
-  if (is_positive_infinity(x)) return true;
-  if (as_intrinsic(x, intrinsic::abs)) return true;
-  const index_t* c = as_constant(x);
-  return c ? *c >= 0 : false;
-}
-
-inline bool is_negative(const expr& x) {
-  if (is_negative_infinity(x)) return true;
-  const index_t* c = as_constant(x);
-  return c ? *c < 0 : false;
-}
-
-inline bool is_non_positive(const expr& x) {
-  if (is_negative_infinity(x)) return true;
-  const index_t* c = as_constant(x);
-  return c ? *c <= 0 : false;
-}
+bool is_positive(const expr& x);
+bool is_non_negative(const expr& x);
+bool is_negative(const expr& x);
+bool is_non_positive(const expr& x);
 
 expr abs(expr x);
 expr align_down(expr x, expr a);

--- a/runtime/expr.h
+++ b/runtime/expr.h
@@ -547,14 +547,10 @@ inline const call* as_intrinsic(const expr& x, intrinsic fn) {
 bool is_buffer_intrinsic(intrinsic fn);
 bool is_buffer_dim_intrinsic(intrinsic fn);
 
-inline bool is_positive_infinity(const expr& x) { return as_intrinsic(x, intrinsic::positive_infinity); }
-inline bool is_negative_infinity(const expr& x) { return as_intrinsic(x, intrinsic::negative_infinity); }
-inline bool is_indeterminate(const expr& x) { return as_intrinsic(x, intrinsic::indeterminate); }
-inline int is_infinity(const expr& x) {
-  if (is_positive_infinity(x)) return 1;
-  if (is_negative_infinity(x)) return -1;
-  return 0;
-}
+bool is_positive_infinity(const expr& x);
+bool is_negative_infinity(const expr& x);
+bool is_indeterminate(const expr& x);
+int is_infinity(const expr& x);
 bool is_finite(const expr& x);
 
 expr boolean(const expr& x);

--- a/runtime/expr.h
+++ b/runtime/expr.h
@@ -708,11 +708,10 @@ public:
   scoped_value_in_symbol_map(const scoped_value_in_symbol_map&) = delete;
   scoped_value_in_symbol_map& operator=(const scoped_value_in_symbol_map&) = delete;
   scoped_value_in_symbol_map& operator=(scoped_value_in_symbol_map&& other) noexcept {
-    context_ = other.context_;
-    sym_ = other.sym_;
-    old_value_ = std::move(other.old_value_);
-    // Don't let other.~scoped_value_in_symbol_map() unset this value.
-    other.context_ = nullptr;
+    std::swap(context_, other.context_);
+    std::swap(sym_, other.sym_);
+    std::swap(old_value_, other.old_value_);
+    return *this;
   }
 
   const std::optional<T>& old_value() const { return old_value_; }

--- a/runtime/expr.h
+++ b/runtime/expr.h
@@ -260,6 +260,7 @@ struct interval_expr {
 
   bool is_point() const { return min.defined() && min.same_as(max); }
   bool is_point(const expr& x) const { return min.same_as(x) && max.same_as(x); }
+  bool is_point(const base_expr_node* x) const { return min.same_as(x) && max.same_as(x); }
 
   static const interval_expr& all();
   static const interval_expr& none();

--- a/runtime/expr_stmt.cc
+++ b/runtime/expr_stmt.cc
@@ -603,9 +603,9 @@ bool is_non_positive(const expr& x) {
 }
 
 expr abs(expr x) { return call::make(intrinsic::abs, {std::move(x)}); }
-expr align_down(expr x, expr a) { return (x / a) * a; }
-expr align_up(expr x, expr a) { return ((x + a - 1) / a) * a; }
-interval_expr align(interval_expr x, expr a) { return {align_down(x.min, a), align_up(x.max + 1, a) - 1}; }
+expr align_down(expr x, const expr& a) { return (std::move(x) / a) * a; }
+expr align_up(expr x, const expr& a) { return ((std::move(x) + a - 1) / a) * a; }
+interval_expr align(interval_expr x, const expr& a) { return {align_down(std::move(x.min), a), align_up(std::move(x.max) + 1, a) - 1}; }
 
 expr and_then(std::vector<expr> args) { return call::make(intrinsic::and_then, std::move(args)); }
 expr or_else(std::vector<expr> args) { return call::make(intrinsic::or_else, std::move(args)); }
@@ -614,7 +614,7 @@ expr buffer_rank(expr buf) { return call::make(intrinsic::buffer_rank, {std::mov
 expr buffer_elem_size(expr buf) { return call::make(intrinsic::buffer_elem_size, {std::move(buf)}); }
 expr buffer_min(expr buf, expr dim) { return call::make(intrinsic::buffer_min, {std::move(buf), std::move(dim)}); }
 expr buffer_max(expr buf, expr dim) { return call::make(intrinsic::buffer_max, {std::move(buf), std::move(dim)}); }
-expr buffer_extent(expr buf, expr dim) { return (buffer_max(buf, dim) - buffer_min(buf, dim)) + 1; }
+expr buffer_extent(const expr& buf, const expr& dim) { return (buffer_max(buf, dim) - buffer_min(buf, dim)) + 1; }
 expr buffer_stride(expr buf, expr dim) {
   return call::make(intrinsic::buffer_stride, {std::move(buf), std::move(dim)});
 }
@@ -623,13 +623,17 @@ expr buffer_fold_factor(expr buf, expr dim) {
 }
 
 expr buffer_at(expr buf, span<const expr> at) {
-  std::vector<expr> args = {buf};
+  std::vector<expr> args;
+  args.reserve(at.size() + 1);
+  args.push_back(std::move(buf));
   args.insert(args.end(), at.begin(), at.end());
   return call::make(intrinsic::buffer_at, std::move(args));
 }
 
 expr buffer_at(expr buf, span<const var> at) {
-  std::vector<expr> args = {buf};
+  std::vector<expr> args;
+  args.reserve(at.size() + 1);
+  args.push_back(std::move(buf));
   args.insert(args.end(), at.begin(), at.end());
   return call::make(intrinsic::buffer_at, std::move(args));
 }

--- a/runtime/expr_stmt.cc
+++ b/runtime/expr_stmt.cc
@@ -774,27 +774,26 @@ void recursive_node_visitor::visit(const let* op) {
 
 namespace {
 
-template <typename T>
-void visit_binary(recursive_node_visitor* _this, const T* op) {
-  if (op->a.defined()) op->a.accept(_this);
-  if (op->b.defined()) op->b.accept(_this);
+void visit_binary(recursive_node_visitor* _this, const expr& a, const expr& b) {
+  if (a.defined()) a.accept(_this);
+  if (b.defined()) b.accept(_this);
 }
 
 }  // namespace
 
-void recursive_node_visitor::visit(const add* op) { visit_binary(this, op); }
-void recursive_node_visitor::visit(const sub* op) { visit_binary(this, op); }
-void recursive_node_visitor::visit(const mul* op) { visit_binary(this, op); }
-void recursive_node_visitor::visit(const div* op) { visit_binary(this, op); }
-void recursive_node_visitor::visit(const mod* op) { visit_binary(this, op); }
-void recursive_node_visitor::visit(const class min* op) { visit_binary(this, op); }
-void recursive_node_visitor::visit(const class max* op) { visit_binary(this, op); }
-void recursive_node_visitor::visit(const equal* op) { visit_binary(this, op); }
-void recursive_node_visitor::visit(const not_equal* op) { visit_binary(this, op); }
-void recursive_node_visitor::visit(const less* op) { visit_binary(this, op); }
-void recursive_node_visitor::visit(const less_equal* op) { visit_binary(this, op); }
-void recursive_node_visitor::visit(const logical_and* op) { visit_binary(this, op); }
-void recursive_node_visitor::visit(const logical_or* op) { visit_binary(this, op); }
+void recursive_node_visitor::visit(const add* op) { visit_binary(this, op->a, op->b); }
+void recursive_node_visitor::visit(const sub* op) { visit_binary(this, op->a, op->b); }
+void recursive_node_visitor::visit(const mul* op) { visit_binary(this, op->a, op->b); }
+void recursive_node_visitor::visit(const div* op) { visit_binary(this, op->a, op->b); }
+void recursive_node_visitor::visit(const mod* op) { visit_binary(this, op->a, op->b); }
+void recursive_node_visitor::visit(const class min* op) { visit_binary(this, op->a, op->b); }
+void recursive_node_visitor::visit(const class max* op) { visit_binary(this, op->a, op->b); }
+void recursive_node_visitor::visit(const equal* op) { visit_binary(this, op->a, op->b); }
+void recursive_node_visitor::visit(const not_equal* op) { visit_binary(this, op->a, op->b); }
+void recursive_node_visitor::visit(const less* op) { visit_binary(this, op->a, op->b); }
+void recursive_node_visitor::visit(const less_equal* op) { visit_binary(this, op->a, op->b); }
+void recursive_node_visitor::visit(const logical_and* op) { visit_binary(this, op->a, op->b); }
+void recursive_node_visitor::visit(const logical_or* op) { visit_binary(this, op->a, op->b); }
 void recursive_node_visitor::visit(const logical_not* op) {
   if (op->a.defined()) op->a.accept(this);
 }

--- a/runtime/expr_stmt.cc
+++ b/runtime/expr_stmt.cc
@@ -345,6 +345,13 @@ interval_expr interval_expr::operator&(interval_expr r) const {
   return result;
 }
 
+interval_expr range(expr begin, expr end) { return {std::move(begin), std::move(end) - 1}; }
+interval_expr bounds(expr min, expr max) { return {std::move(min), std::move(max)}; }
+interval_expr min_extent(const expr& min, expr extent) { return {min, min + std::move(extent) - 1}; }
+
+interval_expr operator*(const expr& a, const interval_expr& b) { return b * a; }
+interval_expr operator+(const expr& a, const interval_expr& b) { return b + a; }
+
 expr clamp(expr x, interval_expr bounds) { return clamp(std::move(x), std::move(bounds.min), std::move(bounds.max)); }
 interval_expr select(const expr& c, interval_expr t, interval_expr f) {
   if (t.is_point() && f.is_point()) {

--- a/runtime/expr_stmt.cc
+++ b/runtime/expr_stmt.cc
@@ -77,9 +77,7 @@ expr let::make(std::vector<std::pair<var, expr>> lets, expr body) {
   return make_let<let>(std::move(lets), std::move(body));
 }
 
-expr let::make(var sym, expr value, expr body) { 
-  return make({{sym, std::move(value)}}, std::move(body)); 
-}
+expr let::make(var sym, expr value, expr body) { return make({{sym, std::move(value)}}, std::move(body)); }
 
 stmt let_stmt::make(std::vector<std::pair<var, expr>> lets, stmt body) {
   return make_let<let_stmt>(std::move(lets), std::move(body));
@@ -673,6 +671,15 @@ bool is_buffer_dim_intrinsic(intrinsic fn) {
   case intrinsic::buffer_fold_factor: return true;
   default: return false;
   }
+}
+
+bool is_positive_infinity(const expr& x) { return as_intrinsic(x, intrinsic::positive_infinity); }
+bool is_negative_infinity(const expr& x) { return as_intrinsic(x, intrinsic::negative_infinity); }
+bool is_indeterminate(const expr& x) { return as_intrinsic(x, intrinsic::indeterminate); }
+int is_infinity(const expr& x) {
+  if (is_positive_infinity(x)) return 1;
+  if (is_negative_infinity(x)) return -1;
+  return 0;
 }
 
 bool is_finite(const expr& x) {

--- a/runtime/expr_stmt.cc
+++ b/runtime/expr_stmt.cc
@@ -83,6 +83,8 @@ stmt let_stmt::make(std::vector<std::pair<var, expr>> lets, stmt body) {
   return make_let<let_stmt>(std::move(lets), std::move(body));
 }
 
+stmt let_stmt::make(var sym, expr value, stmt body) { return make({{sym, std::move(value)}}, std::move(body)); }
+
 namespace {
 
 template <std::int64_t value>
@@ -556,6 +558,14 @@ stmt transpose::make_truncate(var sym, var src, int rank, stmt body) {
   std::iota(dims.begin(), dims.end(), 0);
   return make(sym, src, std::move(dims), std::move(body));
 }
+
+bool transpose::is_truncate(span<const int> dims) {
+  for (std::size_t i = 0; i < dims.size(); ++i) {
+    if (dims[i] != static_cast<int>(i)) return false;
+  }
+  return true;
+}
+bool transpose::is_truncate() const { return is_truncate(dims); }
 
 stmt check::make(expr condition) {
   auto n = new check();

--- a/runtime/print.cc
+++ b/runtime/print.cc
@@ -166,22 +166,21 @@ public:
     *this << indent() << "}\n";
   }
 
-  template <typename T>
-  void visit_bin_op(const T* op, const char* s) {
-    *this << "(" << op->a << s << op->b << ")";
+  void visit_bin_op(const expr& a, const char* s, const expr& b) {
+    *this << "(" << a << s << b << ")";
   }
 
-  void visit(const add* op) override { visit_bin_op(op, " + "); }
-  void visit(const sub* op) override { visit_bin_op(op, " - "); }
-  void visit(const mul* op) override { visit_bin_op(op, " * "); }
-  void visit(const div* op) override { visit_bin_op(op, " / "); }
-  void visit(const mod* op) override { visit_bin_op(op, " % "); }
-  void visit(const equal* op) override { visit_bin_op(op, " == "); }
-  void visit(const not_equal* op) override { visit_bin_op(op, " != "); }
-  void visit(const less* op) override { visit_bin_op(op, " < "); }
-  void visit(const less_equal* op) override { visit_bin_op(op, " <= "); }
-  void visit(const logical_and* op) override { visit_bin_op(op, " && "); }
-  void visit(const logical_or* op) override { visit_bin_op(op, " || "); }
+  void visit(const add* op) override { visit_bin_op(op->a, " + ", op->b); }
+  void visit(const sub* op) override { visit_bin_op(op->a, " - ", op->b); }
+  void visit(const mul* op) override { visit_bin_op(op->a, " * ", op->b); }
+  void visit(const div* op) override { visit_bin_op(op->a, " / ", op->b); }
+  void visit(const mod* op) override { visit_bin_op(op->a, " % ", op->b); }
+  void visit(const equal* op) override { visit_bin_op(op->a, " == ", op->b); }
+  void visit(const not_equal* op) override { visit_bin_op(op->a, " != ", op->b); }
+  void visit(const less* op) override { visit_bin_op(op->a, " < ", op->b); }
+  void visit(const less_equal* op) override { visit_bin_op(op->a, " <= ", op->b); }
+  void visit(const logical_and* op) override { visit_bin_op(op->a, " && ", op->b); }
+  void visit(const logical_or* op) override { visit_bin_op(op->a, " || ", op->b); }
   void visit(const logical_not* op) override { *this << "!" << op->a; }
 
   void visit(const class min* op) override { *this << "min(" << op->a << ", " << op->b << ")"; }

--- a/runtime/print.cc
+++ b/runtime/print.cc
@@ -10,7 +10,7 @@ namespace slinky {
 
 std::string to_string(var sym) { return "<" + std::to_string(sym.id) + ">"; }
 
-std::string to_string(memory_type type) {
+const char* to_string(memory_type type) {
   switch (type) {
   case memory_type::stack: return "stack";
   case memory_type::heap: return "heap";
@@ -18,7 +18,7 @@ std::string to_string(memory_type type) {
   }
 }
 
-std::string to_string(intrinsic fn) {
+const char* to_string(intrinsic fn) {
   switch (fn) {
   case intrinsic::positive_infinity: return "oo";
   case intrinsic::negative_infinity: return "-oo";

--- a/runtime/print.h
+++ b/runtime/print.h
@@ -37,8 +37,8 @@ std::ostream& operator<<(std::ostream& os, const dim& d);
 // intended usage here is to do `using std::to_string;` followed by naked
 // to_string() calls.
 std::string to_string(var sym);
-std::string to_string(intrinsic fn);
-std::string to_string(memory_type type);
+const char* to_string(intrinsic fn);
+const char* to_string(memory_type type);
 
 }  // namespace slinky
 

--- a/runtime/stmt.h
+++ b/runtime/stmt.h
@@ -146,7 +146,7 @@ public:
 
   static stmt make(std::vector<std::pair<var, expr>> lets, stmt body);
 
-  static stmt make(var sym, expr value, stmt body) { return make({{sym, std::move(value)}}, std::move(body)); }
+  static stmt make(var sym, expr value, stmt body);
 
   static constexpr stmt_node_type static_type = stmt_node_type::let_stmt;
 };
@@ -318,13 +318,8 @@ public:
   std::vector<int> dims;
   stmt body;
 
-  static bool is_truncate(span<const int> dims) {
-    for (std::size_t i = 0; i < dims.size(); ++i) {
-      if (dims[i] != static_cast<int>(i)) return false;
-    }
-    return true;
-  }
-  bool is_truncate() const { return is_truncate(dims); }
+  static bool is_truncate(span<const int> dims);
+  bool is_truncate() const;
 
   void accept(stmt_visitor* v) const override;
 

--- a/runtime/test/BUILD
+++ b/runtime/test/BUILD
@@ -42,7 +42,7 @@ cc_test(
         "//runtime",
         "@google_benchmark//:benchmark_main",
     ],
-    args=["--benchmark_min_time=0.1s"],
+    args=["--benchmark_min_time=1x"],
     size = "small",
 )
 
@@ -54,6 +54,6 @@ cc_test(
         "//base:thread_pool",
         "@google_benchmark//:benchmark_main",
     ],
-    args=["--benchmark_min_time=0.1s"],
+    args=["--benchmark_min_time=1x"],
     size = "small",
 )

--- a/runtime/visualize.cc
+++ b/runtime/visualize.cc
@@ -144,22 +144,19 @@ public:
     *this << indent() << "}\n";
   }
 
-  template <typename T>
-  void visit_bin_op(const T* op, const char* s) {
-    *this << "(" << op->a << s << op->b << ")";
-  }
+  void visit_bin_op(const expr& a, const char* s, const expr& b) { *this << "(" << a << s << b << ")"; }
 
-  void visit(const add* op) override { visit_bin_op(op, " + "); }
-  void visit(const sub* op) override { visit_bin_op(op, " - "); }
-  void visit(const mul* op) override { visit_bin_op(op, " * "); }
+  void visit(const add* op) override { visit_bin_op(op->a, " + ", op->b); }
+  void visit(const sub* op) override { visit_bin_op(op->a, " - ", op->b); }
+  void visit(const mul* op) override { visit_bin_op(op->a, " * ", op->b); }
   void visit(const div* op) override { *this << "euclidean_div(" << op->a << ", " << op->b << ")"; }
   void visit(const mod* op) override { *this << "euclidean_mod(" << op->a << ", " << op->b << ")"; }
-  void visit(const equal* op) override { visit_bin_op(op, " == "); }
-  void visit(const not_equal* op) override { visit_bin_op(op, " != "); }
-  void visit(const less* op) override { visit_bin_op(op, " < "); }
-  void visit(const less_equal* op) override { visit_bin_op(op, " <= "); }
-  void visit(const logical_and* op) override { visit_bin_op(op, " && "); }
-  void visit(const logical_or* op) override { visit_bin_op(op, " || "); }
+  void visit(const equal* op) override { visit_bin_op(op->a, " == ", op->b); }
+  void visit(const not_equal* op) override { visit_bin_op(op->a, " != ", op->b); }
+  void visit(const less* op) override { visit_bin_op(op->a, " < ", op->b); }
+  void visit(const less_equal* op) override { visit_bin_op(op->a, " <= ", op->b); }
+  void visit(const logical_and* op) override { visit_bin_op(op->a, " && ", op->b); }
+  void visit(const logical_or* op) override { visit_bin_op(op->a, " || ", op->b); }
   void visit(const logical_not* op) override { *this << "!" << op->a; }
 
   void visit(const class min* op) override { *this << "min(" << op->a << ", " << op->b << ")"; }


### PR DESCRIPTION
This PR is a bunch of minor changes that reduce code size (~30%) and speed up the simplifier for expressions (~2.5x):
- Remove templating where it is marginally useful
- Mark helper functions `static` and/or `inline` where appropriate
- Use `std::move` in more places, especially headers where possible
- Some tweaks to how the simplifier rewriter works to do more work at compile time, which can result in simpler code