### PR TITLE
Fix the order of the function during the IR construction.

### DIFF
--- a/builder/pipeline.cc
+++ b/builder/pipeline.cc
@@ -746,16 +746,6 @@ class pipeline_builder {
     return body;
   }
 
-  // Generate the loops that we want to be explicit.
-  // Returns generated statement as well as the lifetime range covered by it.
-  statement_with_range make_loops(const func* f) {
-    statement_with_range result;
-
-    result = make_loop(result, f, f->loops().size() - 1);
-
-    return result;
-  }
-
   void compute_allocation_bounds() {
     for (const func* f : order_) {
       bounds_map output_bounds = get_output_bounds(f->outputs());
@@ -1019,7 +1009,9 @@ public:
       assert(realize_at != realization_levels_.end());
 
       if (compute_at->second == at && !f->loops().empty()) {
-        statement_with_range f_body = make_loops(f);
+        // Generate the loops that we want to be explicit by recursively calling make_loop starting
+        // from the outer loop.
+        statement_with_range f_body = make_loop(statement_with_range(), f, f->loops().size() - 1);;
         // This is a special case for the buffers which are produced and consumed inside
         // of this loop. In this case we simply wrap loop body with corresponding allocations.
         if (candidates_for_allocation_[at].size() > old_candidates.size() + 1) {

--- a/builder/pipeline.cc
+++ b/builder/pipeline.cc
@@ -1021,7 +1021,7 @@ public:
         // Generate the loops that we want to be explicit by recursively calling make_loop starting
         // from the outer loop.
         statement_with_range f_body = make_loop(f, f->loops().size() - 1);
-        ;
+
         // This is a special case for the buffers which are produced and consumed inside
         // of this loop. In this case we simply wrap loop body with corresponding allocations.
         if (candidates_for_allocation_[at].size() > old_candidates.size() + 1) {

--- a/builder/pipeline.cc
+++ b/builder/pipeline.cc
@@ -983,16 +983,16 @@ public:
 
   const std::vector<var>& external_symbols() const { return sanitizer_.external; }
 
-  // This function works together with the produce() and make_loops() functions
+  // This function works together with the produce() and make_loop() functions
   // to build an initial IR. The high-level approach is the following:
   // * the `build()` function looks through the list of func's
   //   to find funcs which need to be produced or allocated at given
   //   loop level `at`. If func need to be produced it calls the
   //   `produce()` function which actually produces the body of the
-  //   func. If func has loops it calls the 'make_loops()' func to produce
+  //   func. If func has loops it calls the 'make_loop()' func to produce
   //   corresponding loops.
   // * the `produce()` for a given func produces it's body.
-  // * the `make_loops()` will produce the necessary loops defined for the function.
+  // * the `make_loop()` will produce the necessary loops defined for the function.
   //   For each of the new loops, the `build()` is called for the case when there
   //   are func which need to be produced in that new loop.
   statement_with_range build(const statement_with_range& body, const func* base_f, const loop_id& at) {

--- a/builder/pipeline.cc
+++ b/builder/pipeline.cc
@@ -686,6 +686,9 @@ class pipeline_builder {
     return simplify(bounds);
   }
 
+  // Creates a loop body for a given function including all function bodies computed inside of the loops.
+  // It may recursively call itself if there are nested loops, it's assumed that loops are produced
+  // starting from the outer one.
   statement_with_range make_loop(statement_with_range body, const func* base_f, int loop_index) {
     const func::loop_info& loop = base_f->loops()[loop_index];
     assert(loop.defined());

--- a/builder/test/softmax.cc
+++ b/builder/test/softmax.cc
@@ -103,11 +103,7 @@ class softmax : public testing::TestWithParam<std::tuple<int, int, bool, int>> {
 auto split_factors = testing::Values(0, 1, 4);
 
 INSTANTIATE_TEST_SUITE_P(mode, softmax,
-    testing::Combine(split_factors, split_factors, testing::Values(false), testing::Values(0)),
-    test_params_to_string<softmax::ParamType>);
-
-INSTANTIATE_TEST_SUITE_P(compute_at, softmax,
-    testing::Combine(testing::Values(1), testing::Values(1), testing::Values(true), testing::Values(0)),
+    testing::Combine(split_factors, split_factors, testing::Values(false, true), testing::Values(0)),
     test_params_to_string<softmax::ParamType>);
 
 INSTANTIATE_TEST_SUITE_P(with_copy, softmax,
@@ -178,7 +174,7 @@ TEST_P(softmax, pipeline) {
   pass0.loops(loops);
   pass4.loops(loops);
 
-  if (use_compute_at) {
+  if (use_compute_at && split_b > 0) {
     pass1.compute_at({&pass4, b});
   }
 

--- a/builder/test/softmax.cc
+++ b/builder/test/softmax.cc
@@ -107,7 +107,7 @@ INSTANTIATE_TEST_SUITE_P(mode, softmax,
     test_params_to_string<softmax::ParamType>);
 
 INSTANTIATE_TEST_SUITE_P(compute_at, softmax,
-    testing::Combine(testing::Values(1), testing::Values(1), testing::Values(false), testing::Values(0)),
+    testing::Combine(testing::Values(1), testing::Values(1), testing::Values(true), testing::Values(0)),
     test_params_to_string<softmax::ParamType>);
 
 INSTANTIATE_TEST_SUITE_P(with_copy, softmax,


### PR DESCRIPTION
Apparently, the test which checked compute_at was disabled and was failing at head after I enabled it. The issue is that we first were visiting the inner loop which might violate the assumption that the function are added in the order of their occurance in the final IR (this is important so we can merge lifetimes correctly).