### PR TITLE
Fix `canonicalize_nodes` for similar-looking calls

### DIFF
--- a/builder/test/optimizations.cc
+++ b/builder/test/optimizations.cc
@@ -17,6 +17,7 @@ node_context symbols;
 var x(symbols, "x");
 var y(symbols, "y");
 var z(symbols, "z");
+var w(symbols, "w");
 
 MATCHER_P(matches, expected, "") { return match(arg, expected); }
 
@@ -68,6 +69,12 @@ TEST(optimizations, fuse_siblings) {
           use_buffer(z),
           allocate::make(y, memory_type::heap, 1, {}, use_buffer(y)),
       })));
+  ASSERT_THAT(fuse_siblings(block::make({
+                  crop_dim::make(x, y, 0, {0, 10}, crop_dim::make(z, x, 1, {0, 10}, use_buffer(z))),
+                  crop_dim::make(z, y, 0, {0, 10}, crop_dim::make(w, z, 1, {0, 10}, use_buffer(w))),
+              })),
+      matches(crop_dim::make(
+          x, y, 0, {0, 10}, crop_dim::make(z, x, 1, {0, 10}, block::make({use_buffer(z), use_buffer(z)})))));
 }
 
 TEST(optimizations, optimize_symbols) {


### PR DESCRIPTION
We had a terrible bug where if we found two calls with the same arguments (which can happen due to aliasing and reusing allocations), we thought they were equivalent, and canonicalized them.

However, `match` did not check if `call_stmt::target` was equal, which caused us to possibly call a different function.

This also fixes `fuse_siblings` to recursively mutate. Fusing a sibling can reveal new fusions in the result that we missed.