### PR TITLE
Small simplify improvements

### DIFF
--- a/builder/rewrite.h
+++ b/builder/rewrite.h
@@ -14,7 +14,7 @@ namespace slinky {
 namespace rewrite {
 
 // The maximum number of values pattern_wildcard::idx and pattern_constant::idx can have, starting from 0.
-constexpr int symbol_count = 6;
+constexpr int symbol_count = 7;
 constexpr int constant_count = 5;
 
 template <int N>

--- a/builder/simplify.cc
+++ b/builder/simplify.cc
@@ -1225,7 +1225,8 @@ public:
     alignment_type alignment;
     if (auto cstep = as_constant(step)) alignment.modulus = *cstep;
     if (auto cmin = as_constant(bounds.min)) alignment.remainder = *cmin;
-    stmt body = mutate_with_bounds(op->body, op->sym, bounds, alignment);
+    // If we're in the body of the loop, then we know that bounds.max >= bounds.min.
+    stmt body = mutate_with_bounds(op->body, op->sym, {bounds.min, mutate(max(bounds.min, bounds.max))}, alignment);
     for (auto& i : buffers) {
       if (i) --i->loop_depth;
     }

--- a/builder/simplify_rules.h
+++ b/builder/simplify_rules.h
@@ -39,7 +39,9 @@ bool apply_min_rules(Fn&& apply) {
       apply(min(x, y), x && y, is_boolean(x) && is_boolean(y)) ||
 
       // This might be the only rule that doesn't have an analogous max rule.
-      apply(min(max(x, c0), c1), max(min(x, c1), c0), c0 <= c1) ||
+      apply(min(max(x, c0), c1), 
+        c0, c0 == c1,
+        max(min(x, c1), c0), c0 < c1) ||
 
       // Canonicalize trees and find duplicate terms.
       apply(min(min(x, y), min(x, z)), min(x, min(y, z))) ||

--- a/builder/simplify_rules.h
+++ b/builder/simplify_rules.h
@@ -13,6 +13,7 @@ rewrite::pattern_wildcard<2> z;
 rewrite::pattern_wildcard<3> w;
 rewrite::pattern_wildcard<4> u;
 rewrite::pattern_wildcard<5> v;
+rewrite::pattern_wildcard<6> t;
 
 rewrite::pattern_constant<0> c0;
 rewrite::pattern_constant<1> c1;
@@ -105,6 +106,9 @@ bool apply_min_rules(Fn&& apply) {
       apply(min(w + select(x, y, z), select(x, u, v)), select(x, min(u, w + y), min(v, w + z))) ||
       apply(min(w - select(x, y, z), select(x, u, v)), select(x, min(u, w - y), min(v, w - z))) ||
       apply(min(select(x, y, z) - w, select(x, u, v)), select(x, min(u, y - w), min(v, z - w))) ||
+
+      apply(min(select(x, y, select(z, w, u)), select(z, v, t)), select(z, min(v, select(x, y, w)), min(t, select(x, y, u)))) ||
+      apply(min(select(x, select(z, w, u), y), select(z, v, t)), select(z, min(v, select(x, w, y)), min(t, select(x, u, y)))) ||
 
       apply(min(x + c2, select(c0 < x, y, c1)), select(c0 < x, min(x, y - c2), x) + c2, c1 >= c0 + c2) ||
       apply(min(x + c2, select(c0 < x, c1, y)), select(c0 < x, c1, min(y, x + c2)), c1 <= c0 + c2) ||
@@ -273,6 +277,9 @@ bool apply_max_rules(Fn&& apply) {
       apply(max(w + select(x, y, z), select(x, u, v)), select(x, max(u, w + y), max(v, w + z))) ||
       apply(max(w - select(x, y, z), select(x, u, v)), select(x, max(u, w - y), max(v, w - z))) ||
       apply(max(select(x, y, z) - w, select(x, u, v)), select(x, max(u, y - w), max(v, z - w))) ||
+    
+      apply(max(select(x, y, select(z, w, u)), select(z, v, t)), select(z, max(v, select(x, y, w)), max(t, select(x, y, u)))) ||
+      apply(max(select(x, select(z, w, u), y), select(z, v, t)), select(z, max(v, select(x, w, y)), max(t, select(x, u, y)))) ||
 
       apply(max(x + c2, select(c0 < x, y, c1)), select(c0 < x, max(y, x + c2), c1), c1 >= c0 + c2) ||
       apply(max(x + c2, select(c0 < x, c1, y)), select(c0 < x, x, max(x, y - c2)) + c2, c1 <= c0 + c2) ||

--- a/builder/test/simplify/simplify.cc
+++ b/builder/test/simplify/simplify.cc
@@ -204,6 +204,10 @@ TEST(simplify, basic) {
       matches(call_stmt::make(nullptr, {}, {x}, {})));
   ASSERT_THAT(simplify(slice_buffer::make(y, x, {}, call_stmt::make(nullptr, {}, {y}, {}))),
       matches(call_stmt::make(nullptr, {}, {x}, {})));
+
+  ASSERT_THAT(simplify(max(select(z <= 0, -1, select(1 <= y, min(x, z + -1), 0)) + 1, select((1 <= y), z, 0))),
+      matches(select((1 <= y), max(z, 0), (0 < z))));
+  
 }
 
 TEST(simplify, let) {

--- a/builder/test/simplify/simplify.cc
+++ b/builder/test/simplify/simplify.cc
@@ -520,6 +520,11 @@ TEST(simplify, buffer_bounds) {
   ASSERT_THAT(simplify(decl_bounds(b0, {{0, select(1 < x, y, 1) + -1}},
                   crop_dim::make(b1, b0, 0, {0, select(1 < x, expr(), 0)}, use_buffer(b1)))),
       matches(decl_bounds(b0, {{0, select(1 < x, y, 1) + -1}}, use_buffer(b0))));
+
+  ASSERT_THAT(simplify(loop::make(x, loop::serial, {0, y}, z,
+                  crop_dim::make(b1, b0, 0, {select(x <= 0, x, expr()), y}, use_buffer(b1)))),
+      matches(loop::make(
+          x, loop::serial, {0, y}, z, crop_dim::make(b1, b0, 0, {select(x <= 0, 0, expr()), y}, use_buffer(b1)))));
 }
 
 TEST(simplify, crop_not_needed) {
@@ -794,6 +799,8 @@ TEST(simplify, knowledge) {
                   make_buffer::make(b0, expr(), expr(), {{{0, max(abs(x), 1) - 1}}},
                       check::make(buffer_max(b0, 0) <= ((buffer_max(b0, 0) + 16) / 16) * 16 - 1)))),
       matches(stmt()));
+
+  ASSERT_THAT(simplify(let::make(x, clamp(y, 0, 10), select(x <= 0, x, 0))), matches(0));
 
   expr huge_select = 1;
   for (int i = 0; i < 100; ++i) {


### PR DESCRIPTION
- Strengthen `constant_adder` to avoid missed cancellations
- Add some `min`/`max`/`select` rules
- Allow loop bodies to assume the bounds are non-empty