### PR TITLE
Fix bugs in simplify

### DIFF
--- a/builder/simplify.cc
+++ b/builder/simplify.cc
@@ -756,7 +756,7 @@ public:
     // min(x, y + 1) not simplifying if we know the bounds of x are [0, y] and the bounds of y are [z, w],
     // because we end up looking at min(y, z + 1) instead of min(y, y + 1).
     // TODO: This is quite expensive, we should try to find a better way.
-    auto less_equal = [this](const expr& a, const expr& a_max, const expr& b, const expr& b_min) {
+    auto less_equal = [](const expr& a, const expr& a_max, const expr& b, const expr& b_min) {
       return prove_constant_false(simplify(static_cast<const less*>(nullptr), b_min, a_max)) ||
              (!match(a, a_max) && prove_constant_false(simplify(static_cast<const less*>(nullptr), b_min, a))) ||
              (!match(b, b_min) && prove_constant_false(simplify(static_cast<const less*>(nullptr), b, a_max)));

--- a/builder/simplify.cc
+++ b/builder/simplify.cc
@@ -1668,7 +1668,7 @@ public:
         return body;
       } else if (can_substitute_buffer(deps)) {
         // We only needed the buffer meta, not the buffer itself.
-        return mutate_with_buffer(nullptr, op->body, op->sym, find_buffer_dependency(base), std::move(info));
+        return mutate_with_buffer(nullptr, body, op->sym, find_buffer_dependency(base), std::move(info));
       } else if (changed || !body.same_as(op->body)) {
         return make_buffer::make(op->sym, base, info.elem_size, info.dims, std::move(body));
       } else {

--- a/builder/simplify.cc
+++ b/builder/simplify.cc
@@ -191,7 +191,10 @@ public:
   void visit(const call*) override { set_result(expr()); }
 };
 
-expr add_constant(const expr& a, index_t b) { return constant_adder(b).mutate(a); }
+expr add_constant(const expr& a, index_t b) { 
+  if (b == 0) return a;
+  return constant_adder(b).mutate(a); 
+}
 
 // This is based on the simplifier in Halide: https://github.com/halide/Halide/blob/main/src/Simplify_Internal.h
 class simplifier : public node_mutator {

--- a/builder/simplify.cc
+++ b/builder/simplify.cc
@@ -1871,9 +1871,6 @@ public:
         // Nested crops of the same buffer, and the crop isn't used.
         op_bounds.resize(std::max(op_bounds.size(), c->bounds.size()));
         op_bounds = c->bounds & op_bounds;
-        for (interval_expr& i : op_bounds) {
-          i = mutate(i);
-        }
         op_src = c->src;
         info = get_buffer_info(op_src, op_bounds.size());
         op = nullptr;
@@ -1885,7 +1882,7 @@ public:
         }
         // Nested crops of the same buffer, and the crop isn't used.
         op_bounds.resize(std::max<int>(op_bounds.size(), c->dim + 1));
-        op_bounds[c->dim] = mutate(c->bounds & op_bounds[c->dim]);
+        op_bounds[c->dim] = c->bounds & op_bounds[c->dim];
         op_src = c->src;
         info = get_buffer_info(op_src, op_bounds.size());
         op = nullptr;

--- a/builder/substitute.cc
+++ b/builder/substitute.cc
@@ -674,7 +674,8 @@ public:
     if (v->sym == target) {
       if (v->field != buffer_field::none) {
         // The replacement must be another var.
-        set_result(variable::make(replacement_symbol(replacement), v->field, v->dim));
+        var new_sym = replacement_symbol(replacement);
+        set_result(new_sym == v->sym ? expr(v) : variable::make(new_sym, v->field, v->dim));
       } else {
         set_result(replacement);
       }
@@ -741,12 +742,15 @@ public:
 }  // namespace
 
 expr substitute(const expr& e, var target, const expr& replacement) {
+  if (is_variable(replacement, target)) return e;
   return var_substitutor(target, replacement).mutate(e);
 }
 interval_expr substitute(const interval_expr& x, var target, const expr& replacement) {
+  if (is_variable(replacement, target)) return x;
   return var_substitutor(target, replacement).mutate(x);
 }
 stmt substitute(const stmt& s, var target, const expr& replacement) {
+  if (is_variable(replacement, target)) return s;
   scoped_trace trace("substitute");
   return var_substitutor(target, replacement).mutate(s);
 }


### PR DESCRIPTION
- Don't regenerate matching nodes in mutators
- Don't redundantly mutate crop bounds
- Fix redundant mutation of make_buffer body