### PR TITLE
Don't evaluate the loop variable in the closure

### DIFF
--- a/runtime/evaluate.cc
+++ b/runtime/evaluate.cc
@@ -43,7 +43,7 @@ void dump_context_for_expr(
   }
 }
 
-eval_context::eval_context()  {
+eval_context::eval_context() {
   static eval_config default_config;
   config = &default_config;
 }
@@ -429,7 +429,12 @@ public:
             // Assume that this let_stmt is a closure for this loop. We'll evaluate the values using the parent context,
             // but assign them to our local context.
             for (const std::pair<var, expr>& i : closure->lets) {
-              context[i.first] = evaluate(i.second, *parent_context);
+              if (i.first == op->sym) {
+                // The loop variable is part of the closure, because it is defined outside the closure and used inside it.
+                // However, we are going to overwrite it below.
+                continue;
+              }
+              context.set(i.first, evaluate(i.second, *parent_context));
             }
           } else {
             // We don't have a closure, just copy the whole context.

--- a/runtime/test/evaluate_benchmark.cc
+++ b/runtime/test/evaluate_benchmark.cc
@@ -206,7 +206,7 @@ void benchmark_parallel_loop(benchmark::State& state, bool synchronize) {
   const int workers = state.range(0);
 
   std::atomic<int> calls = 0;
-  stmt body = make_call_counter(calls);
+  stmt body = let_stmt::make({{x, x}}, make_call_counter(calls), /*is_closure=*/true);
 
   index_t sem = workers;
   if (synchronize) {


### PR DESCRIPTION
This might or might not be an optimization, but it avoids msan flagging uninitialized memory use. I thought it wouldn't do that, because it doesn't branch/do anything with the uninitialized memory (just read it and write it somewhere else), but apparently not.