### PR TITLE
Add a way to schedule a buffer to be stored at the same level it's computed at

### DIFF
--- a/builder/pipeline.cc
+++ b/builder/pipeline.cc
@@ -736,9 +736,13 @@ class pipeline_builder {
       if (output_syms_.count(b->sym())) continue;
 
       if (b->store_at()) {
-        // Check that this loop_id actually exists.
-        assert(loops_.count(*b->store_at()) > 0);
-        candidates_for_allocation_[*b->store_at()].insert(b->sym());
+        if (b->store_at()->innermost(f)) {
+          candidates_for_allocation_[compute_at_levels_[f]].insert(b->sym());
+        } else {
+          // Check that this loop_id actually exists.
+          assert(loops_.count(*b->store_at()) > 0);
+          candidates_for_allocation_[*b->store_at()].insert(b->sym());
+        }
       } else {
         candidates_for_allocation_[loop_id()].insert(b->sym());
       }

--- a/builder/pipeline.h
+++ b/builder/pipeline.h
@@ -19,7 +19,7 @@ struct loop_id {
   const slinky::func* func = nullptr;
   slinky::var var;
 
-  bool innermost(const slinky::func* other) const { return other == func; }
+  bool innermost(const slinky::func* other) const { return other == func && !var.defined(); }
   bool root() const { return !func; }
   // TODO: Deprecated
   slinky::var sym() const { return var; }

--- a/builder/pipeline.h
+++ b/builder/pipeline.h
@@ -19,6 +19,7 @@ struct loop_id {
   const slinky::func* func = nullptr;
   slinky::var var;
 
+  bool innermost(const slinky::func* other) const { return other == func; }
   bool root() const { return !func; }
   // TODO: Deprecated
   slinky::var sym() const { return var; }


### PR DESCRIPTION
The idea is to do something like:
```
f->output->store_at({f, var()});
```
I'm not sure it's a best interface, but it is concise -- open to other suggestions.