### PR TITLE
Small optimizations for very lightweight pipelines

### DIFF
--- a/runtime/buffer.h
+++ b/runtime/buffer.h
@@ -521,8 +521,10 @@ public:
   }
 
   void free() {
-    ::free(to_free);
-    to_free = nullptr;
+    if (to_free) {
+      ::free(to_free);
+      to_free = nullptr;
+    }
   }
 };
 

--- a/runtime/buffer.h
+++ b/runtime/buffer.h
@@ -51,7 +51,7 @@ class dim {
   index_t fold_factor_;
 
 public:
-  static constexpr index_t auto_stride = std::numeric_limits<index_t>::min();
+  static constexpr index_t auto_stride = std::numeric_limits<index_t>::max();
   static constexpr index_t unfolded = std::numeric_limits<index_t>::max();
 
   dim() : min_(0), max_(-1), stride_(auto_stride), fold_factor_(unfolded) {}

--- a/runtime/evaluate.cc
+++ b/runtime/evaluate.cc
@@ -133,15 +133,6 @@ public:
     }
   }
 
-  dim eval(const dim_expr& x) {
-    dim result;
-    interval bounds = eval(x.bounds);
-    result.set_bounds(bounds.min, bounds.max);
-    result.set_stride(eval(x.stride, dim::auto_stride));
-    result.set_fold_factor(eval(x.fold_factor, dim::unfolded));
-    return result;
-  }
-
   index_t eval(const variable* op) {
     index_t value = context.lookup(op->sym);
     if (op->field == buffer_field::none) return value;
@@ -471,7 +462,12 @@ public:
     buffer.dims = SLINKY_ALLOCA(dim, rank);
 
     for (std::size_t d = 0; d < rank; ++d) {
-      buffer.dim(d) = eval(op->dims[d]);
+      const dim_expr& op_d = op->dims[d];
+      dim& buf_d = buffer.dim(d);
+      interval bounds = eval(op_d.bounds);
+      buf_d.set_bounds(bounds.min, bounds.max);
+      buf_d.set_stride(eval(op_d.stride, dim::auto_stride));
+      buf_d.set_fold_factor(eval(op_d.fold_factor, dim::unfolded));
     }
 
     if (op->storage == memory_type::stack) {
@@ -501,7 +497,12 @@ public:
     buffer.dims = SLINKY_ALLOCA(dim, rank);
 
     for (std::size_t d = 0; d < rank; ++d) {
-      buffer.dim(d) = eval(op->dims[d]);
+      const dim_expr& op_d = op->dims[d];
+      dim& buf_d = buffer.dim(d);
+      interval bounds = eval(op_d.bounds);
+      buf_d.set_bounds(bounds.min, bounds.max);
+      buf_d.set_stride(eval(op_d.stride));
+      buf_d.set_fold_factor(eval(op_d.fold_factor, dim::unfolded));
     }
 
     return eval_with_value(op->body, op->sym, reinterpret_cast<index_t>(&buffer));

--- a/runtime/test/buffer_benchmark.cc
+++ b/runtime/test/buffer_benchmark.cc
@@ -390,4 +390,19 @@ void BM_for_each_element_batch_dims(benchmark::State& state) {
 
 BENCHMARK(BM_for_each_element_batch_dims);
 
+void BM_init_strides(benchmark::State& state) {
+
+  for (auto _ : state) {
+    buffer<int, 4> buf;
+    buf.dim(0).set_min_extent(0, 44);
+    buf.dim(1).set_min_extent(0, 1);
+    buf.dim(2).set_min_extent(0, 1);
+    buf.dim(3).set_min_extent(0, 1);
+
+    buf.init_strides();
+  }
+}
+
+BENCHMARK(BM_init_strides);
+
 }  // namespace slinky


### PR DESCRIPTION
This remove special case from `init_strides` that only exists to make strides "look" better. Some things assert strides are the product of a previous dimension extent and stride, even if the extent is 1 (so the stride is irrelevant to anything). If people want to call other programs with such asserts, they can fix up the strides themselves, but we shouldn't pay the cost to fix them up when they don't matter.

Also:
- Avoid calling `free` on `nullptr` (in case it isn't inline)
- Inline some things in `evaluate` that proved helpful.