### PR TITLE
Simplify cleanups and improvements

### DIFF
--- a/builder/pipeline.cc
+++ b/builder/pipeline.cc
@@ -19,6 +19,7 @@
 #include "builder/simplify.h"
 #include "builder/slide_and_fold_storage.h"
 #include "builder/substitute.h"
+#include "runtime/depends_on.h"
 #include "runtime/evaluate.h"
 #include "runtime/expr.h"
 #include "runtime/pipeline.h"
@@ -542,36 +543,6 @@ stmt substitute_inputs(const stmt& s, const symbol_map<var>& subs) {
   return m(subs).mutate(s);
 }
 
-// Find buffers used inside of the statement.
-class find_buffers : public recursive_node_visitor {
-public:
-  symbol_map<bool> found;
-  void visit(const call_stmt* op) override {
-    for (const auto& i : op->inputs) {
-      found[i] = true;
-    }
-
-    for (const auto& o : op->outputs) {
-      found[o] = true;
-    }
-  }
-  void visit(const copy_stmt* op) override {
-    found[op->src] = true;
-    found[op->dst] = true;
-  }
-
-  void visit(const allocate* op) override {
-    auto s = set_value_in_scope(found, op->sym, false);
-    recursive_node_visitor::visit(op);
-  }
-};
-
-symbol_map<bool> buffers_used_inside(const stmt& body) {
-  find_buffers f;
-  body.accept(&f);
-  return f.found;
-}
-
 class pipeline_builder {
   node_context& ctx;
 
@@ -670,14 +641,14 @@ class pipeline_builder {
       // Find which buffers are used inside of the body.
       // TODO(vksnk): recomputing this seems really wasteful, we can should be
       // able to maintain the list of buffers as we build the IR.
-      symbol_map<bool> buffer_used = buffers_used_inside(body);
+      std::vector<var> buffer_used = find_buffer_dependencies(body);
 
       // Add crops for the used buffers using previously inferred bounds.
       // Input syms should be the innermost.
       for (const auto& i : input_syms_) {
         var sym = i.first;
         if (!allocation_bounds_[sym]) continue;
-        if (!buffer_used[sym]) continue;
+        if (!std::binary_search(buffer_used.begin(), buffer_used.end(), sym)) continue;
         body = crop_buffer::make(sym, sym, *allocation_bounds_[sym], body);
       }
 
@@ -694,7 +665,7 @@ class pipeline_builder {
         for (const func::output& o : f->outputs()) {
           const buffer_expr_ptr& b = o.buffer;
           if (!inferred_bounds_[b->sym()]) continue;
-          if (!buffer_used[b->sym()] || !*buffer_used[b->sym()]) continue;
+          if (!std::binary_search(buffer_used.begin(), buffer_used.end(), b->sym())) continue;
           body = crop_buffer::make(b->sym(), b->sym(), *inferred_bounds_[b->sym()], body);
         }
       }

--- a/builder/simplify.cc
+++ b/builder/simplify.cc
@@ -85,29 +85,6 @@ var find_buffer(const expr& e) {
   return finder.result;
 }
 
-template <typename T>
-bool match(const std::vector<T>& a, const std::vector<T>& b) {
-  if (a.size() != b.size()) return false;
-  for (std::size_t i = 0; i < a.size(); ++i) {
-    if (!match(a[i], b[i])) return false;
-  }
-  return true;
-}
-
-// Like the above, except `a` is represented by a single non-default value at index `idx`.
-template <typename T>
-bool match(int idx, const T& a, const std::vector<T>& b) {
-  if (idx >= static_cast<int>(b.size())) return false;
-  for (int i = 0; i < static_cast<int>(b.size()); ++i) {
-    if (i == idx) {
-      if (!match(a, b[idx])) return false;
-    } else {
-      if (!match(T(), b[i])) return false;
-    }
-  }
-  return true;
-}
-
 // Find the buffers accessed in a stmt. This is trickier than it seems, we need to track the lineage of buffers and
 // report the buffer as it is visible to the caller. So something like:
 //

--- a/runtime/depends_on.h
+++ b/runtime/depends_on.h
@@ -47,6 +47,11 @@ bool can_substitute_buffer(const depends_on_result& r);
 // Check if the node depends on anything that may change value.
 bool is_pure(expr_ref x);
 
+// Find the buffers used by a stmt or expr. Returns the vars accessed in sorted order.
+var find_buffer_dependency(expr_ref e);
+std::vector<var> find_buffer_dependencies(stmt_ref s);
+std::vector<var> find_buffer_dependencies(stmt_ref s, bool input, bool output);
+
 }  // namespace slinky
 
 #endif  // SLINKY_RUNTIME_DEPENDS_ON_H


### PR DESCRIPTION
- Fix `lift_decl_invariants` recreating identical `stmt`s
- Both simplify and the pipeline builder had some very similar code to find buffers used in a stmt. Refactor this into a helper `find_buffer_dependencies`.