### PR TITLE
Make loop::max_workers an expression

### DIFF
--- a/builder/node_mutator.cc
+++ b/builder/node_mutator.cc
@@ -184,11 +184,12 @@ void node_mutator::visit(const call* op) {
 void node_mutator::visit(const loop* op) {
   interval_expr bounds = mutate(op->bounds);
   expr step = mutate(op->step);
+  expr max_workers = mutate(op->max_workers);
   stmt body = mutate(op->body);
-  if (bounds.same_as(op->bounds) && step.same_as(op->step) && body.same_as(op->body)) {
+  if (bounds.same_as(op->bounds) && step.same_as(op->step) && max_workers.same_as(op->max_workers) && body.same_as(op->body)) {
     set_result(op);
   } else {
-    set_result(loop::make(op->sym, op->max_workers, std::move(bounds), std::move(step), std::move(body)));
+    set_result(loop::make(op->sym, std::move(max_workers), std::move(bounds), std::move(step), std::move(body)));
   }
 }
 void node_mutator::visit(const copy_stmt* op) {

--- a/builder/optimizations.cc
+++ b/builder/optimizations.cc
@@ -1357,7 +1357,7 @@ public:
   }
 
   void visit(const loop* op) override {
-    if (op->max_workers != loop::serial) {
+    if (!prove_true(op->max_workers == loop::serial)) {
       // We're entering a parallel loop. All the buffers in scope cannot be mutated in this scope.
       symbol_map<bool> old_can_mutate;
       std::swap(can_mutate, old_can_mutate);

--- a/builder/optimizations.cc
+++ b/builder/optimizations.cc
@@ -1265,16 +1265,17 @@ public:
   void visit(const loop* op) override {
     interval_expr bounds = mutate(op->bounds);
     expr step = mutate(op->step);
+    expr max_workers = mutate(op->max_workers);
     var sym = symbols.contains(op->sym) ? rename(op->sym) : op->sym;
     auto s = set_value_in_scope(symbols, op->sym, sym);
     var old_in_loop = in_loop;
     in_loop = sym;
     stmt body = mutate(op->body);
     in_loop = old_in_loop;
-    if (sym == op->sym && bounds.same_as(op->bounds) && step.same_as(op->step) && body.same_as(op->body)) {
+    if (sym == op->sym && bounds.same_as(op->bounds) && step.same_as(op->step) && max_workers.same_as(op->max_workers) && body.same_as(op->body)) {
       set_result(op);
     } else {
-      set_result(loop::make(sym, op->max_workers, std::move(bounds), std::move(step), std::move(body)));
+      set_result(loop::make(sym, max_workers, std::move(bounds), std::move(step), std::move(body)));
     }
   }
 

--- a/builder/pipeline.h
+++ b/builder/pipeline.h
@@ -151,10 +151,10 @@ public:
   struct loop_info {
     slinky::var var;
     expr step;
-    int max_workers;
+    expr max_workers;
 
     loop_info() = default;
-    loop_info(slinky::var var, expr step = 1, int max_workers = loop::serial)
+    loop_info(slinky::var var, expr step = 1, expr max_workers = loop::serial)
         : var(var), step(step), max_workers(max_workers) {}
 
     slinky::var sym() const { return var; }

--- a/builder/replica_pipeline.cc
+++ b/builder/replica_pipeline.cc
@@ -8,6 +8,7 @@
 #include <vector>
 
 #include "builder/substitute.h"
+#include "builder/simplify.h"
 #include "runtime/print.h"
 
 namespace slinky {
@@ -248,12 +249,13 @@ public:
     return print_vector(fout_names);
   }
 
-  std::string print_max_workers(int x) {
-    switch (x) {
-    case loop::serial: return "loop::serial";
-    case loop::parallel: return "loop::parallel";
-    default: return std::to_string(x);
+  std::string print_max_workers(const expr& x) {
+    if (prove_true(x == loop::serial)) {
+      return "loop::serial";
+    } else if (prove_true(x == loop::parallel)) {
+      return "loop::parallel";
     }
+    return print_expr_maybe_inlined(x);
   }
 
   std::string print(const func::loop_info& loopinfo) {

--- a/builder/simplify.cc
+++ b/builder/simplify.cc
@@ -1334,7 +1334,7 @@ public:
       }
     }
 
-    if (op->is_serial()) {
+    if (prove_true(op->max_workers == loop::serial)) {
       scoped_trace trace("drop_loop");
       // Due to either scheduling or other simplifications, we can end up with a loop that runs a single call or copy on
       // contiguous crops of a buffer. In these cases, we can drop the loop in favor of just calling the body on the

--- a/runtime/depends_on.cc
+++ b/runtime/depends_on.cc
@@ -143,6 +143,7 @@ public:
     op->bounds.min.accept(this);
     op->bounds.max.accept(this);
     if (op->step.defined()) op->step.accept(this);
+    if (op->max_workers.defined()) op->max_workers.accept(this);
 
     visit_sym_body(op->sym, nullptr, op->body);
   }

--- a/runtime/evaluate.cc
+++ b/runtime/evaluate.cc
@@ -410,7 +410,7 @@ public:
     return 0;
   }
 
-  SLINKY_NO_INLINE index_t eval_loop_parallel(const loop* op) {
+  SLINKY_NO_INLINE index_t eval_loop_parallel(const loop* op, index_t max_workers) {
     interval bounds = eval(op->bounds);
     index_t step = eval(op->step, 1);
     assert(step != 0);
@@ -489,7 +489,7 @@ public:
           context.config->thread_pool->cancel(loop.get());
         }
       };
-      int workers = std::min<int>(op->max_workers, std::min<std::size_t>(pool->thread_count() + 1, n));
+      int workers = std::min<int>(max_workers, std::min<std::size_t>(pool->thread_count() + 1, n));
       if (workers > 1) {
         pool->enqueue(workers - 1, worker, loop.get());
       }
@@ -526,8 +526,9 @@ public:
   }
 
   index_t eval(const loop* op) {
-    if (op->max_workers > 1) {
-      return eval_loop_parallel(op);
+    index_t max_workers = eval(op->max_workers);
+    if (max_workers > 1) {
+      return eval_loop_parallel(op, max_workers);
     } else {
       return eval_loop_serial(op);
     }

--- a/runtime/expr_stmt.cc
+++ b/runtime/expr_stmt.cc
@@ -479,7 +479,7 @@ stmt block::make(std::vector<stmt> stmts, stmt tail_stmt) {
   return make(std::move(stmts));
 }
 
-stmt loop::make(var sym, int max_workers, interval_expr bounds, expr step, stmt body) {
+stmt loop::make(var sym, expr max_workers, interval_expr bounds, expr step, stmt body) {
   auto l = new loop();
   l->sym = sym;
   l->max_workers = max_workers;
@@ -855,6 +855,7 @@ void recursive_node_visitor::visit(const loop* op) {
   op->bounds.min.accept(this);
   op->bounds.max.accept(this);
   if (op->step.defined()) op->step.accept(this);
+  if (op->max_workers.defined()) op->max_workers.accept(this);
   if (op->body.defined()) op->body.accept(this);
 }
 void recursive_node_visitor::visit(const call_stmt* op) {}

--- a/runtime/print.cc
+++ b/runtime/print.cc
@@ -289,11 +289,7 @@ public:
 
   void visit(const loop* l) override {
     *this << indent() << l->sym << " = loop(";
-    switch (l->max_workers) {
-    case loop::serial: *this << "serial"; break;
-    case loop::parallel: *this << "parallel"; break;
-    default: *this << l->max_workers; break;
-    }
+    *this << l->max_workers;
     *this << ", " << l->bounds;
     if (l->step.defined()) {
       *this << ", " << l->step;

--- a/runtime/stmt.h
+++ b/runtime/stmt.h
@@ -220,7 +220,7 @@ public:
 class loop : public stmt_node<loop> {
 public:
   var sym;
-  int max_workers;
+  expr max_workers;
   interval_expr bounds;
   expr step;
   stmt body;
@@ -228,12 +228,9 @@ public:
   static constexpr int serial = 1;
   static constexpr int parallel = std::numeric_limits<int>::max();
 
-  bool is_serial() const { return max_workers == serial; }
-  bool is_parallel() const { return max_workers > 1; }
-
   void accept(stmt_visitor* v) const override;
 
-  static stmt make(var sym, int max_workers, interval_expr bounds, expr step, stmt body);
+  static stmt make(var sym, expr max_workers, interval_expr bounds, expr step, stmt body);
 
   static constexpr stmt_node_type static_type = stmt_node_type::loop;
 };


### PR DESCRIPTION
This makes it possible for the loop type (serial vs parallel) to be decided at runtime.