### PR TITLE
Fix ambiguous compilation under bazel on macOS

### DIFF
--- a/builder/replica_pipeline.cc
+++ b/builder/replica_pipeline.cc
@@ -160,7 +160,7 @@ public:
       }
       if (!match(bep->dim(d).fold_factor, buffer_fold_factor(bep_var, d))) {
         std::string e = print_expr_inlined(bep->dim(d).fold_factor);
-        os_ << "  " << name << "->dim(" << d << ").fold_factor = " << e << ";\n";
+        os_ << "  " << name << "->dim(" << d << ").fold_factor = (index_t) " << e << ";\n";
       }
     }
 

--- a/builder/test/replica_pipeline.cc
+++ b/builder/test/replica_pipeline.cc
@@ -198,7 +198,7 @@ auto p = []() -> ::slinky::pipeline {
   auto _fn_0 = func::make(std::move(_replica_fn_3), {{intm1, {{((x + -1)), ((x + 1))}, {((y + -1)), ((y + 1))}}}}, {{out1, {x, y}}}, {});
   _fn_0.loops({{y, 2, loop::serial}});
   auto out2 = buffer_expr::make(ctx, "out2", /*rank=*/1, /*elem_size=*/4);
-  out2->dim(0).fold_factor = 9223372036854775807;
+  out2->dim(0).fold_factor = (index_t) 9223372036854775807;
   auto intm2 = buffer_expr::make(ctx, "intm2", /*rank=*/1, /*elem_size=*/4);
   auto _replica_fn_6 = [=](const buffer<const void>& i0, const buffer<void>& o0) -> index_t {
     const buffer<const void>* input_buffers[] = {&i0};
@@ -257,8 +257,8 @@ auto p = []() -> ::slinky::pipeline {
   auto in1 = buffer_expr::make(ctx, "in1", /*rank=*/2, /*elem_size=*/2);
   auto in2 = buffer_expr::make(ctx, "in2", /*rank=*/2, /*elem_size=*/2);
   auto out = buffer_expr::make(ctx, "out", /*rank=*/2, /*elem_size=*/2);
-  out->dim(0).fold_factor = 9223372036854775807;
-  out->dim(1).fold_factor = 9223372036854775807;
+  out->dim(0).fold_factor = (index_t) 9223372036854775807;
+  out->dim(1).fold_factor = (index_t) 9223372036854775807;
   auto x = var(ctx, "x");
   auto y = var(ctx, "y");
   auto intm1 = buffer_expr::make(ctx, "intm1", /*rank=*/2, /*elem_size=*/2);
@@ -315,9 +315,9 @@ auto p = []() -> ::slinky::pipeline {
   auto in1 = buffer_expr::make(ctx, "in1", /*rank=*/2, /*elem_size=*/2);
   auto in2 = buffer_expr::make(ctx, "in2", /*rank=*/2, /*elem_size=*/2);
   auto out = buffer_expr::make(ctx, "out", /*rank=*/3, /*elem_size=*/2);
-  out->dim(0).fold_factor = 9223372036854775807;
-  out->dim(1).fold_factor = 9223372036854775807;
-  out->dim(2).fold_factor = 9223372036854775807;
+  out->dim(0).fold_factor = (index_t) 9223372036854775807;
+  out->dim(1).fold_factor = (index_t) 9223372036854775807;
+  out->dim(2).fold_factor = (index_t) 9223372036854775807;
   auto x = var(ctx, "x");
   auto y = var(ctx, "y");
   auto intm1 = buffer_expr::make(ctx, "intm1", /*rank=*/2, /*elem_size=*/2);


### PR DESCRIPTION
replica_pipeline.cc fails to compile because of ambiguity between `int` and `long` on Bazel + XCode; explicitly casting it to `index_t` heals it portably.