### PR TITLE
Make `expr(const base_expr_node*)` and `stmt(const base_stmt_node*)` explicit

### DIFF
--- a/builder/node_mutator.cc
+++ b/builder/node_mutator.cc
@@ -32,7 +32,7 @@ expr mutate_binary(node_mutator* this_, const T* op) {
   expr a = this_->mutate(op->a);
   expr b = this_->mutate(op->b);
   if (a.same_as(op->a) && b.same_as(op->b)) {
-    return op;
+    return expr(op);
   } else {
     return T::make(std::move(a), std::move(b));
   }
@@ -80,6 +80,8 @@ stmt clone_with(const slice_buffer* op, stmt new_body) { return clone_with(op, o
 stmt clone_with(const slice_dim* op, stmt new_body) { return clone_with(op, op->sym, std::move(new_body)); }
 stmt clone_with(const transpose* op, stmt new_body) { return clone_with(op, op->sym, std::move(new_body)); }
 
+void node_mutator::visit(const variable* op) { set_result(op); }
+void node_mutator::visit(const constant* op) { set_result(op); }
 void node_mutator::visit(const let* op) { set_result(mutate_let(this, op)); }
 void node_mutator::visit(const let_stmt* op) { set_result(mutate_let(this, op)); }
 void node_mutator::visit(const add* op) { set_result(mutate_binary(this, op)); }

--- a/builder/node_mutator.h
+++ b/builder/node_mutator.h
@@ -21,6 +21,8 @@ public:
     assert(!s_.defined());
     s_ = std::move(s);
   }
+  void set_result(const base_expr_node* e) { set_result(expr(e)); }
+  void set_result(const base_stmt_node* s) { set_result(stmt(s)); }
   const expr& mutated_expr() const { return e_; }
   const stmt& mutated_stmt() const { return s_; }
 
@@ -49,8 +51,8 @@ public:
     }
   }
 
-  void visit(const variable* op) override { set_result(op); }
-  void visit(const constant* op) override { set_result(op); }
+  void visit(const variable* op) override;
+  void visit(const constant* op) override;
 
   void visit(const let*) override;
   void visit(const let_stmt*) override;

--- a/builder/optimizations.cc
+++ b/builder/optimizations.cc
@@ -851,23 +851,22 @@ public:
   }
 
   // Handler for the `terminal` nodes.
-  void visit_terminal(const base_stmt_node* s) {
-    stmt result(s);
-    if (!found && depends_on(stmt(s), names).any()) {
+  void visit_terminal(stmt s) {
+    if (!found && depends_on(s, names).any()) {
       found = true;
       if (visited_something) {
-        result = block::make({result, check::make(call::make(intrinsic::free, {names.front()}))});
+        s = block::make({std::move(s), check::make(call::make(intrinsic::free, {names.front()}))});
       }
     }
 
-    set_result(result);
+    set_result(std::move(s));
   }
 
-  void visit(const loop* op) override { visit_terminal(op); }
-  void visit(const call_stmt* op) override { visit_terminal(op); }
-  void visit(const copy_stmt* op) override { visit_terminal(op); }
-  void visit(const check* op) override { visit_terminal(op); }
-  void visit(const let_stmt* op) override { visit_terminal(op); }
+  void visit(const loop* op) override { visit_terminal(stmt(op)); }
+  void visit(const call_stmt* op) override { visit_terminal(stmt(op)); }
+  void visit(const copy_stmt* op) override { visit_terminal(stmt(op)); }
+  void visit(const check* op) override { visit_terminal(stmt(op)); }
+  void visit(const let_stmt* op) override { visit_terminal(stmt(op)); }
 
   // Remaining functions collect all the buffer symbols which refer the original allocate
   // symbol or its dependencies.

--- a/builder/optimizations.cc
+++ b/builder/optimizations.cc
@@ -851,9 +851,9 @@ public:
   }
 
   // Handler for the `terminal` nodes.
-  void visit_terminal(const stmt& s) {
-    stmt result = s;
-    if (!found && depends_on(s, names).any()) {
+  void visit_terminal(const base_stmt_node* s) {
+    stmt result(s);
+    if (!found && depends_on(stmt(s), names).any()) {
       found = true;
       if (visited_something) {
         result = block::make({result, check::make(call::make(intrinsic::free, {names.front()}))});
@@ -958,7 +958,7 @@ public:
 
   template <typename T>
   void visit_decl(const T* op) {
-    stmt result = op;
+    stmt result(op);
     const std::optional<bool>& sym_defined = symbols[op->sym];
     var sym = op->sym;
     if (sym_defined && *sym_defined) {
@@ -970,7 +970,7 @@ public:
   }
 
   void visit(const loop* op) override {
-    stmt result = op;
+    stmt result(op);
     const std::optional<bool>& sym_defined = symbols[op->sym];
     var sym = op->sym;
     if (sym_defined && *sym_defined) {
@@ -985,7 +985,7 @@ public:
   }
   void visit(const allocate* op) override { visit_decl(op); }
   void visit(const make_buffer* op) override {
-    stmt result = op;
+    stmt result(op);
     // We want to keep the name of allocates that shadow make_buffers, so rename the make_buffer instead.
     // TODO: We should only do this if there is actually an allocate shadowing this buffer.
     var sym = rename(op->sym);

--- a/builder/pipeline.cc
+++ b/builder/pipeline.cc
@@ -912,7 +912,7 @@ stmt inject_traces(const stmt& s, node_context& ctx, std::set<buffer_expr_ptr>& 
       return let_stmt::make({{token, trace_begin}}, block::make({std::move(s), check::make(trace_end)}));
     }
 
-    void visit(const call_stmt* op) override { set_result(add_trace(op, get_trace_arg(op))); }
+    void visit(const call_stmt* op) override { set_result(add_trace(stmt(op), get_trace_arg(op))); }
     void visit(const loop* op) override {
       expr iter_name = get_trace_arg("loop " + ctx.name(op->sym) + " iteration");
       expr loop_name = get_trace_arg("loop " + ctx.name(op->sym));

--- a/builder/rewrite.h
+++ b/builder/rewrite.h
@@ -190,7 +190,7 @@ SLINKY_UNIQUE bool match_binary(const pattern_binary<T, A, B>& p, expr_ref a, ex
     const int this_bit = ctx.variant_bits++;
     if ((ctx.variant & (1 << this_bit)) != 0) {
       // We should commute in this variant.
-      return match<matched>(p.a, b, ctx) && match<matched | pattern_info<A>::matched>(p.b, a, ctx);
+      std::swap(a, b);
     }
   }
   return match<matched>(p.a, a, ctx) && match<matched | pattern_info<A>::matched>(p.b, b, ctx);

--- a/builder/rewrite.h
+++ b/builder/rewrite.h
@@ -29,7 +29,7 @@ struct match_context {
   int variant_bits;
 
   template <int N>
-  const base_expr_node* matched(const pattern_wildcard<N>&) const {
+  expr_ref matched(const pattern_wildcard<N>&) const {
     return vars[N];
   }
   template <int N>
@@ -117,7 +117,7 @@ SLINKY_UNIQUE bool match(const pattern_wildcard<N>& p, expr_ref x, match_context
 }
 
 template <int N>
-SLINKY_UNIQUE const base_expr_node* substitute(const pattern_wildcard<N>& p, const match_context& ctx) {
+SLINKY_UNIQUE expr_ref substitute(const pattern_wildcard<N>& p, const match_context& ctx) {
   return ctx.vars[N];
 }
 
@@ -271,10 +271,6 @@ SLINKY_UNIQUE std::ostream& operator<<(std::ostream& os, const pattern_unary<T, 
 template <typename T>
 SLINKY_UNIQUE expr make_unary(expr a) {
   return T::make(std::move(a));
-}
-template <typename T>
-SLINKY_UNIQUE expr make_unary(expr_ref a) {
-  return T::make(expr(a));
 }
 // clang-format off
 template <typename T> SLINKY_UNIQUE index_t make_unary(index_t a);

--- a/builder/rewrite.h
+++ b/builder/rewrite.h
@@ -315,7 +315,7 @@ SLINKY_UNIQUE bool match(const pattern_select<C, T, F>& p,
 
 template <typename C, typename T, typename F>
 SLINKY_UNIQUE expr substitute(const pattern_select<C, T, F>& p, const match_context& ctx) {
-  return select::make(expr(substitute(p.c, ctx)), expr(substitute(p.t, ctx)), expr(substitute(p.f, ctx)));
+  return select::make(substitute(p.c, ctx), substitute(p.t, ctx), substitute(p.f, ctx));
 }
 
 template <typename C, typename T, typename F>
@@ -362,11 +362,11 @@ SLINKY_UNIQUE bool match(const pattern_call<Args...>& p, expr_ref x, match_conte
 SLINKY_UNIQUE expr substitute(const pattern_call<>& p, const match_context& ctx) { return call::make(p.fn, {}); }
 template <typename A>
 SLINKY_UNIQUE expr substitute(const pattern_call<A>& p, const match_context& ctx) {
-  return call::make(p.fn, {expr(substitute(std::get<0>(p.args), ctx))});
+  return call::make(p.fn, {substitute(std::get<0>(p.args), ctx)});
 }
 template <typename A, typename B>
 SLINKY_UNIQUE expr substitute(const pattern_call<A, B>& p, const match_context& ctx) {
-  return call::make(p.fn, {expr(substitute(std::get<0>(p.args), ctx)), expr(substitute(std::get<1>(p.args), ctx))});
+  return call::make(p.fn, {substitute(std::get<0>(p.args), ctx), substitute(std::get<1>(p.args), ctx)});
 }
 
 SLINKY_UNIQUE std::ostream& operator<<(std::ostream& os, const pattern_call<>& p) { return os << p.fn << "()"; }
@@ -433,7 +433,7 @@ public:
 
 template <typename T>
 SLINKY_UNIQUE auto substitute(const replacement_boolean<T>& r, const match_context& ctx) {
-  return boolean(expr(substitute(r.a, ctx)));
+  return boolean(substitute(r.a, ctx));
 }
 
 template <typename T>
@@ -584,7 +584,7 @@ class base_rewriter {
   SLINKY_ALWAYS_INLINE bool find_replacement(const match_context& ctx, Replacement r) {
     static_assert(pattern_info<Replacement>::is_canonical);
     static_assert(!pattern_info<Pattern>::is_boolean || pattern_info<Replacement>::is_boolean);
-    result = expr(substitute(r, ctx));
+    result = substitute(r, ctx);
     return true;
   }
 
@@ -595,7 +595,7 @@ class base_rewriter {
     static_assert(!pattern_info<Pattern>::is_boolean || pattern_info<Replacement>::is_boolean);
 
     if (substitute(pr, ctx)) {
-      result = expr(substitute(r, ctx));
+      result = substitute(r, ctx);
       return true;
     } else {
       // Try the next replacement
@@ -619,7 +619,7 @@ public:
     match_context ctx;
     if (!match_any_variant(p, x, ctx)) return false;
 
-    result = expr(substitute(r, ctx));
+    result = substitute(r, ctx);
     return true;
   }
 

--- a/builder/rewrite.h
+++ b/builder/rewrite.h
@@ -609,31 +609,17 @@ public:
   base_rewriter(Target x) : x(std::move(x)) {}
   base_rewriter(const base_rewriter&) = delete;
 
-  // If the pattern p matches the target, substitute with the replacement r.
-  template <typename Pattern, typename Replacement>
-  SLINKY_ALWAYS_INLINE bool operator()(Pattern p, Replacement r) {
-    static_assert(pattern_info<Pattern>::is_canonical);
-    static_assert(pattern_info<Replacement>::is_canonical);
-    static_assert(!pattern_info<Pattern>::is_boolean || pattern_info<Replacement>::is_boolean);
-
-    match_context ctx;
-    if (!match_any_variant(p, x, ctx)) return false;
-
-    result = substitute(r, ctx);
-    return true;
-  }
-
   // If the pattern p matches the target, substitute with the replacement r if the predicate pr is true.
   // If the predicate is false, consider the next replacement and predicate.
   // The last predicate is optional and defaults to true.
-  template <typename Pattern, typename Replacement, typename Predicate, typename... ReplacementPredicates>
-  SLINKY_ALWAYS_INLINE bool operator()(Pattern p, Replacement r, Predicate pr, ReplacementPredicates... r_pr) {
+  template <typename Pattern, typename... ReplacementPredicate>
+  SLINKY_ALWAYS_INLINE bool operator()(Pattern p, ReplacementPredicate... r_pr) {
     static_assert(pattern_info<Pattern>::is_canonical);
 
     match_context ctx;
     if (!match_any_variant(p, x, ctx)) return false;
 
-    return find_replacement<Pattern>(ctx, r, pr, r_pr...);
+    return find_replacement<Pattern>(ctx, r_pr...);
   }
 };
 

--- a/builder/simplify_bounds.cc
+++ b/builder/simplify_bounds.cc
@@ -20,7 +20,7 @@ pattern_constant<2> c2;
 template <typename T>
 interval_expr bounds_of_linear(const T* op, interval_expr a, interval_expr b) {
   if (a.is_point(op) && b.is_point(op)) {
-    return point(op);
+    return point(expr(op));
   } else if (a.is_point() && b.is_point()) {
     return point(simplify(op, std::move(a.min), std::move(b.min)));
   } else {
@@ -31,7 +31,7 @@ interval_expr bounds_of_linear(const T* op, interval_expr a, interval_expr b) {
 template <typename T>
 interval_expr bounds_of_less(const T* op, interval_expr a, interval_expr b) {
   if (a.is_point(op) && b.is_point(op)) {
-    return point(op);
+    return point(expr(op));
   } else if (a.is_point() && b.is_point()) {
     return point(simplify(op, std::move(a.min), std::move(b.min)));
   } else {
@@ -133,7 +133,7 @@ void tighten_correlated_bounds(interval_expr& bounds, const expr& a, const expr&
 
 interval_expr bounds_of(const add* op, interval_expr a, interval_expr b) {
   if (a.is_point(op) && b.is_point(op)) {
-    return point(op);
+    return point(expr(op));
   } else if (a.is_point() && b.is_point()) {
     return point(simplify(op, std::move(a.min), std::move(b.min)));
   } else {
@@ -146,7 +146,7 @@ interval_expr bounds_of(const add* op, interval_expr a, interval_expr b) {
 }
 interval_expr bounds_of(const sub* op, interval_expr a, interval_expr b) {
   if (a.is_point(op) && b.is_point(op)) {
-    return point(op);
+    return point(expr(op));
   } else if (a.is_point() && b.is_point()) {
     return point(simplify(op, std::move(a.min), std::move(b.min)));
   } else {
@@ -163,7 +163,7 @@ interval_expr bounds_of(const sub* op, interval_expr a, interval_expr b) {
 interval_expr bounds_of(const mul* op, interval_expr a, interval_expr b) {
   // TODO: I'm pretty sure there are cases missing here that would produce simpler bounds than the fallback cases.
   if (a.is_point(op) && b.is_point(op)) {
-    return point(op);
+    return point(expr(op));
   } else if (a.is_point() && b.is_point()) {
     return point(simplify(op, std::move(a.min), std::move(b.min)));
   } else if (is_non_negative(a.min) && is_non_negative(b.min)) {
@@ -246,7 +246,7 @@ interval_expr bounds_of(const div* op, interval_expr a, interval_expr b) {
   // (we define division by 0 to be 0). The absolute value of the
   // bounds are maximized when b is 1 or -1.
   if (a.is_point(op) && b.is_point(op)) {
-    return point(op);
+    return point(expr(op));
   } else if (b.is_point()) {
     if (is_zero(b.min)) {
       return {0, 0};
@@ -282,7 +282,7 @@ interval_expr bounds_of(const div* op, interval_expr a, interval_expr b) {
 }
 interval_expr bounds_of(const mod* op, interval_expr a, interval_expr b) {
   if (a.is_point(op) && b.is_point(op)) {
-    return point(op);
+    return point(expr(op));
   } else if (a.is_point() && b.is_point()) {
     return point(simplify(op, std::move(a.min), std::move(b.min)));
   }
@@ -324,7 +324,7 @@ interval_expr bounds_of(const less_equal* op, interval_expr a, interval_expr b) 
 }
 interval_expr bounds_of(const equal* op, interval_expr a, interval_expr b) {
   if (a.is_point(op) && b.is_point(op)) {
-    return point(op);
+    return point(expr(op));
   } else if (a.is_point() && b.is_point()) {
     return point(simplify(op, std::move(a.min), std::move(b.min)));
   } else {
@@ -340,7 +340,7 @@ interval_expr bounds_of(const equal* op, interval_expr a, interval_expr b) {
 }
 interval_expr bounds_of(const not_equal* op, interval_expr a, interval_expr b) {
   if (a.is_point(op) && b.is_point(op)) {
-    return point(op);
+    return point(expr(op));
   } else if (a.is_point() && b.is_point()) {
     return point(simplify(op, std::move(a.min), std::move(b.min)));
   } else {
@@ -359,7 +359,7 @@ interval_expr bounds_of(const logical_or* op, interval_expr a, interval_expr b) 
 }
 interval_expr bounds_of(const logical_not* op, interval_expr a) {
   if (a.is_point(op)) {
-    return point(op);
+    return point(expr(op));
   } else if (a.is_point()) {
     return point(simplify(op, std::move(a.min)));
   } else {
@@ -400,9 +400,9 @@ interval_expr bounds_of(const call* op, std::vector<interval_expr> args) {
       return {0, simplify(static_cast<const class max*>(nullptr), std::move(abs_min), std::move(abs_max))};
     }
   case intrinsic::buffer_rank:
-  case intrinsic::buffer_elem_size: return {0, op};
-  case intrinsic::buffer_fold_factor: return {1, op};
-  default: return {op, op};
+  case intrinsic::buffer_elem_size: return {0, expr(op)};
+  case intrinsic::buffer_fold_factor: return {1, expr(op)};
+  default: return point(expr(op));
   }
 }
 

--- a/builder/simplify_exprs.cc
+++ b/builder/simplify_exprs.cc
@@ -29,7 +29,7 @@ expr simplify(const class min* op, expr a, expr b) {
   if (apply_min_rules(r)) {
     return r.result;
   } else if (op && a.same_as(op->a) && b.same_as(op->b)) {
-    return op;
+    return expr(op);
   } else {
     return min::make(std::move(a), std::move(b));
   }
@@ -53,7 +53,7 @@ expr simplify(const class max* op, expr a, expr b) {
   if (apply_max_rules(r)) {
     return r.result;
   } else if (op && a.same_as(op->a) && b.same_as(op->b)) {
-    return op;
+    return expr(op);
   } else {
     return max::make(std::move(a), std::move(b));
   }
@@ -80,7 +80,7 @@ expr simplify(const add* op, expr a, expr b) {
   if (apply_add_rules(r)) {
     return r.result;
   } else if (op && a.same_as(op->a) && b.same_as(op->b)) {
-    return op;
+    return expr(op);
   } else {
     return add::make(std::move(a), std::move(b));
   }
@@ -106,7 +106,7 @@ expr simplify(const sub* op, expr a, expr b) {
   if (apply_sub_rules(r)) {
     return r.result;
   } else if (op && a.same_as(op->a) && b.same_as(op->b)) {
-    return op;
+    return expr(op);
   } else {
     return sub::make(std::move(a), std::move(b));
   }
@@ -133,7 +133,7 @@ expr simplify(const mul* op, expr a, expr b) {
   if (apply_mul_rules(r)) {
     return r.result;
   } else if (op && a.same_as(op->a) && b.same_as(op->b)) {
-    return op;
+    return expr(op);
   } else {
     return mul::make(std::move(a), std::move(b));
   }
@@ -154,7 +154,7 @@ expr simplify(const div* op, expr a, expr b) {
   if (apply_div_rules(r)) {
     return r.result;
   } else if (op && a.same_as(op->a) && b.same_as(op->b)) {
-    return op;
+    return expr(op);
   } else {
     return div::make(std::move(a), std::move(b));
   }
@@ -171,7 +171,7 @@ expr simplify(const mod* op, expr a, expr b) {
   if (apply_mod_rules(r)) {
     return r.result;
   } else if (op && a.same_as(op->a) && b.same_as(op->b)) {
-    return op;
+    return expr(op);
   } else {
     return mod::make(std::move(a), std::move(b));
   }
@@ -188,7 +188,7 @@ expr simplify(const less* op, expr a, expr b) {
   if (apply_less_rules(r)) {
     return r.result;
   } else if (op && a.same_as(op->a) && b.same_as(op->b)) {
-    return op;
+    return expr(op);
   } else {
     return less::make(std::move(a), std::move(b));
   }
@@ -201,7 +201,7 @@ expr simplify(const less_equal* op, expr a, expr b) {
   if (op) {
     if (const less_equal* le = result.as<less_equal>()) {
       if (le->a.same_as(op->a) && le->b.same_as(op->b)) {
-        return op;
+        return expr(op);
       }
     }
   }
@@ -223,7 +223,7 @@ expr simplify(const equal* op, expr a, expr b) {
   if (apply_equal_rules(r)) {
     return r.result;
   } else if (op && a.same_as(op->a) && b.same_as(op->b)) {
-    return op;
+    return expr(op);
   } else {
     return equal::make(std::move(a), std::move(b));
   }
@@ -236,7 +236,7 @@ expr simplify(const not_equal* op, expr a, expr b) {
   if (op) {
     if (const not_equal* ne = result.as<not_equal>()) {
       if (ne->a.same_as(op->a) && ne->b.same_as(op->b)) {
-        return op;
+        return expr(op);
       }
     }
   }
@@ -260,7 +260,7 @@ expr simplify(const logical_and* op, expr a, expr b) {
   if (apply_logical_and_rules(r)) {
     return r.result;
   } else if (op && a.same_as(op->a) && b.same_as(op->b)) {
-    return op;
+    return expr(op);
   } else {
     return logical_and::make(std::move(a), std::move(b));
   }
@@ -283,7 +283,7 @@ expr simplify(const logical_or* op, expr a, expr b) {
   if (apply_logical_or_rules(r)) {
     return r.result;
   } else if (op && a.same_as(op->a) && b.same_as(op->b)) {
-    return op;
+    return expr(op);
   } else {
     return logical_or::make(std::move(a), std::move(b));
   }
@@ -299,7 +299,7 @@ expr simplify(const class logical_not* op, expr a) {
   if (apply_logical_not_rules(r)) {
     return r.result;
   } else if (op && a.same_as(op->a)) {
-    return op;
+    return expr(op);
   } else {
     return logical_not::make(std::move(a));
   }
@@ -316,7 +316,7 @@ expr simplify(const class select* op, expr c, expr t, expr f) {
   if (apply_select_rules(r)) {
     return r.result;
   } else if (op && c.same_as(op->condition) && t.same_as(op->true_value) && f.same_as(op->false_value)) {
-    return op;
+    return expr(op);
   } else {
     return select::make(std::move(c), std::move(t), std::move(f));
   }
@@ -396,7 +396,7 @@ expr simplify(const call* op, intrinsic fn, std::vector<expr> args) {
   expr e;
   if (!changed) {
     assert(op);
-    e = op;
+    e = expr(op);
   } else {
     e = call::make(fn, std::move(args));
   }

--- a/builder/substitute.cc
+++ b/builder/substitute.cc
@@ -306,15 +306,14 @@ public:
   }
 };
 
-bool match(const expr& a, const expr& b) { return compare(a, b) == 0; }
-bool match(const base_expr_node* a, const base_expr_node* b) { return compare(a, b) == 0; }
-bool match(const stmt& a, const stmt& b) { return compare(a, b) == 0; }
+bool match(expr_ref a, expr_ref b) { return compare(a, b) == 0; }
+bool match(stmt_ref a, stmt_ref b) { return compare(a, b) == 0; }
 bool match(const interval_expr& a, const interval_expr& b) { return match(a.min, b.min) && match(a.max, b.max); }
 bool match(const dim_expr& a, const dim_expr& b) {
   return match(a.bounds, b.bounds) && match(a.stride, b.stride) && match(a.fold_factor, b.fold_factor);
 }
 
-const call* match_call(const expr& x, intrinsic fn, var a) {
+const call* match_call(expr_ref x, intrinsic fn, var a) {
   const call* c = as_intrinsic(x, fn);
   if (!c) return nullptr;
 
@@ -325,7 +324,7 @@ const call* match_call(const expr& x, intrinsic fn, var a) {
   return c;
 }
 
-const call* match_call(const expr& x, intrinsic fn, var a, index_t b) {
+const call* match_call(expr_ref x, intrinsic fn, var a, index_t b) {
   const call* c = match_call(x, fn, a);
   if (!c) return nullptr;
 
@@ -341,17 +340,15 @@ int compare(const var& a, const var& b) {
   m.try_match(a, b);
   return m.match;
 }
-int compare(const expr& a, const expr& b) { return compare(a.get(), b.get()); }
-
-int compare(const base_expr_node* a, const base_expr_node* b) {
+int compare(expr_ref a, expr_ref b) {
   matcher m;
-  m.try_match(a, b);
+  m.try_match(a.get(), b.get());
   return m.match;
 }
 
-int compare(const stmt& a, const stmt& b) {
+int compare(stmt_ref a, stmt_ref b) {
   matcher m;
-  m.try_match(a, b);
+  m.try_match(a.get(), b.get());
   return m.match;
 }
 

--- a/builder/substitute.h
+++ b/builder/substitute.h
@@ -6,13 +6,19 @@
 
 namespace slinky {
 
-bool match(const expr& a, const expr& b);
-bool match(const base_expr_node* a, const base_expr_node* b);
-bool match(const stmt& a, const stmt& b);
+bool match(expr_ref a, expr_ref b);
+SLINKY_ALWAYS_INLINE inline bool match(var a, var b) { return a == b; }
+SLINKY_ALWAYS_INLINE inline bool match(var a, expr_ref b) { return is_variable(b, a); }
+SLINKY_ALWAYS_INLINE inline bool match(var a, index_t b) { return false; }
+SLINKY_ALWAYS_INLINE inline bool match(expr_ref a, var b) { return is_variable(a, b); }
+SLINKY_ALWAYS_INLINE inline bool match(expr_ref a, index_t b) { return is_constant(a, b); }
+SLINKY_ALWAYS_INLINE inline bool match(index_t a, expr_ref b) { return is_constant(b, a); }
+SLINKY_ALWAYS_INLINE inline bool match(index_t a, var b) { return false; }
+bool match(stmt_ref a, stmt_ref b);
 bool match(const interval_expr& a, const interval_expr& b);
 bool match(const dim_expr& a, const dim_expr& b);
-const call* match_call(const expr& x, intrinsic fn, var a);
-const call* match_call(const expr& x, intrinsic fn, var a, index_t b);
+const call* match_call(expr_ref x, intrinsic fn, var a);
+const call* match_call(expr_ref x, intrinsic fn, var a, index_t b);
 
 expr substitute(const expr& e, var target, const expr& replacement);
 stmt substitute(const stmt& s, var target, const expr& replacement);
@@ -31,9 +37,8 @@ stmt substitute_bounds(const stmt& s, var buffer, int dim, const interval_expr& 
 
 // Compute a sort ordering of two nodes based on their structure (not their values).
 int compare(const var& a, const var& b);
-int compare(const expr& a, const expr& b);
-int compare(const base_expr_node* a, const base_expr_node* b);
-int compare(const stmt& a, const stmt& b);
+int compare(expr_ref a, expr_ref b);
+int compare(stmt_ref a, stmt_ref b);
 
 // Update buffer metadata expressions to account for a slice that has occurred.
 expr update_sliced_buffer_metadata(const expr& e, var buf, span<const int> slices);
@@ -43,8 +48,8 @@ dim_expr update_sliced_buffer_metadata(const dim_expr& x, var buf, span<const in
 // A comparator suitable for using expr/stmt as keys in an std::map/std::set.
 struct node_less {
   bool operator()(const var& a, const var& b) const { return compare(a, b) < 0; }
-  bool operator()(const expr& a, const expr& b) const { return compare(a, b) < 0; }
-  bool operator()(const stmt& a, const stmt& b) const { return compare(a, b) < 0; }
+  bool operator()(expr_ref a, expr_ref b) const { return compare(a, b) < 0; }
+  bool operator()(stmt_ref a, stmt_ref b) const { return compare(a, b) < 0; }
 };
 
 }  // namespace slinky

--- a/builder/substitute.h
+++ b/builder/substitute.h
@@ -7,13 +7,13 @@
 namespace slinky {
 
 bool match(expr_ref a, expr_ref b);
-SLINKY_ALWAYS_INLINE inline bool match(var a, var b) { return a == b; }
-SLINKY_ALWAYS_INLINE inline bool match(var a, expr_ref b) { return is_variable(b, a); }
-SLINKY_ALWAYS_INLINE inline bool match(var a, index_t b) { return false; }
-SLINKY_ALWAYS_INLINE inline bool match(expr_ref a, var b) { return is_variable(a, b); }
-SLINKY_ALWAYS_INLINE inline bool match(expr_ref a, index_t b) { return is_constant(a, b); }
-SLINKY_ALWAYS_INLINE inline bool match(index_t a, expr_ref b) { return is_constant(b, a); }
-SLINKY_ALWAYS_INLINE inline bool match(index_t a, var b) { return false; }
+SLINKY_ALWAYS_INLINE SLINKY_UNIQUE bool match(var a, var b) { return a == b; }
+SLINKY_ALWAYS_INLINE SLINKY_UNIQUE bool match(var a, expr_ref b) { return is_variable(b, a); }
+SLINKY_ALWAYS_INLINE SLINKY_UNIQUE bool match(var a, index_t b) { return false; }
+SLINKY_ALWAYS_INLINE SLINKY_UNIQUE bool match(expr_ref a, var b) { return is_variable(a, b); }
+SLINKY_ALWAYS_INLINE SLINKY_UNIQUE bool match(expr_ref a, index_t b) { return is_constant(a, b); }
+SLINKY_ALWAYS_INLINE SLINKY_UNIQUE bool match(index_t a, expr_ref b) { return is_constant(b, a); }
+SLINKY_ALWAYS_INLINE SLINKY_UNIQUE bool match(index_t a, var b) { return false; }
 bool match(stmt_ref a, stmt_ref b);
 bool match(const interval_expr& a, const interval_expr& b);
 bool match(const dim_expr& a, const dim_expr& b);

--- a/builder/test/simplify/rule_tester.h
+++ b/builder/test/simplify/rule_tester.h
@@ -81,8 +81,8 @@ public:
     std::stringstream rule_str;
     rule_str << p << " -> " << r;
 
-    expr pattern = substitute(p, m);
-    expr replacement = substitute(r, m);
+    expr pattern = expr(substitute(p, m));
+    expr replacement = expr(substitute(r, m));
 
     // Make sure the expressions have the same value when evaluated.
     test_expr(pattern, replacement, rule_str.str());
@@ -102,8 +102,8 @@ public:
     for (int test = 0; test < 100000; ++test) {
       init_match_context();
       if (substitute(pr, m)) {
-        expr pattern = substitute(p, m);
-        expr replacement = substitute(r, m);
+        expr pattern = expr(substitute(p, m));
+        expr replacement = expr(substitute(r, m));
 
         // Make sure the expressions have the same value when evaluated.
         test_expr(pattern, replacement, rule_str.str());

--- a/runtime/depends_on.cc
+++ b/runtime/depends_on.cc
@@ -210,30 +210,30 @@ public:
 
 }  // namespace
 
-void depends_on(const expr& e, span<const std::pair<var, depends_on_result&>> var_deps) {
+void depends_on(expr_ref e, span<const std::pair<var, depends_on_result&>> var_deps) {
   if (var_deps.empty()) return;
   dependencies v(var_deps);
   if (e.defined()) e.accept(&v);
 }
 
-void depends_on(const stmt& s, span<const std::pair<var, depends_on_result&>> var_deps) {
+void depends_on(stmt_ref s, span<const std::pair<var, depends_on_result&>> var_deps) {
   scoped_trace trace("depends_on");
   if (var_deps.empty()) return;
   dependencies v(var_deps);
   if (s.defined()) s.accept(&v);
 }
 
-void depends_on(const expr& e, var x, depends_on_result& deps) {
+void depends_on(expr_ref e, var x, depends_on_result& deps) {
   std::pair<var, depends_on_result&> var_deps[] = {{x, deps}};
   depends_on(e, var_deps);
 }
 
-void depends_on(const stmt& s, var x, depends_on_result& deps) {
+void depends_on(stmt_ref s, var x, depends_on_result& deps) {
   std::pair<var, depends_on_result&> var_deps[] = {{x, deps}};
   depends_on(s, var_deps);
 }
 
-depends_on_result depends_on(const expr& e, var x) {
+depends_on_result depends_on(expr_ref e, var x) {
   depends_on_result r;
   depends_on(e, x, r);
   return r;
@@ -246,13 +246,13 @@ depends_on_result depends_on(const interval_expr& e, var x) {
   return r;
 }
 
-depends_on_result depends_on(const stmt& s, var x) {
+depends_on_result depends_on(stmt_ref s, var x) {
   depends_on_result r;
   depends_on(s, x, r);
   return r;
 }
 
-depends_on_result depends_on(const expr& e, span<const var> xs) {
+depends_on_result depends_on(expr_ref e, span<const var> xs) {
   depends_on_result r;
   std::vector<std::pair<var, depends_on_result&>> var_deps;
   for (var x : xs) {
@@ -262,7 +262,7 @@ depends_on_result depends_on(const expr& e, span<const var> xs) {
   return r;
 }
 
-depends_on_result depends_on(const stmt& s, span<const var> xs) {
+depends_on_result depends_on(stmt_ref s, span<const var> xs) {
   depends_on_result r;
   std::vector<std::pair<var, depends_on_result&>> var_deps;
   for (var x : xs) {

--- a/runtime/depends_on.h
+++ b/runtime/depends_on.h
@@ -31,15 +31,15 @@ struct depends_on_result {
 
 // Check if the node depends on a symbol or set of symbols.
 
-void depends_on(const expr& e, span<const std::pair<var, depends_on_result&>> var_deps);
-void depends_on(const stmt& s, span<const std::pair<var, depends_on_result&>> var_deps);
-void depends_on(const expr& e, var x, depends_on_result& deps);
-void depends_on(const stmt& s, var x, depends_on_result& deps);
-depends_on_result depends_on(const expr& e, var x);
+void depends_on(expr_ref e, span<const std::pair<var, depends_on_result&>> var_deps);
+void depends_on(stmt_ref s, span<const std::pair<var, depends_on_result&>> var_deps);
+void depends_on(expr_ref e, var x, depends_on_result& deps);
+void depends_on(stmt_ref s, var x, depends_on_result& deps);
+depends_on_result depends_on(expr_ref e, var x);
 depends_on_result depends_on(const interval_expr& e, var x);
-depends_on_result depends_on(const stmt& s, var x);
-depends_on_result depends_on(const expr& e, span<const var> xs);
-depends_on_result depends_on(const stmt& s, span<const var> xs);
+depends_on_result depends_on(stmt_ref s, var x);
+depends_on_result depends_on(expr_ref e, span<const var> xs);
+depends_on_result depends_on(stmt_ref s, span<const var> xs);
 
 // Check if buffer can be safely substituted.
 bool can_substitute_buffer(const depends_on_result& r);

--- a/runtime/expr.h
+++ b/runtime/expr.h
@@ -423,18 +423,6 @@ template <typename T>
 expr make_binary(expr a, expr b) {
   return T::make(std::move(a), std::move(b));
 }
-template <typename T>
-expr make_binary(expr a, expr_ref b) {
-  return T::make(std::move(a), expr(b));
-}
-template <typename T>
-expr make_binary(expr_ref a, expr b) {
-  return T::make(expr(a), std::move(b));
-}
-template <typename T>
-expr make_binary(expr_ref a, expr_ref b) {
-  return T::make(expr(a), expr(b));
-}
 
 // clang-format off
 template <typename T> SLINKY_ALWAYS_INLINE SLINKY_UNIQUE index_t make_binary(index_t a, index_t b);

--- a/runtime/expr.h
+++ b/runtime/expr.h
@@ -440,20 +440,20 @@ expr make_binary(expr_ref a, expr_ref b) {
 }
 
 // clang-format off
-template <typename T> index_t make_binary(index_t a, index_t b);
-template <> inline index_t make_binary<add>(index_t a, index_t b) { return a + b; }
-template <> inline index_t make_binary<sub>(index_t a, index_t b) { return a - b; }
-template <> inline index_t make_binary<mul>(index_t a, index_t b) { return a * b; }
-template <> inline index_t make_binary<div>(index_t a, index_t b) { return euclidean_div(a, b); }
-template <> inline index_t make_binary<mod>(index_t a, index_t b) { return euclidean_mod(a, b); }
-template <> inline index_t make_binary<class min>(index_t a, index_t b) { return std::min(a, b); }
-template <> inline index_t make_binary<class max>(index_t a, index_t b) { return std::max(a, b); }
-template <> inline index_t make_binary<equal>(index_t a, index_t b) { return a == b ? 1 : 0; }
-template <> inline index_t make_binary<not_equal>(index_t a, index_t b) { return a != b ? 1 : 0; }
-template <> inline index_t make_binary<less>(index_t a, index_t b) { return a < b ? 1 : 0; }
-template <> inline index_t make_binary<less_equal>(index_t a, index_t b) { return a <= b ? 1 : 0; }
-template <> inline index_t make_binary<logical_and>(index_t a, index_t b) { return a && b ? 1 : 0; }
-template <> inline index_t make_binary<logical_or>(index_t a, index_t b) { return a || b ? 1 : 0; }
+template <typename T> SLINKY_ALWAYS_INLINE SLINKY_UNIQUE index_t make_binary(index_t a, index_t b);
+template <> SLINKY_ALWAYS_INLINE inline index_t make_binary<add>(index_t a, index_t b) { return a + b; }
+template <> SLINKY_ALWAYS_INLINE inline index_t make_binary<sub>(index_t a, index_t b) { return a - b; }
+template <> SLINKY_ALWAYS_INLINE inline index_t make_binary<mul>(index_t a, index_t b) { return a * b; }
+template <> SLINKY_ALWAYS_INLINE inline index_t make_binary<div>(index_t a, index_t b) { return euclidean_div(a, b); }
+template <> SLINKY_ALWAYS_INLINE inline index_t make_binary<mod>(index_t a, index_t b) { return euclidean_mod(a, b); }
+template <> SLINKY_ALWAYS_INLINE inline index_t make_binary<class min>(index_t a, index_t b) { return std::min(a, b); }
+template <> SLINKY_ALWAYS_INLINE inline index_t make_binary<class max>(index_t a, index_t b) { return std::max(a, b); }
+template <> SLINKY_ALWAYS_INLINE inline index_t make_binary<equal>(index_t a, index_t b) { return a == b ? 1 : 0; }
+template <> SLINKY_ALWAYS_INLINE inline index_t make_binary<not_equal>(index_t a, index_t b) { return a != b ? 1 : 0; }
+template <> SLINKY_ALWAYS_INLINE inline index_t make_binary<less>(index_t a, index_t b) { return a < b ? 1 : 0; }
+template <> SLINKY_ALWAYS_INLINE inline index_t make_binary<less_equal>(index_t a, index_t b) { return a <= b ? 1 : 0; }
+template <> SLINKY_ALWAYS_INLINE inline index_t make_binary<logical_and>(index_t a, index_t b) { return a && b ? 1 : 0; }
+template <> SLINKY_ALWAYS_INLINE inline index_t make_binary<logical_or>(index_t a, index_t b) { return a || b ? 1 : 0; }
 // clang-format on
 
 class logical_not : public expr_node<logical_not> {
@@ -555,35 +555,35 @@ inline void select::accept(expr_visitor* v) const { v->visit(this); }
 inline void call::accept(expr_visitor* v) const { v->visit(this); }
 
 // If `x` is a constant, returns the value of the constant, otherwise `nullptr`.
-SLINKY_ALWAYS_INLINE inline const index_t* as_constant(expr_ref x) {
+SLINKY_ALWAYS_INLINE SLINKY_UNIQUE const index_t* as_constant(expr_ref x) {
   const constant* cx = x.as<constant>();
   return cx ? &cx->value : nullptr;
 }
 
 // If `x` is a variable, returns the `var` of the variable, otherwise `nullptr`.
-SLINKY_ALWAYS_INLINE inline const var* as_variable(expr_ref x) {
+SLINKY_ALWAYS_INLINE SLINKY_UNIQUE const var* as_variable(expr_ref x) {
   const variable* vx = x.as<variable>();
   return vx ? &vx->sym : nullptr;
 }
 
 // Check if `x` is a variable equal to the symbol `sym`.
-SLINKY_ALWAYS_INLINE inline bool is_variable(expr_ref x, var sym) {
+SLINKY_ALWAYS_INLINE SLINKY_UNIQUE bool is_variable(expr_ref x, var sym) {
   const variable* vx = x.as<variable>();
   return vx ? vx->sym == sym : false;
 }
 
 // Check if `x` is equal to the constant `value`.
-SLINKY_ALWAYS_INLINE inline bool is_constant(expr_ref x, index_t value) {
+SLINKY_ALWAYS_INLINE SLINKY_UNIQUE bool is_constant(expr_ref x, index_t value) {
   const constant* cx = x.as<constant>();
   return cx ? cx->value == value : false;
 }
-SLINKY_ALWAYS_INLINE inline bool is_zero(expr_ref x) { return is_constant(x, 0); }
-SLINKY_ALWAYS_INLINE inline bool is_one(expr_ref x) { return is_constant(x, 1); }
-inline bool is_true(expr_ref x) {
+SLINKY_ALWAYS_INLINE SLINKY_UNIQUE bool is_zero(expr_ref x) { return is_constant(x, 0); }
+SLINKY_ALWAYS_INLINE SLINKY_UNIQUE bool is_one(expr_ref x) { return is_constant(x, 1); }
+SLINKY_ALWAYS_INLINE SLINKY_UNIQUE bool is_true(expr_ref x) {
   const constant* cx = x.as<constant>();
   return cx ? cx->value != 0 : false;
 }
-SLINKY_ALWAYS_INLINE inline bool is_false(expr_ref x) { return is_zero(x); }
+SLINKY_ALWAYS_INLINE SLINKY_UNIQUE bool is_false(expr_ref x) { return is_zero(x); }
 
 // Check if `x` is a call to the intrinsic `fn`.
 inline const call* as_intrinsic(expr_ref x, intrinsic fn) {
@@ -599,7 +599,7 @@ bool is_indeterminate(expr_ref x);
 int is_infinity(expr_ref x);
 bool is_finite(expr_ref x);
 
-SLINKY_ALWAYS_INLINE inline index_t boolean(index_t x) { return x != 0 ? 1 : 0; }
+SLINKY_ALWAYS_INLINE SLINKY_UNIQUE index_t boolean(index_t x) { return x != 0 ? 1 : 0; }
 expr boolean(const expr& x);
 bool is_boolean(expr_ref x);
 

--- a/runtime/expr.h
+++ b/runtime/expr.h
@@ -169,6 +169,38 @@ public:
 
 class expr;
 
+// `expr_ref` is a non-owning reference to a `base_expr_node`.
+class expr_ref {
+  const base_expr_node* n_;
+
+public:
+  SLINKY_ALWAYS_INLINE expr_ref(const expr_ref&) = default;
+  SLINKY_ALWAYS_INLINE expr_ref(expr_ref&&) = default;
+  SLINKY_ALWAYS_INLINE expr_ref& operator=(const expr_ref&) = default;
+  SLINKY_ALWAYS_INLINE expr_ref& operator=(expr_ref&&) = default;
+
+  SLINKY_ALWAYS_INLINE expr_ref(const expr& e);
+  SLINKY_ALWAYS_INLINE expr_ref(const base_expr_node* n) : n_(n) {}
+
+  SLINKY_ALWAYS_INLINE void accept(expr_visitor* v) const {
+    assert(defined());
+    n_->accept(v);
+  }
+
+  SLINKY_ALWAYS_INLINE bool defined() const { return n_ != nullptr; }
+  SLINKY_ALWAYS_INLINE expr_node_type type() const { return n_ ? n_->type : expr_node_type::none; }
+  SLINKY_ALWAYS_INLINE const base_expr_node* get() const { return n_; }
+
+  template <typename T>
+  SLINKY_ALWAYS_INLINE const T* as() const {
+    if (n_ && type() == T::static_type) {
+      return reinterpret_cast<const T*>(&*n_);
+    } else {
+      return nullptr;
+    }
+  }
+};
+
 expr operator+(expr a, expr b);
 expr operator-(expr a, expr b);
 expr operator*(expr a, expr b);
@@ -179,26 +211,27 @@ expr operator%(expr a, expr b);
 expr euclidean_div(expr a, expr b);
 expr euclidean_mod(expr a, expr b);
 
-// `expr` is an owner of a reference counted pointer to a `base_expr_node`, `stmt` similarly owns a `base_stmt_node`
-// pointer. Operations that appear to mutate these objects are actually just reassigning this reference counted pointer.
+// `expr` is an owner of a reference counted pointer to a `base_expr_node`.
+// Operations that appear to mutate these objects are actually just reassigning this reference counted pointer.
 class expr {
   ref_count<const base_expr_node> n_;
 
 public:
-  expr() = default;
-  expr(const expr&) = default;
-  expr(expr&&) = default;
-  expr& operator=(const expr&) = default;
-  expr& operator=(expr&&) = default;
+  SLINKY_ALWAYS_INLINE expr() = default;
+  SLINKY_ALWAYS_INLINE expr(const expr&) = default;
+  SLINKY_ALWAYS_INLINE expr(expr&&) = default;
+  SLINKY_ALWAYS_INLINE expr& operator=(const expr&) = default;
+  SLINKY_ALWAYS_INLINE expr& operator=(expr&&) = default;
 
   // Make a new constant expression.
   expr(std::int64_t x);
-  expr(std::int32_t x) : expr(static_cast<std::int64_t>(x)) {}
-  expr(std::size_t x) : expr(static_cast<std::int64_t>(x)) {}
+  SLINKY_ALWAYS_INLINE expr(std::int32_t x) : expr(static_cast<std::int64_t>(x)) {}
+  SLINKY_ALWAYS_INLINE expr(std::size_t x) : expr(static_cast<std::int64_t>(x)) {}
   expr(var sym);
 
   // Make an `expr` referencing an existing node.
-  expr(const base_expr_node* n) : n_(n) {}
+  SLINKY_ALWAYS_INLINE expr(expr_ref e) : n_(e.get()) {}
+  SLINKY_ALWAYS_INLINE explicit expr(const base_expr_node* n) : n_(n) {}
 
   SLINKY_ALWAYS_INLINE void accept(expr_visitor* v) const {
     assert(defined());
@@ -206,8 +239,7 @@ public:
   }
 
   SLINKY_ALWAYS_INLINE bool defined() const { return n_ != nullptr; }
-  SLINKY_ALWAYS_INLINE bool same_as(const expr& other) const { return n_ == other.n_; }
-  SLINKY_ALWAYS_INLINE bool same_as(const base_expr_node* other) const { return n_ == other; }
+  SLINKY_ALWAYS_INLINE bool same_as(expr_ref other) const { return n_ == other.get(); }
   SLINKY_ALWAYS_INLINE expr_node_type type() const { return n_ ? n_->type : expr_node_type::none; }
   SLINKY_ALWAYS_INLINE const base_expr_node* get() const { return n_; }
 
@@ -228,6 +260,8 @@ public:
   expr& operator/=(expr r);
   expr& operator%=(expr r);
 };
+
+SLINKY_ALWAYS_INLINE inline expr_ref::expr_ref(const expr& e) : n_(e.get()) {}
 
 expr operator==(expr a, expr b);
 expr operator!=(expr a, expr b);
@@ -259,8 +293,7 @@ struct interval_expr {
   bool same_as(const interval_expr& r) const { return min.same_as(r.min) && max.same_as(r.max); }
 
   bool is_point() const { return min.defined() && min.same_as(max); }
-  bool is_point(const expr& x) const { return min.same_as(x) && max.same_as(x); }
-  bool is_point(const base_expr_node* x) const { return min.same_as(x) && max.same_as(x); }
+  bool is_point(expr_ref x) const { return min.same_as(x) && max.same_as(x); }
 
   static const interval_expr& all();
   static const interval_expr& none();
@@ -393,6 +426,18 @@ template <typename T>
 expr make_binary(expr a, expr b) {
   return T::make(std::move(a), std::move(b));
 }
+template <typename T>
+expr make_binary(expr a, expr_ref b) {
+  return T::make(std::move(a), expr(b));
+}
+template <typename T>
+expr make_binary(expr_ref a, expr b) {
+  return T::make(expr(a), std::move(b));
+}
+template <typename T>
+expr make_binary(expr_ref a, expr_ref b) {
+  return T::make(expr(a), expr(b));
+}
 
 // clang-format off
 template <typename T> index_t make_binary(index_t a, index_t b);
@@ -510,53 +555,53 @@ inline void select::accept(expr_visitor* v) const { v->visit(this); }
 inline void call::accept(expr_visitor* v) const { v->visit(this); }
 
 // If `x` is a constant, returns the value of the constant, otherwise `nullptr`.
-SLINKY_ALWAYS_INLINE inline const index_t* as_constant(const expr& x) {
+SLINKY_ALWAYS_INLINE inline const index_t* as_constant(expr_ref x) {
   const constant* cx = x.as<constant>();
   return cx ? &cx->value : nullptr;
 }
 
 // If `x` is a variable, returns the `var` of the variable, otherwise `nullptr`.
-SLINKY_ALWAYS_INLINE inline const var* as_variable(const expr& x) {
+SLINKY_ALWAYS_INLINE inline const var* as_variable(expr_ref x) {
   const variable* vx = x.as<variable>();
   return vx ? &vx->sym : nullptr;
 }
 
 // Check if `x` is a variable equal to the symbol `sym`.
-SLINKY_ALWAYS_INLINE inline bool is_variable(const expr& x, var sym) {
+SLINKY_ALWAYS_INLINE inline bool is_variable(expr_ref x, var sym) {
   const variable* vx = x.as<variable>();
   return vx ? vx->sym == sym : false;
 }
 
 // Check if `x` is equal to the constant `value`.
-SLINKY_ALWAYS_INLINE inline bool is_constant(const expr& x, index_t value) {
+SLINKY_ALWAYS_INLINE inline bool is_constant(expr_ref x, index_t value) {
   const constant* cx = x.as<constant>();
   return cx ? cx->value == value : false;
 }
-SLINKY_ALWAYS_INLINE inline bool is_zero(const expr& x) { return is_constant(x, 0); }
-SLINKY_ALWAYS_INLINE inline bool is_one(const expr& x) { return is_constant(x, 1); }
-inline bool is_true(const expr& x) {
+SLINKY_ALWAYS_INLINE inline bool is_zero(expr_ref x) { return is_constant(x, 0); }
+SLINKY_ALWAYS_INLINE inline bool is_one(expr_ref x) { return is_constant(x, 1); }
+inline bool is_true(expr_ref x) {
   const constant* cx = x.as<constant>();
   return cx ? cx->value != 0 : false;
 }
-SLINKY_ALWAYS_INLINE inline bool is_false(const expr& x) { return is_zero(x); }
+SLINKY_ALWAYS_INLINE inline bool is_false(expr_ref x) { return is_zero(x); }
 
 // Check if `x` is a call to the intrinsic `fn`.
-inline const call* as_intrinsic(const expr& x, intrinsic fn) {
+inline const call* as_intrinsic(expr_ref x, intrinsic fn) {
   const call* c = x.as<call>();
   return c && c->intrinsic == fn ? c : nullptr;
 }
 bool is_buffer_intrinsic(intrinsic fn);
 bool is_buffer_dim_intrinsic(intrinsic fn);
 
-bool is_positive_infinity(const expr& x);
-bool is_negative_infinity(const expr& x);
-bool is_indeterminate(const expr& x);
-int is_infinity(const expr& x);
-bool is_finite(const expr& x);
+bool is_positive_infinity(expr_ref x);
+bool is_negative_infinity(expr_ref x);
+bool is_indeterminate(expr_ref x);
+int is_infinity(expr_ref x);
+bool is_finite(expr_ref x);
 
 SLINKY_ALWAYS_INLINE inline index_t boolean(index_t x) { return x != 0 ? 1 : 0; }
 expr boolean(const expr& x);
-bool is_boolean(const expr& x);
+bool is_boolean(expr_ref x);
 
 inline constexpr bool is_boolean_node(expr_node_type t) {
   switch (t) {
@@ -577,10 +622,10 @@ const expr& negative_infinity();
 const expr& infinity(int sign = 1);
 const expr& indeterminate();
 
-bool is_positive(const expr& x);
-bool is_non_negative(const expr& x);
-bool is_negative(const expr& x);
-bool is_non_positive(const expr& x);
+bool is_positive(expr_ref x);
+bool is_non_negative(expr_ref x);
+bool is_negative(expr_ref x);
+bool is_non_positive(expr_ref x);
 
 expr abs(expr x);
 expr align_down(expr x, const expr& a);

--- a/runtime/expr.h
+++ b/runtime/expr.h
@@ -201,16 +201,6 @@ public:
   }
 };
 
-expr operator+(expr a, expr b);
-expr operator-(expr a, expr b);
-expr operator*(expr a, expr b);
-expr operator/(expr a, expr b);
-expr operator%(expr a, expr b);
-
-// These are the same as operator/ and operator% for expr, but having these allows overloaded calls to work properly.
-expr euclidean_div(expr a, expr b);
-expr euclidean_mod(expr a, expr b);
-
 // `expr` is an owner of a reference counted pointer to a `base_expr_node`.
 // Operations that appear to mutate these objects are actually just reassigning this reference counted pointer.
 class expr {
@@ -263,6 +253,13 @@ public:
 
 SLINKY_ALWAYS_INLINE inline expr_ref::expr_ref(const expr& e) : n_(e.get()) {}
 
+expr operator+(expr a, expr b);
+expr operator-(expr a, expr b);
+expr operator*(expr a, expr b);
+expr operator/(expr a, expr b);
+expr operator%(expr a, expr b);
+expr euclidean_div(expr a, expr b);
+expr euclidean_mod(expr a, expr b);
 expr operator==(expr a, expr b);
 expr operator!=(expr a, expr b);
 expr operator<(expr a, expr b);

--- a/runtime/expr.h
+++ b/runtime/expr.h
@@ -571,7 +571,7 @@ SLINKY_ALWAYS_INLINE SLINKY_UNIQUE bool is_true(expr_ref x) {
 SLINKY_ALWAYS_INLINE SLINKY_UNIQUE bool is_false(expr_ref x) { return is_zero(x); }
 
 // Check if `x` is a call to the intrinsic `fn`.
-inline const call* as_intrinsic(expr_ref x, intrinsic fn) {
+SLINKY_ALWAYS_INLINE SLINKY_UNIQUE const call* as_intrinsic(expr_ref x, intrinsic fn) {
   const call* c = x.as<call>();
   return c && c->intrinsic == fn ? c : nullptr;
 }


### PR DESCRIPTION
This is a messy change. The core of it is as the title says: make `expr(const base_expr_node*)` and similar for `stmt` `explicit`. This uncovered a few places where we were doing silly things, like constructing an `expr` just to call a helper function that doesn't affect the lifetime of its argument.

The rest is a wrapper to attempt to avoid requiring explicit conversions everywhere, but without the excessive reference counting due to constructing temporary `expr` objects.

This speeds up the simplifier by 5-10%, and *should* reduce code size, but I think the compiler is inlining more than before this change, so it's a wash.