### PR TITLE
Initialize loop_info::max_workers to 0 by default to avoid creating useless semaphores at the root level

### DIFF
--- a/builder/slide_and_fold_storage.cc
+++ b/builder/slide_and_fold_storage.cc
@@ -188,7 +188,7 @@ public:
     expr orig_min;
     interval_expr bounds;
     expr step;
-    expr max_workers;
+    expr max_workers = 0;
     bool data_parallel = true;
     std::unique_ptr<symbol_map<box_expr>> buffer_bounds = std::make_unique<symbol_map<box_expr>>();
     std::unique_ptr<symbol_map<interval_expr>> expr_bounds = std::make_unique<symbol_map<interval_expr>>();


### PR DESCRIPTION
We start with a bogus loop and if there are call_stmt/copy_stmt at the root level, we might end up with useless semaphores.