### PR TITLE
compute_allocation_bounds() should handle all input_syms_

### DIFF
--- a/builder/pipeline.cc
+++ b/builder/pipeline.cc
@@ -735,7 +735,6 @@ class pipeline_builder {
     // Fortunately, all external inputs (constant or not) should have well-defined
     // boundaries at this point so we can just slurp them in directly here to be
     // permissive of this situation.
-    // we can just slurp directly
     for (const auto& i : input_syms_) {
       if (allocation_bounds_[i.first]) continue;
       box_expr crop(i.second->rank());


### PR DESCRIPTION
In theory, well-formed input to Slinky should only provide `inputs` that are actually inputs to at least one `func` in the pipeline; in practice, translation layers can get this wrong (e.g. constant tensors that are marked as external inputs), and if we end up with anything in `input_syms_` that doesn't have `allocation_bounds_` filled in, things go poorly. Fortunately, we can reasonably assume that everything in `input_syms` that fits this case has well-known boundaries that we can simply copy, making it simple to be a bit permissive in this case.