### PR TITLE
Don't produce crop for buffers allocated inside of the statement

### DIFF
--- a/builder/pipeline.cc
+++ b/builder/pipeline.cc
@@ -561,7 +561,8 @@ public:
   }
 
   void visit(const allocate* op) override {
-    found[op->sym] = false;
+    auto s = set_value_in_scope(found, op->sym, false);
+    recursive_node_visitor::visit(op);
   }
 };
 

--- a/builder/pipeline.cc
+++ b/builder/pipeline.cc
@@ -559,6 +559,10 @@ public:
     found[op->src] = true;
     found[op->dst] = true;
   }
+
+  void visit(const allocate* op) override {
+    found[op->sym] = false;
+  }
 };
 
 symbol_map<bool> buffers_used_inside(const stmt& body) {


### PR DESCRIPTION
Currently it generates something like:
```
out.x = loop(serial, [buffer_min(out, 0), buffer_max(out, 0)], 1) {
 out = crop_dim(out, 0, [out.x, out.x]) {
  intm = crop_buffer(intm, {
    [((buffer_min(out, 0) / 2) * 2), ((((((buffer_max(out, 0) + 1) + 2) - 1) / 2) * 2) - 1)],
    [buffer_min(out, 1), buffer_max(out, 1)]
  }) {
   check((((buffer_min(out, 0) / 2) * 2) <= buffer_min(out, 0)))
   check((buffer_max(out, 0) <= ((((((buffer_max(out, 0) + 1) + 2) - 1) / 2) * 2) - 1)))
   check((buffer_min(out, 1) <= buffer_min(out, 1)))
   check((buffer_max(out, 1) <= buffer_max(out, 1)))
   intm = allocate(stack, 4, {
     {[((buffer_min(out, 0) / 2) * 2), ((((((buffer_max(out, 0) + 1) + 2) - 1) / 2) * 2) - 1)], <>, buffer_fold_factor(intm, 0)},
     {[buffer_min(out, 1), buffer_max(out, 1)], <>, buffer_fold_factor(intm, 1)}
   }) {
    intm.uncropped = clone_buffer(intm) {
     call(<anonymous target>, {}, {intm})
     call(<anonymous target>, {intm.uncropped}, {out})
    }
   }
  }
 }
}
```
which is not really correct, because it crops buffer which wasn't allocated or even defined yet.