### PR TITLE
Add `expect_workers` API

### DIFF
--- a/runtime/evaluate.cc
+++ b/runtime/evaluate.cc
@@ -419,7 +419,7 @@ public:
     context.reserve(op->sym.id + 1);
     context.config->thread_pool->parallel_for(
         n,
-        [parent_context = &context, step, min = bounds.min, op, &result](index_t i) mutable {
+        [parent_context = &context, step, min = bounds.min, op, &result](index_t i) {
           eval_context context;
           if (const let_stmt* closure = is_closure(op->body)) {
             // The body is a closure, so we know exactly which symbols we need to copy to the new local context.


### PR DESCRIPTION
This allows working around an issue where work that had already started prior to adding more threads to the thread pool had an underestimate of how many workers the thread pool contains. `expect_workers` allows the calling program to say how many workers will be available, even if that many are not running yet.