### PR TITLE
Replace buffer intrinsics with `variable` fields

### DIFF
--- a/builder/pipeline.cc
+++ b/builder/pipeline.cc
@@ -575,22 +575,20 @@ class pipeline_builder {
         const buffer_expr_ptr& b = o.buffer;
         if (output_syms_.count(b->sym())) continue;
 
-        expr alloc_var = variable::make(b->sym());
-
         // First substitute the bounds.
         std::vector<std::pair<expr, expr>> substitutions;
         assert(allocation_bounds_[b->sym()]);
         const box_expr& bounds = *allocation_bounds_[b->sym()];
         for (index_t d = 0; d < static_cast<index_t>(bounds.size()); ++d) {
           const interval_expr& bounds_d = bounds[d];
-          substitutions.emplace_back(buffer_min(alloc_var, d), bounds_d.min);
-          substitutions.emplace_back(buffer_max(alloc_var, d), bounds_d.max);
+          substitutions.emplace_back(buffer_min(b->sym(), d), bounds_d.min);
+          substitutions.emplace_back(buffer_max(b->sym(), d), bounds_d.max);
         }
         std::vector<dim_expr> dims = substitute_from_map(b->dims(), substitutions);
 
         substitutions.clear();
         for (index_t d = 0; d < static_cast<index_t>(bounds.size()); ++d) {
-          substitutions.emplace_back(buffer_stride(alloc_var, d), expr());
+          substitutions.emplace_back(buffer_stride(b->sym(), d), expr());
         }
         dims = substitute_from_map(dims, substitutions);
 
@@ -872,20 +870,18 @@ public:
 
 void check_buffer(const buffer_expr_ptr& b, std::vector<stmt>& checks) {
   int rank = static_cast<int>(b->rank());
-  expr buf_var = variable::make(b->sym());
-  checks.push_back(check::make(buf_var != 0));
-  checks.push_back(check::make(buffer_rank(buf_var) == rank));
+  checks.push_back(check::make(expr(b->sym()) != 0));
+  checks.push_back(check::make(buffer_rank(b->sym()) == rank));
 }
 
 void check_buffer_constraints(const buffer_expr_ptr& b, bool output, std::vector<stmt>& checks) {
   int rank = static_cast<int>(b->rank());
-  expr buf_var = variable::make(b->sym());
-  checks.push_back(check::make(buffer_elem_size(buf_var) == b->elem_size()));
+  checks.push_back(check::make(buffer_elem_size(b->sym()) == b->elem_size()));
   for (int d = 0; d < rank; ++d) {
-    expr fold_factor = buffer_fold_factor(buf_var, d);
-    checks.push_back(check::make(b->dim(d).min() == buffer_min(buf_var, d)));
-    checks.push_back(check::make(b->dim(d).max() == buffer_max(buf_var, d)));
-    checks.push_back(check::make(b->dim(d).stride == buffer_stride(buf_var, d)));
+    expr fold_factor = buffer_fold_factor(b->sym(), d);
+    checks.push_back(check::make(b->dim(d).min() == buffer_min(b->sym(), d)));
+    checks.push_back(check::make(b->dim(d).max() == buffer_max(b->sym(), d)));
+    checks.push_back(check::make(b->dim(d).stride == buffer_stride(b->sym(), d)));
     checks.push_back(check::make(b->dim(d).fold_factor == fold_factor));
     if (output) {
       checks.push_back(check::make(or_else({fold_factor == dim::unfolded, b->dim(d).extent() <= fold_factor})));

--- a/builder/pipeline.cc
+++ b/builder/pipeline.cc
@@ -950,25 +950,6 @@ stmt inject_traces(const stmt& s, node_context& ctx, std::set<buffer_expr_ptr>& 
   return result;
 }
 
-class rewrite_buffer_meta : public node_mutator {
-public:
-  void visit(const call* op) override {
-    std::optional<var> sym = op->args.size() > 0 ? as_variable(op->args[0]) : std::nullopt;
-    std::optional<index_t> dim = op->args.size() == 2 ? as_constant(op->args[1]) : std::nullopt;
-    switch (op->intrinsic) {
-    case intrinsic::buffer_rank: set_result(variable::make(*sym, field_id::rank)); return;
-    case intrinsic::buffer_elem_size: set_result(variable::make(*sym, field_id::elem_size)); return;
-    case intrinsic::buffer_size_bytes: set_result(variable::make(*sym, field_id::size_bytes)); return;
-    case intrinsic::buffer_min: set_result(variable::make(*sym, field_id::min, *dim)); return;
-    case intrinsic::buffer_max: set_result(variable::make(*sym, field_id::max, *dim)); return;
-    case intrinsic::buffer_stride: set_result(variable::make(*sym, field_id::stride, *dim)); return;
-    case intrinsic::buffer_fold_factor: set_result(variable::make(*sym, field_id::fold_factor, *dim)); return;
-    default: break;
-    }
-    node_mutator::visit(op);
-  }
-};
-
 stmt build_pipeline(node_context& ctx, const std::vector<buffer_expr_ptr>& inputs,
     const std::vector<buffer_expr_ptr>& outputs, std::set<buffer_expr_ptr>& constants,
     std::vector<std::pair<var, expr>> lets, const build_options& options) {
@@ -1030,7 +1011,6 @@ stmt build_pipeline(node_context& ctx, const std::vector<buffer_expr_ptr>& input
   // `implement_copies` adds shadowed declarations, remove them before simplifying.
   result = deshadow(result, builder.external_symbols(), ctx);
   result = simplify(result);
-  result = rewrite_buffer_meta().mutate(result);
 
   result = optimize_symbols(result, ctx);
 
@@ -1039,8 +1019,6 @@ stmt build_pipeline(node_context& ctx, const std::vector<buffer_expr_ptr>& input
   if (options.trace) {
     result = inject_traces(result, ctx, constants);
   }
-
-  result = rewrite_buffer_meta().mutate(result);
 
   if (is_verbose()) {
     std::cout << result << std::endl;

--- a/builder/pipeline.cc
+++ b/builder/pipeline.cc
@@ -251,7 +251,7 @@ public:
   }
 
   void visit(const variable* op) override {
-    if (op->field == field_id::none) {
+    if (op->field == buffer_field::none) {
       node_mutator::visit(op);
       return;
     }

--- a/builder/replica_pipeline.cc
+++ b/builder/replica_pipeline.cc
@@ -64,7 +64,7 @@ public:
       if (it != buffer_variables_emitted_.end()) {
         name_ = it->second;
       } else {
-        name_ = print_assignment_prefixed("_", "variable::make(" + name + "->sym())");
+        name_ = print_assignment_prefixed("_", name + "->sym()");
         buffer_variables_emitted_[op->sym] = name_;
       }
       return;
@@ -166,21 +166,20 @@ public:
           name, "buffer_expr::make(ctx, \"", name, "\", /*rank=*/", bep->rank(), ", /*elem_size=*/", elem_size, ")");
     }
 
-    expr bep_var = variable::make(bep->sym());
     for (std::size_t d = 0; d < bep->rank(); d++) {
-      if (!match(bep->dim(d).bounds.min, buffer_min(bep_var, d))) {
+      if (!is_buffer_field(bep->dim(d).bounds.min, field_id::min, bep->sym(), d)) {
         std::string e = print_expr_inlined(bep->dim(d).bounds.min);
         os_ << "  " << name << "->dim(" << d << ").bounds.min = " << e << ";\n";
       }
-      if (!match(bep->dim(d).bounds.max, buffer_max(bep_var, d))) {
+      if (!is_buffer_field(bep->dim(d).bounds.max, field_id::max, bep->sym(), d)) {
         std::string e = print_expr_inlined(bep->dim(d).bounds.max);
         os_ << "  " << name << "->dim(" << d << ").bounds.max = " << e << ";\n";
       }
-      if (!match(bep->dim(d).stride, buffer_stride(bep_var, d))) {
+      if (!is_buffer_field(bep->dim(d).stride, field_id::stride, bep->sym(), d)) {
         std::string e = print_expr_inlined(bep->dim(d).stride);
         os_ << "  " << name << "->dim(" << d << ").stride = " << e << ";\n";
       }
-      if (!match(bep->dim(d).fold_factor, buffer_fold_factor(bep_var, d))) {
+      if (!is_buffer_field(bep->dim(d).fold_factor, field_id::fold_factor, bep->sym(), d)) {
         std::string e = print_expr_inlined(bep->dim(d).fold_factor);
         os_ << "  " << name << "->dim(" << d << ").fold_factor = (index_t) " << e << ";\n";
       }

--- a/builder/replica_pipeline.cc
+++ b/builder/replica_pipeline.cc
@@ -57,7 +57,7 @@ public:
   }
 
   void visit(const variable* op) override {
-    const auto& name = ctx_.name(op->sym);
+    const std::string& name = ctx_.name(op->sym);
 
     if (buffers_emitted_.count(op->sym)) {
       auto it = buffer_variables_emitted_.find(op->sym);
@@ -67,10 +67,18 @@ public:
         name_ = print_assignment_prefixed("_", name + "->sym()");
         buffer_variables_emitted_[op->sym] = name_;
       }
-      return;
+    } else {
+      name_ = print(var(op->sym));
     }
 
-    name_ = print(var(op->sym));
+    if (op->field != field_id::none) {
+      name_ = std::string("(buffer_") + to_string(op->field) + "(" + name_;
+      if (op->dim >= 0) {
+        name_ += ", ";
+        name_ += std::to_string(op->dim);
+      }
+      name_ += "))";
+    }
   }
 
   void visit(const constant* op) override { name_ = to_string(op->value); }

--- a/builder/replica_pipeline.cc
+++ b/builder/replica_pipeline.cc
@@ -71,7 +71,7 @@ public:
       name_ = print(var(op->sym));
     }
 
-    if (op->field != field_id::none) {
+    if (op->field != buffer_field::none) {
       name_ = std::string("(buffer_") + to_string(op->field) + "(" + name_;
       if (op->dim >= 0) {
         name_ += ", ";
@@ -175,19 +175,19 @@ public:
     }
 
     for (std::size_t d = 0; d < bep->rank(); d++) {
-      if (!is_variable(bep->dim(d).bounds.min, bep->sym(), field_id::min, d)) {
+      if (!is_variable(bep->dim(d).bounds.min, bep->sym(), buffer_field::min, d)) {
         std::string e = print_expr_inlined(bep->dim(d).bounds.min);
         os_ << "  " << name << "->dim(" << d << ").bounds.min = " << e << ";\n";
       }
-      if (!is_variable(bep->dim(d).bounds.max, bep->sym(), field_id::max, d)) {
+      if (!is_variable(bep->dim(d).bounds.max, bep->sym(), buffer_field::max, d)) {
         std::string e = print_expr_inlined(bep->dim(d).bounds.max);
         os_ << "  " << name << "->dim(" << d << ").bounds.max = " << e << ";\n";
       }
-      if (!is_variable(bep->dim(d).stride, bep->sym(), field_id::stride, d)) {
+      if (!is_variable(bep->dim(d).stride, bep->sym(), buffer_field::stride, d)) {
         std::string e = print_expr_inlined(bep->dim(d).stride);
         os_ << "  " << name << "->dim(" << d << ").stride = " << e << ";\n";
       }
-      if (!is_variable(bep->dim(d).fold_factor, bep->sym(), field_id::fold_factor, d)) {
+      if (!is_variable(bep->dim(d).fold_factor, bep->sym(), buffer_field::fold_factor, d)) {
         std::string e = print_expr_inlined(bep->dim(d).fold_factor);
         os_ << "  " << name << "->dim(" << d << ").fold_factor = (index_t) " << e << ";\n";
       }

--- a/builder/replica_pipeline.cc
+++ b/builder/replica_pipeline.cc
@@ -175,19 +175,19 @@ public:
     }
 
     for (std::size_t d = 0; d < bep->rank(); d++) {
-      if (!is_buffer_field(bep->dim(d).bounds.min, field_id::min, bep->sym(), d)) {
+      if (!is_variable(bep->dim(d).bounds.min, bep->sym(), field_id::min, d)) {
         std::string e = print_expr_inlined(bep->dim(d).bounds.min);
         os_ << "  " << name << "->dim(" << d << ").bounds.min = " << e << ";\n";
       }
-      if (!is_buffer_field(bep->dim(d).bounds.max, field_id::max, bep->sym(), d)) {
+      if (!is_variable(bep->dim(d).bounds.max, bep->sym(), field_id::max, d)) {
         std::string e = print_expr_inlined(bep->dim(d).bounds.max);
         os_ << "  " << name << "->dim(" << d << ").bounds.max = " << e << ";\n";
       }
-      if (!is_buffer_field(bep->dim(d).stride, field_id::stride, bep->sym(), d)) {
+      if (!is_variable(bep->dim(d).stride, bep->sym(), field_id::stride, d)) {
         std::string e = print_expr_inlined(bep->dim(d).stride);
         os_ << "  " << name << "->dim(" << d << ").stride = " << e << ";\n";
       }
-      if (!is_buffer_field(bep->dim(d).fold_factor, field_id::fold_factor, bep->sym(), d)) {
+      if (!is_variable(bep->dim(d).fold_factor, bep->sym(), field_id::fold_factor, d)) {
         std::string e = print_expr_inlined(bep->dim(d).fold_factor);
         os_ << "  " << name << "->dim(" << d << ").fold_factor = (index_t) " << e << ";\n";
       }

--- a/builder/rewrite.h
+++ b/builder/rewrite.h
@@ -543,18 +543,6 @@ template <typename T, bool = typename enable_pattern_ops<T>::type()>
 SLINKY_UNIQUE auto is_boolean(const T& x) { return make_predicate(x, slinky::is_boolean); }
 // clang-format on
 
-template <int N1, int N2>
-using buffer_dim_meta = pattern_call<pattern_wildcard<N1>, pattern_wildcard<N2>>;
-
-template <int N1, int N2>
-SLINKY_UNIQUE auto buffer_min(pattern_wildcard<N1> buf, pattern_wildcard<N2> dim) {
-  return buffer_dim_meta<N1, N2>{intrinsic::buffer_min, {buf, dim}};
-}
-template <int N1, int N2>
-SLINKY_UNIQUE auto buffer_max(pattern_wildcard<N1> buf, pattern_wildcard<N2> dim) {
-  return buffer_dim_meta<N1, N2>{intrinsic::buffer_max, {buf, dim}};
-}
-
 template <typename T>
 SLINKY_UNIQUE auto eval(const T& x) {
   return replacement_eval<T>{x};

--- a/builder/simplify.cc
+++ b/builder/simplify.cc
@@ -47,6 +47,16 @@ const expr& eval_buffer_intrinsic(intrinsic fn, const dim_expr& d) {
   }
 }
 
+const expr& eval_buffer_field(field_id field, const dim_expr& d) {
+  switch (field) {
+  case field_id::min: return d.bounds.min;
+  case field_id::max: return d.bounds.max;
+  case field_id::stride: return d.stride;
+  case field_id::fold_factor: return d.fold_factor;
+  default: std::abort();
+  }
+}
+
 bool deep_is_point(const interval_expr& x) { return x.is_point() || match(x.min, x.max); }
 
 // Ensure that an interval that is a point in a deep equality sense is also a point in a shallow equality sense.
@@ -526,66 +536,61 @@ public:
     symbol_map<expr_info>& vars;
     symbol_map<buffer_info>& buffers;
 
-    void add_var_info(var x, interval_expr bounds, alignment_type alignment = {}) {
-      std::optional<expr_info> info = vars.lookup(x);
-      if (!info) {
-        ensure_is_point(bounds);
-        info = {std::move(bounds), alignment};
+    void add_var_info(const variable* x, interval_expr bounds, alignment_type alignment = {}) {
+      if (x->field == field_id::none) {
+        std::optional<expr_info> info = vars.lookup(x->sym);
+        if (!info) {
+          ensure_is_point(bounds);
+          info = {std::move(bounds), alignment};
+        } else {
+          info->bounds = simplify_intersection(std::move(info->bounds), std::move(bounds));
+          info->alignment = info->alignment & alignment;
+        }
+        if (auto value = as_constant(info->bounds.as_point())) {
+          // The bounds tell us this is a constant point.
+          info->replacement = *value;
+        }
+        vk.push_back(set_value_in_scope(vars, x->sym, std::move(info)));
       } else {
-        info->bounds = simplify_intersection(std::move(info->bounds), std::move(bounds));
-        info->alignment = info->alignment & alignment;
-      }
-      if (auto value = as_constant(info->bounds.as_point())) {
-        // The bounds tell us this is a constant point.
-        info->replacement = *value;
-      }
-      vk.push_back(set_value_in_scope(vars, x, std::move(info)));
-    }
-
-    void set_call_value(const call* c, expr value) {
-      if (!is_buffer_intrinsic(c->intrinsic)) return;
-      if (!is_pure(value)) {
-        // TODO: Try to resolve the circular dependency that can result if we relax this constraint.
-        return;
-      }
-      assert(!c->args.empty());
-      auto buf = as_variable(c->args[0]);
-      assert(buf);
-      if (std::find_if(bk.begin(), bk.end(), [buf](const auto& i) { return i.sym() == *buf; }) == bk.end()) {
-        // Save the value if we haven't already, but we set the new values below.
-        bk.push_back(scoped_value_in_symbol_map<buffer_info>(buffers, *buf));
-      }
-      std::optional<buffer_info>& info = buffers[*buf];
-      if (is_buffer_dim_intrinsic(c->intrinsic)) {
-        assert(c->args.size() == 2);
-        auto dim = as_constant(c->args[1]);
-        assert(dim);
-        if (!info) {
-          info = buffer_info(*buf, *dim + 1);
-        } else {
-          info->init_dims(*buf, *dim + 1);
+        expr value = bounds.as_point();
+        if (!value.defined() || !is_pure(value)) {
+          // TODO: Try to resolve the circular dependency that can result if we relax this constraint.
+          return;
         }
-        switch (c->intrinsic) {
-        case intrinsic::buffer_min: info->dims[*dim].bounds.min = std::move(value); break;
-        case intrinsic::buffer_max: info->dims[*dim].bounds.max = std::move(value); break;
-        case intrinsic::buffer_stride: info->dims[*dim].stride = std::move(value); break;
-        case intrinsic::buffer_fold_factor: info->dims[*dim].fold_factor = std::move(value); break;
-        default: break;
+        var buf = x->sym;
+        if (std::find_if(bk.begin(), bk.end(), [buf](const auto& i) { return i.sym() == buf; }) == bk.end()) {
+          // Save the value if we haven't already, but we set the new values below.
+          bk.push_back(scoped_value_in_symbol_map<buffer_info>(buffers, buf));
         }
-      } else if (c->intrinsic == intrinsic::buffer_elem_size) {
-        if (!info) {
-          info = buffer_info(std::move(value));
-        } else {
-          info->elem_size = std::move(value);
-        }
-      } else if (c->intrinsic == intrinsic::buffer_rank) {
-        if (auto rank = as_constant(value)) {
+        std::optional<buffer_info>& info = buffers[buf];
+        if (x->dim >= 0) {
           if (!info) {
-            info = buffer_info(*buf, *rank);
+            info = buffer_info(buf, x->dim + 1);
           } else {
-            info->init_dims(*buf, *rank);
+            info->init_dims(buf, x->dim + 1);
           }
-          info->all_dims_known = true;
+          switch (x->field) {
+          case field_id::min: info->dims[x->dim].bounds.min = std::move(value); break;
+          case field_id::max: info->dims[x->dim].bounds.max = std::move(value); break;
+          case field_id::stride: info->dims[x->dim].stride = std::move(value); break;
+          case field_id::fold_factor: info->dims[x->dim].fold_factor = std::move(value); break;
+          default: break;
+          }
+        } else if (x->field == field_id::elem_size) {
+          if (!info) {
+            info = buffer_info(std::move(value));
+          } else {
+            info->elem_size = std::move(value);
+          }
+        } else if (x->field == field_id::rank) {
+          if (auto rank = as_constant(value)) {
+            if (!info) {
+              info = buffer_info(buf, *rank);
+            } else {
+              info->init_dims(buf, *rank);
+            }
+            info->all_dims_known = true;
+          }
         }
       }
     }
@@ -608,14 +613,12 @@ public:
 
     void learn_from_equal(const expr& a, const expr& b) {
       if (const variable* v = a.as<variable>()) {
-        add_var_info(v->sym, point(b));
-      } else if (const call* c = a.as<call>()) {
-        set_call_value(c, b);
+        add_var_info(v, point(b));
       } else if (const mod* md = a.as<mod>()) {
         if (const variable* v = md->a.as<variable>()) {
           if (auto m = as_constant(md->b)) {
             if (auto r = as_constant(b)) {
-              add_var_info(v->sym, {}, {*m, *r});
+              add_var_info(v, {}, {*m, *r});
             }
           }
         }
@@ -625,9 +628,7 @@ public:
         facts.push_back({a == b, true});
       }
       if (const variable* v = b.as<variable>()) {
-        add_var_info(v->sym, point(a));
-      } else if (const call* c = b.as<call>()) {
-        set_call_value(c, a);
+        add_var_info(v, point(a));
       }
     }
 
@@ -643,8 +644,8 @@ public:
       } else {
         const variable* av = a.as<variable>();
         const variable* bv = b.as<variable>();
-        if (av) add_var_info(av->sym, {expr(), simplify(static_cast<const add*>(nullptr), b, -1)});
-        if (bv) add_var_info(bv->sym, {simplify(static_cast<const add*>(nullptr), a, 1), expr()});
+        if (av) add_var_info(av, {expr(), simplify(static_cast<const add*>(nullptr), b, -1)});
+        if (bv) add_var_info(bv, {simplify(static_cast<const add*>(nullptr), a, 1), expr()});
         if (!(av || bv)) {
           // We couldn't learn from this, just remember it as a fact.
           facts.push_back({a < b, true});
@@ -663,8 +664,8 @@ public:
       } else {
         const variable* av = a.as<variable>();
         const variable* bv = b.as<variable>();
-        if (av) add_var_info(av->sym, {expr(), b});
-        if (bv) add_var_info(bv->sym, {a, expr()});
+        if (av) add_var_info(av, {expr(), b});
+        if (bv) add_var_info(bv, {a, expr()});
         if (!(av || bv)) {
           // We couldn't learn from this, just remember it as a fact.
           facts.push_back({a <= b, true});
@@ -783,23 +784,81 @@ public:
   bool prove_false(const expr& e) { return prove_constant_false(where_true(e).max); }
 
   void visit(const variable* op) override {
-    if (vars.contains(op->sym)) {
-      expr_info info = *vars[op->sym];
-      if (info.replacement.defined()) {
-        // TODO: This seems like it might be expensive, but it's the simplest way to get correct bounds and alignment
-        // information.
-        // TODO: Maybe we should intersect any information we already had with this?
-        mutate_and_set_result(info.replacement);
-      } else if (auto c = as_constant(info.bounds.as_point())) {
-        set_result(info.bounds.min, {point(info.bounds.min), alignment_type()});
-      } else {
-        if (!info.bounds.min.defined()) info.bounds.min = expr(op);
-        if (!info.bounds.max.defined()) info.bounds.max = expr(op);
-        set_result(op, std::move(info));
+    if (op->field != field_id::none) {
+      var new_sym = op->sym;
+      if (vars.contains(op->sym)) {
+        const expr_info& info = *vars[op->sym];
+        if (info.replacement.defined()) {
+          new_sym = info.replacement_sym();
+        }
+      }
+      const std::optional<buffer_info>& info = buffers[new_sym];
+      expr result = new_sym == op->sym ? expr(op) : variable::make(new_sym, op->field, op->dim);
+      expr bounds = result;
+      if (info) {
+        // TODO: We substitute here because we can't prove things like buffer_elem_size(x) == buffer_elem_size(y) where
+        // x is a crop of y. If we can fix that, we don't need to substitute here, which seems better.
+        auto visit_buffer_meta_value = [&, this](expr x) {
+          // There are many conditions in which we should substitute buffer meta:
+          // - We're being asked to substitute it (decl is undefined).
+          // - The value is something we should substitute (it's simple and pure).
+          // - The value is another buffer meta expression.
+          // - We're trying to prove something (as opposed to producing a simplified expression).
+          if (!info->decl.defined() || should_substitute(x) || x.as<call>() || (proving && x.defined())) {
+            if (!match(x, op)) {
+              // This is a value we should substitute, and it's different from what we started with.
+              mutate_and_set_result(x);
+              return true;
+            }
+          }
+          if (x.defined()) {
+            bounds = x;
+          }
+          return false;
+        };
+        switch (op->field) {
+        case field_id::elem_size:
+          if (visit_buffer_meta_value(info->elem_size)) return;
+          break;
+        case field_id::min:
+        case field_id::max:
+        case field_id::stride:
+        case field_id::fold_factor:
+          if (op->dim < static_cast<index_t>(info->dims.size())) {
+            const expr& value = eval_buffer_field(op->field, info->dims[op->dim]);
+            if (visit_buffer_meta_value(value)) return;
+          }
+          break;
+        default: break;
+        }
+      }
+      switch (op->field) {
+      case field_id::rank:
+      case field_id::elem_size: set_result(std::move(result), {{0, std::move(bounds)}, alignment_type()}); return;
+      case field_id::fold_factor: set_result(std::move(result), {{1, std::move(bounds)}, alignment_type()}); return;
+      default: set_result(std::move(result), {point(std::move(bounds)), alignment_type()}); return;
       }
     } else {
-      set_result(op, {point(expr(op)), alignment_type()});
+      if (vars.contains(op->sym)) {
+        expr_info info = *vars[op->sym];
+        if (info.replacement.defined()) {
+          // TODO: This seems like it might be expensive, but it's the simplest way to get correct bounds and alignment
+          // information.
+          // TODO: Maybe we should intersect any information we already had with this?
+          mutate_and_set_result(info.replacement);
+          return;
+        } else if (auto c = as_constant(info.bounds.as_point())) {
+          set_result(info.bounds.min, {point(info.bounds.min), alignment_type()});
+          return;
+        } else {
+          if (!info.bounds.min.defined()) info.bounds.min = expr(op);
+          if (!info.bounds.max.defined()) info.bounds.max = expr(op);
+          set_result(op, std::move(info));
+          return;
+        }
+      }
     }
+    set_result(op, {point(expr(op)), alignment_type()});
   }
 
   var visit_symbol(var x) {
@@ -1602,46 +1661,49 @@ public:
 
   // If d is equal to buffer_dim(sym, x), return x, otherwise return -1.
   int is_buffer_dim(const dim_expr& d, var sym) {
-    const call* min = match_call(d.bounds.min, intrinsic::buffer_min, sym);
-    if (min) {
+    int dim = -1;
+    if (is_buffer_field(d.bounds.min, field_id::min, sym)) {
+      dim = d.bounds.min.as<variable>()->dim;
+    } else if (const call* min = match_call(d.bounds.min, intrinsic::buffer_min, sym)) {
       assert(min->args.size() == 2);
-      auto dim = as_constant(min->args[1]);
-      assert(dim);
-      if (match_call(d.bounds.max, intrinsic::buffer_max, sym, *dim) &&
-          match_call(d.stride, intrinsic::buffer_stride, sym, *dim) &&
-          match_call(d.fold_factor, intrinsic::buffer_fold_factor, sym, *dim)) {
-        return *dim;
-      }
+      dim = *as_constant(min->args[1]);
+    } else {
+      return -1;
+    }
+    if (is_buffer_field(d.bounds.max, field_id::max, sym, dim) &&
+        is_buffer_field(d.stride, field_id::stride, sym, dim) &&
+        is_buffer_field(d.fold_factor, field_id::fold_factor, sym, dim)) {
+      return dim;
     }
     return -1;
   }
 
-  bool is_buffer_meta(const expr& x, const expr& value, intrinsic fn, var sym, int dim) {
-    return (!x.defined() && !value.defined()) || match_call(x, fn, sym, dim) || prove_true(x == value);
+  bool is_buffer_meta(const expr& x, const expr& value, field_id field, var sym, int dim) {
+    return (!x.defined() && !value.defined()) || is_buffer_field(x, field, sym, dim) || prove_true(x == value);
   }
 
   // Returns true if d can be represented as buffer_dim(sym, dim)
   bool is_buffer_dim(const dim_expr& d, const dim_expr& src, var sym, int dim) {
-    if (!is_buffer_meta(d.bounds.min, src.bounds.min, intrinsic::buffer_min, sym, dim)) return false;
-    if (!is_buffer_meta(d.bounds.max, src.bounds.max, intrinsic::buffer_max, sym, dim)) return false;
+    if (!is_buffer_meta(d.bounds.min, src.bounds.min, field_id::min, sym, dim)) return false;
+    if (!is_buffer_meta(d.bounds.max, src.bounds.max, field_id::max, sym, dim)) return false;
 
     if (prove_true(src.bounds.min == src.bounds.max)) {
       // The extent is 1, the stride and fold factor don't matter.
       return true;
     } else {
-      return is_buffer_meta(d.stride, src.stride, intrinsic::buffer_stride, sym, dim) &&
-             is_buffer_meta(d.fold_factor, src.fold_factor, intrinsic::buffer_fold_factor, sym, dim);
+      return is_buffer_meta(d.stride, src.stride, field_id::stride, sym, dim) &&
+             is_buffer_meta(d.fold_factor, src.fold_factor, field_id::fold_factor, sym, dim);
     }
   }
 
   // If we know that buffer metadata has some values, rewrite references to that dim to use buffer intrinsics
   // when those references use the same values.
-  void canonicalize_buffer_meta(expr& x, const expr& value, intrinsic fn, var sym) {
-    if (!match_call(x, fn, sym) && prove_true(x == value)) x = call::make(fn, {sym});
+  void canonicalize_buffer_meta(expr& x, const expr& value, field_id field, var sym) {
+    if (!is_buffer_field(x, field, sym) && prove_true(x == value)) x = variable::make(sym, field);
   }
   void canonicalize_buffer(buffer_info& buf, const buffer_info& src, var sym) {
     scoped_trace trace("canonicalize_buffer");
-    canonicalize_buffer_meta(buf.elem_size, src.elem_size, intrinsic::buffer_elem_size, sym);
+    canonicalize_buffer_meta(buf.elem_size, src.elem_size, field_id::elem_size, sym);
     for (int buf_d = 0; buf_d < static_cast<int>(buf.dims.size()); ++buf_d) {
       dim_expr& d = buf.dims[buf_d];
       // Try buf_d first, to prefer making identical buffers.
@@ -1724,8 +1786,8 @@ public:
         auto is_crop = [&]() {
           if (bc->args.size() > info.dims.size() + 1) return false;
           for (index_t d = 0; d < static_cast<index_t>(info.dims.size()); ++d) {
-            if (!match_call(info.dims[d].stride, intrinsic::buffer_stride, *src_buf, d) ||
-                !match_call(info.dims[d].fold_factor, intrinsic::buffer_fold_factor, *src_buf, d)) {
+            if (!is_buffer_field(info.dims[d].stride, field_id::stride, *src_buf, d) ||
+                !is_buffer_field(info.dims[d].fold_factor, field_id::fold_factor, *src_buf, d)) {
               return false;
             }
 
@@ -1950,8 +2012,9 @@ public:
     rewrite::pattern_wildcard<2> z;
     rewrite::pattern_wildcard<3> w;
     rewrite::match_context ctx;
-    if (match(ctx, select(buffer_max(x, y) < buffer_min(x, y), z, w), result.min)) {
-      if (is_variable(ctx.matched(x), buf) && is_constant(ctx.matched(y), dim)) {
+    if (match(ctx, select(x < y, z, w), result.min)) {
+      if (is_buffer_field(ctx.matched(x), field_id::max, buf, dim) &&
+          is_buffer_field(ctx.matched(y), field_id::min, buf, dim)) {
         // This select is a check that the dimension we are cropping is empty.
         // If the buffer is empty, it doesn't matter what we do, the resulting crop will still be empty, so we can
         // just take the new min.
@@ -1959,9 +2022,9 @@ public:
       }
     } else if (match(ctx, x + min(y, z), result.min)) {
       // This is the same as above, but the select was simplified.
-      if (match_call(ctx.matched(y), intrinsic::buffer_max, buf, dim) || match(ctx.matched(y), result.max)) {
+      if (is_buffer_field(ctx.matched(y), field_id::max, buf, dim) || match(ctx.matched(y), result.max)) {
         result.min = mutate(ctx.matched(x) + ctx.matched(z));
-      } else if (match_call(ctx.matched(z), intrinsic::buffer_max, buf, dim) || match(ctx.matched(z), result.max)) {
+      } else if (is_buffer_field(ctx.matched(z), field_id::max, buf, dim) || match(ctx.matched(z), result.max)) {
         result.min = mutate(ctx.matched(x) + ctx.matched(y));
       }
     }

--- a/builder/simplify.cc
+++ b/builder/simplify.cc
@@ -804,7 +804,7 @@ public:
           // - The value is something we should substitute (it's simple and pure).
           // - The value is another buffer meta expression.
           // - We're trying to prove something (as opposed to producing a simplified expression).
-          if (!info->decl.defined() || should_substitute(x) || x.as<call>() || (proving && x.defined())) {
+          if (!info->decl.defined() || should_substitute(x) || x.as<variable>() || (proving && x.defined())) {
             if (!match(x, op)) {
               // This is a value we should substitute, and it's different from what we started with.
               mutate_and_set_result(x);
@@ -1120,7 +1120,9 @@ public:
     }
   }
 
-  static bool should_substitute(const expr& e) { return e.as<constant>() || e.as<variable>(); }
+  static bool should_substitute(const expr& e) {
+    return e.as<constant>() || (e.as<variable>() && e.as<variable>()->field == field_id::none);
+  }
 
   void visit(const call* op) override {
     std::vector<expr> args;
@@ -1153,7 +1155,8 @@ public:
           // - The value is something we should substitute (it's simple and pure).
           // - The value is another buffer meta expression.
           // - We're trying to prove something (as opposed to producing a simplified expression).
-          if (!info->decl.defined() || should_substitute(x) || x.as<call>() || (proving && x.defined())) {
+          if (!info->decl.defined() || should_substitute(x) || x.as<call>() || x.as<variable>() ||
+              (proving && x.defined())) {
             if (!match(x, op)) {
               // This is a value we should substitute, and it's different from what we started with.
               mutate_and_set_result(x);

--- a/builder/simplify_bounds.cc
+++ b/builder/simplify_bounds.cc
@@ -413,9 +413,6 @@ interval_expr bounds_of(const call* op, std::vector<interval_expr> args) {
       expr abs_max = simplify(op, intrinsic::abs, {args[0].max});
       return {0, simplify(static_cast<const class max*>(nullptr), std::move(abs_min), std::move(abs_max))};
     }
-  case intrinsic::buffer_rank:
-  case intrinsic::buffer_elem_size: return {0, expr(op)};
-  case intrinsic::buffer_fold_factor: return {1, expr(op)};
   default: return point(expr(op));
   }
 }

--- a/builder/simplify_exprs.cc
+++ b/builder/simplify_exprs.cc
@@ -346,8 +346,10 @@ expr simplify(const call* op, intrinsic fn, std::vector<expr> args) {
     }
   } else if (fn == intrinsic::buffer_at) {
     for (index_t d = 1; d < static_cast<index_t>(args.size()); ++d) {
+      auto buf = as_variable(args[0]);
+      assert(buf);
       // buffer_at(b, buffer_min(b, 0)) is equivalent to buffer_at(b, <>)
-      if (args[d].defined() && match(args[d], buffer_min(args[0], d - 1))) {
+      if (args[d].defined() && is_buffer_field(args[d], field_id::min, *buf, d - 1)) {
         args[d] = expr();
         changed = true;
       }

--- a/builder/simplify_exprs.cc
+++ b/builder/simplify_exprs.cc
@@ -349,7 +349,7 @@ expr simplify(const call* op, intrinsic fn, std::vector<expr> args) {
       auto buf = as_variable(args[0]);
       assert(buf);
       // buffer_at(b, buffer_min(b, 0)) is equivalent to buffer_at(b, <>)
-      if (args[d].defined() && is_buffer_field(args[d], field_id::min, *buf, d - 1)) {
+      if (args[d].defined() && is_variable(args[d], *buf, field_id::min, d - 1)) {
         args[d] = expr();
         changed = true;
       }

--- a/builder/simplify_exprs.cc
+++ b/builder/simplify_exprs.cc
@@ -349,7 +349,7 @@ expr simplify(const call* op, intrinsic fn, std::vector<expr> args) {
       auto buf = as_variable(args[0]);
       assert(buf);
       // buffer_at(b, buffer_min(b, 0)) is equivalent to buffer_at(b, <>)
-      if (args[d].defined() && is_variable(args[d], *buf, field_id::min, d - 1)) {
+      if (args[d].defined() && is_variable(args[d], *buf, buffer_field::min, d - 1)) {
         args[d] = expr();
         changed = true;
       }

--- a/builder/slide_and_fold_storage.cc
+++ b/builder/slide_and_fold_storage.cc
@@ -304,9 +304,8 @@ public:
     // TODO: Is this actually a good design...?
     const std::vector<dim_fold_info>& fold_info = *fold_factors[op->sym];
     std::vector<std::pair<expr, expr>> replacements;
-    expr alloc_var = variable::make(op->sym);
     for (index_t d = 0; d < static_cast<index_t>(op->dims.size()); ++d) {
-      replacements.emplace_back(buffer_fold_factor(alloc_var, d), fold_info[d].factor);
+      replacements.emplace_back(buffer_fold_factor(op->sym, d), fold_info[d].factor);
     }
     std::vector<dim_expr> dims = recursive_substitute(op->dims, replacements);
     // Replace infinite fold factors with undefined.

--- a/builder/substitute.cc
+++ b/builder/substitute.cc
@@ -599,13 +599,17 @@ void substitutor::visit(const call* op) {
         args.pop_back();
         changed = true;
       }
-    }
 
-    expr result = changed ? call::make(op->intrinsic, args) : expr(op);
-    set_result(mutate_buffer_intrinsic(result.as<call>(), op->intrinsic, *buf, span<const expr>(args).subspan(1)));
-    return;
-  }
-  if (changed) {
+      if (changed) {
+        set_result(call::make(op->intrinsic, args));
+      } else {
+        set_result(expr(op));
+      }
+    } else {
+      expr result = changed ? call::make(op->intrinsic, args) : expr(op);
+      set_result(mutate_buffer_intrinsic(result.as<call>(), op->intrinsic, *buf, span<const expr>(args).subspan(1)));
+    }
+  } else if (changed) {
     set_result(call::make(op->intrinsic, std::move(args)));
   } else {
     set_result(op);

--- a/builder/substitute.cc
+++ b/builder/substitute.cc
@@ -11,7 +11,6 @@
 #include "builder/node_mutator.h"
 #include "runtime/depends_on.h"
 #include "runtime/expr.h"
-#include "runtime/print.h"
 
 namespace slinky {
 
@@ -733,7 +732,7 @@ public:
     case buffer_field::stride:
     case buffer_field::fold_factor:
       return dim < static_cast<index_t>(dims.size()) ? dims[dim].get_field(field) : expr(op);
-    default: std::cerr << "substituting " << field << " not implemented " << std::endl; std::abort();
+    case buffer_field::none: std::abort();
     }
     return expr(op);
   }

--- a/builder/substitute.cc
+++ b/builder/substitute.cc
@@ -320,22 +320,6 @@ bool match(stmt_ref a, stmt_ref b) { return matcher().try_match(a.get(), b.get()
 bool match(const interval_expr& a, const interval_expr& b) { return matcher().try_match(a, b); }
 bool match(const dim_expr& a, const dim_expr& b) { return matcher().try_match(a, b); }
 
-bool is_buffer_field(expr_ref x, field_id field, var b) {
-  if (const variable* v = x.as<variable>()) {
-    return v->sym == b && v->field == field;
-  } else {
-    return false;
-  }
-}
-
-bool is_buffer_field(expr_ref x, field_id field, var b, int dim) {
-  if (const variable* v = x.as<variable>()) {
-    return v->sym == b && v->field == field && v->dim == dim;
-  } else {
-    return false;
-  }
-}
-
 int compare(const var& a, const var& b) {
   matcher m;
   m.try_match(a, b);

--- a/builder/substitute.cc
+++ b/builder/substitute.cc
@@ -320,33 +320,11 @@ bool match(stmt_ref a, stmt_ref b) { return matcher().try_match(a.get(), b.get()
 bool match(const interval_expr& a, const interval_expr& b) { return matcher().try_match(a, b); }
 bool match(const dim_expr& a, const dim_expr& b) { return matcher().try_match(a, b); }
 
-const call* match_call(expr_ref x, intrinsic fn, var a) {
-  const call* c = as_intrinsic(x, fn);
-  if (!c) return nullptr;
-
-  assert(c->args.size() >= 1);
-  auto av = as_variable(c->args[0]);
-  if (!av || *av != a) return nullptr;
-
-  return c;
-}
-
-const call* match_call(expr_ref x, intrinsic fn, var a, index_t b) {
-  const call* c = match_call(x, fn, a);
-  if (!c) return nullptr;
-
-  assert(c->args.size() >= 2);
-  auto bv = as_constant(c->args[1]);
-  if (!bv || *bv != b) return nullptr;
-
-  return c;
-}
-
 bool is_buffer_field(expr_ref x, field_id field, var b) {
   if (const variable* v = x.as<variable>()) {
     return v->sym == b && v->field == field;
   } else {
-    return match_call(x, to_intrinsic(field), b);
+    return false;
   }
 }
 
@@ -354,7 +332,7 @@ bool is_buffer_field(expr_ref x, field_id field, var b, int dim) {
   if (const variable* v = x.as<variable>()) {
     return v->sym == b && v->field == field && v->dim == dim;
   } else {
-    return match_call(x, to_intrinsic(field), b, dim);
+    return false;
   }
 }
 

--- a/builder/substitute.cc
+++ b/builder/substitute.cc
@@ -726,6 +726,7 @@ public:
     if (buf != target) return expr(op);
 
     switch (field) {
+    case field_id::rank: return expr(dims.size());
     case field_id::elem_size: return elem_size.defined() ? elem_size : expr(op);
     case field_id::min:
     case field_id::max:

--- a/builder/substitute.h
+++ b/builder/substitute.h
@@ -18,8 +18,6 @@ SLINKY_ALWAYS_INLINE SLINKY_UNIQUE bool match(index_t a, var b) { return false; 
 bool match(stmt_ref a, stmt_ref b);
 bool match(const interval_expr& a, const interval_expr& b);
 bool match(const dim_expr& a, const dim_expr& b);
-bool is_buffer_field(expr_ref x, field_id field, var b);
-bool is_buffer_field(expr_ref x, field_id field, var b, int dim);
 
 // Compute a sort ordering of two nodes based on their structure (not their values).
 int compare(const var& a, const var& b);
@@ -40,7 +38,7 @@ public:
   virtual var visit_symbol(var x) { return x; }
 
   // Implementation of substitution for buffer fields.
-  virtual expr mutate_buffer_field(const variable* op, field_id field, var buf, int dim) { return expr(op); }
+  virtual expr mutate_variable(const variable* op, var buf, field_id field, int dim) { return expr(op); }
 
   // The implementation must provide the maximum rank of any substitution of buffer metadata for x.
   virtual std::size_t get_target_buffer_rank(var x) { return 0; }

--- a/builder/substitute.h
+++ b/builder/substitute.h
@@ -38,7 +38,7 @@ public:
   virtual var visit_symbol(var x) { return x; }
 
   // Implementation of substitution for buffer fields.
-  virtual expr mutate_variable(const variable* op, var buf, field_id field, int dim) { return expr(op); }
+  virtual expr mutate_variable(const variable* op, var buf, buffer_field field, int dim) { return expr(op); }
 
   // The implementation must provide the maximum rank of any substitution of buffer metadata for x.
   virtual std::size_t get_target_buffer_rank(var x) { return 0; }

--- a/builder/substitute.h
+++ b/builder/substitute.h
@@ -20,6 +20,8 @@ bool match(const interval_expr& a, const interval_expr& b);
 bool match(const dim_expr& a, const dim_expr& b);
 const call* match_call(expr_ref x, intrinsic fn, var a);
 const call* match_call(expr_ref x, intrinsic fn, var a, index_t b);
+bool is_buffer_field(expr_ref x, field_id field, var b);
+bool is_buffer_field(expr_ref x, field_id field, var b, int dim);
 
 // Compute a sort ordering of two nodes based on their structure (not their values).
 int compare(const var& a, const var& b);
@@ -39,11 +41,8 @@ public:
   // Implementation of substitution for vars.
   virtual var visit_symbol(var x) { return x; }
 
-  // Implementation of substitution for buffer intrinsics.
-  virtual expr mutate_buffer_intrinsic(const call* op, intrinsic fn, var buf, span<const expr> args) {
-    return expr(op);
-  }
-  virtual expr mutate_buffer_dim_intrinsic(const call* op, intrinsic fn, var buf, int dim) { return expr(op); }
+  // Implementation of substitution for buffer fields.
+  virtual expr mutate_buffer_field(const variable* op, field_id field, var buf, int dim) { return expr(op); }
 
   // The implementation must provide the maximum rank of any substitution of buffer metadata for x.
   virtual std::size_t get_target_buffer_rank(var x) { return 0; }

--- a/builder/substitute.h
+++ b/builder/substitute.h
@@ -18,8 +18,6 @@ SLINKY_ALWAYS_INLINE SLINKY_UNIQUE bool match(index_t a, var b) { return false; 
 bool match(stmt_ref a, stmt_ref b);
 bool match(const interval_expr& a, const interval_expr& b);
 bool match(const dim_expr& a, const dim_expr& b);
-const call* match_call(expr_ref x, intrinsic fn, var a);
-const call* match_call(expr_ref x, intrinsic fn, var a, index_t b);
 bool is_buffer_field(expr_ref x, field_id field, var b);
 bool is_buffer_field(expr_ref x, field_id field, var b, int dim);
 

--- a/builder/test/replica_pipeline.cc
+++ b/builder/test/replica_pipeline.cc
@@ -27,7 +27,7 @@ auto p = []() -> ::slinky::pipeline {
   auto j = var(ctx, "j");
   auto ab = buffer_expr::make(ctx, "ab", /*rank=*/2, /*elem_size=*/4);
   ab->dim(1).stride = 4;
-  auto _2 = variable::make(a->sym());
+  auto _2 = a->sym();
   auto _replica_fn_3 = [=](const buffer<const void>& i0, const buffer<const void>& i1, const buffer<void>& o0) -> index_t {
     const buffer<const void>* input_buffers[] = {&i0, &i1};
     const buffer<void>* output_buffers[] = {&o0};
@@ -36,7 +36,7 @@ auto p = []() -> ::slinky::pipeline {
     return ::slinky::internal::replica_pipeline_handler(input_buffers, output_buffers, inputs, outputs);
   };
   auto _fn_1 = func::make(std::move(_replica_fn_3), {{a, {point(i), {(buffer_min(_2, 1)), (buffer_max(_2, 1))}}}, {b, {{(buffer_min(_2, 1)), (buffer_max(_2, 1))}, point(j)}}}, {{ab, {i, j}}}, {});
-  auto _4 = variable::make(c->sym());
+  auto _4 = c->sym();
   auto _replica_fn_5 = [=](const buffer<const void>& i0, const buffer<const void>& i1, const buffer<void>& o0) -> index_t {
     const buffer<const void>* input_buffers[] = {&i0, &i1};
     const buffer<void>* output_buffers[] = {&o0};
@@ -135,7 +135,7 @@ auto p = []() -> ::slinky::pipeline {
   auto sum_x = buffer_expr::make(ctx, "sum_x", /*rank=*/2, /*elem_size=*/4);
   auto y = var(ctx, "y");
   auto z = var(ctx, "z");
-  auto _1 = variable::make(in->sym());
+  auto _1 = in->sym();
   auto _replica_fn_2 = [=](const buffer<const void>& i0, const buffer<void>& o0, const buffer<void>& o1) -> index_t {
     const buffer<const void>* input_buffers[] = {&i0};
     const buffer<void>* output_buffers[] = {&o0, &o1};
@@ -270,7 +270,7 @@ auto p = []() -> ::slinky::pipeline {
     return ::slinky::internal::replica_pipeline_handler(input_buffers, output_buffers, inputs, outputs);
   };
   auto _fn_1 = func::make(std::move(_replica_fn_2), {{in1, {point(x), point(y)}}}, {{intm1, {x, y}}}, {});
-  auto _3 = variable::make(in1->sym());
+  auto _3 = in1->sym();
   auto intm2 = buffer_expr::make(ctx, "intm2", /*rank=*/2, /*elem_size=*/2);
   auto _replica_fn_5 = [=](const buffer<const void>& i0, const buffer<void>& o0) -> index_t {
     const buffer<const void>* input_buffers[] = {&i0};
@@ -280,7 +280,7 @@ auto p = []() -> ::slinky::pipeline {
     return ::slinky::internal::replica_pipeline_handler(input_buffers, output_buffers, inputs, outputs);
   };
   auto _fn_4 = func::make(std::move(_replica_fn_5), {{in2, {point(x), point(y)}}}, {{intm2, {x, y}}}, {});
-  auto _6 = variable::make(out->sym());
+  auto _6 = out->sym();
   auto _fn_0 = func::make_copy({{intm1, {point(x), point(((y - 0)))}, {point(expr()), {0, (((((((((buffer_max(_3, 1)) - (buffer_min(_3, 1)))) + 1)) - 0)) - 1))}}, {point(expr()), {0, (((((((buffer_max(_3, 1)) - (buffer_min(_3, 1)))) + 1)) - 1))}}, {}}, {intm2, {point(x), point(((y - (((((buffer_max(_3, 1)) - (buffer_min(_3, 1)))) + 1)))))}, {point(expr()), {0, (((((((((buffer_max(_6, 1)) - (buffer_min(_6, 1)))) + 1)) - (((((buffer_max(_3, 1)) - (buffer_min(_3, 1)))) + 1)))) - 1))}}, {point(expr()), {(((((buffer_max(_3, 1)) - (buffer_min(_3, 1)))) + 1)), (((((((buffer_max(_6, 1)) - (buffer_min(_6, 1)))) + 1)) - 1))}}, {}}}, {out, {x, y}});
   auto p = build_pipeline(ctx, {}, {in1, in2}, {out}, {}, {.no_alias_buffers = true});
   return p;
@@ -382,7 +382,7 @@ auto p = []() -> ::slinky::pipeline {
     return ::slinky::internal::replica_pipeline_handler(input_buffers, output_buffers, inputs, outputs);
   };
   auto _fn_2 = func::make(std::move(_replica_fn_3), {{in, {point(x), point(y)}}}, {{intm, {x, y}}}, {});
-  auto _4 = variable::make(in->sym());
+  auto _4 = in->sym();
   auto _fn_1 = func::make_copy({intm, {point(x), point(y)}, {{(buffer_min(_4, 0)), (buffer_max(_4, 0))}, {(buffer_min(_4, 1)), (buffer_max(_4, 1))}}, {}, {}}, {padded_intm, {x, y}}, {6, 0});
   _fn_1.compute_root();
   auto _replica_fn_5 = [=](const buffer<const void>& i0, const buffer<void>& o0) -> index_t {

--- a/builder/test/substitute.cc
+++ b/builder/test/substitute.cc
@@ -27,6 +27,7 @@ TEST(substitute, basic) {
   ASSERT_THAT(substitute(x + y, x, z), matches(z + y));
   ASSERT_THAT(substitute(buffer_min(x, 2), x, y), matches(buffer_min(y, 2)));
   ASSERT_THAT(substitute(buffer_min(x, 2), buffer_min(x, 2), buffer_max(x, 2)), matches(buffer_max(x, 2)));
+  ASSERT_THAT(substitute(buffer_at(x), x, expr()), matches(buffer_at(expr())));
   ASSERT_THAT(substitute(crop_dim::make(x, y, 0, {0, 0}, call_stmt::make(nullptr, {}, {x}, {})), y, z),
       matches(crop_dim::make(x, z, 0, interval_expr{0, 0}, call_stmt::make(nullptr, {}, {x}, {}))));
   ASSERT_THAT(substitute(crop_dim::make(y, z, 0, {0, 0}, call_stmt::make(nullptr, {x}, {y}, {})), x, w),

--- a/builder/test/substitute.cc
+++ b/builder/test/substitute.cc
@@ -40,6 +40,7 @@ TEST(substitute, basic) {
   ASSERT_THAT(substitute_buffer(buffer_stride(x, 0), x, expr(), {}), matches(buffer_stride(x, 0)));
   ASSERT_THAT(substitute_buffer(buffer_stride(x, 0), x, expr(), {{{0, 1}, 2, 3}}), matches(2));
   ASSERT_THAT(substitute_buffer(buffer_stride(x, 0), x, expr(), {dim_expr()}), matches(expr()));
+  ASSERT_THAT(substitute_buffer(buffer_rank(x), x, expr(), {dim_expr(), dim_expr()}), matches(2));
 }
 
 TEST(substitute, shadowed) {

--- a/builder/test/substitute.cc
+++ b/builder/test/substitute.cc
@@ -25,6 +25,8 @@ MATCHER_P(matches, expected, "") { return match(arg, expected); }
 
 TEST(substitute, basic) {
   ASSERT_THAT(substitute(x + y, x, z), matches(z + y));
+  ASSERT_THAT(substitute(buffer_min(x, 2), x, y), matches(buffer_min(y, 2)));
+  ASSERT_THAT(substitute(buffer_min(x, 2), buffer_min(x, 2), buffer_max(x, 2)), matches(buffer_max(x, 2)));
   ASSERT_THAT(substitute(crop_dim::make(x, y, 0, {0, 0}, call_stmt::make(nullptr, {}, {x}, {})), y, z),
       matches(crop_dim::make(x, z, 0, interval_expr{0, 0}, call_stmt::make(nullptr, {}, {x}, {}))));
   ASSERT_THAT(substitute(crop_dim::make(y, z, 0, {0, 0}, call_stmt::make(nullptr, {x}, {y}, {})), x, w),

--- a/runtime/depends_on.cc
+++ b/runtime/depends_on.cc
@@ -40,19 +40,19 @@ public:
   depends_on_result* no_dummy(depends_on_result* deps) const { return deps != &dummy_deps ? deps : nullptr; }
 
   void visit(const variable* op) override {
-    if (is_pure && op->field != field_id::none) is_pure = false;
+    if (is_pure && op->field != buffer_field::none) is_pure = false;
     if (depends_on_result* deps = find_deps(op->sym)) {
       switch (op->field) {
-      case field_id::none: deps->var = true; break;
-      case field_id::min:
-      case field_id::max:
+      case buffer_field::none: deps->var = true; break;
+      case buffer_field::min:
+      case buffer_field::max:
         deps->buffer_bounds = true;
         deps->buffer_dims = true;
         break;
-      case field_id::stride:
-      case field_id::fold_factor: deps->buffer_dims = true; break;
-      case field_id::rank:
-      case field_id::elem_size: deps->var = true; break;
+      case buffer_field::stride:
+      case buffer_field::fold_factor: deps->buffer_dims = true; break;
+      case buffer_field::rank:
+      case buffer_field::elem_size: deps->var = true; break;
       default: std::abort();
       }
     }

--- a/runtime/depends_on.cc
+++ b/runtime/depends_on.cc
@@ -49,8 +49,11 @@ public:
         break;
       case field_id::stride:
       case field_id::fold_factor: deps->buffer_dims = true; break;
+      case field_id::rank:
+      case field_id::elem_size:
       case field_id::size_bytes:
-      default: deps->var = true;
+      case field_id::none: deps->var = true; break;
+      default: std::abort();
       }
     }
   }
@@ -71,7 +74,8 @@ public:
           if (op->intrinsic == intrinsic::buffer_at) {
             deps->buffer_base = true;
           }
-          if (op->intrinsic == intrinsic::buffer_size_bytes) {
+          if (op->intrinsic == intrinsic::buffer_size_bytes || op->intrinsic == intrinsic::buffer_rank ||
+              op->intrinsic == intrinsic::buffer_elem_size) {
             deps->var = true;
           }
         }

--- a/runtime/depends_on.cc
+++ b/runtime/depends_on.cc
@@ -40,8 +40,10 @@ public:
   depends_on_result* no_dummy(depends_on_result* deps) const { return deps != &dummy_deps ? deps : nullptr; }
 
   void visit(const variable* op) override {
+    if (is_pure && op->field != field_id::none) is_pure = false;
     if (depends_on_result* deps = find_deps(op->sym)) {
       switch (op->field) {
+      case field_id::none: deps->var = true; break;
       case field_id::min:
       case field_id::max:
         deps->buffer_bounds = true;
@@ -51,8 +53,7 @@ public:
       case field_id::fold_factor: deps->buffer_dims = true; break;
       case field_id::rank:
       case field_id::elem_size:
-      case field_id::size_bytes:
-      case field_id::none: deps->var = true; break;
+      case field_id::size_bytes: deps->var = true; break;
       default: std::abort();
       }
     }

--- a/runtime/depends_on.cc
+++ b/runtime/depends_on.cc
@@ -41,7 +41,17 @@ public:
 
   void visit(const variable* op) override {
     if (depends_on_result* deps = find_deps(op->sym)) {
-      deps->var = true;
+      switch (op->field) {
+      case field_id::min:
+      case field_id::max:
+        deps->buffer_bounds = true;
+        deps->buffer_dims = true;
+        break;
+      case field_id::stride:
+      case field_id::fold_factor: deps->buffer_dims = true; break;
+      case field_id::size_bytes:
+      default: deps->var = true;
+      }
     }
   }
   void visit(const call* op) override {

--- a/runtime/evaluate.cc
+++ b/runtime/evaluate.cc
@@ -157,16 +157,16 @@ public:
   index_t eval(const variable* op) {
     auto value = context.lookup(op->sym);
     assert(value);
-    if (op->field == field_id::none) return *value;
+    if (op->field == buffer_field::none) return *value;
 
     const raw_buffer* buf = reinterpret_cast<const raw_buffer*>(*value);
     switch (op->field) {
-    case field_id::rank: return buf->rank;
-    case field_id::elem_size: return buf->elem_size;
-    case field_id::min: return buf->dim(op->dim).min();
-    case field_id::max: return buf->dim(op->dim).max();
-    case field_id::stride: return buf->dim(op->dim).stride();
-    case field_id::fold_factor: return buf->dim(op->dim).fold_factor();
+    case buffer_field::rank: return buf->rank;
+    case buffer_field::elem_size: return buf->elem_size;
+    case buffer_field::min: return buf->dim(op->dim).min();
+    case buffer_field::max: return buf->dim(op->dim).max();
+    case buffer_field::stride: return buf->dim(op->dim).stride();
+    case buffer_field::fold_factor: return buf->dim(op->dim).fold_factor();
     default: std::abort();
     }
   }

--- a/runtime/evaluate.cc
+++ b/runtime/evaluate.cc
@@ -238,28 +238,7 @@ public:
     raw_buffer* buf = reinterpret_cast<raw_buffer*>(*context.lookup(*sym));
     assert(buf);
     switch (op->intrinsic) {
-    case intrinsic::buffer_rank: return buf->rank;
-    case intrinsic::buffer_elem_size: return buf->elem_size;
     case intrinsic::buffer_size_bytes: return buf->size_bytes();
-    default: std::abort();
-    }
-  }
-
-  index_t eval_dim_metadata(const call* op) {
-    assert(op->args.size() == 2);
-    auto sym = as_variable(op->args[0]);
-    assert(sym);
-    auto d = as_constant(op->args[1]);
-    assert(d);
-    raw_buffer* buffer = reinterpret_cast<raw_buffer*>(*context.lookup(*sym));
-    assert(buffer);
-    assert(*d < static_cast<index_t>(buffer->rank));
-    const slinky::dim& dim = buffer->dim(*d);
-    switch (op->intrinsic) {
-    case intrinsic::buffer_min: return dim.min();
-    case intrinsic::buffer_max: return dim.max();
-    case intrinsic::buffer_stride: return dim.stride();
-    case intrinsic::buffer_fold_factor: return dim.fold_factor();
     default: std::abort();
     }
   }
@@ -366,14 +345,7 @@ public:
 
     case intrinsic::define_undef: return eval_define_undef(op);
 
-    case intrinsic::buffer_rank:
-    case intrinsic::buffer_elem_size:
     case intrinsic::buffer_size_bytes: return eval_buffer_metadata(op);
-
-    case intrinsic::buffer_min:
-    case intrinsic::buffer_max:
-    case intrinsic::buffer_stride:
-    case intrinsic::buffer_fold_factor: return eval_dim_metadata(op);
 
     case intrinsic::buffer_at: return reinterpret_cast<index_t>(eval_buffer_at(op));
 

--- a/runtime/evaluate.cc
+++ b/runtime/evaluate.cc
@@ -162,7 +162,6 @@ public:
     case field_id::none: return *value;
     case field_id::rank: return buf->rank;
     case field_id::elem_size: return buf->elem_size;
-    case field_id::size_bytes: return buf->size_bytes();
     case field_id::min: return buf->dim(op->dim).min();
     case field_id::max: return buf->dim(op->dim).max();
     case field_id::stride: return buf->dim(op->dim).stride();
@@ -346,7 +345,6 @@ public:
     case intrinsic::define_undef: return eval_define_undef(op);
 
     case intrinsic::buffer_size_bytes: return eval_buffer_metadata(op);
-
     case intrinsic::buffer_at: return reinterpret_cast<index_t>(eval_buffer_at(op));
 
     case intrinsic::semaphore_init: return eval_semaphore_init(op);

--- a/runtime/evaluate.cc
+++ b/runtime/evaluate.cc
@@ -157,18 +157,18 @@ public:
   index_t eval(const variable* op) {
     auto value = context.lookup(op->sym);
     assert(value);
+    if (op->field == field_id::none) return *value;
+
     const raw_buffer* buf = reinterpret_cast<const raw_buffer*>(*value);
     switch (op->field) {
-    case field_id::none: return *value;
     case field_id::rank: return buf->rank;
     case field_id::elem_size: return buf->elem_size;
     case field_id::min: return buf->dim(op->dim).min();
     case field_id::max: return buf->dim(op->dim).max();
     case field_id::stride: return buf->dim(op->dim).stride();
     case field_id::fold_factor: return buf->dim(op->dim).fold_factor();
+    default: std::abort();
     }
-    std::cout << "Unknown meta: " << op->field << " " << op->dim << std::endl;
-    std::abort();
   }
 
   static index_t eval(const constant* op) { return op->value; }

--- a/runtime/expr.h
+++ b/runtime/expr.h
@@ -144,6 +144,19 @@ enum class intrinsic {
   free,
 };
 
+inline intrinsic to_intrinsic(field_id field) {
+  switch (field) {
+  case field_id::min: return intrinsic::buffer_min;
+  case field_id::max: return intrinsic::buffer_max;
+  case field_id::stride: return intrinsic::buffer_stride;
+  case field_id::fold_factor: return intrinsic::buffer_fold_factor;
+  case field_id::rank: return intrinsic::buffer_rank;
+  case field_id::elem_size: return intrinsic::buffer_elem_size;
+  case field_id::size_bytes: return intrinsic::buffer_size_bytes;
+  default: std::abort();
+  }
+}
+
 class expr_visitor;
 
 // The next few classes are the base of the expression (`expr`) and statement (`stmt`) mechanism.
@@ -663,13 +676,18 @@ interval_expr align(interval_expr x, const expr& a);
 expr and_then(std::vector<expr> args);
 expr or_else(std::vector<expr> args);
 
-expr buffer_rank(expr buf);
-expr buffer_elem_size(expr buf);
-expr buffer_min(expr buf, expr dim);
-expr buffer_max(expr buf, expr dim);
-expr buffer_extent(const expr& buf, const expr& dim);
-expr buffer_stride(expr buf, expr dim);
-expr buffer_fold_factor(expr buf, expr dim);
+expr buffer_rank(var buf);
+expr buffer_elem_size(var buf);
+expr buffer_min(var buf, int dim);
+expr buffer_max(var buf, int dim);
+expr buffer_extent(var buf, int dim);
+expr buffer_stride(var buf, int dim);
+expr buffer_fold_factor(var buf, int dim);
+
+interval_expr buffer_bounds(var buf, int dim);
+dim_expr buffer_dim(var buf, int dim);
+std::vector<dim_expr> buffer_dims(var buf, int rank);
+
 expr buffer_at(expr buf, span<const expr> at);
 expr buffer_at(expr buf, span<const var> at);
 expr buffer_at(expr buf);
@@ -679,10 +697,6 @@ expr buffer_at(expr buf, expr at0, Args... at) {
   expr args[] = {at0, at...};
   return buffer_at(buf, args);
 }
-
-interval_expr buffer_bounds(const expr& buf, const expr& dim);
-dim_expr buffer_dim(const expr& buf, const expr& dim);
-std::vector<dim_expr> buffer_dims(const expr& buf, int rank);
 
 box_expr dims_bounds(span<const dim_expr> dims);
 

--- a/runtime/expr.h
+++ b/runtime/expr.h
@@ -373,7 +373,7 @@ public:
   // The variable being referenced.
   var sym;
 
-  // THe field of the variable being referenced, if any (field != buffer_field::none).
+  // The field of the variable being referenced, if any (field != buffer_field::none).
   buffer_field field;
 
   // If `field` is a per-dimension field, which dimension being referenced.

--- a/runtime/expr.h
+++ b/runtime/expr.h
@@ -21,6 +21,19 @@ namespace slinky {
 class node_context;
 class expr;
 
+enum class field_id : unsigned {
+  none = 0,
+
+  rank,
+  elem_size,
+  size_bytes,
+
+  min,
+  max,
+  stride,
+  fold_factor,
+};
+
 class var {
 public:
   using type = std::size_t;
@@ -367,10 +380,13 @@ public:
 class variable : public expr_node<variable> {
 public:
   var sym;
+  field_id field;
+  int dim;
 
   void accept(expr_visitor* v) const override;
 
   static expr make(var sym);
+  static expr make(var sym, field_id field, int dim = -1);
 
   static constexpr expr_node_type static_type = expr_node_type::variable;
 };

--- a/runtime/expr.h
+++ b/runtime/expr.h
@@ -26,7 +26,6 @@ enum class field_id : unsigned {
 
   rank,
   elem_size,
-  size_bytes,
 
   min,
   max,
@@ -114,16 +113,8 @@ enum class intrinsic {
   // `define_undef(x, def)` means that undefined expressions take the value `def` when evaluating `x`.
   define_undef,
 
-  // Functions with arguments (buf) that return buffer metadata.
-  buffer_rank,
-  buffer_elem_size,
+  // Returns the size of a buffer in bytes.
   buffer_size_bytes,
-
-  // Functions with arguments (buf, dim) that return dim metadata of a buffer.
-  buffer_min,
-  buffer_max,
-  buffer_stride,
-  buffer_fold_factor,
 
   // This function returns the address of the element x in (buf, x_0, x_1, ...). x can be any rank, including 0.
   buffer_at,
@@ -143,19 +134,6 @@ enum class intrinsic {
   // Free a buffer.
   free,
 };
-
-inline intrinsic to_intrinsic(field_id field) {
-  switch (field) {
-  case field_id::min: return intrinsic::buffer_min;
-  case field_id::max: return intrinsic::buffer_max;
-  case field_id::stride: return intrinsic::buffer_stride;
-  case field_id::fold_factor: return intrinsic::buffer_fold_factor;
-  case field_id::rank: return intrinsic::buffer_rank;
-  case field_id::elem_size: return intrinsic::buffer_elem_size;
-  case field_id::size_bytes: return intrinsic::buffer_size_bytes;
-  default: std::abort();
-  }
-}
 
 class expr_visitor;
 
@@ -631,7 +609,6 @@ SLINKY_ALWAYS_INLINE SLINKY_UNIQUE const call* as_intrinsic(expr_ref x, intrinsi
   return c && c->intrinsic == fn ? c : nullptr;
 }
 bool is_buffer_intrinsic(intrinsic fn);
-bool is_buffer_dim_intrinsic(intrinsic fn);
 
 bool is_positive_infinity(expr_ref x);
 bool is_negative_infinity(expr_ref x);

--- a/runtime/expr.h
+++ b/runtime/expr.h
@@ -577,7 +577,7 @@ SLINKY_ALWAYS_INLINE SLINKY_UNIQUE std::optional<index_t> as_constant(expr_ref x
 // If `x` is a variable, returns the `var` of the variable, otherwise `nullopt`.
 SLINKY_ALWAYS_INLINE SLINKY_UNIQUE std::optional<var> as_variable(expr_ref x) {
   const variable* vx = x.as<variable>();
-  if (vx) {
+  if (vx && vx->field == field_id::none) {
     return vx->sym;
   } else {
     return std::nullopt;
@@ -587,8 +587,11 @@ SLINKY_ALWAYS_INLINE SLINKY_UNIQUE std::optional<var> as_variable(expr_ref x) {
 // Check if `x` is a variable equal to the symbol `sym`.
 SLINKY_ALWAYS_INLINE SLINKY_UNIQUE bool is_variable(expr_ref x, var sym) {
   const variable* vx = x.as<variable>();
-  return vx ? vx->sym == sym : false;
+  return vx ? vx->sym == sym && vx->field == field_id::none : false;
 }
+
+bool is_buffer_field(expr_ref x, field_id field, var b);
+bool is_buffer_field(expr_ref x, field_id field, var b, int dim);
 
 // Check if `x` is equal to the constant `value`.
 SLINKY_ALWAYS_INLINE SLINKY_UNIQUE bool is_constant(expr_ref x, index_t value) {

--- a/runtime/expr_stmt.cc
+++ b/runtime/expr_stmt.cc
@@ -99,6 +99,8 @@ const constant* make_static_constant() {
 const variable* make_variable(var sym) {
   auto n = new variable();
   n->sym = sym;
+  n->field = field_id::none;
+  n->dim = -1;
   return n;
 }
 
@@ -124,6 +126,13 @@ expr::expr(std::int64_t x) : expr(make_constant(x)) {}
 expr::expr(var sym) : expr(make_variable(sym)) {}
 
 expr variable::make(var sym) { return expr(make_variable(sym)); }
+expr variable::make(var sym, field_id field, int dim) { 
+  variable* n = new variable();
+  n->sym = sym;
+  n->field = field;
+  n->dim = dim;
+  return expr(n);
+}
 
 expr constant::make(index_t value) { return expr(make_constant(value)); }
 expr constant::make(const void* value) { return make(reinterpret_cast<index_t>(value)); }

--- a/runtime/expr_stmt.cc
+++ b/runtime/expr_stmt.cc
@@ -632,6 +632,22 @@ bool is_non_positive(expr_ref x) {
   return c ? *c <= 0 : false;
 }
 
+bool is_buffer_field(expr_ref x, field_id field, var b) {
+  if (const variable* v = x.as<variable>()) {
+    return v->sym == b && v->field == field;
+  } else {
+    return false;
+  }
+}
+
+bool is_buffer_field(expr_ref x, field_id field, var b, int dim) {
+  if (const variable* v = x.as<variable>()) {
+    return v->sym == b && v->field == field && v->dim == dim;
+  } else {
+    return false;
+  }
+}
+
 expr abs(expr x) { return call::make(intrinsic::abs, {std::move(x)}); }
 expr align_down(expr x, const expr& a) { return (std::move(x) / a) * a; }
 expr align_up(expr x, const expr& a) { return ((std::move(x) + a - 1) / a) * a; }

--- a/runtime/expr_stmt.cc
+++ b/runtime/expr_stmt.cc
@@ -695,24 +695,8 @@ box_expr dims_bounds(span<const dim_expr> dims) {
 
 bool is_buffer_intrinsic(intrinsic fn) {
   switch (fn) {
-  case intrinsic::buffer_rank:
-  case intrinsic::buffer_elem_size:
   case intrinsic::buffer_size_bytes:
-  case intrinsic::buffer_min:
-  case intrinsic::buffer_max:
-  case intrinsic::buffer_stride:
-  case intrinsic::buffer_fold_factor:
   case intrinsic::buffer_at: return true;
-  default: return false;
-  }
-}
-
-bool is_buffer_dim_intrinsic(intrinsic fn) {
-  switch (fn) {
-  case intrinsic::buffer_min:
-  case intrinsic::buffer_max:
-  case intrinsic::buffer_stride:
-  case intrinsic::buffer_fold_factor: return true;
   default: return false;
   }
 }

--- a/runtime/expr_stmt.cc
+++ b/runtime/expr_stmt.cc
@@ -632,15 +632,7 @@ bool is_non_positive(expr_ref x) {
   return c ? *c <= 0 : false;
 }
 
-bool is_buffer_field(expr_ref x, field_id field, var b) {
-  if (const variable* v = x.as<variable>()) {
-    return v->sym == b && v->field == field;
-  } else {
-    return false;
-  }
-}
-
-bool is_buffer_field(expr_ref x, field_id field, var b, int dim) {
+bool is_variable(expr_ref x, var b, field_id field, int dim) {
   if (const variable* v = x.as<variable>()) {
     return v->sym == b && v->field == field && v->dim == dim;
   } else {

--- a/runtime/expr_stmt.cc
+++ b/runtime/expr_stmt.cc
@@ -99,7 +99,7 @@ const constant* make_static_constant() {
 const variable* make_variable(var sym) {
   auto n = new variable();
   n->sym = sym;
-  n->field = field_id::none;
+  n->field = buffer_field::none;
   n->dim = -1;
   return n;
 }
@@ -126,7 +126,7 @@ expr::expr(std::int64_t x) : expr(make_constant(x)) {}
 expr::expr(var sym) : expr(make_variable(sym)) {}
 
 expr variable::make(var sym) { return expr(make_variable(sym)); }
-expr variable::make(var sym, field_id field, int dim) { 
+expr variable::make(var sym, buffer_field field, int dim) { 
   variable* n = new variable();
   n->sym = sym;
   n->field = field;
@@ -632,7 +632,7 @@ bool is_non_positive(expr_ref x) {
   return c ? *c <= 0 : false;
 }
 
-bool is_variable(expr_ref x, var b, field_id field, int dim) {
+bool is_variable(expr_ref x, var b, buffer_field field, int dim) {
   if (const variable* v = x.as<variable>()) {
     return v->sym == b && v->field == field && v->dim == dim;
   } else {
@@ -649,17 +649,17 @@ expr and_then(std::vector<expr> args) { return call::make(intrinsic::and_then, s
 expr or_else(std::vector<expr> args) { return call::make(intrinsic::or_else, std::move(args)); }
 
 expr buffer_rank(var buf) {
-  return variable::make(buf, field_id::rank);
+  return variable::make(buf, buffer_field::rank);
 }
-expr buffer_elem_size(var buf) { return variable::make(buf, field_id::elem_size); }
-expr buffer_min(var buf, int dim) { return variable::make(buf, field_id::min, dim); }
-expr buffer_max(var buf, int dim) { return variable::make(buf, field_id::max, dim); }
+expr buffer_elem_size(var buf) { return variable::make(buf, buffer_field::elem_size); }
+expr buffer_min(var buf, int dim) { return variable::make(buf, buffer_field::min, dim); }
+expr buffer_max(var buf, int dim) { return variable::make(buf, buffer_field::max, dim); }
 expr buffer_extent(var buf, int dim) { return (buffer_max(buf, dim) - buffer_min(buf, dim)) + 1; }
 expr buffer_stride(var buf, int dim) {
-  return variable::make(buf, field_id::stride, dim);
+  return variable::make(buf, buffer_field::stride, dim);
 }
 expr buffer_fold_factor(var buf, int dim) {
-  return variable::make(buf, field_id::fold_factor, dim);
+  return variable::make(buf, buffer_field::fold_factor, dim);
 }
 
 interval_expr buffer_bounds(var buf, int dim) { return {buffer_min(buf, dim), buffer_max(buf, dim)}; }

--- a/runtime/print.cc
+++ b/runtime/print.cc
@@ -17,16 +17,16 @@ const char* to_string(memory_type type) {
   }
 }
 
-const char* to_string(field_id m) {
+const char* to_string(buffer_field m) {
   switch (m) {
-  case field_id::rank: return "rank";
-  case field_id::elem_size: return "elem_size";
-  case field_id::min: return "min";
-  case field_id::max: return "max";
-  case field_id::stride: return "stride";
-  case field_id::fold_factor: return "fold_factor";
+  case buffer_field::rank: return "rank";
+  case buffer_field::elem_size: return "elem_size";
+  case buffer_field::min: return "min";
+  case buffer_field::max: return "max";
+  case buffer_field::stride: return "stride";
+  case buffer_field::fold_factor: return "fold_factor";
 
-  default: return "<invalid field_id>";
+  default: return "<invalid buffer_field>";
   }
 }
 
@@ -53,7 +53,7 @@ const char* to_string(intrinsic fn) {
 
 std::ostream& operator<<(std::ostream& os, memory_type type) { return os << to_string(type); }
 std::ostream& operator<<(std::ostream& os, intrinsic fn) { return os << to_string(fn); }
-std::ostream& operator<<(std::ostream& os, field_id f) { return os << to_string(f); }
+std::ostream& operator<<(std::ostream& os, buffer_field f) { return os << to_string(f); }
 
 std::ostream& operator<<(std::ostream& os, const interval_expr& i) {
   return os << "[" << i.min << ", " << i.max << "]";
@@ -152,13 +152,13 @@ public:
 
   void visit(const variable* v) override { 
     switch (v->field) {
-    case field_id::none: *this << v->sym; return;
-    case field_id::rank: *this << "buffer_rank(" << v->sym << ")"; return;
-    case field_id::elem_size: *this << "buffer_elem_size(" << v->sym << ")"; return;
-    case field_id::min: *this << "buffer_min(" << v->sym << ", " << v->dim << ")"; return;
-    case field_id::max: *this << "buffer_max(" << v->sym << ", " << v->dim << ")"; return;
-    case field_id::stride: *this << "buffer_stride(" << v->sym << ", " << v->dim << ")"; return;
-    case field_id::fold_factor: *this << "buffer_fold_factor(" << v->sym << ", " << v->dim << ")"; return;
+    case buffer_field::none: *this << v->sym; return;
+    case buffer_field::rank: *this << "buffer_rank(" << v->sym << ")"; return;
+    case buffer_field::elem_size: *this << "buffer_elem_size(" << v->sym << ")"; return;
+    case buffer_field::min: *this << "buffer_min(" << v->sym << ", " << v->dim << ")"; return;
+    case buffer_field::max: *this << "buffer_max(" << v->sym << ", " << v->dim << ")"; return;
+    case buffer_field::stride: *this << "buffer_stride(" << v->sym << ", " << v->dim << ")"; return;
+    case buffer_field::fold_factor: *this << "buffer_fold_factor(" << v->sym << ", " << v->dim << ")"; return;
     default: std::abort();
     }
   }

--- a/runtime/print.cc
+++ b/runtime/print.cc
@@ -21,7 +21,6 @@ const char* to_string(field_id m) {
   switch (m) {
   case field_id::rank: return "rank";
   case field_id::elem_size: return "elem_size";
-  case field_id::size_bytes: return "size_bytes";
   case field_id::min: return "min";
   case field_id::max: return "max";
   case field_id::stride: return "stride";
@@ -39,13 +38,7 @@ const char* to_string(intrinsic fn) {
   case intrinsic::abs: return "abs";
   case intrinsic::and_then: return "and_then";
   case intrinsic::or_else: return "or_else";
-  case intrinsic::buffer_rank: return "buffer_rank";
-  case intrinsic::buffer_elem_size: return "buffer_elem_size";
   case intrinsic::buffer_size_bytes: return "buffer_size_bytes";
-  case intrinsic::buffer_min: return "buffer_min";
-  case intrinsic::buffer_max: return "buffer_max";
-  case intrinsic::buffer_stride: return "buffer_stride";
-  case intrinsic::buffer_fold_factor: return "buffer_fold_factor";
   case intrinsic::buffer_at: return "buffer_at";
   case intrinsic::semaphore_init: return "semaphore_init";
   case intrinsic::semaphore_signal: return "semaphore_signal";
@@ -162,7 +155,6 @@ public:
     case field_id::none: *this << v->sym; return;
     case field_id::rank: *this << "buffer_rank(" << v->sym << ")"; return;
     case field_id::elem_size: *this << "buffer_elem_size(" << v->sym << ")"; return;
-    case field_id::size_bytes: *this << "buffer_size_bytes(" << v->sym << ")"; return;
     case field_id::min: *this << "buffer_min(" << v->sym << ", " << v->dim << ")"; return;
     case field_id::max: *this << "buffer_max(" << v->sym << ", " << v->dim << ")"; return;
     case field_id::stride: *this << "buffer_stride(" << v->sym << ", " << v->dim << ")"; return;

--- a/runtime/print.h
+++ b/runtime/print.h
@@ -24,7 +24,7 @@ std::ostream& operator<<(std::ostream& os, var sym);
 std::ostream& operator<<(std::ostream& os, const interval_expr& i);
 std::ostream& operator<<(std::ostream& os, const box_expr& i);
 std::ostream& operator<<(std::ostream& os, intrinsic fn);
-std::ostream& operator<<(std::ostream& os, field_id f);
+std::ostream& operator<<(std::ostream& os, buffer_field f);
 std::ostream& operator<<(std::ostream& os, memory_type type);
 
 template <typename T>
@@ -40,7 +40,7 @@ std::ostream& operator<<(std::ostream& os, const dim& d);
 // to_string() calls.
 std::string to_string(var sym);
 const char* to_string(intrinsic fn);
-const char* to_string(field_id f);
+const char* to_string(buffer_field f);
 const char* to_string(memory_type type);
 
 }  // namespace slinky

--- a/runtime/print.h
+++ b/runtime/print.h
@@ -9,6 +9,7 @@
 
 namespace slinky {
 
+void print(std::ostream& os, var x, const node_context* ctx = nullptr);
 void print(std::ostream& os, const expr& e, const node_context* ctx = nullptr);
 void print(std::ostream& os, const stmt& s, const node_context* ctx = nullptr);
 
@@ -23,6 +24,7 @@ std::ostream& operator<<(std::ostream& os, var sym);
 std::ostream& operator<<(std::ostream& os, const interval_expr& i);
 std::ostream& operator<<(std::ostream& os, const box_expr& i);
 std::ostream& operator<<(std::ostream& os, intrinsic fn);
+std::ostream& operator<<(std::ostream& os, field_id f);
 std::ostream& operator<<(std::ostream& os, memory_type type);
 
 template <typename T>
@@ -38,6 +40,7 @@ std::ostream& operator<<(std::ostream& os, const dim& d);
 // to_string() calls.
 std::string to_string(var sym);
 const char* to_string(intrinsic fn);
+const char* to_string(field_id f);
 const char* to_string(memory_type type);
 
 }  // namespace slinky

--- a/runtime/test/depends_on.cc
+++ b/runtime/test/depends_on.cc
@@ -48,6 +48,10 @@ TEST(depends_on, basic) {
   ASSERT_EQ(depends_on(x + x, x), (depends_on_result{.var = true}));
   ASSERT_EQ(depends_on(buffer_at(x), x), (depends_on_result{.buffer_base = true}));
 
+  ASSERT_EQ(depends_on(buffer_min(x, 0), x), (depends_on_result{.buffer_dims = true, .buffer_bounds = true}));
+  ASSERT_EQ(depends_on(buffer_stride(x, 0), x), (depends_on_result{.buffer_dims = true}));
+  ASSERT_EQ(depends_on(buffer_elem_size(x), x), (depends_on_result{.var = true}));
+
   stmt loop_x = loop::make(x, loop::serial, {y, z}, 1, check::make(x && z));
   ASSERT_EQ(depends_on(loop_x, x), depends_on_result{});
   ASSERT_EQ(depends_on(loop_x, y), (depends_on_result{.var = true}));

--- a/runtime/visualize.cc
+++ b/runtime/visualize.cc
@@ -126,7 +126,6 @@ public:
     case field_id::none: *this << v->sym; return;
     case field_id::rank: *this << "buffer_rank(" << v->sym << ")"; return;
     case field_id::elem_size: *this << "buffer_elem_size(" << v->sym << ")"; return;
-    case field_id::size_bytes: *this << "buffer_size_bytes(" << v->sym << ")"; return;
     case field_id::min: *this << "buffer_min(" << v->sym << ", " << v->dim << ")"; return;
     case field_id::max: *this << "buffer_max(" << v->sym << ", " << v->dim << ")"; return;
     case field_id::stride: *this << "buffer_stride(" << v->sym << ", " << v->dim << ")"; return;

--- a/runtime/visualize.cc
+++ b/runtime/visualize.cc
@@ -123,13 +123,13 @@ public:
 
   void visit(const variable* v) override {
     switch (v->field) {
-    case field_id::none: *this << v->sym; return;
-    case field_id::rank: *this << "buffer_rank(" << v->sym << ")"; return;
-    case field_id::elem_size: *this << "buffer_elem_size(" << v->sym << ")"; return;
-    case field_id::min: *this << "buffer_min(" << v->sym << ", " << v->dim << ")"; return;
-    case field_id::max: *this << "buffer_max(" << v->sym << ", " << v->dim << ")"; return;
-    case field_id::stride: *this << "buffer_stride(" << v->sym << ", " << v->dim << ")"; return;
-    case field_id::fold_factor: *this << "buffer_fold_factor(" << v->sym << ", " << v->dim << ")"; return;
+    case buffer_field::none: *this << v->sym; return;
+    case buffer_field::rank: *this << "buffer_rank(" << v->sym << ")"; return;
+    case buffer_field::elem_size: *this << "buffer_elem_size(" << v->sym << ")"; return;
+    case buffer_field::min: *this << "buffer_min(" << v->sym << ", " << v->dim << ")"; return;
+    case buffer_field::max: *this << "buffer_max(" << v->sym << ", " << v->dim << ")"; return;
+    case buffer_field::stride: *this << "buffer_stride(" << v->sym << ", " << v->dim << ")"; return;
+    case buffer_field::fold_factor: *this << "buffer_fold_factor(" << v->sym << ", " << v->dim << ")"; return;
     default: std::abort();
     }
   }

--- a/runtime/visualize.cc
+++ b/runtime/visualize.cc
@@ -40,7 +40,7 @@ public:
     return *this;
   }
 
-  std::string sanitize(std::string s) {
+  std::string sanitize(std::string s) const {
     std::replace(s.begin(), s.end(), '.', '_');
     std::replace(s.begin(), s.end(), '/', '_');
     std::replace(s.begin(), s.end(), '#', '_');
@@ -121,7 +121,19 @@ public:
 
   std::string indent(int extra = 0) const { return std::string((depth + extra) * 2, ' '); }
 
-  void visit(const variable* v) override { *this << v->sym; }
+  void visit(const variable* v) override {
+    switch (v->field) {
+    case field_id::none: *this << v->sym; return;
+    case field_id::rank: *this << "buffer_rank(" << v->sym << ")"; return;
+    case field_id::elem_size: *this << "buffer_elem_size(" << v->sym << ")"; return;
+    case field_id::size_bytes: *this << "buffer_size_bytes(" << v->sym << ")"; return;
+    case field_id::min: *this << "buffer_min(" << v->sym << ", " << v->dim << ")"; return;
+    case field_id::max: *this << "buffer_max(" << v->sym << ", " << v->dim << ")"; return;
+    case field_id::stride: *this << "buffer_stride(" << v->sym << ", " << v->dim << ")"; return;
+    case field_id::fold_factor: *this << "buffer_fold_factor(" << v->sym << ", " << v->dim << ")"; return;
+    default: std::abort();
+    }
+  }
   void visit(const constant* c) override { *this << c->value; }
 
   void visit(const let* l) override {
@@ -166,7 +178,9 @@ public:
     *this << "select(" << op->condition << ", " << op->true_value << ", " << op->false_value << ")";
   }
 
-  void visit(const call* op) override { *this << op->intrinsic << "(" << op->args << ")"; }
+  void visit(const call* op) override { 
+    *this << op->intrinsic << "(" << op->args << ")"; 
+  }
 
   void visit(const block* b) override {
     for (const auto& s : b->stmts) {


### PR DESCRIPTION
This PR changes buffer intrinsics (e.g. `buffer_min(buf, dim)`) from being implemented as `call` nodes to `variable` nodes, by adding new fields to `variable`.

This change has a few motivations and implications:
- It is an improvement to #396 and #466, because evaluating a buffer intrinsic now requires evaluating only one node instead of 3. The `BM_buffer_meta` benchmark gets ~5x faster with this branch.
- It loses flexibility, because the `buf` and `dim` arguments to buffer intrinsics are now required to be constants. However, in dozens of places in the code, we asserted those values were `variable` and `constant` nodes anyways, and I doubt we'd ever change that.
- The main motivation for this change is that the simplifier currently treats variables and buffers very differently, with different features for each. `expr_info` tracks bounds and alignment for each variable, but `buffer_info` only tracks the value of the various buffer fields. This PR doesn't do this yet, but I have a follow-up WIP branch that (mostly) unifies this. This has a bunch of benefits:
  - It's a step towards passing buffer information to the simplifier from outside, currently we cannot. We could add new arguments for this, but it's a plumbing mess to do so.
  - It allows us to learn bounds of buffer fields, currently we can only learn specific values. Right now, if the program does `check(buffer_min(x, 0) == 0 && buffer_max(x, 0) > 0)`, we can learn that the buffer min is 0 (because it is a specific value we can store in `buffer_info`), but we cannot learn that the `buffer_max` (and thus the buffer extent too) is greater than 0, which would be valuable information in many cases.
  - The simplifier code gets simpler.