### PR TITLE
pipeline_builder needs to ensure all outputs have allocation_bounds

### DIFF
--- a/builder/pipeline.cc
+++ b/builder/pipeline.cc
@@ -574,6 +574,9 @@ class pipeline_builder {
       for (const func::output& o : f->outputs()) {
         const buffer_expr_ptr& b = o.buffer;
         if (output_syms_.count(b->sym())) continue;
+        // This can happen if this func output isn't used as an input by any
+        // other func in the pipeline (and isn't an output of the pipeline itself)
+        if (!allocation_bounds_[b->sym()]) continue;
 
         expr alloc_var = variable::make(b->sym());
 
@@ -789,6 +792,9 @@ public:
       for (const func::output& o : f->outputs()) {
         const buffer_expr_ptr& b = o.buffer;
         if (output_syms_.count(b->sym())) continue;
+        // This can happen if this func output isn't used as an input by any
+        // other func in the pipeline (and isn't an output of the pipeline itself)
+        if (!allocation_bounds_[b->sym()]) continue;
 
         if ((b->store_at() && *b->store_at() == at) || (!b->store_at() && at.root())) {
           var uncropped = ctx.insert_unique(ctx.name(b->sym()) + ".uncropped");

--- a/builder/pipeline.cc
+++ b/builder/pipeline.cc
@@ -722,7 +722,7 @@ class pipeline_builder {
         if (allocation_bounds_[o.sym()]) continue;
         box_expr crop(o.buffer->rank());
         for (std::size_t d = 0; d < crop.size(); ++d) {
-          crop[d] = {0, 0};
+          crop[d] = {std::numeric_limits<index_t>::max(), std::numeric_limits<index_t>::min()};
         }
         allocation_bounds_[o.sym()] = crop;
       }

--- a/builder/test/pipeline.cc
+++ b/builder/test/pipeline.cc
@@ -663,9 +663,9 @@ TEST_P(multiple_outputs, pipeline) {
   // For a 3D input in(x, y, z), compute sum_x = sum(input(:, y, z)) and sum_xy = sum(input(:, :, z)) in one stage.
   func::callable<const int, int, int> sum_x_xy = [](const buffer<const int>& in, const buffer<int>& sum_x,
                                                      const buffer<int>& sum_xy) -> index_t {
-    for (index_t z = in.dim(2).min(); z <= in.dim(2).max(); ++z) {
+    for (index_t z = std::min(sum_xy.dim(0).min(), sum_x.dim(1).min()); z <= std::max(sum_xy.dim(0).max(), sum_x.dim(1).max()); ++z) {
       if (sum_xy.contains(z)) sum_xy(z) = 0;
-      for (index_t y = in.dim(1).min(); y <= in.dim(1).max(); ++y) {
+      for (index_t y = sum_x.dim(0).min(); y <= sum_x.dim(0).max(); ++y) {
         if (sum_x.contains(y, z)) sum_x(y, z) = 0;
         for (index_t x = in.dim(0).min(); x <= in.dim(0).max(); ++x) {
           if (sum_x.contains(y, z)) sum_x(y, z) += in(x, y, z);

--- a/runtime/buffer.cc
+++ b/runtime/buffer.cc
@@ -27,7 +27,7 @@ index_t alloc_extent(const dim& dim) {
     // TODO: We can do better than this if the dim doesn't cross a fold boundary.
     return dim.fold_factor();
   } else {
-    return dim.extent();
+    return dim.max() >= dim.min() ? dim.extent() : 0;
   }
 }
 


### PR DESCRIPTION
This can happen if this func output isn't used as an input by any other func in the pipeline (and isn't an output of the pipeline itself).