### PR TITLE
Add support for multiple replacement, predicate pairs in rewrite rules

### DIFF
--- a/builder/test/simplify/rule_tester.h
+++ b/builder/test/simplify/rule_tester.h
@@ -118,6 +118,11 @@ public:
     // Returning true stops any more tests.
     return true;
   }
+
+  template <typename Pattern, typename Replacement, typename Predicate, typename... ReplacementPredicate>
+  bool operator()(const Pattern& p, const Replacement& r, const Predicate& pr, ReplacementPredicate... r_pr) {
+    return operator()(p, r, pr) && operator()(p, r_pr...);
+  }
 };
 
 }  // namespace slinky


### PR DESCRIPTION
This allows writing multiple rules with the same pattern more concisely, and generates smaller and faster code because we only attempt to match the expression once for multiple rules with the same pattern.