### PR TITLE
Produce crops for all transitively used buffers inside of the loop body

### DIFF
--- a/builder/pipeline.cc
+++ b/builder/pipeline.cc
@@ -1181,8 +1181,8 @@ public:
     // Find which buffers are used inside of the body.
     std::vector<var> buffers_used = find_buffer_dependencies(body.body);
     std::set<var> transitive_deps;
-    // NOTE(vksnk): we could be more clever here and stop once we reach specific buffer -- this
-    // could prevent adding crops which are not affected by this loop's crop_dim.
+    // NOTE(vksnk): we could be more clever here and stop once we reach this loop's parent buffer(s)
+    // which will avoid adding unnecessary crops which are not affected by this loop's crop_dim.
     find_transitive_deps(buffers_used, transitive_deps);
 
     // Add crops for the used buffers using previously inferred bounds.

--- a/builder/test/softmax.cc
+++ b/builder/test/softmax.cc
@@ -227,10 +227,8 @@ TEST_P(softmax, pipeline) {
                                             softmax_in_size, softmax_out_size, add_out_size));
     } else {
       if (use_compute_at == 2) {
-        // TODO(vksnk): investigate why after using store_at on max_in, the storages folding stops working
-        // for softmax_in.
         ASSERT_THAT(eval_ctx.heap.allocs,
-            testing::UnorderedElementsAre(sum_exp_in_size, exp_in_size, B * softmax_in_size / split_b, softmax_out_size));
+            testing::UnorderedElementsAre(sum_exp_in_size, exp_in_size, softmax_in_size, softmax_out_size));
       } else {
         ASSERT_THAT(eval_ctx.heap.allocs,
             testing::UnorderedElementsAre(sum_exp_in_size, exp_in_size, max_in_size, softmax_in_size, softmax_out_size));


### PR DESCRIPTION
This actually improves one of the few tests which uses store_at (we could probably use more tests with store_at though).