### PR TITLE
Add `slice` constant for use with `at`/`address_at`

### DIFF
--- a/runtime/test/buffer.cc
+++ b/runtime/test/buffer.cc
@@ -164,6 +164,35 @@ TEST(buffer, buffer) {
   }
 }
 
+TEST(buffer, address_at_slice) {
+  buffer<int, 2> buf;
+
+  ASSERT_EQ(buf.rank, 2);
+
+  buf.dim(0) = {4, 14};
+  buf.dim(1) = {5, 20};
+  buf.allocate();
+
+  ASSERT_EQ(&buf(), buf.base());
+  ASSERT_EQ(&buf(4), buf.base());
+  ASSERT_EQ(&buf(4, 5), buf.base());
+  ASSERT_EQ(&buf(slice, 5), buf.base());
+}
+
+TEST(buffer, folded_address_at_slice) {
+  buffer<char, 2> buf;
+
+  ASSERT_EQ(buf.rank, 2);
+
+  buf.dim(0) = {4, 14, dim::auto_stride, 3};
+  buf.dim(1) = {5, 20, dim::auto_stride, 6};
+  buf.allocate();
+
+  ASSERT_EQ(&buf(), buf.base());
+  ASSERT_EQ(&buf(4), buf.base() + buf.dim(0).flat_offset_bytes(4));
+  ASSERT_EQ(&buf(slice, 5), buf.base() + buf.dim(1).flat_offset_bytes(5));
+}
+
 TEST(buffer, empty_buffer) {
   buffer<int, 3> buf({1, 0, 2});
 


### PR DESCRIPTION
This allows calling `at` and `address_at` with a value `slice` that essentially skips the dimension. This is useful for writing func implementations where you want to get a pointer to the beginning of a region to process that is the min in some dimensions (that aren't the training dimensions) and not others.

It's a bit tricky what this means for folded dimensions, because the base doesn't point to the min of folded dimensions. I think the right thing to do is just skip these dimensions, because the code is likely to add the offset for this dimension later.