### PR TITLE
Alias inputs and outputs of calls that can be performed in-place

### DIFF
--- a/builder/optimizations.cc
+++ b/builder/optimizations.cc
@@ -729,6 +729,12 @@ class in_place_aliaser : public stmt_mutator {
   symbol_map<bool> used;
 
 public:
+  in_place_aliaser(const std::vector<buffer_expr_ptr>& outputs) {
+    for (const buffer_expr_ptr& i : outputs) {
+      aliases[i->sym()] = i->sym();
+    }
+  }
+
   void visit(const allocate* op) override {
     auto set_alias = set_value_in_scope(aliases, op->sym, op->sym);
     auto set_replace = set_value_in_scope(replace, op->sym, var());
@@ -815,9 +821,9 @@ public:
 
 }  // namespace
 
-stmt alias_in_place(const stmt& s) {
+stmt alias_in_place(const stmt& s, const std::vector<buffer_expr_ptr>& outputs) {
   scoped_trace trace("alias_in_place");
-  return in_place_aliaser().mutate(s);
+  return in_place_aliaser(outputs).mutate(s);
 }
 
 stmt implement_copy(const copy_stmt* op, node_context& ctx) {

--- a/builder/optimizations.h
+++ b/builder/optimizations.h
@@ -11,7 +11,7 @@ stmt alias_copies(const stmt& s, node_context& ctx, const std::vector<buffer_exp
     const std::vector<buffer_expr_ptr>& outputs);
 
 // Replace allocations of input buffers to calls that can be computed in place with crops of the output buffer.
-stmt alias_in_place(const stmt& s);
+stmt alias_in_place(const stmt& s, const std::vector<buffer_expr_ptr>& outputs);
 
 // Given a copy_stmt, produce an implementation that calls `slinky::copy`, possibly inside loops that implement copy
 // operations that `slinky::copy` cannot express.

--- a/builder/optimizations.h
+++ b/builder/optimizations.h
@@ -10,9 +10,10 @@ namespace slinky {
 stmt alias_copies(const stmt& s, node_context& ctx, const std::vector<buffer_expr_ptr>& inputs,
     const std::vector<buffer_expr_ptr>& outputs);
 
+// Replace allocations of input buffers to calls that can be computed in place with crops of the output buffer.
 stmt alias_in_place(const stmt& s);
 
-  // Given a copy_stmt, produce an implementation that calls `slinky::copy`, possibly inside loops that implement copy
+// Given a copy_stmt, produce an implementation that calls `slinky::copy`, possibly inside loops that implement copy
 // operations that `slinky::copy` cannot express.
 stmt implement_copy(const copy_stmt* c, node_context& ctx);
 

--- a/builder/optimizations.h
+++ b/builder/optimizations.h
@@ -10,7 +10,9 @@ namespace slinky {
 stmt alias_copies(const stmt& s, node_context& ctx, const std::vector<buffer_expr_ptr>& inputs,
     const std::vector<buffer_expr_ptr>& outputs);
 
-// Given a copy_stmt, produce an implementation that calls `slinky::copy`, possibly inside loops that implement copy
+stmt alias_in_place(const stmt& s);
+
+  // Given a copy_stmt, produce an implementation that calls `slinky::copy`, possibly inside loops that implement copy
 // operations that `slinky::copy` cannot express.
 stmt implement_copy(const copy_stmt* c, node_context& ctx);
 

--- a/builder/pipeline.cc
+++ b/builder/pipeline.cc
@@ -1329,6 +1329,7 @@ stmt build_pipeline(node_context& ctx, const std::vector<buffer_expr_ptr>& input
     inputs_and_constants.insert(inputs_and_constants.end(), inputs.begin(), inputs.end());
     inputs_and_constants.insert(inputs_and_constants.end(), constants.begin(), constants.end());
     result = alias_copies(result, ctx, inputs_and_constants, outputs);
+    result = alias_in_place(result);
   }
 
   // `evaluate` currently can't handle `copy_stmt`, so this is required.

--- a/builder/pipeline.cc
+++ b/builder/pipeline.cc
@@ -1329,7 +1329,7 @@ stmt build_pipeline(node_context& ctx, const std::vector<buffer_expr_ptr>& input
     inputs_and_constants.insert(inputs_and_constants.end(), inputs.begin(), inputs.end());
     inputs_and_constants.insert(inputs_and_constants.end(), constants.begin(), constants.end());
     result = alias_copies(result, ctx, inputs_and_constants, outputs);
-    result = alias_in_place(result);
+    result = alias_in_place(result, outputs);
   }
 
   // `evaluate` currently can't handle `copy_stmt`, so this is required.

--- a/builder/test/pipeline.cc
+++ b/builder/test/pipeline.cc
@@ -1444,8 +1444,8 @@ TEST(split, pipeline) {
       },
       {{intm, {point(x + W), point(y)}}}, {{intm2, {x, y}}}, call_stmt::attributes{.allow_in_place = true});
 
-  func sum_out =
-      func::make(subtract<short>, {{intm1, {point(x), point(y)}}, {intm2, {point(x), point(y)}}}, {{out, {x, y}}});
+  func sum_out = func::make(subtract<short>, {{intm1, {point(x), point(y)}}, {intm2, {point(x), point(y)}}},
+      {{out, {x, y}}}, call_stmt::attributes{.allow_in_place = true});
 
   pipeline p = build_pipeline(ctx, {in}, {out});
 

--- a/runtime/expr.h
+++ b/runtime/expr.h
@@ -829,6 +829,10 @@ template <typename T>
 scoped_value_in_symbol_map<T> set_value_in_scope(symbol_map<T>& context, var sym, std::optional<T> value) {
   return scoped_value_in_symbol_map<T>(context, sym, std::move(value));
 }
+template <typename T>
+scoped_value_in_symbol_map<T> set_value_in_scope(symbol_map<T>& context, var sym, std::nullopt_t) {
+  return scoped_value_in_symbol_map<T>(context, sym, std::nullopt);
+}
 
 }  // namespace slinky
 

--- a/runtime/expr.h
+++ b/runtime/expr.h
@@ -755,6 +755,12 @@ public:
     return values[i];
   }
 
+  void erase(var v) {
+    if (v.id < values.size()) {
+      values[v.id] = std::nullopt;
+    }
+  }
+
   std::size_t size() const { return values.size(); }
   void reserve(std::size_t size) { values.resize(std::max(values.size(), size)); }
   auto begin() { return values.begin(); }


### PR DESCRIPTION
This recovers functionality lost in #548 