### PR TITLE
Add helper to make padded copies

### DIFF
--- a/builder/pipeline.h
+++ b/builder/pipeline.h
@@ -258,6 +258,12 @@ public:
   static func make_copy(input in, output out, std::vector<char> padding) {
     return func({std::move(in)}, std::move(out), std::move(padding));
   }
+  template <typename T>
+  static func make_copy(input in, output out, T padding) {
+    std::vector<char> p(sizeof(padding));
+    memcpy(p.data(), &padding, sizeof(T));
+    return make_copy(std::move(in), std::move(out), std::move(p));
+  }
   // Make a copy from multiple inputs with undefined padding.
   static func make_copy(std::vector<input> in, output out) { return func(std::move(in), {std::move(out)}); }
   // Make a concatenation copy. This is a helper function for `make_copy`, where the crop for input i is a `crop_dim` in

--- a/builder/test/copy.cc
+++ b/builder/test/copy.cc
@@ -60,11 +60,9 @@ TEST(trivial_1d, copy) {
 
   var x(ctx, "x");
 
-  std::vector<char> padding(sizeof(int), 0);
-
   // Crop the output to the intersection of the input and output buffer.
   box_expr output_crop = in->bounds() & out->bounds();
-  func copy = func::make_copy({in, {point(x)}, output_crop}, {out, {x}}, padding);
+  func copy = func::make_copy({in, {point(x)}, output_crop}, {out, {x}}, static_cast<int>(0));
 
   pipeline p = build_pipeline(ctx, {in}, {out});
 
@@ -105,11 +103,9 @@ TEST(trivial_2d, copy) {
   var x(ctx, "x");
   var y(ctx, "y");
 
-  std::vector<char> padding(sizeof(int), 0);
-
   // Crop the output to the intersection of the input and output buffer.
   box_expr output_crop = in->bounds() & out->bounds();
-  func copy = func::make_copy({in, {point(x), point(y)}, output_crop}, {out, {x, y}}, padding);
+  func copy = func::make_copy({in, {point(x), point(y)}, output_crop}, {out, {x, y}}, static_cast<int>(0));
 
   pipeline p = build_pipeline(ctx, {in}, {out});
 
@@ -196,9 +192,8 @@ TEST(padded, copy) {
   int padding_x = 3;
   int padding_y = 2;
 
-  std::vector<char> padding(sizeof(int), 0);
-
-  func copy = func::make_copy({in, {point(x) - padding_x, point(y) - padding_y}, in->bounds()}, {out, {x, y}}, padding);
+  func copy = func::make_copy(
+      {in, {point(x) - padding_x, point(y) - padding_y}, in->bounds()}, {out, {x, y}}, static_cast<int>(0));
 
   pipeline p = build_pipeline(ctx, {in}, {out});
 
@@ -239,13 +234,12 @@ TEST(custom_pad, copy) {
   var x(ctx, "x");
   var y(ctx, "y");
 
-  std::vector<char> padding(sizeof(int), 0);
-
   const int x_min = 1;
   const int x_max = 8;
   const int y_min = 2;
   const int y_max = 4;
-  func copy = func::make_copy({in, {point(x), point(y)}, {{x_min, x_max}, {y_min, y_max}}}, {out, {x, y}}, padding);
+  func copy =
+      func::make_copy({in, {point(x), point(y)}, {{x_min, x_max}, {y_min, y_max}}}, {out, {x, y}}, static_cast<int>(0));
 
   pipeline p = build_pipeline(ctx, {in}, {out});
 

--- a/builder/test/copy_pipeline.cc
+++ b/builder/test/copy_pipeline.cc
@@ -160,7 +160,7 @@ TEST_P(copy_sequence, pipeline) {
   auto make_copy = [&](int stage, buffer_expr_ptr src, buffer_expr_ptr dst) {
     if (((1 << stage) & pad_mask) != 0) {
       return func::make_copy(
-          {src, {point(x + 1)}, {bounds(pad_min(stage), pad_max(stage))}}, {dst, {x}}, {(char)stage});
+          {src, {point(x + 1)}, {bounds(pad_min(stage), pad_max(stage))}}, {dst, {x}}, static_cast<char>(stage));
     } else {
       return func::make_copy({src, {point(x + 1)}}, {dst, {x}});
     }


### PR DESCRIPTION
Having to make an `std::vector<char>` is a bit annoying.