### PR TITLE
Upgrade as_constant and as_variable

### DIFF
--- a/builder/replica_pipeline.cc
+++ b/builder/replica_pipeline.cc
@@ -160,7 +160,7 @@ public:
       }
       if (!match(bep->dim(d).fold_factor, buffer_fold_factor(bep_var, d))) {
         std::string e = print_expr_inlined(bep->dim(d).fold_factor);
-        os_ << "  " << name << "->dim(" << d << ").fold_factor = " << e << ";\n";
+        os_ << "  " << name << "->dim(" << d << ").fold_factor = (index_t) " << e << ";\n";
       }
     }
 

--- a/builder/rewrite.h
+++ b/builder/rewrite.h
@@ -519,7 +519,7 @@ SLINKY_UNIQUE auto indeterminate() { return pattern_call<>{intrinsic::indetermin
 template <typename T, bool = typename enable_pattern_ops<T>::type()>
 SLINKY_UNIQUE auto is_finite(const T& x) { return make_predicate(x, slinky::is_finite); }
 template <typename T, bool = typename enable_pattern_ops<T>::type()>
-SLINKY_UNIQUE auto is_constant(const T& x) { return make_predicate(x, slinky::as_constant); }
+SLINKY_UNIQUE auto is_constant(const T& x) { return make_predicate(x, [](expr_ref x) { return x.as<constant>() != nullptr; }); }
 template <typename T, bool = typename enable_pattern_ops<T>::type()>
 SLINKY_UNIQUE auto is_zero(const T& x) { return make_predicate(x, slinky::is_zero); }
 template <typename T, bool = typename enable_pattern_ops<T>::type()>

--- a/builder/simplify_exprs.cc
+++ b/builder/simplify_exprs.cc
@@ -16,8 +16,8 @@ expr simplify(const class min* op, expr a, expr b) {
     std::swap(a, b);
   }
 
-  const index_t* ca = as_constant(a);
-  const index_t* cb = as_constant(b);
+  auto ca = as_constant(a);
+  auto cb = as_constant(b);
   if (ca && cb) {
     return std::min(*ca, *cb);
   }
@@ -40,8 +40,8 @@ expr simplify(const class max* op, expr a, expr b) {
     std::swap(a, b);
   }
 
-  const index_t* ca = as_constant(a);
-  const index_t* cb = as_constant(b);
+  auto ca = as_constant(a);
+  auto cb = as_constant(b);
   if (ca && cb) {
     return std::max(*ca, *cb);
   }
@@ -64,8 +64,8 @@ expr simplify(const add* op, expr a, expr b) {
     std::swap(a, b);
   }
 
-  const index_t* ca = as_constant(a);
-  const index_t* cb = as_constant(b);
+  auto ca = as_constant(a);
+  auto cb = as_constant(b);
   if (ca && cb) {
     return *ca + *cb;
   }
@@ -87,8 +87,8 @@ expr simplify(const add* op, expr a, expr b) {
 }
 
 expr simplify(const sub* op, expr a, expr b) {
-  const index_t* ca = as_constant(a);
-  const index_t* cb = as_constant(b);
+  auto ca = as_constant(a);
+  auto cb = as_constant(b);
   if (ca && cb) {
     return *ca - *cb;
   } else if (cb) {
@@ -117,8 +117,8 @@ expr simplify(const mul* op, expr a, expr b) {
     std::swap(a, b);
   }
 
-  const index_t* ca = as_constant(a);
-  const index_t* cb = as_constant(b);
+  auto ca = as_constant(a);
+  auto cb = as_constant(b);
   if (ca && cb) {
     return *ca * *cb;
   }
@@ -140,8 +140,8 @@ expr simplify(const mul* op, expr a, expr b) {
 }
 
 expr simplify(const div* op, expr a, expr b) {
-  const index_t* ca = as_constant(a);
-  const index_t* cb = as_constant(b);
+  auto ca = as_constant(a);
+  auto cb = as_constant(b);
   if (ca && cb) {
     return euclidean_div(*ca, *cb);
   }
@@ -161,8 +161,8 @@ expr simplify(const div* op, expr a, expr b) {
 }
 
 expr simplify(const mod* op, expr a, expr b) {
-  const index_t* ca = as_constant(a);
-  const index_t* cb = as_constant(b);
+  auto ca = as_constant(a);
+  auto cb = as_constant(b);
   if (ca && cb) {
     return euclidean_mod(*ca, *cb);
   }
@@ -178,8 +178,8 @@ expr simplify(const mod* op, expr a, expr b) {
 }
 
 expr simplify(const less* op, expr a, expr b) {
-  const index_t* ca = as_constant(a);
-  const index_t* cb = as_constant(b);
+  auto ca = as_constant(a);
+  auto cb = as_constant(b);
   if (ca && cb) {
     return *ca < *cb;
   }
@@ -213,8 +213,8 @@ expr simplify(const equal* op, expr a, expr b) {
     std::swap(a, b);
   }
 
-  const index_t* ca = as_constant(a);
-  const index_t* cb = as_constant(b);
+  auto ca = as_constant(a);
+  auto cb = as_constant(b);
   if (ca && cb) {
     return *ca == *cb;
   }
@@ -247,8 +247,8 @@ expr simplify(const logical_and* op, expr a, expr b) {
   if (should_commute(a, b)) {
     std::swap(a, b);
   }
-  const index_t* ca = as_constant(a);
-  const index_t* cb = as_constant(b);
+  auto ca = as_constant(a);
+  auto cb = as_constant(b);
 
   if (ca && cb) {
     return *ca != 0 && *cb != 0;
@@ -270,8 +270,8 @@ expr simplify(const logical_or* op, expr a, expr b) {
   if (should_commute(a, b)) {
     std::swap(a, b);
   }
-  const index_t* ca = as_constant(a);
-  const index_t* cb = as_constant(b);
+  auto ca = as_constant(a);
+  auto cb = as_constant(b);
 
   if (ca && cb) {
     return *ca != 0 || *cb != 0;
@@ -290,7 +290,7 @@ expr simplify(const logical_or* op, expr a, expr b) {
 }
 
 expr simplify(const class logical_not* op, expr a) {
-  const index_t* cv = as_constant(a);
+  auto cv = as_constant(a);
   if (cv) {
     return *cv == 0;
   }

--- a/builder/slide_and_fold_storage.cc
+++ b/builder/slide_and_fold_storage.cc
@@ -647,8 +647,8 @@ public:
       auto set_expr_bounds = set_value_in_scope(current_expr_bounds(), op->sym,
           {loop_bounds.min, loop_bounds.min + align_down(loop_bounds.extent() - 1, op->step)});
 
-      const index_t* maybe_min = as_constant(loop_bounds.min);
-      const index_t* maybe_step = as_constant(op->step);
+      auto maybe_min = as_constant(loop_bounds.min);
+      auto maybe_step = as_constant(op->step);
       index_t modulus = maybe_step ? *maybe_step : 1;
       index_t remainder = (maybe_min && maybe_step) ? *maybe_min % *maybe_step : 0;
 

--- a/builder/substitute.cc
+++ b/builder/substitute.cc
@@ -318,7 +318,7 @@ const call* match_call(expr_ref x, intrinsic fn, var a) {
   if (!c) return nullptr;
 
   assert(c->args.size() >= 1);
-  const var* av = as_variable(c->args[0]);
+  auto av = as_variable(c->args[0]);
   if (!av || *av != a) return nullptr;
 
   return c;
@@ -329,7 +329,7 @@ const call* match_call(expr_ref x, intrinsic fn, var a, index_t b) {
   if (!c) return nullptr;
 
   assert(c->args.size() >= 2);
-  const index_t* bv = as_constant(c->args[1]);
+  auto bv = as_constant(c->args[1]);
   if (!bv || *bv != b) return nullptr;
 
   return c;
@@ -558,7 +558,7 @@ public:
       changed = changed || !args.back().same_as(i);
     }
     if (is_buffer_intrinsic(op->intrinsic) && !args.empty() && args.front().defined()) {
-      const var* buf = as_variable(args[0]);
+      auto buf = as_variable(args[0]);
       assert(buf);
       if (op->intrinsic == intrinsic::buffer_at) {
         const std::size_t buf_rank = get_target_buffer_rank(*buf);
@@ -674,7 +674,7 @@ public:
   using substitutor::visit;
 
   static var replacement_symbol(const expr& r) {
-    const var* s = as_variable(r);
+    auto s = as_variable(r);
     assert(s);
     return *s;
   }
@@ -753,7 +753,7 @@ public:
   std::size_t get_target_buffer_rank(var x) override {
     if (const call* c = target.as<call>()) {
       if (is_buffer_dim_intrinsic(c->intrinsic) && is_variable(c->args[0], x)) {
-        const index_t* dim = as_constant(c->args[1]);
+        auto dim = as_constant(c->args[1]);
         assert(dim);
         return *dim + 1;
       }
@@ -825,7 +825,7 @@ public:
       }
     } else if (is_buffer_dim_intrinsic(fn)) {
       assert(args.size() == 1);
-      const index_t* dim = as_constant(args[0]);
+      auto dim = as_constant(args[0]);
       assert(dim);
       if (*dim < static_cast<index_t>(dims.size())) {
         return eval_buffer_intrinsic(fn, dims[*dim]);
@@ -872,7 +872,7 @@ interval_expr substitute(const interval_expr& x, var target, const expr& replace
 }
 
 expr substitute(const expr& e, const expr& target, const expr& replacement) {
-  if (const var* v = as_variable(target)) {
+  if (auto v = as_variable(target)) {
     return var_substitutor(*v, replacement).mutate(e);
   } else {
     return expr_substitutor(target, replacement).mutate(e);
@@ -880,7 +880,7 @@ expr substitute(const expr& e, const expr& target, const expr& replacement) {
 }
 stmt substitute(const stmt& s, const expr& target, const expr& replacement) {
   scoped_trace trace("substitute");
-  if (const var* v = as_variable(target)) {
+  if (auto v = as_variable(target)) {
     return var_substitutor(*v, replacement).mutate(s);
   } else {
     return expr_substitutor(target, replacement).mutate(s);
@@ -925,7 +925,7 @@ public:
     case intrinsic::buffer_stride:
     case intrinsic::buffer_fold_factor:
       if (is_variable(op->args[0], sym)) {
-        const index_t* dim = as_constant(op->args[1]);
+        auto dim = as_constant(op->args[1]);
         assert(dim);
         index_t new_dim = *dim;
         for (int i = static_cast<int>(slices.size()) - 1; i >= 0; --i) {

--- a/builder/test/replica_pipeline.cc
+++ b/builder/test/replica_pipeline.cc
@@ -198,7 +198,7 @@ auto p = []() -> ::slinky::pipeline {
   auto _fn_0 = func::make(std::move(_replica_fn_3), {{intm1, {{((x + -1)), ((x + 1))}, {((y + -1)), ((y + 1))}}}}, {{out1, {x, y}}}, {});
   _fn_0.loops({{y, 2, loop::serial}});
   auto out2 = buffer_expr::make(ctx, "out2", /*rank=*/1, /*elem_size=*/4);
-  out2->dim(0).fold_factor = 9223372036854775807;
+  out2->dim(0).fold_factor = (index_t) 9223372036854775807;
   auto intm2 = buffer_expr::make(ctx, "intm2", /*rank=*/1, /*elem_size=*/4);
   auto _replica_fn_6 = [=](const buffer<const void>& i0, const buffer<void>& o0) -> index_t {
     const buffer<const void>* input_buffers[] = {&i0};
@@ -257,8 +257,8 @@ auto p = []() -> ::slinky::pipeline {
   auto in1 = buffer_expr::make(ctx, "in1", /*rank=*/2, /*elem_size=*/2);
   auto in2 = buffer_expr::make(ctx, "in2", /*rank=*/2, /*elem_size=*/2);
   auto out = buffer_expr::make(ctx, "out", /*rank=*/2, /*elem_size=*/2);
-  out->dim(0).fold_factor = 9223372036854775807;
-  out->dim(1).fold_factor = 9223372036854775807;
+  out->dim(0).fold_factor = (index_t) 9223372036854775807;
+  out->dim(1).fold_factor = (index_t) 9223372036854775807;
   auto x = var(ctx, "x");
   auto y = var(ctx, "y");
   auto intm1 = buffer_expr::make(ctx, "intm1", /*rank=*/2, /*elem_size=*/2);
@@ -315,9 +315,9 @@ auto p = []() -> ::slinky::pipeline {
   auto in1 = buffer_expr::make(ctx, "in1", /*rank=*/2, /*elem_size=*/2);
   auto in2 = buffer_expr::make(ctx, "in2", /*rank=*/2, /*elem_size=*/2);
   auto out = buffer_expr::make(ctx, "out", /*rank=*/3, /*elem_size=*/2);
-  out->dim(0).fold_factor = 9223372036854775807;
-  out->dim(1).fold_factor = 9223372036854775807;
-  out->dim(2).fold_factor = 9223372036854775807;
+  out->dim(0).fold_factor = (index_t) 9223372036854775807;
+  out->dim(1).fold_factor = (index_t) 9223372036854775807;
+  out->dim(2).fold_factor = (index_t) 9223372036854775807;
   auto x = var(ctx, "x");
   auto y = var(ctx, "y");
   auto intm1 = buffer_expr::make(ctx, "intm1", /*rank=*/2, /*elem_size=*/2);

--- a/runtime/depends_on.cc
+++ b/runtime/depends_on.cc
@@ -51,7 +51,7 @@ public:
     if (is_buffer_intrinsic(op->intrinsic)) {
       assert(op->args.size() >= 1);
       if (op->args[0].defined()) {
-        const var* buf = as_variable(op->args[0]);
+        auto buf = as_variable(op->args[0]);
         assert(buf);
         update_deps(*buf, [fn = op->intrinsic](depends_on_result& deps) {
           deps.buffer_meta = true;

--- a/runtime/evaluate.cc
+++ b/runtime/evaluate.cc
@@ -221,7 +221,7 @@ public:
 
   index_t eval_buffer_metadata(const call* op) {
     assert(op->args.size() == 1);
-    const var* sym = as_variable(op->args[0]);
+    auto sym = as_variable(op->args[0]);
     assert(sym);
     raw_buffer* buf = reinterpret_cast<raw_buffer*>(*context.lookup(*sym));
     assert(buf);
@@ -235,9 +235,9 @@ public:
 
   index_t eval_dim_metadata(const call* op) {
     assert(op->args.size() == 2);
-    const var* sym = as_variable(op->args[0]);
+    auto sym = as_variable(op->args[0]);
     assert(sym);
-    const index_t* d = as_constant(op->args[1]);
+    auto d = as_constant(op->args[1]);
     assert(d);
     raw_buffer* buffer = reinterpret_cast<raw_buffer*>(*context.lookup(*sym));
     assert(buffer);

--- a/runtime/expr.h
+++ b/runtime/expr.h
@@ -539,16 +539,24 @@ inline void logical_not::accept(expr_visitor* v) const { v->visit(this); }
 inline void select::accept(expr_visitor* v) const { v->visit(this); }
 inline void call::accept(expr_visitor* v) const { v->visit(this); }
 
-// If `x` is a constant, returns the value of the constant, otherwise `nullptr`.
-SLINKY_ALWAYS_INLINE SLINKY_UNIQUE const index_t* as_constant(expr_ref x) {
+// If `x` is a constant, returns the value of the constant, otherwise `nullopt`.
+SLINKY_ALWAYS_INLINE SLINKY_UNIQUE std::optional<index_t> as_constant(expr_ref x) {
   const constant* cx = x.as<constant>();
-  return cx ? &cx->value : nullptr;
+  if (cx) {
+    return cx->value;
+  } else {
+    return std::nullopt;
+  }
 }
 
-// If `x` is a variable, returns the `var` of the variable, otherwise `nullptr`.
-SLINKY_ALWAYS_INLINE SLINKY_UNIQUE const var* as_variable(expr_ref x) {
+// If `x` is a variable, returns the `var` of the variable, otherwise `nullopt`.
+SLINKY_ALWAYS_INLINE SLINKY_UNIQUE std::optional<var> as_variable(expr_ref x) {
   const variable* vx = x.as<variable>();
-  return vx ? &vx->sym : nullptr;
+  if (vx) {
+    return vx->sym;
+  } else {
+    return std::nullopt;
+  }
 }
 
 // Check if `x` is a variable equal to the symbol `sym`.

--- a/runtime/expr_stmt.cc
+++ b/runtime/expr_stmt.cc
@@ -596,26 +596,26 @@ bool is_positive(expr_ref x) {
     assert(c->args.size() == 1);
     return is_positive(c->args[0]);
   }
-  const index_t* c = as_constant(x);
+  auto c = as_constant(x);
   return c ? *c > 0 : false;
 }
 
 bool is_non_negative(expr_ref x) {
   if (is_positive_infinity(x)) return true;
   if (as_intrinsic(x, intrinsic::abs)) return true;
-  const index_t* c = as_constant(x);
+  auto c = as_constant(x);
   return c ? *c >= 0 : false;
 }
 
 bool is_negative(expr_ref x) {
   if (is_negative_infinity(x)) return true;
-  const index_t* c = as_constant(x);
+  auto c = as_constant(x);
   return c ? *c < 0 : false;
 }
 
 bool is_non_positive(expr_ref x) {
   if (is_negative_infinity(x)) return true;
-  const index_t* c = as_constant(x);
+  auto c = as_constant(x);
   return c ? *c <= 0 : false;
 }
 
@@ -722,7 +722,7 @@ bool is_finite(expr_ref x) {
 expr boolean(const expr& x) {
   if (!x.defined() || is_boolean(x)) {
     return x;
-  } else if (const index_t* c = as_constant(x)) {
+  } else if (auto c = as_constant(x)) {
     return *c != 0;
   } else {
     return not_equal::make(x, 0);


### PR DESCRIPTION
They now return `std::optional<T>` instead of `const T*`. This turns out to matter in subtle cases like

```
      int foo = *as_constant(simplify(thing()));
```

where the return value of `simplify` is a temporary that's discarded immediately, but that as_constant() assumes will remain valid. Using `std::optional` captures the value in a way that should be safer against this pattern, as well as more easily debuggable (since dereferencing an empty std::optional is caught by clang-tidy in many cases and is also checked for by debug builds of libc++).