### PR TITLE
Split evaluate into setup + evaluate in pipeline

### DIFF
--- a/runtime/pipeline.cc
+++ b/runtime/pipeline.cc
@@ -7,7 +7,7 @@
 
 namespace slinky {
 
-index_t pipeline::evaluate(scalars args, buffers inputs, buffers outputs, eval_context& ctx) const {
+void pipeline::setup(scalars args, buffers inputs, buffers outputs, eval_context& ctx) const {
   assert(args.size() == this->args.size());
   assert(inputs.size() == this->inputs.size());
   assert(outputs.size() == this->outputs.size());
@@ -24,12 +24,22 @@ index_t pipeline::evaluate(scalars args, buffers inputs, buffers outputs, eval_c
   for (const auto& i : constants) {
     ctx[i.first] = reinterpret_cast<index_t>(i.second.get());
   }
+}
 
+void pipeline::setup(buffers inputs, buffers outputs, eval_context& ctx) const {
+  setup({}, inputs, outputs, ctx);
+}
+
+index_t pipeline::evaluate(eval_context& ctx) const { return slinky::evaluate(body, ctx); }
+
+index_t pipeline::evaluate(scalars args, buffers inputs, buffers outputs, eval_context& ctx) const {
+  setup(args, inputs, outputs, ctx);
   return slinky::evaluate(body, ctx);
 }
 
 index_t pipeline::evaluate(buffers inputs, buffers outputs, eval_context& ctx) const {
-  return evaluate({}, inputs, outputs, ctx);
+  setup(inputs, outputs, ctx);
+  return slinky::evaluate(body, ctx);
 }
 
 index_t pipeline::evaluate(scalars args, buffers inputs, buffers outputs) const {

--- a/runtime/pipeline.h
+++ b/runtime/pipeline.h
@@ -23,6 +23,14 @@ public:
   using scalars = span<const index_t>;
   using buffers = span<const raw_buffer*>;
 
+  // Set up the context to run the pipeline, but do not run it.
+  void setup(scalars args, buffers inputs, buffers outputs, eval_context& ctx) const;
+  void setup(buffers inputs, buffers outputs, eval_context& ctx) const;
+
+  // Run an already set up pipeline.
+  index_t evaluate(eval_context& ctx) const;
+
+  // Combines setup + evaluate.
   index_t evaluate(scalars args, buffers inputs, buffers outputs, eval_context& ctx) const;
   index_t evaluate(buffers inputs, buffers outputs, eval_context& ctx) const;
   index_t evaluate(scalars args, buffers inputs, buffers outputs) const;


### PR DESCRIPTION
This allows avoiding the overhead of setting up a new context when running the same pipeline repeatedly.