### PR TITLE
Fix evaluate for unshadowed crops

### DIFF
--- a/runtime/evaluate.cc
+++ b/runtime/evaluate.cc
@@ -586,17 +586,14 @@ public:
     const raw_buffer* src_buf = reinterpret_cast<raw_buffer*>(context.lookup(op->src));
     assert(src_buf);
 
-    std::size_t crop_rank = op->bounds.size();
-
     raw_buffer sym_buf = *src_buf;
     sym_buf.dims = SLINKY_ALLOCA(dim, src_buf->rank);
-    for (std::size_t d = 0; d < crop_rank; ++d) {
-      slinky::dim& dim = sym_buf.dims[d];
-      dim = src_buf->dims[d];
+    internal::copy_small_n(src_buf->dims, src_buf->rank, sym_buf.dims);
+    for (std::size_t d = 0; d < op->bounds.size(); ++d) {
+      const slinky::dim& dim = sym_buf.dims[d];
       interval bounds = eval(op->bounds[d], {dim.min(), dim.max()});
       sym_buf.crop(d, bounds.min, bounds.max);
     }
-    internal::copy_small_n(src_buf->dims + crop_rank, src_buf->rank - crop_rank, sym_buf.dims + crop_rank);
 
     return eval_with_value(op->body, op->sym, reinterpret_cast<index_t>(&sym_buf));
   }

--- a/runtime/test/evaluate.cc
+++ b/runtime/test/evaluate.cc
@@ -138,11 +138,15 @@ TEST(evaluate, crop_dim) {
   buffer<void, 2> buf({10, 20});
   buf.allocate();
   ctx[x] = reinterpret_cast<index_t>(&buf);
+  buffer<void, 1> y_buf({3});
+  ctx[y] = reinterpret_cast<index_t>(&y_buf);
 
   auto buf_before = buf;
 
   evaluate(crop_dim::make(x, x, 0, {1, 3}, make_check(x, {3, 20})), ctx);
   evaluate(crop_dim::make(y, x, 0, {1, 3}, block::make({make_check(x, {10, 20}), make_check(y, {3, 20})})), ctx);
+  evaluate(
+      crop_dim::make(y, x, 0, buffer_bounds(y, 0), block::make({make_check(x, {10, 20}), make_check(y, {3, 20})})), ctx);
   ASSERT_EQ(buf_before, buf);
 }
 
@@ -151,12 +155,17 @@ TEST(evaluate, crop_buffer) {
   buffer<void, 4> buf({10, 20, 30, 40});
   buf.allocate();
   ctx[x] = reinterpret_cast<index_t>(&buf);
+  buffer<void, 4> y_buf({3, 4, 5, 6});
+  ctx[y] = reinterpret_cast<index_t>(&y_buf);
 
   auto buf_before = buf;
 
   evaluate(crop_buffer::make(x, x, {{1, 3}, {}, {2, 5}}, make_check(x, {3, 20, 4, 40})), ctx);
   evaluate(crop_buffer::make(y, x, {{1, 3}, {}, {2, 5}},
                block::make({make_check(x, {10, 20, 30, 40}), make_check(y, {3, 20, 4, 40})})),
+      ctx);
+  evaluate(crop_buffer::make(y, x, {buffer_bounds(y, 0), buffer_bounds(y, 1)},
+               block::make({make_check(x, {10, 20, 30, 40}), make_check(y, {3, 4, 30, 40})})),
       ctx);
   ASSERT_EQ(buf_before, buf);
 }


### PR DESCRIPTION
This fixes a long-standing subtle bug: evaluating the bounds of unshadowed crops *after* assigning the new buffer to the context.

This is not correct because if the bounds use that symbol, they'll use the new buffer that could shadow something from the bounds expressions.

We haven't hit this bug yet because we currently aren't very aggressive about re-using symbols, so actually shadowing something like this was rare.

This should also be a bit of an optimization, because we previously saved and restored the buffer state even in the unshadowed case, which isn't necessary.