### PR TITLE
Add `memory_type::automatic`

### DIFF
--- a/builder/pipeline.h
+++ b/builder/pipeline.h
@@ -33,7 +33,7 @@ class buffer_expr : public ref_counted<buffer_expr> {
   func* producer_;
   const_raw_buffer_ptr constant_;
 
-  memory_type storage_ = memory_type::heap;
+  memory_type storage_ = memory_type::automatic;
   std::optional<loop_id> store_at_;
 
   buffer_expr(var sym, std::size_t rank, expr elem_size);

--- a/builder/test/BUILD
+++ b/builder/test/BUILD
@@ -147,6 +147,18 @@ cc_test(
 )
 
 cc_test(
+    name = "auto_stack_threshold",
+    srcs = ["auto_stack_threshold.cc"],
+    deps = [
+        ":util",
+        "//builder",
+        "//runtime",
+        "@googletest//:gtest_main",
+    ],
+    size = "small",
+)
+
+cc_test(
     name = "cannot_alias",
     srcs = ["cannot_alias.cc"],
     deps = [

--- a/builder/test/auto_stack_threshold.cc
+++ b/builder/test/auto_stack_threshold.cc
@@ -1,0 +1,67 @@
+#include <gtest/gtest.h>
+
+#include "builder/pipeline.h"
+#include "builder/test/context.h"
+#include "builder/test/funcs.h"
+#include "builder/test/util.h"
+#include "runtime/expr.h"
+#include "runtime/pipeline.h"
+
+namespace slinky {
+
+// An example of two 2D elementwise operations in sequence.
+
+TEST(auto_stack_threshold, pipeline) {
+  // Make the pipeline
+  node_context ctx;
+
+  auto in = buffer_expr::make(ctx, "in", 1, sizeof(uint8_t));
+  auto out = buffer_expr::make(ctx, "out", 1, sizeof(uint8_t));
+  auto intm = buffer_expr::make(ctx, "intm", 1, sizeof(uint8_t));
+
+  var x(ctx, "x");
+  func a = func::make(add_1<uint8_t>, {{in, {point(x)}}}, {{intm, {x}}});
+  func b = func::make(add_1<uint8_t>, {{intm, {point(x)}}}, {{out, {x}}});
+
+  // Split the loops such that we limit the number of elements produced to a total number across both dimensions.
+  var split_factor(ctx, "split_factor");
+  b.loops({{x, split_factor}});
+
+  intm->dim(0).fold_factor = split_factor;
+
+  pipeline p = build_pipeline(ctx, {split_factor}, {in}, {out});
+
+  // Run the pipeline
+  const int N = 16 * 1024;
+
+  buffer<uint8_t, 1> in_buf({N});
+  in_buf.allocate();
+  for (int x = 0; x < N; ++x) {
+    in_buf(x) = static_cast<uint8_t>(x);
+  }
+
+  buffer<uint8_t, 1> out_buf({N});
+  out_buf.allocate();
+
+  // Not having span(std::initializer_list<T>) is unfortunate.
+  for (int split : {1, 100, 1000, 10000}) {
+    const index_t args[] = {split};
+    const raw_buffer* inputs[] = {&in_buf};
+    const raw_buffer* outputs[] = {&out_buf};
+    test_context eval_ctx;
+    eval_ctx.config.auto_stack_threshold = 512;
+    p.evaluate(args, inputs, outputs, eval_ctx);
+
+    for (int x = 0; x < N; ++x) {
+      ASSERT_EQ(out_buf(x), static_cast<uint8_t>(x + 2));
+    }
+
+    if (split > static_cast<int>(eval_ctx.config.auto_stack_threshold)) {
+      ASSERT_EQ(eval_ctx.heap.allocs.size(), 1);
+    } else {
+      ASSERT_EQ(eval_ctx.heap.allocs.size(), 0);
+    }
+  }
+}
+
+}  // namespace slinky

--- a/builder/test/context.cc
+++ b/builder/test/context.cc
@@ -60,6 +60,9 @@ test_context::test_context() {
 
   config.thread_pool = &threads;
 
+  // Many tests count the number of allocations that go on the heap, don't let memory_type::automatic corrupt those counts.
+  config.auto_stack_threshold = 0;
+
   eval_context::config = &config;
 }
 

--- a/builder/test/pipeline.cc
+++ b/builder/test/pipeline.cc
@@ -289,7 +289,7 @@ TEST(elementwise, outside_fold) {
   // Not having span(std::initializer_list<T>) is unfortunate.
   const raw_buffer* inputs[] = {&in_buf};
   const raw_buffer* outputs[] = {&out_buf};
-  test_context eval_ctx;
+  eval_context eval_ctx;
   p.evaluate(inputs, outputs, eval_ctx);
 
   for (int y = 0; y < H; ++y) {

--- a/builder/test/visualize/softmax_split_0.html
+++ b/builder/test/visualize/softmax_split_0.html
@@ -384,7 +384,6 @@ function pipeline(__in, out) {
             produce(softmax_in);
             produce(sum_exp_in);
             __event_t++;
-            check(free(max_in));
             consume(softmax_in);
             consume(sum_exp_in);
             produce(softmax_out);

--- a/runtime/evaluate.h
+++ b/runtime/evaluate.h
@@ -39,6 +39,9 @@ struct eval_config {
   // Functions implementing the `trace_begin` and `trace_end` intrinsics.
   std::function<index_t(const char*)> trace_begin;
   std::function<void(index_t)> trace_end;
+
+  // Allocations that have memory_type::automatic and are not greater than this size will be placed on the stack.
+  std::size_t auto_stack_threshold = 4 * 1024;
 };
 
 class eval_context {

--- a/runtime/evaluate.h
+++ b/runtime/evaluate.h
@@ -40,7 +40,7 @@ struct eval_config {
   std::function<index_t(const char*)> trace_begin;
   std::function<void(index_t)> trace_end;
 
-  // Allocations that have memory_type::automatic and are not greater than this size will be placed on the stack.
+  // Allocations with storage `memory_type::automatic` not bigger than this size (bytes) will be placed on the stack.
   std::size_t auto_stack_threshold = 4 * 1024;
 };
 

--- a/runtime/print.cc
+++ b/runtime/print.cc
@@ -11,6 +11,7 @@ namespace slinky {
 
 const char* to_string(memory_type type) {
   switch (type) {
+  case memory_type::automatic: return "automatic";
   case memory_type::stack: return "stack";
   case memory_type::heap: return "heap";
   default: return "<invalid memory_type>";

--- a/runtime/stmt.h
+++ b/runtime/stmt.h
@@ -32,7 +32,7 @@ enum class stmt_node_type {
 };
 
 enum class memory_type {
-  // Automatically place small stack allocations on the heap, as determined by `eval_config::auto_stack_threshold`.
+  // Automatically place small stack allocations on the stack, as determined by `eval_config::auto_stack_threshold`.
   automatic,
   stack,
   heap,

--- a/runtime/stmt.h
+++ b/runtime/stmt.h
@@ -32,6 +32,8 @@ enum class stmt_node_type {
 };
 
 enum class memory_type {
+  // Automatically place small stack allocations on the heap, as determined by `eval_config::auto_stack_threshold`.
+  automatic,
   stack,
   heap,
 };


### PR DESCRIPTION
This PR makes it so by default, buffer allocations are placed on the stack if they are small, as determined by a parameter `eval_config::auto_stack_threshold`.