### PR TITLE
Minor refactoring to avoid benign UB in `for_each_element`

### DIFF
--- a/runtime/buffer.cc
+++ b/runtime/buffer.cc
@@ -453,7 +453,7 @@ SLINKY_ALWAYS_INLINE inline T* increment_plan(void*& x, std::size_t n = 1) {
 // Helper function to write a plan that does nothing when interpreted by for_each_impl.
 void write_empty_plan(void* plan, std::size_t bufs_size) {
   for_each_loop* next = increment_plan<for_each_loop>(plan);
-  next->impl = for_each_loop::linear | for_each_loop::call_f;
+  next->impl = for_each_loop::folded | for_each_loop::call_f;
   next->extent = 0;
 }
 
@@ -475,23 +475,6 @@ SLINKY_NO_INLINE index_t make_for_each_loops_impl(
   void* plan = plan_base;
   index_t slice_extent = 1;
   index_t extent = 1;
-#ifdef UNDEFINED_BEHAVIOR_SANITIZER
-  if (buf->rank == 0) {
-    // This is here mainly to ensure that the strides[] array is initialized
-    // properly for the zero-dimensional case; we don't use the results of
-    // adding these strides, but in certain Sanitizer modes we could fail
-    // if we added garbage to a pointer and it overflowed.
-    for_each_loop* loop = increment_plan<for_each_loop>(plan);
-    loop->impl = for_each_loop::linear | for_each_loop::call_f;
-    loop->extent = 1;
-
-    index_t* strides = increment_plan<index_t>(plan, bufs_size);
-    for (std::size_t n = 0; n < bufs_size; n++) {
-      strides[n] = 0;
-    }
-    return 1;
-  }
-#endif
   for (index_t d = static_cast<index_t>(buf->rank) - 1; d >= 0; --d) {
     const dim& buf_dim = buf->dim(d);
 


### PR DESCRIPTION
- Rewrite `for_each_impl_linear` to only use strides when they are actually needed.
- Use folded loops for empty dimensions, so we don't need an extra branch in `for_each_impl_linear`. `for_each_impl_folded` already has a lot of extra control flow, so the extra branch doesn't matter as much.