### PR TITLE
Use `function_ref` where appropriate

### DIFF
--- a/base/BUILD
+++ b/base/BUILD
@@ -20,7 +20,10 @@ cc_library(
 cc_library(
     name = "thread_pool",
     srcs = ["thread_pool.cc"],
-    hdrs = ["thread_pool.h"],
+    hdrs = [
+        "thread_pool.h",
+        "function_ref.h",
+    ],
     visibility = ["//visibility:public"],
 )
 

--- a/base/function_ref.h
+++ b/base/function_ref.h
@@ -1,6 +1,8 @@
 #ifndef SLINKY_BASE_FUNCTION_REF_H
 #define SLINKY_BASE_FUNCTION_REF_H
 
+#include <cstddef>
+
 namespace slinky {
 
 template <typename Ret, typename... Args>
@@ -16,15 +18,18 @@ class function_ref<Ret(Args...)> {
   }
 
   typedef Ret (*impl_fn)(const void*, Args...);
-  impl_fn impl;
+  impl_fn impl_;
   const void* obj_;
 
 public:
-  function_ref() : impl(nullptr), obj_(nullptr) {}
+  function_ref() : impl_(nullptr), obj_(nullptr) {}
+  function_ref(std::nullptr_t) : function_ref() {}
   template <typename F>
-  function_ref(const F& f) : impl(reinterpret_cast<impl_fn>(get_impl<F>)), obj_(&f) {}
+  function_ref(const F& f) : impl_(reinterpret_cast<impl_fn>(get_impl<F>)), obj_(&f) {}
 
-  Ret operator()(Args... args) const { return impl(obj_, args...); }
+  operator bool() const { return impl_ != nullptr; }
+
+  Ret operator()(Args... args) const { return impl_(obj_, args...); }
 };
 
 }  // namespace slinky

--- a/builder/node_mutator.h
+++ b/builder/node_mutator.h
@@ -1,6 +1,7 @@
 #ifndef SLINKY_BUILDER_NODE_MUTATOR_H
 #define SLINKY_BUILDER_NODE_MUTATOR_H
 
+#include "base/function_ref.h"
 #include "runtime/expr.h"
 #include "runtime/stmt.h"
 
@@ -140,12 +141,12 @@ stmt clone_with(const transpose* op, var sym, stmt new_body);
 
 // Helper for single statement mutators.
 template <typename T>
-stmt recursive_mutate(const stmt& s, const std::function<stmt(const T*)>& mutator) {
-  using mutator_fn = std::function<stmt(const T*)>;
+stmt recursive_mutate(const stmt& s, function_ref<stmt(const T*)> mutator) {
+  using mutator_fn = function_ref<stmt(const T*)>;
   class impl : public stmt_mutator {
   public:
-    const mutator_fn& mutator;
-    impl(const mutator_fn& mutator) : mutator(mutator) {}
+    mutator_fn mutator;
+    impl(mutator_fn mutator) : mutator(mutator) {}
     stmt mutate(const stmt& s) override {
       if (const T* t = s.as<T>()) {
         return mutator(t);

--- a/builder/optimizations.cc
+++ b/builder/optimizations.cc
@@ -12,6 +12,7 @@
 #include <vector>
 
 #include "base/chrome_trace.h"
+#include "base/function_ref.h"
 #include "builder/node_mutator.h"
 #include "builder/pipeline.h"
 #include "builder/simplify.h"
@@ -641,7 +642,7 @@ public:
   }
 
   void merge_buffer_info(
-      symbol_map<buffer_info>& old_buffers, var sym, var src, std::function<void(alias_info&)> handler) {
+      symbol_map<buffer_info>& old_buffers, var sym, var src, function_ref<void(alias_info&)> handler) {
     for (std::optional<buffer_info>& i : buffers) {
       if (!i) continue;
       for (auto& a : i->aliases) {
@@ -688,7 +689,7 @@ public:
   }
 
   template <typename T>
-  void visit_buffer_mutator(const T* op, std::function<void(alias_info&)> handler) {
+  void visit_buffer_mutator(const T* op, function_ref<void(alias_info&)> handler) {
     // We need to know which alias candidates are added inside this mutator.
     symbol_map<buffer_info> old_buffers(buffers.size());
     std::swap(old_buffers, buffers);


### PR DESCRIPTION
This was a speculative optimization for the thread pool. It didn't do much in my case, but it's a good change anyways.