### PR TITLE
Optimize context copies for parallel loops

### DIFF
--- a/base/BUILD
+++ b/base/BUILD
@@ -6,6 +6,7 @@ package(
 cc_library(
     name = "base",
     hdrs = [
+        "allocator.h",
         "arithmetic.h",
         "ref_count.h",
         "modulus_remainder.h",

--- a/base/allocator.h
+++ b/base/allocator.h
@@ -1,0 +1,44 @@
+#ifndef SLINKY_BASE_ALLOCATOR_H
+#define SLINKY_BASE_ALLOCATOR_H
+
+#include <cstddef>
+#include <memory>
+#include <type_traits>
+
+namespace slinky {
+
+// https://howardhinnant.github.io/allocator_boilerplate.html, modified to not default construct.
+template <class T>
+class uninitialized_allocator {
+public:
+  using value_type = T;
+
+  uninitialized_allocator() noexcept {}
+  template <class U>
+  uninitialized_allocator(uninitialized_allocator<U> const&) noexcept {}
+
+  value_type* allocate(std::size_t n) { return static_cast<value_type*>(::operator new(n * sizeof(value_type))); }
+
+  void deallocate(value_type* p, std::size_t) noexcept { ::operator delete(p); }
+
+  template <class U, class... Args>
+  void construct(U* p, Args&&... args) {
+    if (sizeof...(args) > 0) {
+      ::new (p) U(std::forward<Args>(args)...);
+    }
+  }
+};
+
+template <class T, class U>
+bool operator==(uninitialized_allocator<T> const&, uninitialized_allocator<U> const&) noexcept {
+  return true;
+}
+
+template <class T, class U>
+bool operator!=(uninitialized_allocator<T> const& x, uninitialized_allocator<U> const& y) noexcept {
+  return !(x == y);
+}
+
+}  // namespace slinky
+
+#endif  // SLINKY_BASE_ARITHMETIC_H

--- a/builder/optimizations.cc
+++ b/builder/optimizations.cc
@@ -1045,7 +1045,7 @@ stmt implement_copy(const copy_stmt* op, node_context& ctx) {
         const raw_buffer* src_buf = ctx.lookup_buffer(op->outputs[0]);
         const raw_buffer* dst_buf = ctx.lookup_buffer(op->outputs[1]);
         const void* pad_value = (!padding || padding->empty()) ? nullptr : padding->data();
-        ctx.copy(*src_buf, *dst_buf, pad_value);
+        ctx.config->copy(*src_buf, *dst_buf, pad_value);
         return 0;
       },
       {}, {op->src, dst}, std::move(copy_attrs));

--- a/builder/pipeline.cc
+++ b/builder/pipeline.cc
@@ -1375,13 +1375,13 @@ stmt build_pipeline(node_context& ctx, const std::vector<buffer_expr_ptr>& input
     result = simplify(result);
   }
 
-  result = optimize_symbols(result, ctx);
-
   result = insert_early_free(result);
 
   if (options.trace) {
     result = inject_traces(result, ctx);
   }
+
+  result = optimize_symbols(result, ctx);
 
   result = canonicalize_nodes(result);
 

--- a/builder/test/checks.cc
+++ b/builder/test/checks.cc
@@ -30,7 +30,9 @@ TEST(pipeline, checks) {
   int checks_failed = 0;
 
   eval_context eval_ctx;
-  eval_ctx.check_failed = [&](const expr& c) { checks_failed++; };
+  eval_config eval_cfg;
+  eval_cfg.check_failed = [&](const expr& c) { checks_failed++; };
+  eval_ctx.config = &eval_cfg;
 
   buffer<int, 1> in_buf({N});
   buffer<int, 1> out_buf({N});

--- a/builder/test/context.cc
+++ b/builder/test/context.cc
@@ -9,7 +9,7 @@
 
 namespace slinky {
 
-void setup_tracing(eval_context& ctx, const std::string& filename) {
+void setup_tracing(eval_config& cfg, const std::string& filename) {
   struct tracer {
     std::string trace_file;
     // Store the trace in a stringstream and write it at the end, to avoid overhead influencing the trace.
@@ -25,40 +25,42 @@ void setup_tracing(eval_context& ctx, const std::string& filename) {
 
   auto t = std::make_shared<tracer>(filename);
 
-  ctx.trace_begin = [t](const char* op) -> index_t {
+  cfg.trace_begin = [t](const char* op) -> index_t {
     t->trace.begin(op);
     // chrome_trace expects trace_begin and trace_end to pass the string, while slinky's API expects to pass a token to
     // trace_end returned by trace_begin. Because `index_t` must be able to hold a pointer, we'll just use the token to
     // store the pointer.
     return reinterpret_cast<index_t>(op);
   };
-  ctx.trace_end = [t](index_t token) { t->trace.end(reinterpret_cast<const char*>(token)); };
+  cfg.trace_end = [t](index_t token) { t->trace.end(reinterpret_cast<const char*>(token)); };
 }
 
 test_context::test_context() {
   static thread_pool_impl threads;
 
-  allocate = [this](var, raw_buffer* b) {
+  config.allocate = [this](var, raw_buffer* b) {
     void* allocation = b->allocate();
     heap.track_allocate(b->size_bytes());
     return allocation;
   };
-  free = [this](var, raw_buffer* b, void* allocation) {
+  config.free = [this](var, raw_buffer* b, void* allocation) {
     ::free(allocation);
     heap.track_free(b->size_bytes());
   };
 
-  copy = [this](const raw_buffer& src, const raw_buffer& dst, const void* padding) {
+  config.copy = [this](const raw_buffer& src, const raw_buffer& dst, const void* padding) {
     ++copy_calls;
     copy_elements += dst.elem_count();
     slinky::copy(src, dst, padding);
   };
-  pad = [this](const dim* in_bounds, const raw_buffer& dst, const void* padding) {
+  config.pad = [this](const dim* in_bounds, const raw_buffer& dst, const void* padding) {
     ++pad_calls;
     slinky::pad(in_bounds, dst, padding);
   };
 
-  thread_pool = &threads;
+  config.thread_pool = &threads;
+
+  eval_context::config = &config;
 }
 
 }  // namespace slinky

--- a/builder/test/context.h
+++ b/builder/test/context.h
@@ -9,7 +9,7 @@
 
 namespace slinky {
 
-void setup_tracing(eval_context& ctx, const std::string& filename);
+void setup_tracing(eval_config& config, const std::string& filename);
 
 struct memory_info {
   std::atomic<index_t> live_count = 0;
@@ -36,6 +36,8 @@ public:
   int copy_calls = 0;
   int copy_elements = 0;
   int pad_calls = 0;
+
+  eval_config config;
 
   test_context();
 };

--- a/builder/test/pipeline.cc
+++ b/builder/test/pipeline.cc
@@ -599,9 +599,9 @@ TEST_P(stencil_chain, pipeline) {
 
   std::string test_name = "stencil_chain_split_" + std::string(max_workers == loop::serial ? "serial" : "parallel") +
                           "_split_" + std::to_string(split);
-  setup_tracing(eval_ctx, test_name + ".json");
+  setup_tracing(eval_ctx.config, test_name + ".json");
 
-  p.evaluate(inputs, outputs, eval_ctx);
+  p.evaluate(inputs, outputs, eval_ctx); 
 
   // Run the pipeline stages manually to get the reference result.
   buffer<short, 2> ref_intm({W + 4, H + 4});

--- a/runtime/depends_on.h
+++ b/runtime/depends_on.h
@@ -47,8 +47,14 @@ bool can_substitute_buffer(const depends_on_result& r);
 // Check if the node depends on anything that may change value.
 bool is_pure(expr_ref x);
 
-// Find the buffers used by a stmt or expr. Returns the vars accessed in sorted order.
+// Find all the variables used by a node.
+std::vector<var> find_dependencies(expr_ref e);
+std::vector<var> find_dependencies(stmt_ref s);
+
+// Find a single buffer data dependency in e.
 var find_buffer_data_dependency(expr_ref e);
+
+// Find the buffers used by a stmt or expr. Returns the vars accessed in sorted order.
 std::vector<var> find_buffer_dependencies(stmt_ref s);
 std::vector<var> find_buffer_dependencies(stmt_ref s, bool input, bool output);
 

--- a/runtime/evaluate.cc
+++ b/runtime/evaluate.cc
@@ -43,6 +43,11 @@ void dump_context_for_expr(
   }
 }
 
+eval_context::eval_context()  {
+  static eval_config default_config;
+  config = &default_config;
+}
+
 namespace {
 
 struct allocated_buffer : public raw_buffer {
@@ -240,7 +245,7 @@ public:
     assert(op->args.size() == 2);
     index_t* sem = reinterpret_cast<index_t*>(eval(op->args[0]));
     index_t count = eval(op->args[1], 0);
-    context.thread_pool->atomic_call([=]() { *sem = count; });
+    context.config->thread_pool->atomic_call([=]() { *sem = count; });
     return 1;
   }
 
@@ -253,7 +258,7 @@ public:
       sems[i] = reinterpret_cast<index_t*>(eval(op->args[i * 2 + 0]));
       counts[i] = eval(op->args[i * 2 + 1], 1);
     }
-    context.thread_pool->atomic_call([=]() {
+    context.config->thread_pool->atomic_call([=]() {
       for (std::size_t i = 0; i < sem_count; ++i) {
         *sems[i] += counts[i];
       }
@@ -270,7 +275,7 @@ public:
       sems[i] = reinterpret_cast<index_t*>(eval(op->args[i * 2 + 0]));
       counts[i] = eval(op->args[i * 2 + 1], 1);
     }
-    context.thread_pool->wait_for([=]() {
+    context.config->thread_pool->wait_for([=]() {
       // Check we can acquire all of the semaphores before acquiring any of them.
       for (std::size_t i = 0; i < sem_count; ++i) {
         if (*sems[i] < counts[i]) return false;
@@ -287,13 +292,13 @@ public:
   index_t eval_trace_begin(const call* op) {
     assert(op->args.size() == 1);
     const char* name = reinterpret_cast<const char*>(eval(op->args[0]));
-    return context.trace_begin ? context.trace_begin(name) : 0;
+    return context.config->trace_begin ? context.config->trace_begin(name) : 0;
   }
 
   index_t eval_trace_end(const call* op) {
     assert(op->args.size() == 1);
-    if (context.trace_end) {
-      context.trace_end(eval(op->args[0]));
+    if (context.config->trace_end) {
+      context.config->trace_end(eval(op->args[0]));
     }
     return 1;
   }
@@ -302,7 +307,7 @@ public:
     assert(op->args.size() == 1);
     var sym = *as_variable(op->args[0]);
     allocated_buffer* buf = reinterpret_cast<allocated_buffer*>(context.lookup(sym));
-    context.free(sym, buf, buf->allocation);
+    context.config->free(sym, buf, buf->allocation);
     buf->allocation = nullptr;
     return 1;
   }
@@ -413,7 +418,7 @@ public:
     std::size_t n = ceil_div(bounds.max - bounds.min + 1, step);
     context.reserve(op->sym.id + 1);
     index_t old_value = context.set(op->sym, 0);
-    context.thread_pool->parallel_for(
+    context.config->thread_pool->parallel_for(
         n,
         [context = this->context, step, min = bounds.min, op, &result](index_t i) mutable {
           context.set(op->sym, i * step + min);
@@ -457,8 +462,8 @@ public:
   }
 
   SLINKY_NO_INLINE void call_failed(index_t result, const call_stmt* op) {
-    if (context.call_failed) {
-      context.call_failed(op);
+    if (context.config->call_failed) {
+      context.config->call_failed(op);
     } else {
       std::cerr << "call_stmt failed: " << stmt(op) << "->" << result << std::endl;
       std::abort();
@@ -495,7 +500,7 @@ public:
     }
 
     if (op->storage == memory_type::heap) {
-      buffer.allocation = context.allocate(op->sym, &buffer);
+      buffer.allocation = context.config->allocate(op->sym, &buffer);
     } else {
       assert(op->storage == memory_type::stack);
       std::size_t size = buffer.init_strides();
@@ -506,7 +511,7 @@ public:
     index_t result = eval_with_value(op->body, op->sym, reinterpret_cast<index_t>(&buffer));
 
     if (op->storage == memory_type::heap) {
-      context.free(op->sym, &buffer, buffer.allocation);
+      context.config->free(op->sym, &buffer, buffer.allocation);
     }
 
     return result;
@@ -735,8 +740,8 @@ public:
   }
 
   SLINKY_NO_INLINE index_t check_failed(const check* op) {
-    if (context.check_failed) {
-      context.check_failed(op->condition);
+    if (context.config->check_failed) {
+      context.config->check_failed(op->condition);
     } else {
       std::cerr << "Check failed: " << op->condition << std::endl;
       std::cerr << "Context: " << std::endl;

--- a/runtime/evaluate.h
+++ b/runtime/evaluate.h
@@ -1,6 +1,7 @@
 #ifndef SLINKY_RUNTIME_EVALUATE_H
 #define SLINKY_RUNTIME_EVALUATE_H
 
+#include "base/allocator.h"
 #include "runtime/expr.h"
 #include "runtime/stmt.h"
 
@@ -9,9 +10,8 @@ namespace slinky {
 class thread_pool;
 
 class eval_context {
-  // TODO: This should be uninitialized memory, not just for performance, but so we can detect uninitialized memory
-  // usage when evaluating.
-  std::vector<index_t> values_;
+  // Leave uninitialized to avoid overhead and to detect uninitialized memory access via msan.
+  std::vector<index_t, uninitialized_allocator<index_t>> values_;
 
 public:
   void reserve(std::size_t size) {

--- a/runtime/evaluate.h
+++ b/runtime/evaluate.h
@@ -9,11 +9,45 @@ namespace slinky {
 
 class thread_pool;
 
+struct eval_config {
+  // These two functions implement allocation. `allocate` is called before
+  // running the body, and should assign `base` of the buffer to the address
+  // of the min in each dimension. `free` is called after running the body,
+  // passing the result of `allocate` in addition to the buffer.
+  // If these functions are not defined, the default handler will call
+  // `raw_buffer::allocate` and `::free`.
+  std::function<void*(var, raw_buffer*)> allocate = [](var, raw_buffer* buf) { return buf->allocate(); };
+  std::function<void(var, raw_buffer*, void*)> free = [](var, raw_buffer*, void* allocation) { ::free(allocation); };
+
+  // Functions called when there is a failure in the pipeline.
+  // If these functions are not defined, the default handler will write a
+  // message to cerr and abort.
+  std::function<void(const expr&)> check_failed;
+  std::function<void(const call_stmt*)> call_failed;
+
+  // A pointer to a thread pool, required for parallel
+  slinky::thread_pool* thread_pool = nullptr;
+
+  // Functions implementing buffer data movement:
+  // - `copy` should copy from `src` to `dst`, filling `dst` with `padding` when out of bounds of `src`.
+  // - `pad` should fill the area out of bounds of `src_dims` with `padding` in `dst`.
+  std::function<void(const raw_buffer& src, const raw_buffer& dst, const void* padding)> copy =
+      static_cast<void (*)(const raw_buffer&, const raw_buffer&, const void*)>(slinky::copy);
+  std::function<void(const dim* in_bounds, const raw_buffer& dst, const void* padding)> pad =
+      static_cast<void (*)(const dim*, const raw_buffer&, const void*)>(slinky::pad);
+
+  // Functions implementing the `trace_begin` and `trace_end` intrinsics.
+  std::function<index_t(const char*)> trace_begin;
+  std::function<void(index_t)> trace_end;
+};
+
 class eval_context {
   // Leave uninitialized to avoid overhead and to detect uninitialized memory access via msan.
   std::vector<index_t, uninitialized_allocator<index_t>> values_;
 
 public:
+  eval_context();
+
   void reserve(std::size_t size) {
     if (size > values_.size()) {
       values_.resize(std::max(values_.size() * 2, size));
@@ -46,35 +80,7 @@ public:
 
   std::size_t size() const { return values_.size(); }
 
-  // These two functions implement allocation. `allocate` is called before
-  // running the body, and should assign `base` of the buffer to the address
-  // of the min in each dimension. `free` is called after running the body,
-  // passing the result of `allocate` in addition to the buffer.
-  // If these functions are not defined, the default handler will call
-  // `raw_buffer::allocate` and `::free`.
-  std::function<void*(var, raw_buffer*)> allocate = [](var, raw_buffer* buf) { return buf->allocate(); };
-  std::function<void(var, raw_buffer*, void*)> free = [](var, raw_buffer*, void* allocation) { ::free(allocation); };
-
-  // Functions called when there is a failure in the pipeline.
-  // If these functions are not defined, the default handler will write a
-  // message to cerr and abort.
-  std::function<void(const expr&)> check_failed;
-  std::function<void(const call_stmt*)> call_failed;
-
-  // A pointer to a thread pool, required for parallel
-  slinky::thread_pool* thread_pool = nullptr;
-
-  // Functions implementing buffer data movement:
-  // - `copy` should copy from `src` to `dst`, filling `dst` with `padding` when out of bounds of `src`.
-  // - `pad` should fill the area out of bounds of `src_dims` with `padding` in `dst`.
-  std::function<void(const raw_buffer& src, const raw_buffer& dst, const void* padding)> copy =
-      static_cast<void (*)(const raw_buffer&, const raw_buffer&, const void*)>(slinky::copy);
-  std::function<void(const dim* in_bounds, const raw_buffer& dst, const void* padding)> pad =
-      static_cast<void (*)(const dim*, const raw_buffer&, const void*)>(slinky::pad);
-
-  // Functions called every time a stmt begins or ends evaluation.
-  std::function<index_t(const char*)> trace_begin;
-  std::function<void(index_t)> trace_end;
+  const eval_config* config;
 };
 
 index_t evaluate(const expr& e, eval_context& context);

--- a/runtime/expr_stmt.cc
+++ b/runtime/expr_stmt.cc
@@ -62,7 +62,7 @@ expr make_bin_op(expr a, expr b) {
 }
 
 template <typename T, typename Body>
-Body make_let(std::vector<std::pair<var, expr>> lets, Body body) {
+T* make_let(std::vector<std::pair<var, expr>> lets, Body body) {
   auto n = new T();
   n->lets = std::move(lets);
   if (const T* l = body.template as<T>()) {
@@ -71,17 +71,19 @@ Body make_let(std::vector<std::pair<var, expr>> lets, Body body) {
   } else {
     n->body = std::move(body);
   }
-  return Body(n);
+  return n;
 }
 
 expr let::make(std::vector<std::pair<var, expr>> lets, expr body) {
-  return make_let<let>(std::move(lets), std::move(body));
+  return expr(make_let<let>(std::move(lets), std::move(body)));
 }
 
 expr let::make(var sym, expr value, expr body) { return make({{sym, std::move(value)}}, std::move(body)); }
 
-stmt let_stmt::make(std::vector<std::pair<var, expr>> lets, stmt body) {
-  return make_let<let_stmt>(std::move(lets), std::move(body));
+stmt let_stmt::make(std::vector<std::pair<var, expr>> lets, stmt body, bool is_closure) {
+  let_stmt* n = make_let<let_stmt>(std::move(lets), std::move(body));
+  n->is_closure = is_closure;
+  return stmt(n);
 }
 
 stmt let_stmt::make(var sym, expr value, stmt body) { return make({{sym, std::move(value)}}, std::move(body)); }

--- a/runtime/print.cc
+++ b/runtime/print.cc
@@ -233,10 +233,11 @@ public:
   }
 
   void visit(const let_stmt* l) override {
+    const char* tag = l->is_closure ? "closure" : "let";
     if (l->lets.size() == 1) {
-      *this << indent() << "let " << l->lets.front().first << " = " << l->lets.front().second << " in {\n";
+      *this << indent() << tag << " " << l->lets.front().first << " = " << l->lets.front().second << " in {\n";
     } else {
-      *this << indent() << "let {\n";
+      *this << indent() << tag << " {\n";
       *this << indent(2);
       print_vector(l->lets, ",\n" + indent(2));
       *this << "\n" << indent() << "} in {\n";

--- a/runtime/stmt.h
+++ b/runtime/stmt.h
@@ -183,9 +183,12 @@ public:
   std::vector<std::pair<var, expr>> lets;
   stmt body;
 
+  // If this is true, then the body does not access any symbols outside of those defined by `lets`.
+  bool is_closure;
+
   void accept(stmt_visitor* v) const override;
 
-  static stmt make(std::vector<std::pair<var, expr>> lets, stmt body);
+  static stmt make(std::vector<std::pair<var, expr>> lets, stmt body, bool is_closure = false);
 
   static stmt make(var sym, expr value, stmt body);
 
@@ -395,6 +398,11 @@ public:
 
   static constexpr stmt_node_type static_type = stmt_node_type::check;
 };
+
+SLINKY_ALWAYS_INLINE inline const let_stmt* is_closure(const stmt& s) {
+  const let_stmt* let = s.as<let_stmt>();
+  return let && let->is_closure ? let : nullptr;
+}
 
 class stmt_visitor {
 public:

--- a/runtime/test/evaluate.cc
+++ b/runtime/test/evaluate.cc
@@ -98,7 +98,9 @@ TEST(evaluate, call) {
 TEST(evaluate, loop) {
   eval_context ctx;
   thread_pool_impl t;
-  ctx.thread_pool = &t;
+  eval_config cfg;
+  cfg.thread_pool = &t;
+  ctx.config = &cfg;
 
   for (int max_workers : {loop::serial, 2, 3, loop::parallel}) {
     std::atomic<index_t> sum_x = 0;
@@ -229,7 +231,9 @@ TEST(evaluate, clone_buffer) {
 TEST(evaluate, semaphore) {
   eval_context ctx;
   thread_pool_impl t;
-  ctx.thread_pool = &t;
+  eval_config cfg;
+  cfg.thread_pool = &t;
+  ctx.config = &cfg;
 
   index_t sem1 = 0;
   index_t sem2 = 0;

--- a/runtime/test/evaluate_benchmark.cc
+++ b/runtime/test/evaluate_benchmark.cc
@@ -216,8 +216,10 @@ void benchmark_parallel_loop(benchmark::State& state, bool synchronize) {
   body = loop::make(x, workers, range(0, iterations), 1, body);
 
   eval_context eval_ctx;
+  eval_config config;
   thread_pool_impl t(workers);
-  eval_ctx.thread_pool = &t;
+  config.thread_pool = &t;
+  eval_ctx.config = &config;
 
   for (auto _ : state) {
     evaluate(body, eval_ctx);


### PR DESCRIPTION
When executing code in parallel, each thread needs its own copy of the `eval_context` object, to avoid race conditions. For large programs, where the symbol table can have many thousands of entries, this added a lot of overhead.

This PR fixes a few performance issues related to this:
- Adds an `is_closure` flag to `let_stmt`, which allows us to communicate to `evaluate` exactly which symbols we need to copy to the thread local context, instead of copying the entire thing.
- Adds `uninitialized_allocator` and uses it for the symbol table. This way, when we allocate memory for the context, we don't need to memset it via `std::vector`'s constructor.
- Move the user configurable functions from `eval_context` to a separate object `eval_config`, and only store a pointer to that.