### PR TITLE
Better layout for the constant buffers

### DIFF
--- a/builder/pipeline.cc
+++ b/builder/pipeline.cc
@@ -916,10 +916,10 @@ class pipeline_builder {
         if (!is_ready) {
           continue;
         }
-        // std::cout << new_results[ix].body << std::endl;
+
         results[ix].body = constant_buffer::make(i.first, i.second->constant(), results[ix].body);
-        // std::cout << new_results[ix].body << std::endl;
         constants_to_remove.push_back(i.first);
+
         break;
       }
     }

--- a/builder/pipeline.cc
+++ b/builder/pipeline.cc
@@ -886,10 +886,6 @@ class pipeline_builder {
       for (const auto& i : f->inputs()) {
         const auto& input = i.buffer;
 
-        // if (!input->producer()) {
-        //   continue;
-        // }
-
         if ((!f->impl() && !f->padding()) || (input->constant())) {
           // Collect all buffers which are inputs to the copy
           // and the outputs of the copy as their dependencies.
@@ -1325,7 +1321,6 @@ stmt build_pipeline(node_context& ctx, const std::vector<buffer_expr_ptr>& input
   result = builder.build({}, nullptr, loop_id()).body;
   result = builder.add_input_checks(result);
   result = builder.make_buffers(result);
-  std::cout << result << std::endl;
   result = builder.define_sanitized_replacements(result);
 
   std::vector<stmt> constraint_checks;


### PR DESCRIPTION
They are handled in almost the same way to "special" allocations (really need a better name for these, maybe "constrained"?), due to this code is fairly similar but not quite, I'm not sure if it's worth it to try to make it more general. 

This seems to be pretty effective way to do it, for one of the larger pipelines the depth went from 313 to 6!

There are also some somewhat related refactorings.