### PR TITLE
Simplify improvements

### DIFF
--- a/builder/node_mutator.cc
+++ b/builder/node_mutator.cc
@@ -147,7 +147,7 @@ void node_mutator::visit(const block* op) {
   }
 }
 void node_mutator::visit(const loop* op) {
-  interval_expr bounds = {mutate(op->bounds.min), mutate(op->bounds.max)};
+  interval_expr bounds = mutate(op->bounds);
   expr step = mutate(op->step);
   stmt body = mutate(op->body);
   if (bounds.same_as(op->bounds) && step.same_as(op->step) && body.same_as(op->body)) {
@@ -177,8 +177,7 @@ void node_mutator::visit(const allocate* op) {
   dims.reserve(op->dims.size());
   bool changed = false;
   for (const dim_expr& i : op->dims) {
-    interval_expr bounds = {mutate(i.bounds.min), mutate(i.bounds.max)};
-    dims.push_back({std::move(bounds), mutate(i.stride), mutate(i.fold_factor)});
+    dims.push_back({mutate(i.bounds), mutate(i.stride), mutate(i.fold_factor)});
     changed = changed || !dims.back().same_as(i);
   }
   stmt body = mutate(op->body);
@@ -195,8 +194,7 @@ void node_mutator::visit(const make_buffer* op) {
   dims.reserve(op->dims.size());
   bool changed = false;
   for (const dim_expr& i : op->dims) {
-    interval_expr bounds = {mutate(i.bounds.min), mutate(i.bounds.max)};
-    dims.push_back({std::move(bounds), mutate(i.stride), mutate(i.fold_factor)});
+    dims.push_back({mutate(i.bounds), mutate(i.stride), mutate(i.fold_factor)});
     changed = changed || !dims.back().same_as(i);
   }
   stmt body = mutate(op->body);
@@ -219,7 +217,7 @@ void node_mutator::visit(const crop_buffer* op) {
   bounds.reserve(op->bounds.size());
   bool changed = false;
   for (const interval_expr& i : op->bounds) {
-    bounds.emplace_back(mutate(i.min), mutate(i.max));
+    bounds.emplace_back(mutate(i));
     changed = changed || !bounds.back().same_as(i);
   }
   stmt body = mutate(op->body);
@@ -230,7 +228,7 @@ void node_mutator::visit(const crop_buffer* op) {
   }
 }
 void node_mutator::visit(const crop_dim* op) {
-  interval_expr bounds = {mutate(op->bounds.min), mutate(op->bounds.max)};
+  interval_expr bounds = mutate(op->bounds);
   stmt body = mutate(op->body);
   if (bounds.same_as(op->bounds) && body.same_as(op->body)) {
     set_result(op);

--- a/builder/pipeline.cc
+++ b/builder/pipeline.cc
@@ -784,7 +784,7 @@ public:
   //   of the new loops, the `build()` is called for the case when there
   //   are func which need to be produced in that new loop.
   stmt build(const stmt& body, const func* base_f, const loop_id& at) {
-    stmt result;
+    std::vector<stmt> results;
 
     // Build the functions computed at this loop level.
     for (auto i = order_.rbegin(); i != order_.rend(); ++i) {
@@ -792,11 +792,11 @@ public:
       const auto& compute_at = compute_at_levels_.find(f);
       assert(compute_at != compute_at_levels_.end());
       if (compute_at->second == at) {
-        result = block::make({result, produce(f)});
+        results.push_back(produce(f));
       }
     }
 
-    result = block::make({result, body});
+    stmt result = block::make(std::move(results), body);
 
     symbol_map<var> uncropped_subs;
     // Add all allocations at this loop level. The allocations can be added in any order. This order enables aliasing

--- a/builder/simplify.cc
+++ b/builder/simplify.cc
@@ -1725,22 +1725,14 @@ public:
     if (!deps.any()) {
       set_result(std::move(body));
       return;
+    } else if (!crop_needed(deps)) {
+      set_result(substitute(body, op_sym, op_src));
+      return;
     }
 
     // Remove trailing undefined bounds.
     while (!bounds.empty() && !bounds.back().min.defined() && !bounds.back().max.defined()) {
       bounds.pop_back();
-    }
-
-    if (!crop_needed(deps)) {
-      // Add clamps for the implicit bounds like crop would have done.
-      for (index_t d = 0; d < static_cast<index_t>(bounds.size()); ++d) {
-        bounds[d] &= slinky::buffer_bounds(op_src, d);
-      }
-      body = substitute_bounds(body, op_sym, bounds);
-      body = substitute(body, op_sym, op_src);
-      set_result(mutate(body));
-      return;
     }
 
     // Rewrite nested crops to be one crop where possible.

--- a/builder/simplify.cc
+++ b/builder/simplify.cc
@@ -1457,7 +1457,7 @@ public:
       // This make_buffer is unused.
       set_result(std::move(body));
       return;
-    } else if (can_substitute_buffer(depends_on(op->body, op->sym))) {
+    } else if (can_substitute_buffer(deps)) {
       // We only needed the buffer meta, not the buffer itself.
       set_result(mutate(substitute_buffer(body, op->sym, info.elem_size, info.dims)));
       return;

--- a/builder/simplify.cc
+++ b/builder/simplify.cc
@@ -1253,7 +1253,7 @@ public:
           interval_expr prev_iter = substitute(crop->bounds, op->sym, expr(op->sym) - op->step);
           auto set_bounds_of_sym = set_value_in_scope(info_map, op->sym, {bounds, alignment_type()});
           // TODO: Currently we only support crops that monotonically increase the crop bounds as the loop progresses.
-          if (prove_true((next_iter.min > crop->bounds.min && crop->bounds.max + 1 >= next_iter.min) || 
+          if (prove_true((next_iter.min > crop->bounds.min && crop->bounds.max + 1 >= next_iter.min) ||
                          (crop->bounds.min > prev_iter.min && prev_iter.max + 1 >= crop->bounds.min))) {
             result = crop->body;
             expr_info info_of_min, info_of_max;
@@ -1422,7 +1422,7 @@ public:
   void canonicalize_buffer(buffer_info& buf, const buffer_info& src, var sym) {
     scoped_trace trace("canonicalize_buffer");
     canonicalize_buffer_meta(buf.elem_size, src.elem_size, intrinsic::buffer_elem_size, sym);
-    for (int buf_d = 0; buf_d < static_cast<int>(buf.dims.size());  ++buf_d) {
+    for (int buf_d = 0; buf_d < static_cast<int>(buf.dims.size()); ++buf_d) {
       dim_expr& d = buf.dims[buf_d];
       // Try buf_d first, to prefer making identical buffers.
       if (buf_d < static_cast<int>(src.dims.size()) && is_buffer_dim(d, src.dims[buf_d], sym, buf_d)) {
@@ -1677,9 +1677,8 @@ public:
       result = mutate(deduped);
     }
 
-    // TODO: We should not need to compare to both buffer_bounds(buf, dim) and buffer.
-    if (prove_true(result.min <= buffer.min || result.min <= buffer_min(buf, dim))) result.min = expr();
-    if (prove_true(result.max >= buffer.max || result.max >= buffer_max(buf, dim))) result.max = expr();
+    if (result.min.defined() && prove_true(result.min <= buffer.min)) result.min = expr();
+    if (result.max.defined() && prove_true(result.max >= buffer.max)) result.max = expr();
 
     // We already proved above that this min/max is necessary (otherwise result would be undefined here).
     if (result.min.defined()) buffer.min = max(buffer.min, result.min);

--- a/builder/simplify.cc
+++ b/builder/simplify.cc
@@ -1989,7 +1989,7 @@ public:
     if (!deps.any()) {
       set_result(std::move(body));
     } else if (!deps.buffer_dims) {
-      set_result(mutate(substitute(body, op->sym, op->src)));
+      set_result(substitute(body, op->sym, op->src));
     } else if (body.same_as(op->body) && src == op->src && dims == op->dims) {
       set_result(op);
     } else {

--- a/builder/simplify.cc
+++ b/builder/simplify.cc
@@ -2120,6 +2120,15 @@ public:
 
   template <typename T>
   void visit_mul_div(const T* op) {
+    auto make = [](expr a, expr b) {
+      auto ac = as_constant(a);
+      auto bc = as_constant(b);
+      if (ac && bc) {
+        return make_or_eval_binary<T>(*ac, *bc);
+      } else {
+        return T::make(std::move(a), std::move(b));
+      }
+    };
     // When we multiply by a negative number, we need to flip whether we are looking for an upper or lower bound.
     int sign_a = sign_of(op->a);
     int sign_b = sign_of(op->b);
@@ -2132,7 +2141,7 @@ public:
       if (b.same_as(op->b)) {
         set_result(op);
       } else {
-        set_result(T::make(op->a, std::move(b)));
+        set_result(make(op->a, std::move(b)));
       }
     } else if (sign_b != 0) {
       int old_sign = sign;
@@ -2142,7 +2151,7 @@ public:
       if (a.same_as(op->a)) {
         set_result(op);
       } else {
-        set_result(T::make(std::move(a), op->b));
+        set_result(make(std::move(a), op->b));
       }
     } else {
       set_result(op);

--- a/builder/simplify.cc
+++ b/builder/simplify.cc
@@ -1583,18 +1583,6 @@ public:
     return info;
   }
 
-  // Crop bounds like min(buffer_max(x, d), y) can be rewritten to just y because the crop will clamp anyways.
-  static expr simplify_crop_bound(expr x, var sym, int dim) {
-    if (const class max* m = x.as<class max>()) {
-      if (match_call(m->a, intrinsic::buffer_min, sym, dim)) return simplify_crop_bound(m->b, sym, dim);
-      if (match_call(m->b, intrinsic::buffer_min, sym, dim)) return simplify_crop_bound(m->a, sym, dim);
-    } else if (const class min* m = x.as<class min>()) {
-      if (match_call(m->a, intrinsic::buffer_max, sym, dim)) return simplify_crop_bound(m->b, sym, dim);
-      if (match_call(m->b, intrinsic::buffer_max, sym, dim)) return simplify_crop_bound(m->a, sym, dim);
-    }
-    return x;
-  }
-
   template <typename T>
   static void enumerate_bounds(expr x, std::set<expr, node_less>& bounds) {
     bounds.insert(x);

--- a/builder/slide_and_fold_storage.cc
+++ b/builder/slide_and_fold_storage.cc
@@ -268,12 +268,10 @@ public:
           // Wait for the previous iteration of this stage to complete.
           // The l.sym here is equal to l.min + x * l.step, so dividing l.sym by l.step we  get floor_div(l.min) + x.
           // This works even if l.min is not divisible by l.step, because it remains constant w.r.t to the loop index.
-          check::make(
-              semaphore_wait(buffer_at(l.semaphores, std::vector<expr>{*l.stage, floor_div(expr(l.sym), l.step) - 1}))),
+          check::make(semaphore_wait(buffer_at(l.semaphores, *l.stage, floor_div(expr(l.sym), l.step) - 1))),
           result,
           // Signal we've done this iteration.
-          check::make(
-              semaphore_signal(buffer_at(l.semaphores, std::vector<expr>{*l.stage, floor_div(expr(l.sym), l.step)}))),
+          check::make(semaphore_signal(buffer_at(l.semaphores, *l.stage, floor_div(expr(l.sym), l.step)))),
       });
       l.stage = std::nullopt;
     }

--- a/builder/substitute.cc
+++ b/builder/substitute.cc
@@ -424,7 +424,7 @@ public:
   void visit(const let_stmt* op) override { set_result(mutate_let(op)); }
 
   void visit(const loop* op) override {
-    interval_expr bounds = {mutate(op->bounds.min), mutate(op->bounds.max)};
+    interval_expr bounds = mutate(op->bounds);
     expr step = mutate(op->step);
     stmt body = mutate_decl_body(op->sym, op->body);
     if (bounds.same_as(op->bounds) && step.same_as(op->step) && body.same_as(op->body)) {
@@ -439,8 +439,7 @@ public:
     dims.reserve(op->dims.size());
     bool changed = false;
     for (const dim_expr& i : op->dims) {
-      interval_expr bounds = {mutate(i.bounds.min), mutate(i.bounds.max)};
-      dims.push_back({std::move(bounds), mutate(i.stride), mutate(i.fold_factor)});
+      dims.push_back({mutate(i.bounds), mutate(i.stride), mutate(i.fold_factor)});
       changed = changed || !dims.back().same_as(i);
     }
     stmt body = mutate_decl_body(op->sym, op->body);
@@ -457,8 +456,7 @@ public:
     dims.reserve(op->dims.size());
     bool changed = false;
     for (const dim_expr& i : op->dims) {
-      interval_expr bounds = {mutate(i.bounds.min), mutate(i.bounds.max)};
-      dims.push_back({std::move(bounds), mutate(i.stride), mutate(i.fold_factor)});
+      dims.push_back({mutate(i.bounds), mutate(i.stride), mutate(i.fold_factor)});
       changed = changed || !dims.back().same_as(i);
     }
     stmt body = mutate_decl_body(op->sym, op->body);
@@ -511,8 +509,8 @@ public:
     // When substituting crop bounds, we need to apply the implicit clamp, which uses buffer_min(sym, dim) and
     // buffer_max(src, dim).
     interval_expr old_bounds = buffer_bounds(src, dim);
-    interval_expr new_bounds = {mutate(old_bounds.min), mutate(old_bounds.max)};
-    interval_expr result = {mutate(bounds.min), mutate(bounds.max)};
+    interval_expr new_bounds = mutate(old_bounds);
+    interval_expr result = mutate(bounds);
     if (new_bounds.min.defined() && !old_bounds.min.same_as(new_bounds.min) &&
         !match_call(new_bounds.min, intrinsic::buffer_min, new_src, dim)) {
       // The substitution changed the implicit clamp, include it.

--- a/builder/test/simplify/simplify.cc
+++ b/builder/test/simplify/simplify.cc
@@ -647,6 +647,29 @@ TEST(simplify, make_buffer) {
                       call_stmt::make(nullptr, {}, {b0}, {})))),
       matches(make_buffer::make(
           b0, buffer_at(b2), buffer_elem_size(b2), {{{0, 10}, 2}}, call_stmt::make(nullptr, {}, {b0}, {}))));
+
+  // The same buffer
+  ASSERT_THAT(simplify(allocate::make(b0, memory_type::heap, 4, {{{0, 255}, {}, {}}, {{0, 0}, {}, {}}},
+                  make_buffer::make(b1, buffer_at(b0), buffer_elem_size(b0), {buffer_dim(b0, 0), buffer_dim(b0, 1)},
+                      call_stmt::make(nullptr, {}, {b1}, {})))),
+      matches(allocate::make(
+          b0, memory_type::heap, 4, {{{0, 255}, {}, {}}, {{0, 0}, {}, {}}}, call_stmt::make(nullptr, {}, {b0}, {}))));
+  ASSERT_THAT(simplify(allocate::make(b0, memory_type::heap, 4, {{{0, 255}, {}, {}}, {{0, 0}, {}, {}}},
+                  make_buffer::make(b1, buffer_at(b0), buffer_elem_size(b0), {buffer_dim(b0, 0), buffer_dim(b0, 1)},
+                      call_stmt::make(nullptr, {}, {b1}, {})))),
+      matches(allocate::make(
+          b0, memory_type::heap, 4, {{{0, 255}, {}, {}}, {{0, 0}, {}, {}}}, call_stmt::make(nullptr, {}, {b0}, {}))));
+  ASSERT_THAT(simplify(allocate::make(b0, memory_type::heap, 4, {{{0, 255}, {}, {}}, {{0, 0}, {}, {}}},
+                  make_buffer::make(b1, buffer_at(b0), buffer_elem_size(b0), {buffer_dim(b0, 0), {{0, 0}, 0, {}}},
+                      call_stmt::make(nullptr, {}, {b1}, {})))),
+      matches(allocate::make(
+          b0, memory_type::heap, 4, {{{0, 255}, {}, {}}, {{0, 0}, {}, {}}}, call_stmt::make(nullptr, {}, {b0}, {}))));
+  ASSERT_THAT(
+      simplify(allocate::make(b0, memory_type::heap, 4, {{{0, 255}, {}, {}}, {{0, 0}, {}, {}}, {{0, 0}, {}, {}}},
+          make_buffer::make(b1, buffer_at(b0), buffer_elem_size(b0),
+              {buffer_dim(b0, 0), {{0, 0}, 0, {}}, {{0, 0}, 0, {}}}, call_stmt::make(nullptr, {}, {b1}, {})))),
+      matches(allocate::make(b0, memory_type::heap, 4, {{{0, 255}, {}, {}}, {{0, 0}, {}, {}}, {{0, 0}, {}, {}}},
+          call_stmt::make(nullptr, {}, {b0}, {}))));
 }
 
 TEST(simplify, transpose) {

--- a/builder/test/simplify/simplify.cc
+++ b/builder/test/simplify/simplify.cc
@@ -276,9 +276,6 @@ TEST(simplify, siblings) {
   auto make_crop_x = [](var out, var in, int dim, const stmt& body) {
     return crop_dim::make(out, in, dim, point(x), body);
   };
-  auto make_crop_y = [](var out, var in, int dim, const stmt& body) {
-    return crop_dim::make(out, in, dim, point(y), body);
-  };
 
   ASSERT_THAT(simplify(make_crop_x(b1, b0, 0, block::make({make_call(b1), make_call(b0)}))),
       matches(block::make({make_crop_x(b1, b0, 0, make_call(b1)), make_call(b0)})));

--- a/builder/test/simplify/simplify.cc
+++ b/builder/test/simplify/simplify.cc
@@ -747,20 +747,32 @@ TEST(simplify, bounds_of) {
   }
 }
 
+TEST(simplify, constant_lower_bound) {
+  ASSERT_THAT(constant_lower_bound(min(x, 0) < 0), matches(0));
+  ASSERT_THAT(constant_lower_bound(min(x, 0) * 256 < 0), matches(0));
+  ASSERT_THAT(constant_lower_bound(max(x, 0) < 0), matches(0));
+  ASSERT_THAT(constant_lower_bound(max(x, 0) * 256 < 0), matches(0));
+}
+
 TEST(simplify, constant_upper_bound) {
   ASSERT_THAT(constant_upper_bound(min(x, 4)), matches(4));
   ASSERT_THAT(constant_upper_bound(max(x, 4)), matches(max(x, 4)));
   ASSERT_THAT(constant_upper_bound(x - min(y, 4)), matches(x - min(y, 4)));
   ASSERT_THAT(constant_upper_bound(x - max(y, 4)), matches(x - 4));
   ASSERT_THAT(constant_upper_bound(x * 3), matches(x * 3));
-  ASSERT_THAT(constant_upper_bound(min(x, 4) * 2), matches(expr(4) * 2));
+  ASSERT_THAT(constant_upper_bound(min(x, 4) * 2), matches(8));
   ASSERT_THAT(constant_upper_bound(min(x, 4) * -2), matches(min(x, 4) * -2));
-  ASSERT_THAT(constant_upper_bound(max(x, 4) * -2), matches(expr(4) * -2));
-  ASSERT_THAT(constant_upper_bound(min(x, 4) / 2), matches(expr(4) / 2));
+  ASSERT_THAT(constant_upper_bound(max(x, 4) * -2), matches(-8));
+  ASSERT_THAT(constant_upper_bound(min(x, 4) / 2), matches(2));
   ASSERT_THAT(constant_upper_bound(max(x, 4) / 2), matches(max(x, 4) / 2));
   ASSERT_THAT(constant_upper_bound(min(x, 4) / -2), matches(min(x, 4) / -2));
-  ASSERT_THAT(constant_upper_bound(max(x, 4) / -2), matches(expr(4) / -2));
+  ASSERT_THAT(constant_upper_bound(max(x, 4) / -2), matches(-2));
   ASSERT_THAT(constant_upper_bound(select(x, 3, 1)), matches(3));
+
+  ASSERT_THAT(constant_upper_bound(min(x, 0) < 0), matches(1));
+  ASSERT_THAT(constant_upper_bound(min(x, 0) * 256 < 0), matches(1));
+  ASSERT_THAT(constant_upper_bound(max(x, 0) < 0), matches(0));
+  ASSERT_THAT(constant_upper_bound(max(x, 0) * 256 < 0), matches(0));
 }
 
 TEST(simplify, modulus_remainder) {

--- a/builder/test/substitute.cc
+++ b/builder/test/substitute.cc
@@ -113,8 +113,7 @@ TEST(substitute, implicit_bounds) {
       matches(crop_dim::make(x, u, 0, bounds(max(y, w), z), check::make(x))));
   ASSERT_THAT(substitute(crop_dim::make(x, u, 0, bounds(y, z), check::make(x)), buffer_max(u, 0), w),
       matches(crop_dim::make(x, u, 0, bounds(y, min(z, w)), check::make(x))));
-  ASSERT_THAT(
-      substitute(buffer_at(x), buffer_min(x, 2), y), matches(buffer_at(x, std::vector<expr>{expr(), expr(), expr(y)})));
+  ASSERT_THAT(substitute(buffer_at(x), buffer_min(x, 2), y), matches(buffer_at(x, expr(), expr(), expr(y))));
 }
 
 TEST(match, basic) {

--- a/builder/test/visualize/padded_stencil_0.html
+++ b/builder/test/visualize/padded_stencil_0.html
@@ -361,20 +361,14 @@ function pipeline(__in, out) {
         {bounds:[(buffer_min(out, 0) + -1), (buffer_max(out, 0) + 1)], stride:NaN, fold_factor:NaN},
         {bounds:[(buffer_min(out, 1) + -1), (buffer_max(out, 1) + 1)], stride:NaN, fold_factor:NaN}
       ]);
-      { let __intm_padded_intm = crop_buffer(intm_padded_intm, [
-          [g, g_0],
-          [g_1, g_2]
-      ]); {
-        let intm_padded_intm = __intm_padded_intm;
-        consume(__in);
-        produce(intm_padded_intm);
-        __event_t++;
-      }}
       { let __intm_2 = crop_buffer(intm_padded_intm, [
           [g, g_0],
           [g_1, g_2]
       ]); {
         let intm_2 = __intm_2;
+        consume(__in);
+        produce(intm_2);
+        __event_t++;
         produce(intm_2);
         produce(intm_padded_intm);
         __event_t++;

--- a/builder/test/visualize/padded_stencil_1.html
+++ b/builder/test/visualize/padded_stencil_1.html
@@ -361,20 +361,14 @@ function pipeline(__in, out) {
         {bounds:[(buffer_min(out, 0) + -1), (buffer_max(out, 0) + 1)], stride:NaN, fold_factor:NaN},
         {bounds:[(buffer_min(out, 1) + -1), (buffer_max(out, 1) + 1)], stride:NaN, fold_factor:NaN}
       ]);
-      { let __intm_padded_intm = crop_buffer(intm_padded_intm, [
-          [g, g_0],
-          [g_1, g_2]
-      ]); {
-        let intm_padded_intm = __intm_padded_intm;
-        consume(__in);
-        produce(intm_padded_intm);
-        __event_t++;
-      }}
       { let __intm_2 = crop_buffer(intm_padded_intm, [
           [g, g_0],
           [g_1, g_2]
       ]); {
         let intm_2 = __intm_2;
+        consume(__in);
+        produce(intm_2);
+        __event_t++;
         produce(intm_2);
         produce(intm_padded_intm);
         __event_t++;

--- a/runtime/depends_on.h
+++ b/runtime/depends_on.h
@@ -31,7 +31,6 @@ struct depends_on_result {
 };
 
 // Check if the node depends on a symbol or set of symbols.
-
 void depends_on(expr_ref e, span<const std::pair<var, depends_on_result&>> var_deps);
 void depends_on(stmt_ref s, span<const std::pair<var, depends_on_result&>> var_deps);
 void depends_on(expr_ref e, var x, depends_on_result& deps);
@@ -44,6 +43,9 @@ depends_on_result depends_on(stmt_ref s, span<const var> xs);
 
 // Check if buffer can be safely substituted.
 bool can_substitute_buffer(const depends_on_result& r);
+
+// Check if the node depends on anything that may change value.
+bool is_pure(expr_ref x);
 
 }  // namespace slinky
 

--- a/runtime/expr.h
+++ b/runtime/expr.h
@@ -656,6 +656,12 @@ expr buffer_at(expr buf, span<const expr> at);
 expr buffer_at(expr buf, span<const var> at);
 expr buffer_at(expr buf);
 
+template <typename... Args>
+expr buffer_at(expr buf, expr at0, Args... at) {
+  expr args[] = {at0, at...};
+  return buffer_at(buf, args);
+}
+
 interval_expr buffer_bounds(const expr& buf, const expr& dim);
 dim_expr buffer_dim(const expr& buf, const expr& dim);
 std::vector<dim_expr> buffer_dims(const expr& buf, int rank);

--- a/runtime/test/depends_on.cc
+++ b/runtime/test/depends_on.cc
@@ -92,4 +92,11 @@ TEST(depends_on, copy) {
   ASSERT_EQ(depends_on(copy_stmt::make(x, {z + w}, y, {z}, {}), w), (depends_on_result{.var = true}));
 }
 
+TEST(depends_on, is_pure) {
+  ASSERT_TRUE(is_pure(x + y));
+  ASSERT_TRUE(is_pure(abs(x)));
+  ASSERT_FALSE(is_pure(buffer_min(x, 0)));
+  ASSERT_FALSE(is_pure(y + buffer_min(x, 0)));
+}
+
 }  // namespace slinky


### PR DESCRIPTION
Minor fixes to simplify, mostly that improve scalability with large pipelines
- Do constant folding in `constant_bound`
- Strengthen `canonicalize_buffer` by ignoring stride and fold factor of extent 1 dimensions
- Prefer constructing identity transposes in `canonicalize_buffer`, which may turn into `clone_buffer`.
- Add `is_pure` helper. Not actually used by anything in slinky, but might be useful for clients.
- Make `lift_decl_invariants` smarter so we don't duplicate identical buffer mutators for sibling stmts.
- Fix some unnecessary recursive quadratic complexity operations (`substitute_buffer` not needed for crops, `depends_on` not needed to be recomputed in `make_buffer`).
- Fix quadratic block construction in pipeline builder

Fixes #457