### PR TITLE
Fix loop of one crop simplification

### DIFF
--- a/builder/rewrite.h
+++ b/builder/rewrite.h
@@ -482,8 +482,8 @@ template <typename T, typename A, typename... Ts>
 struct enable_pattern_ops<pattern_unary<T, A>, Ts...> { using type = std::true_type; };
 template <typename C, typename T, typename F, typename... Ts>
 struct enable_pattern_ops<pattern_select<C, T, F>, Ts...> { using type = std::true_type; };
-template <typename Args, typename... Ts>
-struct enable_pattern_ops<pattern_call<Args>, Ts...> { using type = std::true_type; };
+template <typename... Args, typename... Ts>
+struct enable_pattern_ops<pattern_call<Args...>, Ts...> { using type = std::true_type; };
 template <typename T, typename... Ts>
 struct enable_pattern_ops<replacement_eval<T>, Ts...> { using type = std::true_type; };
 template <typename T, typename Fn, typename... Ts>

--- a/builder/simplify.cc
+++ b/builder/simplify.cc
@@ -1252,7 +1252,9 @@ public:
           interval_expr next_iter = substitute(crop->bounds, op->sym, expr(op->sym) + op->step);
           interval_expr prev_iter = substitute(crop->bounds, op->sym, expr(op->sym) - op->step);
           auto set_bounds_of_sym = set_value_in_scope(info_map, op->sym, {bounds, alignment_type()});
-          if (prove_true(crop->bounds.max + 1 >= next_iter.min || prev_iter.max + 1 >= crop->bounds.min)) {
+          // TODO: Currently we only support crops that monotonically increase the crop bounds as the loop progresses.
+          if (prove_true((next_iter.min > crop->bounds.min && crop->bounds.max + 1 >= next_iter.min) || 
+                         (crop->bounds.min > prev_iter.min && prev_iter.max + 1 >= crop->bounds.min))) {
             result = crop->body;
             expr_info info_of_min, info_of_max;
             mutate(crop->bounds, &info_of_min, &info_of_max);

--- a/builder/simplify_rules.h
+++ b/builder/simplify_rules.h
@@ -964,6 +964,16 @@ bool apply_select_rules(Fn&& apply) {
       apply(select(x, y, false), x && y, is_boolean(y)) ||
       apply(select(x, true, y), x || y, is_boolean(y)) ||
       apply(select(x, false, y), y && !x, is_boolean(y)) ||
+    
+      // Simplifications of min/max
+      apply(select(x < y, min(x, y), z), select(x < y, x, z)) ||
+      apply(select(x < y, max(x, y), z), select(x < y, y, z)) ||
+      apply(select(x < y, z, min(x, y)), select(x < y, z, y)) ||
+      apply(select(x < y, z, max(x, y)), select(x < y, z, x)) ||
+      apply(select(x <= y, min(x, y), z), select(x <= y, x, z)) ||
+      apply(select(x <= y, max(x, y), z), select(x <= y, y, z)) ||
+      apply(select(x <= y, z, min(x, y)), select(x <= y, z, y)) ||
+      apply(select(x <= y, z, max(x, y)), select(x <= y, z, x)) ||
 
       // Equivalents with min/max
       apply(select(x <= y, x, y), min(x, y)) ||

--- a/builder/test/simplify/simplify.cc
+++ b/builder/test/simplify/simplify.cc
@@ -263,6 +263,12 @@ TEST(simplify, loop) {
   ASSERT_THAT(simplify(loop::make(x, loop::serial, buffer_bounds(b0, 0), y,
                   crop_dim::make(b1, b0, 0, min_extent(x, y), make_call(b2, b1)))),
       matches(make_call(b2, b0)));
+  ASSERT_THAT(simplify(loop::make(x, loop::serial, buffer_bounds(b3, 0), y,
+                  crop_dim::make(b1, b0, 0, bounds(x, min(x + y - 1, buffer_max(b3, 0))), make_call(b2, b1)))),
+      matches(crop_dim::make(b1, b0, 0, buffer_bounds(b3, 0), make_call(b2, b1))));
+  ASSERT_THAT(simplify(loop::make(x, loop::serial, bounds(0, buffer_max(b3, 0)), y,
+                  crop_dim::make(b1, b0, 0, bounds(x, min(x + y - 1, buffer_max(b3, 0))), make_call(b2, b1)))),
+      matches(crop_dim::make(b1, b0, 0, bounds(0, buffer_max(b3, 0)), make_call(b2, b1))));
 }
 
 TEST(simplify, licm) {

--- a/builder/test/simplify/simplify.cc
+++ b/builder/test/simplify/simplify.cc
@@ -245,30 +245,30 @@ TEST(simplify, let) {
 }
 
 TEST(simplify, loop) {
-  auto make_call = [](const var& in, const var& out) { return call_stmt::make(nullptr, {in}, {out}, {}); };
+  auto make_call = [](const var& out) { return call_stmt::make(nullptr, {}, {out}, {}); };
 
   ASSERT_THAT(simplify(loop::make(
-                  x, loop::serial, buffer_bounds(b0, 0), 1, crop_dim::make(b1, b0, 0, point(x), make_call(b2, b1)))),
-      matches(make_call(b2, b0)));
+                  x, loop::serial, buffer_bounds(b0, 0), 1, crop_dim::make(b1, b0, 0, point(x), make_call(b1)))),
+      matches(make_call(b0)));
   ASSERT_THAT(simplify(loop::make(
-                  x, loop::serial, buffer_bounds(b3, 0), 1, crop_dim::make(b1, b0, 0, point(x), make_call(b2, b1)))),
-      matches(crop_dim::make(b1, b0, 0, buffer_bounds(b3, 0), make_call(b2, b1))));
+                  x, loop::serial, buffer_bounds(b3, 0), 1, crop_dim::make(b1, b0, 0, point(x), make_call(b1)))),
+      matches(crop_dim::make(b1, b0, 0, buffer_bounds(b3, 0), make_call(b1))));
   ASSERT_THAT(simplify(loop::make(
-                  x, loop::serial, bounds(0, buffer_max(b0, 0)), 1, crop_dim::make(b1, b0, 0, point(x), make_call(b2, b1)))),
-      matches(crop_dim::make(b1, b0, 0, bounds(0, expr()), make_call(b2, b1))));
+                  x, loop::serial, bounds(0, buffer_max(b0, 0)), 1, crop_dim::make(b1, b0, 0, point(x), make_call(b1)))),
+      matches(crop_dim::make(b1, b0, 0, bounds(0, expr()), make_call(b1))));
   ASSERT_THAT(simplify(loop::make(
-                  x, loop::serial, buffer_bounds(b0, 0), y, crop_dim::make(b1, b0, 0, point(x), make_call(b2, b1)))),
+                  x, loop::serial, buffer_bounds(b0, 0), y, crop_dim::make(b1, b0, 0, point(x), make_call(b1)))),
       matches(loop::make(
-          x, loop::serial, buffer_bounds(b0, 0), y, crop_dim::make(b1, b0, 0, point(x), make_call(b2, b1)))));
+          x, loop::serial, buffer_bounds(b0, 0), y, crop_dim::make(b1, b0, 0, point(x), make_call(b1)))));
   ASSERT_THAT(simplify(loop::make(x, loop::serial, buffer_bounds(b0, 0), y,
-                  crop_dim::make(b1, b0, 0, min_extent(x, y), make_call(b2, b1)))),
-      matches(make_call(b2, b0)));
+                  crop_dim::make(b1, b0, 0, min_extent(x, y), make_call(b1)))),
+      matches(make_call(b0)));
   ASSERT_THAT(simplify(loop::make(x, loop::serial, buffer_bounds(b3, 0), y,
-                  crop_dim::make(b1, b0, 0, bounds(x, min(x + y - 1, buffer_max(b3, 0))), make_call(b2, b1)))),
-      matches(crop_dim::make(b1, b0, 0, buffer_bounds(b3, 0), make_call(b2, b1))));
+                  crop_dim::make(b1, b0, 0, bounds(x, min(x + y - 1, buffer_max(b3, 0))), make_call(b1)))),
+      matches(crop_dim::make(b1, b0, 0, buffer_bounds(b3, 0), make_call(b1))));
   ASSERT_THAT(simplify(loop::make(x, loop::serial, bounds(0, buffer_max(b3, 0)), y,
-                  crop_dim::make(b1, b0, 0, bounds(x, min(x + y - 1, buffer_max(b3, 0))), make_call(b2, b1)))),
-      matches(crop_dim::make(b1, b0, 0, bounds(0, buffer_max(b3, 0)), make_call(b2, b1))));
+                  crop_dim::make(b1, b0, 0, bounds(x, min(x + y - 1, buffer_max(b3, 0))), make_call(b1)))),
+      matches(crop_dim::make(b1, b0, 0, bounds(0, buffer_max(b3, 0)), make_call(b1))));
 }
 
 TEST(simplify, licm) {


### PR DESCRIPTION
This PR fixes a number of issues with loops of crops:
- We need to check if the loop is empty, and ensure the new crop is also empty in such cases.
- That results in a new select, which we can then simplify away with new rules and logic.
- Strengthen the loop simplification to handle more cases where the proof that the crop bounds overlap is tricky.