### PR TITLE
Optimize `for_each_element`

### DIFF
--- a/base/span.h
+++ b/base/span.h
@@ -43,8 +43,8 @@ public:
   const value_type* end() const { return data_ + size(); }
 
   const value_type& operator[](std::size_t i) const { return data_[i]; }
-  const value_type& front() { return data_[0]; }
-  const value_type& back() { return data_[size() - 1]; }
+  const value_type& front() const { return data_[0]; }
+  const value_type& back() const { return data_[size() - 1]; }
 
   span<T, dynamic_extent> subspan(std::size_t offset) const {
     return span<T, dynamic_extent>(data_ + offset, size() - offset);
@@ -87,11 +87,93 @@ public:
   const value_type* end() const { return data_ + size(); }
 
   const value_type& operator[](std::size_t i) const { return data_[i]; }
-  const value_type& front() { return data_[0]; }
-  const value_type& back() { return data_[size() - 1]; }
+  const value_type& front() const { return data_[0]; }
+  const value_type& back() const { return data_[size() - 1]; }
 
   span subspan(std::size_t offset) const { return span(data_ + offset, size() - offset); }
   span subspan(std::size_t offset, std::size_t size) const { return span(data_ + offset, size); }
+};
+
+template <typename T, std::size_t Extent = dynamic_extent>
+class mutable_span {
+public:
+  using value_type = std::remove_const_t<T>;
+
+private:
+  value_type* data_;
+
+public:
+  mutable_span(value_type* data, std::size_t size) : data_(data) { assert(size == Extent); }
+  mutable_span(value_type* begin, value_type* end) : data_(begin) { assert(end - begin == Extent); }
+  template <std::size_t N>
+  mutable_span(value_type (&x)[N]) : data_(&x[0]) {
+    static_assert(N == Extent, "");
+  }
+  mutable_span(std::array<value_type, Extent>& x) : data_(std::data(x)) {}
+  mutable_span(std::vector<value_type>& c) : data_(std::data(c)) { assert(c.size() == Extent); }
+
+  // Allow shallow copying/assignment.
+  mutable_span(const mutable_span&) = default;
+  mutable_span(mutable_span&&) = default;
+  mutable_span& operator=(const mutable_span&) = default;
+  mutable_span& operator=(mutable_span&&) = default;
+
+  value_type* data() const { return data_; }
+  static constexpr std::size_t size() { return Extent; }
+  static constexpr bool empty() { return Extent == 0; }
+  value_type* begin() const { return data_; }
+  value_type* end() const { return data_ + size(); }
+
+  value_type& operator[](std::size_t i) const { return data_[i]; }
+  value_type& front() const { return data_[0]; }
+  value_type& back() const { return data_[size() - 1]; }
+
+  mutable_span<T, dynamic_extent> subspan(std::size_t offset) const {
+    return mutable_span<T, dynamic_extent>(data_ + offset, size() - offset);
+  }
+  mutable_span<T, dynamic_extent> subspan(std::size_t offset, std::size_t size) const {
+    return mutable_span<T, dynamic_extent>(data_ + offset, size);
+  }
+};
+
+template <typename T>
+class mutable_span<T, dynamic_extent> {
+public:
+  using value_type = std::remove_const_t<T>;
+
+private:
+  value_type* data_;
+  std::size_t size_;
+
+public:
+  mutable_span() : data_(nullptr), size_(0) {}
+  mutable_span(value_type* data, std::size_t size) : data_(data), size_(size) {}
+  mutable_span(value_type* begin, value_type* end) : data_(begin), size_(end - begin) {}
+  template <std::size_t N>
+  mutable_span(value_type (&x)[N]) : data_(&x[0]), size_(N) {}
+  mutable_span(value_type (&x)[0]) : data_(nullptr), size_(0) {}
+  template <std::size_t N>
+  mutable_span(std::array<value_type, N>& x) : data_(std::data(x)), size_(N) {}
+  mutable_span(std::vector<value_type>& c) : data_(std::data(c)), size_(std::size(c)) {}
+
+  // Allow shallow copying/assignment.
+  mutable_span(const mutable_span&) = default;
+  mutable_span(mutable_span&&) = default;
+  mutable_span& operator=(const mutable_span&) = default;
+  mutable_span& operator=(mutable_span&&) = default;
+
+  value_type* data() const { return data_; }
+  std::size_t size() const { return size_; }
+  bool empty() const { return size() == 0; }
+  value_type* begin() const { return data_; }
+  value_type* end() const { return data_ + size(); }
+
+  value_type& operator[](std::size_t i) const { return data_[i]; }
+  value_type& front() const { return data_[0]; }
+  value_type& back() const { return data_[size() - 1]; }
+
+  mutable_span subspan(std::size_t offset) const { return mutable_span(data_ + offset, size() - offset); }
+  mutable_span subspan(std::size_t offset, std::size_t size) const { return mutable_span(data_ + offset, size); }
 };
 
 template <typename T>

--- a/base/span.h
+++ b/base/span.h
@@ -2,15 +2,60 @@
 #define SLINKY_BASE_SPAN_H
 
 #include <array>
+#include <cassert>
 #include <vector>
 
 namespace slinky {
 
+constexpr std::size_t dynamic_extent = std::numeric_limits<std::size_t>::max();
+
 // Don't want to depend on C++20, so just provide our own span-like helper. Differences:
 // - const-only
 // - No fixed size extents
-template <typename T>
+template <typename T, std::size_t Extent = dynamic_extent>
 class span {
+public:
+  using value_type = std::remove_const_t<T>;
+
+private:
+  const value_type* data_;
+
+public:
+  span(const value_type* data, std::size_t size) : data_(data) { assert(size == Extent); }
+  span(const value_type* begin, const value_type* end) : data_(begin) { assert(end - begin == Extent); }
+  template <std::size_t N>
+  span(const value_type (&x)[N]) : data_(&x[0]) {
+    static_assert(N == Extent, "");
+  }
+  span(const std::array<value_type, Extent>& x) : data_(std::data(x)) {}
+  span(const std::vector<value_type>& c) : data_(std::data(c)) { assert(c.size() == Extent); }
+
+  // Allow shallow copying/assignment.
+  span(const span&) = default;
+  span(span&&) = default;
+  span& operator=(const span&) = default;
+  span& operator=(span&&) = default;
+
+  const value_type* data() const { return data_; }
+  static constexpr std::size_t size() { return Extent; }
+  static constexpr bool empty() { return Extent == 0; }
+  const value_type* begin() const { return data_; }
+  const value_type* end() const { return data_ + size(); }
+
+  const value_type& operator[](std::size_t i) const { return data_[i]; }
+  const value_type& front() { return data_[0]; }
+  const value_type& back() { return data_[size() - 1]; }
+
+  span<T, dynamic_extent> subspan(std::size_t offset) const {
+    return span<T, dynamic_extent>(data_ + offset, size() - offset);
+  }
+  span<T, dynamic_extent> subspan(std::size_t offset, std::size_t size) const {
+    return span<T, dynamic_extent>(data_ + offset, size);
+  }
+};
+
+template <typename T>
+class span<T, dynamic_extent> {
 public:
   using value_type = std::remove_const_t<T>;
 
@@ -37,15 +82,15 @@ public:
 
   const value_type* data() const { return data_; }
   std::size_t size() const { return size_; }
-  bool empty() const { return size_ == 0; }
+  bool empty() const { return size() == 0; }
   const value_type* begin() const { return data_; }
-  const value_type* end() const { return data_ + size_; }
+  const value_type* end() const { return data_ + size(); }
 
   const value_type& operator[](std::size_t i) const { return data_[i]; }
   const value_type& front() { return data_[0]; }
-  const value_type& back() { return data_[size_ - 1]; }
+  const value_type& back() { return data_[size() - 1]; }
 
-  span subspan(std::size_t offset) const { return span(data_ + offset, size_ - offset); }
+  span subspan(std::size_t offset) const { return span(data_ + offset, size() - offset); }
   span subspan(std::size_t offset, std::size_t size) const { return span(data_ + offset, size); }
 };
 

--- a/runtime/buffer.cc
+++ b/runtime/buffer.cc
@@ -506,8 +506,7 @@ struct callback {
 };
 
 std::ptrdiff_t sizeof_for_each_loop(std::size_t bufs_size) {
-  // Aligning this seems to help with performance (BM_for_each_element_batch_dims)
-  return (sizeof(for_each_loop<>) - sizeof(for_each_loop<>::dims) + sizeof(for_each_loop<>::dims) * bufs_size + 15) & ~15;
+  return sizeof(for_each_loop<>) - sizeof(for_each_loop<>::dims) + sizeof(for_each_loop<>::dims) * bufs_size;
 }
 
 // We store a plan for a parallel for loop in a structure of the following layout, for N buffers and rank R loops:

--- a/runtime/buffer.cc
+++ b/runtime/buffer.cc
@@ -392,7 +392,10 @@ SLINKY_ALWAYS_INLINE inline bool is_contiguous_slice(const raw_buffer* const* bu
   }
   for (std::size_t n = 1; n < size; n++) {
     const raw_buffer& buf_n = *bufs[n];
-    if (d >= buf_n.rank) {
+    if (&buf_n == &buf) {
+      // This is the same buffer as the base.
+      continue;
+    } else if (d >= buf_n.rank) {
       // This dimension is broadcasted, it's not contiguous.
       return false;
     } else if (buf_n.dim(d).stride() != static_cast<index_t>(buf_n.elem_size)) {
@@ -420,6 +423,10 @@ SLINKY_ALWAYS_INLINE inline bool can_fuse(const raw_buffer* const* bufs, std::si
 
   for (std::size_t n = 1; n < size; n++) {
     const raw_buffer& buf_n = *bufs[n];
+    if (&buf_n == &buf) {
+      // This is the same buffer as the base.
+      continue;
+    }
     const std::size_t rank = buf_n.rank;
     if (d > rank) {
       // Both dimensions are broadcasts, they can be fused.
@@ -453,7 +460,10 @@ SLINKY_ALWAYS_INLINE inline bool use_folded_loop(const raw_buffer* const* bufs, 
   }
   for (std::size_t n = 1; n < size; ++n) {
     const raw_buffer& buf_n = *bufs[n];
-    if (d >= buf_n.rank) {
+    if (&buf_n == &buf) {
+      // This is the same buffer as the base.
+      continue;
+    } else if (d >= buf_n.rank) {
       // Broadcast dimension.
       continue;
     }

--- a/runtime/buffer.cc
+++ b/runtime/buffer.cc
@@ -594,7 +594,6 @@ SLINKY_NO_STACK_PROTECTOR SLINKY_ALWAYS_INLINE inline void for_each_impl(span<co
     } else if (buf_dim.max() < buf_dim.min() || use_folded_loop(bufs.data(), bufs_size, d)) {
       // extent > 1 and there is a folded dimension in one of the buffers, or we need to crop one of the buffers, or the
       // loops are empty.
-      assert(extent == 1 || buf_dim.max() < buf_dim.min());
       loop->impl = for_each_impl_folded<F, BufsSize, false>;
       last_impl = for_each_impl_folded<F, BufsSize, true>;
       loop->extent = buf_dim.extent();

--- a/runtime/buffer.cc
+++ b/runtime/buffer.cc
@@ -620,7 +620,7 @@ SLINKY_NO_STACK_PROTECTOR SLINKY_ALWAYS_INLINE inline void for_each_impl(span<co
     }
 
     // Align the bases for dimensions we will access via linear pointer arithmetic.
-    if (buf_dim.fold_factor() != dim::unfolded && bases[0]) {
+    if (buf_dim.fold_factor() != dim::unfolded) {
       // This function is expected to adjust all bases to point to the min of `buf_dim`. For non-folded dimensions, that
       // is true by construction, but not for folded dimensions.
       index_t offset = buf_dim.flat_offset_bytes(buf_dim.min());

--- a/runtime/buffer.cc
+++ b/runtime/buffer.cc
@@ -379,9 +379,9 @@ namespace internal {
 
 namespace {
 
-SLINKY_ALWAYS_INLINE inline const dim& get_dim(const raw_buffer& buf, std::size_t d) { 
+SLINKY_ALWAYS_INLINE inline const dim& get_dim(const raw_buffer& buf, std::size_t d) {
   // Dimensions beyond the rank are broadcasts.
-  return d < buf.rank ? buf.dim(d) : broadcast_dim; 
+  return d < buf.rank ? buf.dim(d) : broadcast_dim;
 }
 
 SLINKY_ALWAYS_INLINE inline bool is_contiguous_slice(const raw_buffer* const* bufs, std::size_t size, std::size_t d) {
@@ -453,7 +453,7 @@ SLINKY_ALWAYS_INLINE inline bool use_folded_loop(const raw_buffer* const* bufs, 
     if (d >= buf_n.rank) {
       // Broadcast dimension.
       continue;
-    } 
+    }
     const dim& buf_n_dim = buf_n.dim(d);
     if (buf_n_dim.is_folded(buf_dim)) {
       // There's a folded buffer, we need a folded loop.
@@ -589,7 +589,7 @@ SLINKY_NO_STACK_PROTECTOR SLINKY_ALWAYS_INLINE inline void for_each_impl(span<co
   }
 
   // Start out with a loop of extent 1, in case the buffer is rank 0.
-  for_each_loop_impl inner_impl = for_each_impl_call_f<F, BufsSize>;
+  for_each_loop_impl inner_impl;
   for_each_loop* outer_loop = loop;
 
   index_t slice_extent = 1;

--- a/runtime/buffer.cc
+++ b/runtime/buffer.cc
@@ -620,7 +620,7 @@ SLINKY_NO_STACK_PROTECTOR SLINKY_ALWAYS_INLINE inline void for_each_impl(span<co
     }
 
     // Align the bases for dimensions we will access via linear pointer arithmetic.
-    if (SLINKY_LIKELY(bases[0])) {
+    if (buf_dim.fold_factor() != dim::unfolded && bases[0]) {
       // This function is expected to adjust all bases to point to the min of `buf_dim`. For non-folded dimensions, that
       // is true by construction, but not for folded dimensions.
       index_t offset = buf_dim.flat_offset_bytes(buf_dim.min());

--- a/runtime/buffer.cc
+++ b/runtime/buffer.cc
@@ -392,8 +392,8 @@ SLINKY_ALWAYS_INLINE inline bool is_contiguous_slice(const raw_buffer* const* bu
   }
   for (std::size_t n = 1; n < size; n++) {
     const raw_buffer& buf_n = *bufs[n];
-    if (&buf_n == &buf) {
-      // This is the same buffer as the base.
+    if (&buf_n == &buf || !buf_n.base) {
+      // This is the same buffer as the base, or the base pointer is nullptr.
       continue;
     } else if (d >= buf_n.rank) {
       // This dimension is broadcasted, it's not contiguous.
@@ -423,8 +423,8 @@ SLINKY_ALWAYS_INLINE inline bool can_fuse(const raw_buffer* const* bufs, std::si
 
   for (std::size_t n = 1; n < size; n++) {
     const raw_buffer& buf_n = *bufs[n];
-    if (&buf_n == &buf) {
-      // This is the same buffer as the base.
+    if (&buf_n == &buf || !buf_n.base) {
+      // This is the same buffer as the base, or the base pointer is nullptr.
       continue;
     }
     const std::size_t rank = buf_n.rank;
@@ -460,8 +460,8 @@ SLINKY_ALWAYS_INLINE inline bool use_folded_loop(const raw_buffer* const* bufs, 
   }
   for (std::size_t n = 1; n < size; ++n) {
     const raw_buffer& buf_n = *bufs[n];
-    if (&buf_n == &buf) {
-      // This is the same buffer as the base.
+    if (&buf_n == &buf || !buf_n.base) {
+      // This is the same buffer as the base, or the base pointer is nullptr.
       continue;
     } else if (d >= buf_n.rank) {
       // Broadcast dimension.

--- a/runtime/buffer.cc
+++ b/runtime/buffer.cc
@@ -379,6 +379,11 @@ namespace internal {
 
 namespace {
 
+SLINKY_ALWAYS_INLINE inline const dim& get_dim(const raw_buffer& buf, std::size_t d) { 
+  // Dimensions beyond the rank are broadcasts.
+  return d < buf.rank ? buf.dim(d) : broadcast_dim; 
+}
+
 SLINKY_ALWAYS_INLINE inline bool is_contiguous_slice(const raw_buffer* const* bufs, std::size_t size, std::size_t d) {
   if (bufs[0]->dim(d).stride() != static_cast<index_t>(bufs[0]->elem_size)) {
     // This dimension is not contiguous.
@@ -606,8 +611,7 @@ SLINKY_NO_STACK_PROTECTOR SLINKY_ALWAYS_INLINE inline void for_each_impl(span<co
       const dim** dims = loop->dims;
       dims[0] = &buf->dim(d);
       for (std::size_t n = 1; n < bufs_size; n++) {
-        const raw_buffer& buf_n = *bufs[n];
-        dims[n] = d < static_cast<std::ptrdiff_t>(buf_n.rank) ? &buf_n.dim(d) : &broadcast_dim;
+        dims[n] = &get_dim(*bufs[n], d);
       }
       prev_loop = loop;
       loop = offset_bytes_non_null(loop, sizeof_for_each_loop(bufs_size));

--- a/runtime/buffer.h
+++ b/runtime/buffer.h
@@ -556,9 +556,9 @@ public:
     return *this;
   }
 
-  void allocate() {
+  void allocate(index_t alignment = 1) {
     assert(!to_free);
-    to_free = raw_buffer::allocate();
+    to_free = raw_buffer::allocate(alignment);
   }
 
   void free() {

--- a/runtime/buffer.h
+++ b/runtime/buffer.h
@@ -55,7 +55,7 @@ const T* align_up(const T* x, std::size_t align) {
 // TODO(https://github.com/dsharlet/slinky/issues/1): This and buffer_expr in pipeline.h should have the same API
 // (except for expr instead of index_t).
 class dim {
-  index_t min_;
+  alignas(16) index_t min_;
   index_t max_;
   index_t stride_;
   index_t fold_factor_;

--- a/runtime/test/buffer_benchmark.cc
+++ b/runtime/test/buffer_benchmark.cc
@@ -260,6 +260,20 @@ void BM_for_each_element_batch_dims(benchmark::State& state) {
 
 BENCHMARK(BM_for_each_element_batch_dims);
 
+void BM_for_each_element_folded(benchmark::State& state) {
+  buffer<char, 1> src({256});
+  src.dim(0).set_fold_factor(state.range(0));
+  src.allocate();
+  buffer<char, 1> dst({256});
+  dst.allocate();
+
+  for (auto _ : state) {
+    for_each_element([&](const void* x, const void*) {}, dst, src);
+  }
+}
+
+BENCHMARK(BM_for_each_element_folded)->Range(1, 256);
+
 void BM_init_strides(benchmark::State& state) {
   int extent0 = state.range(0);
   int extent1 = state.range(1);


### PR DESCRIPTION
I've now invested a silly amount of effort in this function, and I'm hoping this is basically as good as it can get, barring the possibility that we change the definition of `raw_buffer` in some way that affects this. This makes it 10-30% faster, depending on the benchmark.

The major change here is to use function pointers stored in the `for_each_loop` stack, instead of flags + a dispatcher function. Also:
- Add the `constexpr` `Extent` template parameter of our `std::span` clone, and use it to avoid passing an unused parameter around.
- Avoid changing the type of rank/dim indices, which adds some overhead.
- A bunch of other minor simplifications and cleanups.

My ultimate goal was to get to the point where we could use computed gotos and implement this without function calls at all. However, I wasn't actually able to beat the function pointer approach, because my manual stack management is basically equivalent to what the standard calling convention does, if not a little worse, and it's a lot more of a headache to debug it.

This change also changes the benchmarks to be no-ops, instead of `memcpy`/`memset` calls. I found that there were some optimizations that made `for_each_element` faster, but were overall slower because of compiler stupidity in the callbacks that I don't think are durable across real usages (dropping from 4 register passed parameters to 3 should never hurt).