### PR TITLE
Allow unconstrained input bounds

### DIFF
--- a/builder/pipeline.cc
+++ b/builder/pipeline.cc
@@ -305,9 +305,8 @@ bounds_map get_output_bounds(const std::vector<func::output>& outputs) {
 
 box_expr compute_input_bounds(
     const func* f, const func::input& i, const bounds_map& output_bounds, sanitize_user_exprs& sanitizer) {
-  assert(i.bounds.size() == i.buffer->rank());
   box_expr crop(i.buffer->rank());
-  for (std::size_t d = 0; d < crop.size(); ++d) {
+  for (std::size_t d = 0; d < std::min(crop.size(), i.bounds.size()); ++d) {
     crop[d] = bounds_of(sanitizer.mutate(i.bounds[d]), output_bounds);
 
     if (d < i.input_crop.size()) {


### PR DESCRIPTION
This is a subset of #570. I think maybe we should just submit this change, which allows people to define constants that are empty buffers as placeholders.