### PR TITLE
Refactor parallel_for implementation to a helper class

### DIFF
--- a/base/test/thread_pool.cc
+++ b/base/test/thread_pool.cc
@@ -9,6 +9,25 @@ namespace slinky {
 
 int sum_arithmetic_sequence(int n) { return n * (n - 1) / 2; }
 
+template <std::size_t K>
+bool test_parallel_for_done(int n) {
+  std::vector<bool> ran(n);
+
+  parallel_for<K> p(n);
+  p.run([&](int i) { ran[i] = true; });
+  return std::all_of(ran.begin(), ran.end(), [](bool i) { return i; });
+}
+
+TEST(parallel_for, done) {
+  for (int n : {0, 1, 2, 10, 20, 30}) {
+    ASSERT_TRUE(test_parallel_for_done<1>(n));
+    ASSERT_TRUE(test_parallel_for_done<2>(n));
+    ASSERT_TRUE(test_parallel_for_done<3>(n));
+    ASSERT_TRUE(test_parallel_for_done<4>(n));
+    ASSERT_TRUE(test_parallel_for_done<16>(n));
+  }
+}
+
 TEST(parallel_for, sum) {
   thread_pool_impl t;
   for (int n = 0; n < 100; ++n) {

--- a/base/test/thread_pool_benchmark.cc
+++ b/base/test/thread_pool_benchmark.cc
@@ -7,8 +7,6 @@
 
 namespace slinky {
 
-constexpr int cache_line_size = 64;
-
 struct unshared {
   alignas(cache_line_size) int value;
 };

--- a/base/thread_pool.h
+++ b/base/thread_pool.h
@@ -121,7 +121,11 @@ public:
     auto loop = std::make_shared<slinky::parallel_for<>>(n);
 
     // Capture n by value becuase this may run after the parallel_for call returns.
-    auto worker = [this, loop, body = std::move(body)]() mutable { loop->run(body); };
+    auto worker = [this, loop, body = std::move(body)]() mutable { 
+      loop->run(body); 
+      // If we get here, there's no more work to start. Cancel any remaining tasks.
+      cancel(loop.get());
+    };
     int workers = std::min<int>(max_workers, std::min<std::size_t>(thread_count() + 1, n));
     if (workers > 1) {
       enqueue(workers - 1, worker, loop.get());


### PR DESCRIPTION
This also adds some new functionality to enable thread-local parallel for state, but it is currently not enabled (we still use `K = 1` for `thread_pool::parallel_for`).