### PR TITLE
Unpadded copies require full src

### DIFF
--- a/runtime/test/buffer.cc
+++ b/runtime/test/buffer.cc
@@ -702,11 +702,11 @@ TEST(buffer, copy_empty_src) {
     for (int d = 0; d < rank; d++) {
       dst.dim(0).set_min_extent(0, D);
     }
-    // We want to verify that dst is unchanged, so fill it with easy to verify data
     dst.allocate();
     fill(dst, 7);
-    slinky::copy(src, dst);
-    ASSERT_TRUE(is_filled_buffer(dst, 7));
+    // The result of copying an empty buffer should be entirely padding.
+    slinky::copy(src, dst, 3);
+    ASSERT_TRUE(is_filled_buffer(dst, 3));
   }
 }
 


### PR DESCRIPTION
Currently, `copy` is inconsistent in how it handles non-padded copies with missing `src` elements. This PR fixes this to be consistent with what the header claimed: https://github.com/dsharlet/slinky/blob/d8a6cf5fe347d6396500e9e8cb8d8636a5f6bf2b/runtime/buffer.h#L535