### PR TITLE
Don't rely on `match` for `call_stmt`

### DIFF
--- a/builder/optimizations.cc
+++ b/builder/optimizations.cc
@@ -1377,6 +1377,10 @@ public:
   using node_mutator::mutate;
 
   stmt mutate(const stmt& s) override {
+    if (s.as<call_stmt>()) {
+      // calls can capture state in their target that we can't compare for equality here.
+      return s;
+    }
     stmt& result = stmts[s];
     if (!result.defined()) result = node_mutator::mutate(s);
     return result;
@@ -1391,6 +1395,9 @@ public:
 
 }  // namespace
 
+expr canonicalize_nodes(const expr& e) {
+  return node_canonicalizer().mutate(e);
+}
 stmt canonicalize_nodes(const stmt& s) {
   scoped_trace trace("canonicalize_nodes");
   return node_canonicalizer().mutate(s);

--- a/builder/optimizations.h
+++ b/builder/optimizations.h
@@ -36,6 +36,7 @@ stmt optimize_symbols(const stmt& s, node_context& ctx);
 
 // Guarantees that if match(a, b) is true, then a.same_as(b) is true, i.e. it rewrites matching nodes to be the same
 // object.
+expr canonicalize_nodes(const expr& s);
 stmt canonicalize_nodes(const stmt& s);
 
 }  // namespace slinky


### PR DESCRIPTION
#566 was incomplete, an std::function might point to the same function pointer, but have a different capture state. This just gives up on attempting to canonicalize calls to avoid these problems.