### PR TITLE
Tighten `constant_bounds`

### DIFF
--- a/builder/simplify.cc
+++ b/builder/simplify.cc
@@ -2355,21 +2355,12 @@ public:
     }
   }
   void visit(const call* op) override {
-    switch (op->intrinsic) {
-    case intrinsic::abs:
-      if (sign < 0) {
-        expr a = mutate(op->args[0]);
-        if (auto ca = as_constant(a)) {
-          set_result(std::max<index_t>(0, *ca));
-        } else {
-          set_result(expr(0));
-        }
-        return;
-      }
-      break;
-    default: break;
+    if (op->intrinsic == intrinsic::abs) {
+      expr equiv = max(0, max(op->args[0], -op->args[0]));
+      equiv.accept(this);
+    } else {
+      set_result(op);
     }
-    set_result(op);
   }
 };
 

--- a/builder/simplify.cc
+++ b/builder/simplify.cc
@@ -2178,11 +2178,8 @@ public:
 
   template <typename T>
   void visit_min_max(const T* op, bool take_constant) {
-    // We can only learn about upper bounds from min and lower bounds from max. Furthermore, it is an error to
-    // attempt to recursively mutate into a max while finding upper bounds or vice versa, because we might find
-    // incorrect conservative bounds in the wrong direction.
-    expr a = take_constant ? mutate(op->a) : op->a;
-    expr b = take_constant ? mutate(op->b) : op->b;
+    expr a = mutate(op->a);
+    expr b = mutate(op->b);
     auto ca = as_constant(a);
     auto cb = as_constant(b);
     if (ca && cb) {

--- a/builder/simplify_exprs.cc
+++ b/builder/simplify_exprs.cc
@@ -66,7 +66,7 @@ expr simplify(const add* op, expr a, expr b) {
 
   auto ca = as_constant(a);
   auto cb = as_constant(b);
-  if (ca && cb) {
+  if (ca && cb && !add_overflows(*ca, *cb)) {
     return *ca + *cb;
   }
 
@@ -89,9 +89,9 @@ expr simplify(const add* op, expr a, expr b) {
 expr simplify(const sub* op, expr a, expr b) {
   auto ca = as_constant(a);
   auto cb = as_constant(b);
-  if (ca && cb) {
+  if (ca && cb && !sub_overflows(*ca, *cb)) {
     return *ca - *cb;
-  } else if (cb) {
+  } else if (cb && !sub_overflows<index_t>(0, *cb)) {
     // Canonicalize to addition with constants.
     return simplify(static_cast<add*>(nullptr), a, -*cb);
   }
@@ -119,7 +119,7 @@ expr simplify(const mul* op, expr a, expr b) {
 
   auto ca = as_constant(a);
   auto cb = as_constant(b);
-  if (ca && cb) {
+  if (ca && cb && !mul_overflows(*ca, *cb)) {
     return *ca * *cb;
   }
 

--- a/builder/test/simplify/simplify.cc
+++ b/builder/test/simplify/simplify.cc
@@ -804,8 +804,10 @@ TEST(simplify, constant_lower_bound) {
   ASSERT_THAT(constant_lower_bound(max(x, 0) < 0), matches(0));
   ASSERT_THAT(constant_lower_bound(max(x, 0) * 256 < 0), matches(0));
   ASSERT_THAT(constant_lower_bound(x % 4), matches(0));
-
+  ASSERT_THAT(constant_lower_bound(abs(x)), matches(0));
+  ASSERT_THAT(constant_lower_bound(abs(min(x, -5))), matches(5));
   ASSERT_THAT(constant_lower_bound(min(1, max(x, 1))), matches(1));
+  ASSERT_THAT(constant_lower_bound(clamp(x, -2, 3)), matches(-2));
 }
 
 TEST(simplify, constant_upper_bound) {
@@ -823,6 +825,7 @@ TEST(simplify, constant_upper_bound) {
   ASSERT_THAT(constant_upper_bound(max(x, 4) / -2), matches(-2));
   ASSERT_THAT(constant_upper_bound(select(x, 3, 1)), matches(3));
   ASSERT_THAT(constant_upper_bound(x % 4), matches(3));
+  ASSERT_THAT(constant_upper_bound(clamp(x, -2, 3)), matches(3));
 
   ASSERT_THAT(constant_upper_bound(min(x, 0) < 0), matches(1));
   ASSERT_THAT(constant_upper_bound(min(x, 0) * 256 < 0), matches(1));

--- a/builder/test/simplify/simplify.cc
+++ b/builder/test/simplify/simplify.cc
@@ -489,6 +489,11 @@ TEST(simplify, buffer_bounds) {
                               crop_dim::make(b3, b0, 0, {expr(), buffer_max(b2, 0)}, use_buffers({b1, b3}))))))),
       matches(let_stmt::make(x, select(1 < y, y, max(w, 1)),
           decl_bounds(b0, {{0, x + -1}}, decl_bounds(b1, {{0, x + -1}}, use_buffers({b1, b0}))))));
+
+  ASSERT_THAT(simplify(decl_bounds(b0, {{0, select(1 <= x, ((y + 15) / 16) * 16, 16) + -1}},
+                  decl_bounds(b1, {{0, select(1 <= x, y + -1, 0)}},
+                      crop_dim::make(b2, b0, 0, {expr(), (buffer_max(b0, 0) / 16) * 16 + 15}, use_buffer(b2))))),
+      matches(decl_bounds(b0, {{0, select(1 <= x, ((y + 15) / 16) * 16, 16) + -1}}, use_buffer(b0))));
 }
 
 TEST(simplify, crop_not_needed) {
@@ -798,6 +803,7 @@ TEST(simplify, constant_lower_bound) {
   ASSERT_THAT(constant_lower_bound(min(x, 0) * 256 < 0), matches(0));
   ASSERT_THAT(constant_lower_bound(max(x, 0) < 0), matches(0));
   ASSERT_THAT(constant_lower_bound(max(x, 0) * 256 < 0), matches(0));
+  ASSERT_THAT(constant_lower_bound(x % 4), matches(0));
 
   ASSERT_THAT(constant_lower_bound(min(1, max(x, 1))), matches(1));
 }
@@ -816,6 +822,7 @@ TEST(simplify, constant_upper_bound) {
   ASSERT_THAT(constant_upper_bound(min(x, 4) / -2), matches(min(x, 4) / -2));
   ASSERT_THAT(constant_upper_bound(max(x, 4) / -2), matches(-2));
   ASSERT_THAT(constant_upper_bound(select(x, 3, 1)), matches(3));
+  ASSERT_THAT(constant_upper_bound(x % 4), matches(3));
 
   ASSERT_THAT(constant_upper_bound(min(x, 0) < 0), matches(1));
   ASSERT_THAT(constant_upper_bound(min(x, 0) * 256 < 0), matches(1));

--- a/builder/test/simplify/simplify.cc
+++ b/builder/test/simplify/simplify.cc
@@ -433,6 +433,12 @@ TEST(simplify, bounds) {
   // Tricky case because want to use the bounds of x but the value of y.
   symbol_map<interval_expr> xy_bounds = {{x, {0, y}}, {y, {z, w}}};
   ASSERT_THAT(simplify(min(x, y + 1), xy_bounds), matches(x));
+
+  ASSERT_THAT(simplify(let::make(x, select(1 < y, y, max(z, 1)), max(x, 0))),
+      matches(let::make(x, select(1 < y, y, max(z, 1)), x)));
+
+  ASSERT_THAT(simplify(let::make({{x, select(1 < y, y, max(z, 1))}, {w, select(1 < x, x, max(u, 1))}}, max(w, 0))),
+      matches(let::make({{x, select(1 < y, y, max(z, 1))}, {w, select(1 < x, x, max(u, 1))}}, w)));
 }
 
 TEST(simplify, buffer_bounds) {
@@ -792,6 +798,8 @@ TEST(simplify, constant_lower_bound) {
   ASSERT_THAT(constant_lower_bound(min(x, 0) * 256 < 0), matches(0));
   ASSERT_THAT(constant_lower_bound(max(x, 0) < 0), matches(0));
   ASSERT_THAT(constant_lower_bound(max(x, 0) * 256 < 0), matches(0));
+
+  ASSERT_THAT(constant_lower_bound(min(1, max(x, 1))), matches(1));
 }
 
 TEST(simplify, constant_upper_bound) {


### PR DESCRIPTION
- Handle `mod` at least in part
- Remove apparently hack/workaround for a bug that seems to have since been fixed that prevents us from learning constant bounds of clamps/mixed `min`-`max`.