### PR TITLE
Add make_binary_maybe_constant()

### DIFF
--- a/builder/simplify.cc
+++ b/builder/simplify.cc
@@ -2038,7 +2038,7 @@ public:
     auto ca = as_constant(a);
     auto cb = as_constant(b);
     if (ca && cb) {
-      set_result(make_binary_maybe_constant<T>(*ca, *cb));
+      set_result(make_binary<T>(*ca, *cb));
     } else if (take_constant && ca) {
       set_result(std::move(a));
     } else if (take_constant && cb) {
@@ -2062,7 +2062,7 @@ public:
     auto ca = as_constant(a);
     auto cb = as_constant(b);
     if (ca && cb) {
-      set_result(make_binary_maybe_constant<T>(*ca, *cb));
+      set_result(make_or_eval_binary<T>(*ca, *cb));
     } else if (a.same_as(op->a) && b.same_as(op->b)) {
       set_result(op);
     } else {
@@ -2141,7 +2141,7 @@ public:
     auto ca = as_constant(a);
     auto cb = as_constant(b);
     if (ca && cb) {
-      set_result(make_binary_maybe_constant<T>(*ca, *cb));
+      set_result(make_binary<T>(*ca, *cb));
     } else if (sign < 0) {
       set_result(expr(0));
     } else {
@@ -2163,7 +2163,7 @@ public:
     auto cb = as_constant(b);
 
     if (ca && cb) {
-      set_result(make_binary_maybe_constant<T>(*ca != 0, *cb != 0));
+      set_result(make_binary<T>(*ca != 0, *cb != 0));
     } else if (sign < 0) {
       set_result(expr(0));
     } else {

--- a/builder/simplify.cc
+++ b/builder/simplify.cc
@@ -2038,7 +2038,7 @@ public:
     auto ca = as_constant(a);
     auto cb = as_constant(b);
     if (ca && cb) {
-      set_result(make_binary<T>(*ca, *cb));
+      set_result(make_binary_maybe_constant<T>(*ca, *cb));
     } else if (take_constant && ca) {
       set_result(std::move(a));
     } else if (take_constant && cb) {
@@ -2062,7 +2062,7 @@ public:
     auto ca = as_constant(a);
     auto cb = as_constant(b);
     if (ca && cb) {
-      set_result(make_binary<T>(*ca, *cb));
+      set_result(make_binary_maybe_constant<T>(*ca, *cb));
     } else if (a.same_as(op->a) && b.same_as(op->b)) {
       set_result(op);
     } else {
@@ -2141,7 +2141,7 @@ public:
     auto ca = as_constant(a);
     auto cb = as_constant(b);
     if (ca && cb) {
-      set_result(make_binary<T>(*ca, *cb));
+      set_result(make_binary_maybe_constant<T>(*ca, *cb));
     } else if (sign < 0) {
       set_result(expr(0));
     } else {
@@ -2163,7 +2163,7 @@ public:
     auto cb = as_constant(b);
 
     if (ca && cb) {
-      set_result(make_binary<T>(*ca != 0, *cb != 0));
+      set_result(make_binary_maybe_constant<T>(*ca != 0, *cb != 0));
     } else if (sign < 0) {
       set_result(expr(0));
     } else {

--- a/runtime/expr.h
+++ b/runtime/expr.h
@@ -441,6 +441,22 @@ template <> SLINKY_ALWAYS_INLINE inline index_t make_binary<logical_and>(index_t
 template <> SLINKY_ALWAYS_INLINE inline index_t make_binary<logical_or>(index_t a, index_t b) { return a || b ? 1 : 0; }
 // clang-format on
 
+// clang-format off
+template <typename T> SLINKY_ALWAYS_INLINE SLINKY_UNIQUE bool binary_op_overflows(index_t a, index_t b) { return false; }
+template <> SLINKY_ALWAYS_INLINE inline bool binary_op_overflows<add>(index_t a, index_t b) { return add_overflows(a, b); }
+template <> SLINKY_ALWAYS_INLINE inline bool binary_op_overflows<sub>(index_t a, index_t b) { return sub_overflows(a, b); }
+template <> SLINKY_ALWAYS_INLINE inline bool binary_op_overflows<mul>(index_t a, index_t b) { return mul_overflows(a, b); }
+// clang-format on
+
+template <typename T>
+expr make_binary_maybe_constant(index_t a, index_t b) {
+  if (binary_op_overflows<T>(a, b)) {
+    return make_binary<T>(expr(a), expr(b));
+  } else {
+    return make_binary<T>(a, b);
+  }
+}
+
 class logical_not : public expr_node<logical_not> {
 public:
   expr a;

--- a/runtime/expr.h
+++ b/runtime/expr.h
@@ -442,15 +442,15 @@ template <> SLINKY_ALWAYS_INLINE inline index_t make_binary<logical_or>(index_t 
 // clang-format on
 
 // clang-format off
-template <typename T> SLINKY_ALWAYS_INLINE SLINKY_UNIQUE bool binary_op_overflows(index_t a, index_t b) { return false; }
-template <> SLINKY_ALWAYS_INLINE inline bool binary_op_overflows<add>(index_t a, index_t b) { return add_overflows(a, b); }
-template <> SLINKY_ALWAYS_INLINE inline bool binary_op_overflows<sub>(index_t a, index_t b) { return sub_overflows(a, b); }
-template <> SLINKY_ALWAYS_INLINE inline bool binary_op_overflows<mul>(index_t a, index_t b) { return mul_overflows(a, b); }
+template <typename T> SLINKY_ALWAYS_INLINE SLINKY_UNIQUE bool binary_overflows(index_t a, index_t b) { return false; }
+template <> SLINKY_ALWAYS_INLINE inline bool binary_overflows<add>(index_t a, index_t b) { return add_overflows(a, b); }
+template <> SLINKY_ALWAYS_INLINE inline bool binary_overflows<sub>(index_t a, index_t b) { return sub_overflows(a, b); }
+template <> SLINKY_ALWAYS_INLINE inline bool binary_overflows<mul>(index_t a, index_t b) { return mul_overflows(a, b); }
 // clang-format on
 
 template <typename T>
-expr make_binary_maybe_constant(index_t a, index_t b) {
-  if (binary_op_overflows<T>(a, b)) {
+expr make_or_eval_binary(index_t a, index_t b) {
+  if (binary_overflows<T>(a, b)) {
     return make_binary<T>(expr(a), expr(b));
   } else {
     return make_binary<T>(a, b);


### PR DESCRIPTION
In simplify(), we need to be more careful about operations that can overflow; in particular, add/sub call make_binary() which can overflow in degenerate conditions. This PR adds make_binary_maybe_constant(), which detects overflow for constants and in those cases preserves the expression in `expr` form to avoid overflow.