### PR TITLE
Check if stride is defined before visiting

### DIFF
--- a/runtime/expr_stmt.cc
+++ b/runtime/expr_stmt.cc
@@ -880,7 +880,7 @@ void recursive_node_visitor::visit(const make_buffer* op) {
   for (const dim_expr& i : op->dims) {
     i.bounds.min.accept(this);
     i.bounds.max.accept(this);
-    i.stride.accept(this);
+    if (i.stride.defined()) i.stride.accept(this);
     if (i.fold_factor.defined()) i.fold_factor.accept(this);
   }
   if (op->body.defined()) op->body.accept(this);


### PR DESCRIPTION
This is what visit(allocate*) is doing too.