### PR TITLE
Small optimizations

### DIFF
--- a/base/util.h
+++ b/base/util.h
@@ -40,6 +40,14 @@ namespace slinky {
 #define SLINKY_NO_STACK_PROTECTOR /* nothing */
 #endif
 
+#if defined(__GNUC__)
+#define SLINKY_LIKELY(condition) (__builtin_expect(!!(condition), 1))
+#define SLINKY_UNLIKELY(condition) (__builtin_expect(!!(condition), 0))
+#else
+#define SLINKY_LIKELY(condition) (!!(condition))
+#define SLINKY_UNLIKELY(condition) (!!(condition))
+#endif
+
 class unreachable {
 public:
   unreachable() = default;

--- a/builder/optimizations.cc
+++ b/builder/optimizations.cc
@@ -1139,4 +1139,33 @@ stmt optimize_symbols(const stmt& s, node_context& ctx) {
   return reuse_shadows().mutate(s);
 }
 
+namespace {
+
+class node_canonicalizer : public node_mutator {
+  std::map<expr, expr, node_less> exprs;
+  std::map<stmt, stmt, node_less> stmts;
+
+public:
+  using node_mutator::mutate;
+
+  stmt mutate(const stmt& s) override {
+    stmt& result = stmts[s];
+    if (!result.defined()) result = node_mutator::mutate(s);
+    return result;
+  }
+
+  expr mutate(const expr& e) override {
+    expr& result = exprs[e];
+    if (!result.defined()) result = node_mutator::mutate(e);
+    return result;
+  }
+};
+
+}  // namespace
+
+stmt canonicalize_nodes(const stmt& s) {
+  scoped_trace trace("canonicalize_nodes");
+  return node_canonicalizer().mutate(s);
+}
+
 }  // namespace slinky

--- a/builder/optimizations.cc
+++ b/builder/optimizations.cc
@@ -781,7 +781,7 @@ public:
 
   void visit(const transpose*) override {
     // TODO: We should be able to handle this.
-    std::abort();
+    SLINKY_UNREACHABLE << "transpose not handled by buffer_aliaser";
   }
 };
 

--- a/builder/optimizations.h
+++ b/builder/optimizations.h
@@ -30,6 +30,10 @@ stmt deshadow(const stmt& s, span<var> external_symbols, node_context& ctx);
 // - Symbols are indexed such that there are no unused symbol indices.
 stmt optimize_symbols(const stmt& s, node_context& ctx);
 
+// Guarantees that if match(a, b) is true, then a.same_as(b) is true, i.e. it rewrites matching nodes to be the same
+// object.
+stmt canonicalize_nodes(const stmt& s);
+
 }  // namespace slinky
 
 #endif  // SLINKY_BUILDER_OPTIMIZATIONS_H

--- a/builder/pipeline.cc
+++ b/builder/pipeline.cc
@@ -1020,13 +1020,15 @@ stmt build_pipeline(node_context& ctx, const std::vector<buffer_expr_ptr>& input
   // `evaluate` currently can't handle `copy_stmt`, so this is required.
   result = implement_copies(result, ctx);
 
-  if (options.no_checks) {
-    result = recursive_mutate<check>(result, [](const check* op) { return stmt(); });
-  }
-
   // `implement_copies` adds shadowed declarations, remove them before simplifying.
   result = deshadow(result, builder.external_symbols(), ctx);
   result = simplify(result);
+
+  if (options.no_checks) {
+    result = recursive_mutate<check>(result, [](const check* op) { return stmt(); });
+    // Simplify again, in case there are lets that the checks used that are now dead.
+    result = simplify(result);
+  }
 
   result = optimize_symbols(result, ctx);
 

--- a/builder/pipeline.cc
+++ b/builder/pipeline.cc
@@ -1036,6 +1036,8 @@ stmt build_pipeline(node_context& ctx, const std::vector<buffer_expr_ptr>& input
     result = inject_traces(result, ctx, constants);
   }
 
+  result = canonicalize_nodes(result);
+
   if (is_verbose()) {
     std::cout << result << std::endl;
   }

--- a/builder/replica_pipeline.cc
+++ b/builder/replica_pipeline.cc
@@ -51,11 +51,6 @@ class pipeline_replicator : public expr_visitor {
 public:
   explicit pipeline_replicator(node_context& ctx) : ctx_(ctx) {}
 
-  void fail(const char* msg) {
-    std::cerr << "Unimplemented/TODO: " << msg << "\n";
-    std::abort();
-  }
-
   void visit(const variable* op) override {
     const std::string& name = ctx_.name(op->sym);
 
@@ -82,7 +77,7 @@ public:
   }
 
   void visit(const constant* op) override { name_ = to_string(op->value); }
-  void visit(const let* op) override { fail("unimplemented let"); }
+  void visit(const let* op) override { SLINKY_UNREACHABLE; }
   void visit(const add* op) override { visit_binary_op(op, "+"); }
   void visit(const sub* op) override { visit_binary_op(op, "-"); }
   void visit(const mul* op) override { visit_binary_op(op, "*"); }
@@ -616,7 +611,8 @@ struct rph_handler {
     case 0x82: DO_XOR(uint64_t, uint16_t); break;
     case 0x84: DO_XOR(uint64_t, uint32_t); break;
     case 0x88: DO_XOR(uint64_t, uint64_t); break;
-    default: std::cerr << "Unsupported elem_size combination\n"; std::abort();
+
+    default: SLINKY_UNREACHABLE << "Unsupported elem_size combination";
     }
 
 #undef DO_XOR

--- a/builder/rewrite.h
+++ b/builder/rewrite.h
@@ -247,7 +247,7 @@ std::ostream& operator<<(std::ostream& os, const pattern_binary<T, A, B>& p) {
   case not_equal::static_type: return os << '(' << p.a << " != " << p.b << ')';
   case logical_and::static_type: return os << '(' << p.a << " && " << p.b << ')';
   case logical_or::static_type: return os << '(' << p.a << " || " << p.b << ')';
-  default: std::abort();
+  default: SLINKY_UNREACHABLE << "unknown binary operator " << to_string(T::static_type);
   }
 }
 
@@ -279,7 +279,7 @@ template <typename T, typename A>
 SLINKY_UNIQUE std::ostream& operator<<(std::ostream& os, const pattern_unary<T, A>& p) {
   switch (T::static_type) {
   case logical_not::static_type: return os << '!' << p.a;
-  default: std::abort();
+  default: SLINKY_UNREACHABLE << "unknown unary operator " << to_string(T::static_type);
   }
 }
 

--- a/builder/slide_and_fold_storage.cc
+++ b/builder/slide_and_fold_storage.cc
@@ -602,7 +602,7 @@ public:
       set_result(clone_with(op, std::move(body)));
     }
   }
-  void visit(const transpose*) override { std::abort(); }
+  void visit(const transpose*) override { SLINKY_UNREACHABLE << "transpose not handled by slide_and_fold_storage"; }
   void visit(const clone_buffer* op) override {
     auto set_alias = set_value_in_scope(aliases, op->sym, op->src);
     stmt_mutator::visit(op);

--- a/builder/substitute.cc
+++ b/builder/substitute.cc
@@ -714,8 +714,7 @@ public:
   var enter_decl(var x) override { return x != target ? x : var(); }
 
   stmt mutate(const stmt& s) override {
-    // We don't support substituting buffers into stmts.
-    std::abort();
+    SLINKY_UNREACHABLE << "can't substitute buffer into stmt";
   }
   dim_expr mutate(const dim_expr& e) { return {mutate(e.bounds), mutate(e.stride), mutate(e.fold_factor)}; }
   using substitutor::mutate;
@@ -733,7 +732,7 @@ public:
     case buffer_field::stride:
     case buffer_field::fold_factor:
       return dim < static_cast<index_t>(dims.size()) ? dims[dim].get_field(field) : expr(op);
-    case buffer_field::none: std::abort();
+    default: SLINKY_UNREACHABLE << "got scalar var instead of buffer";
     }
     return expr(op);
   }
@@ -800,7 +799,7 @@ public:
   }
   stmt mutate(const stmt& op) override {
     // We don't support substituting exprs into stmts.
-    std::abort();
+    SLINKY_UNREACHABLE << "can't substitute expr into stmt";
   }
   using node_mutator::mutate;
 };

--- a/builder/test/elementwise.cc
+++ b/builder/test/elementwise.cc
@@ -128,9 +128,9 @@ public:
     result_funcs.push_back(std::move(r));
   }
 
-  void visit(const let*) override { std::abort(); }
-  void visit(const call*) override { std::abort(); }
-  void visit(const logical_not*) override { std::abort(); }
+  void visit(const let*) override { SLINKY_UNREACHABLE; }
+  void visit(const call*) override { SLINKY_UNREACHABLE; }
+  void visit(const logical_not*) override { SLINKY_UNREACHABLE; }
 };
 
 template <typename T, std::size_t Rank>
@@ -203,9 +203,9 @@ public:
     for_each_element([&](T* result, const T* c, const T* t) { *result = *c ? *t : *result; }, result, c_buf, t_buf);
   }
 
-  void visit(const let*) override { std::abort(); }
-  void visit(const call*) override { std::abort(); }
-  void visit(const logical_not*) override { std::abort(); }
+  void visit(const let*) override { SLINKY_UNREACHABLE; }
+  void visit(const call*) override { SLINKY_UNREACHABLE; }
+  void visit(const logical_not*) override { SLINKY_UNREACHABLE; }
 };
 
 template <typename T, std::size_t Rank>

--- a/builder/test/simplify/expr_generator.h
+++ b/builder/test/simplify/expr_generator.h
@@ -63,7 +63,7 @@ public:
     case 4: return rng_() % 8 != 0 ? ac() && bc() : and_then(ac(), bc());
     case 5: return rng_() % 8 != 0 ? ac() || bc() : or_else(ac(), bc());
     case 6: return !random_condition(depth - 1);
-    default: std::abort();
+    default: SLINKY_UNREACHABLE;
     }
   }
 
@@ -88,7 +88,7 @@ public:
       case 8: return random_constant();
       case 9: return random_variable();
       case 10: return random_condition(depth);
-      default: std::abort();
+      default: SLINKY_UNREACHABLE;
       }
     }
   }

--- a/runtime/buffer.cc
+++ b/runtime/buffer.cc
@@ -547,7 +547,7 @@ SLINKY_NO_INLINE index_t make_for_each_loops_impl(
       }
     }
 
-    if (d > 0 && (extent == 1 || can_fuse(bufs, bufs_size, d))) {
+    if (extent == 1 || (d > 0 && can_fuse(bufs, bufs_size, d))) {
       // Let this fuse with the next dimension.
     } else if (SkipContiguous && is_contiguous_slice(bufs, bufs_size, d)) {
       // This is the slice dimension.
@@ -564,7 +564,7 @@ SLINKY_NO_INLINE index_t make_for_each_loops_impl(
       extent = 1;
 
       index_t* strides = increment_plan<index_t>(plan, bufs_size);
-      strides[0] = buf->dim(d).stride();
+      strides[0] = buf_dim.stride();
       for (std::size_t n = 1; n < bufs_size; n++) {
         strides[n] = d < static_cast<index_t>(bufs[n]->rank) ? bufs[n]->dim(d).stride() : 0;
       }

--- a/runtime/buffer.cc
+++ b/runtime/buffer.cc
@@ -146,14 +146,15 @@ void raw_buffer::init_strides(index_t alignment) {
 
     const index_t alloc_extent_i = alloc_extent(dim(i));
 
-    span<const init_stride_dim> known_dims{dims, dims_end};
-
     if (alloc_extent_i <= 1) {
       // This dimension can have stride elem_size, no other stride could be better.
       dim(i).set_stride(elem_size);
       // We don't need to consider strides proposed by extent 1 dimensions, we always consider that below.
       continue;
-    } else if (is_stride_ok(elem_size, alloc_extent_i, known_dims)) {
+    }
+
+    span<const init_stride_dim> known_dims{dims, dims_end};
+    if (is_stride_ok(elem_size, alloc_extent_i, known_dims)) {
       // This dimension can have stride elem_size, no other stride could be better.
       dim(i).set_stride(elem_size);
       learn_dim(init_stride_dim(elem_size, alloc_extent_i));

--- a/runtime/buffer.cc
+++ b/runtime/buffer.cc
@@ -176,7 +176,9 @@ void raw_buffer::init_strides(index_t alignment) {
     }
     assert(min < std::numeric_limits<index_t>::max());
     dim(i).set_stride(min);
-    learn_dim(init_stride_dim(min, alloc_extent_i));
+    if (i + 1 < rank) {
+      learn_dim(init_stride_dim(min, alloc_extent_i));
+    }
   }
 }
 

--- a/runtime/buffer.cc
+++ b/runtime/buffer.cc
@@ -526,16 +526,16 @@ SLINKY_NO_INLINE index_t make_for_each_loops_impl(
     }
 
     // Align the bases for dimensions we will access via linear pointer arithmetic.
-    if (bases[0]) {
+    if (SLINKY_LIKELY(bases[0])) {
       // This function is expected to adjust all bases to point to the min of `buf_dim`. For non-folded dimensions, that
       // is true by construction, but not for folded dimensions.
       index_t offset = buf_dim.flat_offset_bytes(buf_dim.min());
       bases[0] = offset_bytes_non_null(bases[0], offset);
     }
     for (std::size_t n = 1; n < bufs_size; n++) {
-      if (bases[n] && d < static_cast<index_t>(bufs[n]->rank)) {
+      if (SLINKY_LIKELY(bases[n] && d < static_cast<index_t>(bufs[n]->rank))) {
         const dim& buf_n_dim = bufs[n]->dim(d);
-        if (buf_n_dim.contains(buf_dim)) {
+        if (SLINKY_LIKELY(buf_n_dim.contains(buf_dim))) {
           index_t offset = buf_n_dim.flat_offset_bytes(buf_dim.min());
           bases[n] = offset_bytes_non_null(bases[n], offset);
         } else {

--- a/runtime/buffer.h
+++ b/runtime/buffer.h
@@ -801,7 +801,7 @@ void for_each_impl_linear(const std::array<void*, NumBufs>& bases, const for_eac
     } else {
       for_each_impl(bases_i, loop, f);
     }
-    if (--extent <= 0) break;
+    if (SLINKY_UNLIKELY(--extent <= 0)) break;
     bases_i[0] = offset_bytes_non_null(bases_i[0], strides[0]);
     // This is a critical loop, and it seems we can't trust the compiler to unroll it. These ifs are constexpr.
     if (1 < NumBufs) bases_i[1] = offset_bytes(bases_i[1], strides[1]);
@@ -836,7 +836,7 @@ void for_each_impl_folded(const std::array<void*, NumBufs>& bases, const for_eac
 template <typename F, std::size_t NumBufs>
 SLINKY_ALWAYS_INLINE inline void for_each_impl(
     const std::array<void*, NumBufs>& bases, const for_each_loop<NumBufs>* loop, const F& f) {
-  if (loop->impl == for_each_loop<>::innermost) {
+  if (SLINKY_LIKELY(loop->impl == for_each_loop<>::innermost)) {
     for_each_impl_linear<true>(bases, loop, f);
   } else if (loop->impl == 0) {
     for_each_impl_linear<false>(bases, loop, f);

--- a/runtime/buffer.h
+++ b/runtime/buffer.h
@@ -331,6 +331,7 @@ public:
   std::size_t elem_count() const;
 
   // If any strides are `auto_stride`, replace them with automatically determined strides.
+  // `alignment` must be a power of 2.
   void init_strides(index_t alignment = 1);
 
   // Allocate and set the base pointer using `malloc`. Returns a pointer to the allocated memory, which should
@@ -371,6 +372,18 @@ void copy_small_n(const T* src, std::size_t n, T* dst) {
   case 1: *dst++ = *src++;
   case 0: return;
   default: std::copy_n(src, n, dst); return;
+  }
+}
+
+template <typename T>
+void copy_small_n_backward(const T* src, std::size_t n, T* dst) {
+  switch (n) {
+  case 4: *(--dst) = *(--src);
+  case 3: *(--dst) = *(--src);
+  case 2: *(--dst) = *(--src);
+  case 1: *(--dst) = *(--src);
+  case 0: return;
+  default: std::copy_backward(src, src + n, dst + n); return;
   }
 }
 

--- a/runtime/buffer.h
+++ b/runtime/buffer.h
@@ -332,7 +332,7 @@ public:
 
   // If any strides are `auto_stride`, replace them with automatically determined strides.
   // `alignment` must be a power of 2.
-  void init_strides(index_t alignment = 1);
+  std::size_t init_strides(index_t alignment = 1);
 
   // Allocate and set the base pointer using `malloc`. Returns a pointer to the allocated memory, which should
   // be deallocated with `free`.

--- a/runtime/depends_on.cc
+++ b/runtime/depends_on.cc
@@ -4,6 +4,7 @@
 
 #include "base/chrome_trace.h"
 #include "runtime/expr.h"
+#include "runtime/print.h"
 
 namespace slinky {
 
@@ -53,7 +54,7 @@ public:
       case buffer_field::fold_factor: deps->buffer_dims = true; break;
       case buffer_field::rank:
       case buffer_field::elem_size: deps->var = true; break;
-      default: std::abort();
+      default: SLINKY_UNREACHABLE << "unknown buffer_field " << to_string(op->field);
       }
     }
   }

--- a/runtime/evaluate.cc
+++ b/runtime/evaluate.cc
@@ -135,10 +135,9 @@ public:
 
   index_t eval(const variable* op) {
     index_t value = context.lookup(op->sym);
-    if (op->field == buffer_field::none) return value;
-
     const raw_buffer* buf = reinterpret_cast<const raw_buffer*>(value);
     switch (op->field) {
+    case buffer_field::none: return value;
     case buffer_field::rank: return buf->rank;
     case buffer_field::elem_size: return buf->elem_size;
     case buffer_field::min: return buf->dim(op->dim).min();
@@ -462,9 +461,9 @@ public:
 
   // Not using SLINKY_NO_STACK_PROTECTOR here because this actually could allocate a lot of memory on the stack.
   index_t eval(const allocate* op) {
-    std::size_t rank = op->dims.size();
     allocated_buffer buffer;
     buffer.elem_size = eval(op->elem_size);
+    std::size_t rank = op->dims.size();
     buffer.rank = rank;
     buffer.dims = SLINKY_ALLOCA(dim, rank);
 
@@ -496,7 +495,6 @@ public:
   }
 
   SLINKY_NO_STACK_PROTECTOR index_t eval(const make_buffer* op) {
-    std::size_t rank = op->dims.size();
     raw_buffer buffer;
     buffer.elem_size = eval(op->elem_size, 0);
     // The base is very likely a buffer_at call, try to skip the eval overhead.
@@ -505,6 +503,7 @@ public:
     } else {
       buffer.base = reinterpret_cast<void*>(eval(op->base, 0));
     }
+    std::size_t rank = op->dims.size();
     buffer.rank = rank;
     buffer.dims = SLINKY_ALLOCA(dim, rank);
 

--- a/runtime/evaluate.cc
+++ b/runtime/evaluate.cc
@@ -107,8 +107,8 @@ public:
 
   // If `e` is defined, evaluate it and return the result. Otherwise, return default `def`.
   index_t eval(const expr& e, index_t def) {
-    undef = false;
     if (e.defined()) {
+      undef = false;
       index_t result = eval(e);
       return undef ? def : result;
     } else {

--- a/runtime/evaluate.cc
+++ b/runtime/evaluate.cc
@@ -476,13 +476,13 @@ public:
       buf_d.set_fold_factor(eval(op_d.fold_factor, dim::unfolded));
     }
 
-    if (op->storage == memory_type::stack) {
+    if (op->storage == memory_type::heap) {
+      buffer.allocation = context.allocate(op->sym, &buffer);
+    } else {
+      assert(op->storage == memory_type::stack);
       std::size_t size = buffer.init_strides();
       buffer.base = __builtin_alloca(size);
       buffer.allocation = nullptr;
-    } else {
-      assert(op->storage == memory_type::heap);
-      buffer.allocation = context.allocate(op->sym, &buffer);
     }
 
     index_t result = eval_with_value(op->body, op->sym, reinterpret_cast<index_t>(&buffer));

--- a/runtime/evaluate.cc
+++ b/runtime/evaluate.cc
@@ -170,20 +170,12 @@ public:
   index_t eval(const logical_not* op) { return eval(op->a) == 0; }
 
   index_t eval(const class select* op) {
-    if (eval(op->condition)) {
-      if (op->true_value.defined()) {
-        return eval(op->true_value);
-      } else {
-        undef = true;
-        return 0;
-      }
+    const expr& value = eval(op->condition) ? op->true_value : op->false_value;
+    if (value.defined()) {
+      return eval(value);
     } else {
-      if (op->false_value.defined()) {
-        return eval(op->false_value);
-      } else {
-        undef = true;
-        return 0;
-      }
+      undef = true;
+      return 0;
     }
   }
 

--- a/runtime/evaluate.cc
+++ b/runtime/evaluate.cc
@@ -220,7 +220,10 @@ public:
 
   void* eval_buffer_at(const call* op) {
     assert(op->args.size() >= 1);
-    raw_buffer* buf = reinterpret_cast<raw_buffer*>(eval(op->args[0]));
+    auto sym = as_variable(op->args[0]);
+    assert(sym);
+    const raw_buffer* buf = context.lookup_buffer(*sym);
+    assert(buf);
     void* result = buf->base;
     assert(op->args.size() <= buf->rank + 1);
     for (std::size_t d = 0; d < op->args.size() - 1; ++d) {

--- a/runtime/evaluate.cc
+++ b/runtime/evaluate.cc
@@ -101,7 +101,7 @@ public:
     case expr_node_type::less_equal: return make_binary<less_equal>(a, b);
     case expr_node_type::logical_and: return make_binary<logical_and>(a, b);
     case expr_node_type::logical_or: return make_binary<logical_or>(a, b);
-    default: std::abort();
+    default: SLINKY_UNREACHABLE << "unknown binary operator " << to_string(op->type);
     }
   }
 
@@ -145,7 +145,7 @@ public:
     case buffer_field::max: return buf->dim(op->dim).max();
     case buffer_field::stride: return buf->dim(op->dim).stride();
     case buffer_field::fold_factor: return buf->dim(op->dim).fold_factor();
-    default: std::abort();
+    default: SLINKY_UNREACHABLE << "unkonwn var field " << to_string(op->field);
     }
   }
 
@@ -214,7 +214,7 @@ public:
     assert(buf);
     switch (op->intrinsic) {
     case intrinsic::buffer_size_bytes: return buf->size_bytes();
-    default: std::abort();
+    default: SLINKY_UNREACHABLE << "unknown buffer metadata intrinsic " << to_string(op->intrinsic);
     }
   }
 
@@ -309,9 +309,9 @@ public:
 
   SLINKY_NO_INLINE index_t eval(const call* op) {
     switch (op->intrinsic) {
-    case intrinsic::positive_infinity: std::cerr << "Cannot evaluate positive_infinity" << std::endl; std::abort();
-    case intrinsic::negative_infinity: std::cerr << "Cannot evaluate negative_infinity" << std::endl; std::abort();
-    case intrinsic::indeterminate: std::cerr << "Cannot evaluate indeterminate" << std::endl; std::abort();
+    case intrinsic::positive_infinity: SLINKY_UNREACHABLE << "cannot evaluate positive_infinity";
+    case intrinsic::negative_infinity: SLINKY_UNREACHABLE << "cannot evaluate negative_infinity";
+    case intrinsic::indeterminate: SLINKY_UNREACHABLE << "cannot evaluate indeterminate";
 
     case intrinsic::abs: assert(op->args.size() == 1); return std::abs(eval(op->args[0]));
 
@@ -332,7 +332,7 @@ public:
 
     case intrinsic::free: return eval_free(op);
 
-    default: std::cerr << "Unknown intrinsic: " << op->intrinsic << std::endl; std::abort();
+    default: SLINKY_UNREACHABLE << "unknown intrinsic: " << to_string(op->intrinsic);
     }
   }
 
@@ -341,9 +341,7 @@ public:
     // we handle common node types here, and call a non-inlined handler for the less common nodes below.
     switch (op.type()) {
     case stmt_node_type::call_stmt: return eval(reinterpret_cast<const call_stmt*>(op.get()));
-    case stmt_node_type::copy_stmt: return eval(reinterpret_cast<const copy_stmt*>(op.get()));
     case stmt_node_type::crop_dim: return eval(reinterpret_cast<const crop_dim*>(op.get()));
-    case stmt_node_type::slice_dim: return eval(reinterpret_cast<const slice_dim*>(op.get()));
     default: return eval_non_inlined(op);
     }
   }
@@ -360,6 +358,7 @@ public:
 
   SLINKY_NO_INLINE index_t eval_non_inlined(const stmt& op) {
     switch (op.type()) {
+    case stmt_node_type::copy_stmt: return eval(reinterpret_cast<const copy_stmt*>(op.get()));
     case stmt_node_type::let_stmt: return eval(reinterpret_cast<const let_stmt*>(op.get()));
     case stmt_node_type::block: return eval(reinterpret_cast<const block*>(op.get()));
     case stmt_node_type::loop: return eval(reinterpret_cast<const loop*>(op.get()));
@@ -368,9 +367,10 @@ public:
     case stmt_node_type::clone_buffer: return eval(reinterpret_cast<const clone_buffer*>(op.get()));
     case stmt_node_type::crop_buffer: return eval(reinterpret_cast<const crop_buffer*>(op.get()));
     case stmt_node_type::slice_buffer: return eval(reinterpret_cast<const slice_buffer*>(op.get()));
+    case stmt_node_type::slice_dim: return eval(reinterpret_cast<const slice_dim*>(op.get()));
     case stmt_node_type::transpose: return eval(reinterpret_cast<const transpose*>(op.get()));
     case stmt_node_type::check: return eval(reinterpret_cast<const check*>(op.get()));
-    default: std::abort();
+    default: SLINKY_UNREACHABLE << "unknown stmt type " << to_string(op.type());
     }
   }
 
@@ -449,8 +449,7 @@ public:
   }
 
   index_t eval(const copy_stmt* op) {
-    std::cerr << "copy_stmt should have been implemented by calls to copy/pad." << std::endl;
-    std::abort();
+    SLINKY_UNREACHABLE << "copy_stmt should have been implemented by calls to copy/pad.";
   }
 
   // Not using SLINKY_NO_STACK_PROTECTOR here because this actually could allocate a lot of memory on the stack.

--- a/runtime/evaluate.cc
+++ b/runtime/evaluate.cc
@@ -106,7 +106,7 @@ public:
   }
 
   // If `e` is defined, evaluate it and return the result. Otherwise, return default `def`.
-  index_t eval(const expr& e, index_t def) {
+  SLINKY_ALWAYS_INLINE index_t eval(const expr& e, index_t def) {
     if (e.defined()) {
       undef = false;
       index_t result = eval(e);
@@ -116,7 +116,7 @@ public:
     }
   }
 
-  interval eval(const interval_expr& x) {
+  SLINKY_ALWAYS_INLINE interval eval(const interval_expr& x) {
     index_t min = eval(x.min);
     if (x.is_point()) {
       return {min, min};
@@ -124,8 +124,8 @@ public:
       return {min, eval(x.max)};
     }
   }
-  interval eval(const interval_expr& x, interval def) {
-    if (x.is_point() && x.min.defined()) {
+  SLINKY_ALWAYS_INLINE interval eval(const interval_expr& x, interval def) {
+    if (x.is_point()) {
       index_t result = eval(x.min);
       return {result, result};
     } else {

--- a/runtime/evaluate.cc
+++ b/runtime/evaluate.cc
@@ -477,8 +477,8 @@ public:
     }
 
     if (op->storage == memory_type::stack) {
-      buffer.init_strides();
-      buffer.base = __builtin_alloca(buffer.size_bytes());
+      std::size_t size = buffer.init_strides();
+      buffer.base = __builtin_alloca(size);
       buffer.allocation = nullptr;
     } else {
       assert(op->storage == memory_type::heap);

--- a/runtime/evaluate.cc
+++ b/runtime/evaluate.cc
@@ -494,7 +494,12 @@ public:
     std::size_t rank = op->dims.size();
     raw_buffer buffer;
     buffer.elem_size = eval(op->elem_size, 0);
-    buffer.base = reinterpret_cast<void*>(eval(op->base, 0));
+    // The base is very likely a buffer_at call, try to skip the eval overhead.
+    if (const call* c = op->base.as<call>()) {
+      buffer.base = reinterpret_cast<void*>(eval(c));
+    } else {
+      buffer.base = reinterpret_cast<void*>(eval(op->base, 0));
+    }
     buffer.rank = rank;
     buffer.dims = SLINKY_ALLOCA(dim, rank);
 

--- a/runtime/evaluate.cc
+++ b/runtime/evaluate.cc
@@ -191,7 +191,8 @@ public:
     return op->intrinsic == intrinsic::and_then;
   }
 
-  index_t eval_define_undef(const call* op) {
+  // Only used for testing, should not inline.
+  SLINKY_NO_INLINE index_t eval_define_undef(const call* op) {
     assert(op->args.size() == 2);
     index_t def = eval(op->args[1]);
     return eval(op->args[0], def);

--- a/runtime/evaluate.h
+++ b/runtime/evaluate.h
@@ -13,21 +13,20 @@ class eval_context {
   // usage when evaluating.
   std::vector<index_t> values_;
 
-  void grow(std::size_t size) {
+public:
+  void reserve(std::size_t size) {
     if (size > values_.size()) {
       values_.resize(std::max(values_.size() * 2, size));
     }
   }
 
-public:
   index_t& operator[](var id) {
-    grow(id.id + 1);
+    reserve(id.id + 1);
     return values_[id.id];
   }
   index_t operator[](var id) const { return values_[id.id]; }
 
   index_t set(var id, index_t value) {
-    grow(id.id + 1);
     index_t& value_ref = values_[id.id];
     index_t old_value = value_ref;
     value_ref = value;

--- a/runtime/evaluate.h
+++ b/runtime/evaluate.h
@@ -13,16 +13,31 @@ class eval_context {
   // usage when evaluating.
   std::vector<index_t> values_;
 
+  void grow(std::size_t size) {
+    if (size > values_.size()) {
+      values_.resize(std::max(values_.size() * 2, size));
+    }
+  }
+
 public:
   index_t& operator[](var id) {
-    if (id.id >= values_.size()) {
-      values_.resize(std::max(values_.size() * 2, id.id + 1));
-    }
+    grow(id.id + 1);
     return values_[id.id];
   }
   index_t operator[](var id) const { return values_[id.id]; }
 
-  index_t lookup(var id) const { return values_[id.id]; }
+  index_t set(var id, index_t value) {
+    grow(id.id + 1);
+    index_t& value_ref = values_[id.id];
+    index_t old_value = value_ref;
+    value_ref = value;
+    return old_value;
+  }
+
+  index_t lookup(var id) const {
+    assert(id.id < values_.size());
+    return values_[id.id];
+  }
   const raw_buffer* lookup_buffer(var id) const { return reinterpret_cast<const raw_buffer*>(lookup(id)); }
   template <typename T>
   const buffer<T>* lookup_buffer(var id) const {

--- a/runtime/expr.h
+++ b/runtime/expr.h
@@ -526,15 +526,7 @@ struct dim_expr {
     return bounds.same_as(r.bounds) && stride.same_as(r.stride) && fold_factor.same_as(r.fold_factor);
   }
 
-  const expr& get_field(buffer_field field) const {
-    switch (field) {
-    case buffer_field::min: return bounds.min;
-    case buffer_field::max: return bounds.max;
-    case buffer_field::stride: return stride;
-    case buffer_field::fold_factor: return fold_factor;
-    default: std::abort();
-    }
-  }
+  const expr& get_field(buffer_field field) const;
 };
 
 class expr_visitor {

--- a/runtime/expr_stmt.cc
+++ b/runtime/expr_stmt.cc
@@ -1,5 +1,6 @@
 #include "runtime/expr.h"
 #include "runtime/stmt.h"
+#include "runtime/print.h"
 
 #include <algorithm>
 #include <cassert>
@@ -699,6 +700,17 @@ box_expr dims_bounds(span<const dim_expr> dims) {
     result[d] = dims[d].bounds;
   }
   return result;
+}
+
+
+const expr& dim_expr::get_field(buffer_field field) const {
+  switch (field) {
+  case buffer_field::min: return bounds.min;
+  case buffer_field::max: return bounds.max;
+  case buffer_field::stride: return stride;
+  case buffer_field::fold_factor: return fold_factor;
+  default: SLINKY_UNREACHABLE << "buffer_field " << to_string(field) << " is not a dim field";
+  }
 }
 
 bool is_buffer_intrinsic(intrinsic fn) {

--- a/runtime/print.cc
+++ b/runtime/print.cc
@@ -51,9 +51,60 @@ const char* to_string(intrinsic fn) {
   }
 }
 
+const char* to_string(stmt_node_type type) {
+  switch (type) {
+  case stmt_node_type::none: return "none";
+  case stmt_node_type::call_stmt: return "call_stmt";
+  case stmt_node_type::copy_stmt: return "copy_stmt";
+  case stmt_node_type::let_stmt: return "let_stmt";
+  case stmt_node_type::block: return "block";
+  case stmt_node_type::loop: return "loop";
+  case stmt_node_type::allocate: return "allocate";
+  case stmt_node_type::make_buffer: return "make_buffer";
+  case stmt_node_type::clone_buffer: return "clone_buffer";
+  case stmt_node_type::crop_buffer: return "crop_buffer";
+  case stmt_node_type::crop_dim: return "crop_dim";
+  case stmt_node_type::slice_buffer: return "slice_buffer";
+  case stmt_node_type::slice_dim: return "slice_dim";
+  case stmt_node_type::transpose: return "transpose";
+  case stmt_node_type::check: return "check";
+
+  default: return "<invalid stmt_node_type>";
+  }
+}
+
+const char* to_string(expr_node_type type) {
+  switch (type) {
+  case expr_node_type::none: return "none";
+  case expr_node_type::variable: return "variable";
+  case expr_node_type::let: return "let";
+  case expr_node_type::add: return "add";
+  case expr_node_type::sub: return "sub";
+  case expr_node_type::mul: return "mul";
+  case expr_node_type::div: return "div";
+  case expr_node_type::mod: return "mod";
+  case expr_node_type::min: return "min";
+  case expr_node_type::max: return "max";
+  case expr_node_type::equal: return "equal";
+  case expr_node_type::not_equal: return "not_equal";
+  case expr_node_type::less: return "less";
+  case expr_node_type::less_equal: return "less_equal";
+  case expr_node_type::logical_and: return "logical_and";
+  case expr_node_type::logical_or: return "logical_or";
+  case expr_node_type::logical_not: return "logical_not";
+  case expr_node_type::select: return "select";
+  case expr_node_type::call: return "call";
+  case expr_node_type::constant: return "constant";
+
+  default: return "<invalid expr_node_type>";
+  }
+}
+
 std::ostream& operator<<(std::ostream& os, memory_type type) { return os << to_string(type); }
 std::ostream& operator<<(std::ostream& os, intrinsic fn) { return os << to_string(fn); }
 std::ostream& operator<<(std::ostream& os, buffer_field f) { return os << to_string(f); }
+std::ostream& operator<<(std::ostream& os, stmt_node_type t) { return os << to_string(t); }
+std::ostream& operator<<(std::ostream& os, expr_node_type t) { return os << to_string(t); }
 
 std::ostream& operator<<(std::ostream& os, const interval_expr& i) {
   return os << "[" << i.min << ", " << i.max << "]";
@@ -159,7 +210,7 @@ public:
     case buffer_field::max: *this << "buffer_max(" << v->sym << ", " << v->dim << ")"; return;
     case buffer_field::stride: *this << "buffer_stride(" << v->sym << ", " << v->dim << ")"; return;
     case buffer_field::fold_factor: *this << "buffer_fold_factor(" << v->sym << ", " << v->dim << ")"; return;
-    default: std::abort();
+    default: SLINKY_UNREACHABLE << "unknown buffer_field " << to_string(v->field);
     }
   }
   void visit(const constant* c) override { *this << c->value; }

--- a/runtime/print.h
+++ b/runtime/print.h
@@ -26,6 +26,8 @@ std::ostream& operator<<(std::ostream& os, const box_expr& i);
 std::ostream& operator<<(std::ostream& os, intrinsic fn);
 std::ostream& operator<<(std::ostream& os, buffer_field f);
 std::ostream& operator<<(std::ostream& os, memory_type type);
+std::ostream& operator<<(std::ostream& os, stmt_node_type type);
+std::ostream& operator<<(std::ostream& os, expr_node_type type);
 
 template <typename T>
 std::ostream& operator<<(std::ostream& os, const modulus_remainder<T>& i) {
@@ -39,9 +41,11 @@ std::ostream& operator<<(std::ostream& os, const dim& d);
 // intended usage here is to do `using std::to_string;` followed by naked
 // to_string() calls.
 std::string to_string(var sym);
-const char* to_string(intrinsic fn);
-const char* to_string(buffer_field f);
-const char* to_string(memory_type type);
+SLINKY_PURE const char* to_string(intrinsic fn);
+SLINKY_PURE const char* to_string(buffer_field f);
+SLINKY_PURE const char* to_string(memory_type type);
+SLINKY_PURE const char* to_string(stmt_node_type type);
+SLINKY_PURE const char* to_string(expr_node_type type);
 
 }  // namespace slinky
 

--- a/runtime/test/buffer_benchmark.cc
+++ b/runtime/test/buffer_benchmark.cc
@@ -391,18 +391,26 @@ void BM_for_each_element_batch_dims(benchmark::State& state) {
 BENCHMARK(BM_for_each_element_batch_dims);
 
 void BM_init_strides(benchmark::State& state) {
+  int extent0 = state.range(0);
+  int extent1 = state.range(1);
+  int extent2 = state.range(2);
+  int extent3 = state.range(3);
 
   for (auto _ : state) {
     buffer<int, 4> buf;
-    buf.dim(0).set_min_extent(0, 44);
-    buf.dim(1).set_min_extent(0, 1);
-    buf.dim(2).set_min_extent(0, 1);
-    buf.dim(3).set_min_extent(0, 1);
+    buf.dim(0).set_min_extent(0, extent0);
+    buf.dim(1).set_min_extent(0, extent1);
+    buf.dim(2).set_min_extent(0, extent2);
+    buf.dim(3).set_min_extent(0, extent3);
 
     buf.init_strides();
   }
 }
 
-BENCHMARK(BM_init_strides);
+BENCHMARK(BM_init_strides)->Args({5, 4, 3, 2});
+BENCHMARK(BM_init_strides)->Args({4, 3, 2, 1});
+BENCHMARK(BM_init_strides)->Args({3, 2, 1, 1});
+BENCHMARK(BM_init_strides)->Args({2, 1, 1, 1});
+BENCHMARK(BM_init_strides)->Args({1, 1, 1, 1});
 
 }  // namespace slinky

--- a/runtime/visualize.cc
+++ b/runtime/visualize.cc
@@ -130,7 +130,7 @@ public:
     case buffer_field::max: *this << "buffer_max(" << v->sym << ", " << v->dim << ")"; return;
     case buffer_field::stride: *this << "buffer_stride(" << v->sym << ", " << v->dim << ")"; return;
     case buffer_field::fold_factor: *this << "buffer_fold_factor(" << v->sym << ", " << v->dim << ")"; return;
-    default: std::abort();
+    default: SLINKY_UNREACHABLE << "unknown buffer_field " << to_string(v->field);
     }
   }
   void visit(const constant* c) override { *this << c->value; }


### PR DESCRIPTION
- Add a proper "unreachable" code function/macro
- Optimize `init_strides` by maintaining a sorted list of dimensions
- Compute buffer size in `init_strides`, so allocation uses don't need to call both functions
- Add some guesses to likely nodes types in evaluate
- Lift growing the context "memory" out of loops
- Tweak inlining of evaluate implementations
- Remove checks later, so the second `simplify` can see them
- Add `canonicalize_nodes`
- Tweaks to `for_each_element`