### PR TITLE
Only alias copies, not calls

### DIFF
--- a/builder/optimizations.h
+++ b/builder/optimizations.h
@@ -6,10 +6,8 @@
 
 namespace slinky {
 
-// Where possible, replace `allocate` with `make_buffer` referring to another buffer with appropriate metadata:
-// - `copy_stmt`s that only do simple copies or broadcasts in each dimension.
-// - `call_stmt`s that can be in-place may be able to replace an allocation for the output with an alias of an input.
-stmt alias_buffers(const stmt& s, node_context& ctx, const std::vector<buffer_expr_ptr>& inputs,
+// Where possible, replace `allocate` with `make_buffer` referring to another buffer with appropriate metadata for copies.
+stmt alias_copies(const stmt& s, node_context& ctx, const std::vector<buffer_expr_ptr>& inputs,
     const std::vector<buffer_expr_ptr>& outputs);
 
 // Given a copy_stmt, produce an implementation that calls `slinky::copy`, possibly inside loops that implement copy

--- a/builder/pipeline.cc
+++ b/builder/pipeline.cc
@@ -1014,7 +1014,7 @@ stmt build_pipeline(node_context& ctx, const std::vector<buffer_expr_ptr>& input
     inputs_and_constants.reserve(inputs.size() + constants.size());
     inputs_and_constants.insert(inputs_and_constants.end(), inputs.begin(), inputs.end());
     inputs_and_constants.insert(inputs_and_constants.end(), constants.begin(), constants.end());
-    result = alias_buffers(result, ctx, inputs_and_constants, outputs);
+    result = alias_copies(result, ctx, inputs_and_constants, outputs);
   }
 
   // `evaluate` currently can't handle `copy_stmt`, so this is required.

--- a/builder/test/pipeline.cc
+++ b/builder/test/pipeline.cc
@@ -160,7 +160,7 @@ TEST_P(elementwise, pipeline_1d) {
     ASSERT_EQ(out_buf(i), 2 * i + 1);
   }
 
-  if (schedule_storage) {
+  if (split > 0 && schedule_storage) {
     ASSERT_EQ(eval_ctx.heap.allocs.size(), 0);  // The intermediate only needs stack.
   }
 }
@@ -237,7 +237,7 @@ TEST_P(elementwise, pipeline_2d) {
     }
   }
 
-  if (schedule_storage) {
+  if (split > 0 && schedule_storage) {
     ASSERT_EQ(eval_ctx.heap.allocs.size(), 0);  // The intermediate only needs stack.
   }
 }
@@ -898,7 +898,8 @@ TEST(unrelated, pipeline) {
   }
 
   // intm2 aliased to out2.
-  ASSERT_THAT(eval_ctx.heap.allocs, testing::UnorderedElementsAre((W1 + 2) * 4 * sizeof(short)));
+  // TODO: Bring back aliasing in-place calls.
+  //ASSERT_THAT(eval_ctx.heap.allocs, testing::UnorderedElementsAre((W1 + 2) * 4 * sizeof(short)));
 }
 
 class padded_stencil : public testing::TestWithParam<int> {};


### PR DESCRIPTION
This changes `alias_buffers` to only alias copies, rather than copies and in-place calls. Doing in-place calls correctly is tricky, and doesn't really need all the complexity of `alias_buffers`. I think it will be better done as a separate pass. We also don't have much that actually relies on this functionality, and in fact a few tests were accidentally relying on it (fixed in this PR), and this should unblock #543.