### PR TITLE
Improve simplification of crops

### DIFF
--- a/builder/substitute.cc
+++ b/builder/substitute.cc
@@ -339,6 +339,7 @@ bool match(expr_ref a, expr_ref b) { return matcher().try_match(a.get(), b.get()
 bool match(stmt_ref a, stmt_ref b) { return matcher().try_match(a.get(), b.get()); }
 bool match(const interval_expr& a, const interval_expr& b) { return matcher().try_match(a, b); }
 bool match(const dim_expr& a, const dim_expr& b) { return matcher().try_match(a, b); }
+bool match(const box_expr& a, const box_expr& b) { return matcher().try_match(a, b); }
 
 int compare(const var& a, const var& b) {
   matcher m;

--- a/builder/substitute.h
+++ b/builder/substitute.h
@@ -18,6 +18,7 @@ SLINKY_ALWAYS_INLINE SLINKY_UNIQUE bool match(index_t a, var b) { return false; 
 bool match(stmt_ref a, stmt_ref b);
 bool match(const interval_expr& a, const interval_expr& b);
 bool match(const dim_expr& a, const dim_expr& b);
+bool match(const box_expr& a, const box_expr& b);
 
 // Compute a sort ordering of two nodes based on their structure (not their values).
 int compare(const var& a, const var& b);

--- a/builder/test/simplify/simplify.cc
+++ b/builder/test/simplify/simplify.cc
@@ -606,6 +606,16 @@ TEST(simplify, crop) {
   ASSERT_THAT(
       simplify(crop_buffer::make(b1, b0, {{x, y}, {z, w}}, crop_buffer::make(b2, b1, {{}, {z, w}, {u, v}}, body))),
       matches(crop_buffer::make(b2, b0, {{x, y}, {z, w}, {u, v}}, body)));
+
+  // Nested crops of the same buffer.
+  ASSERT_THAT(simplify(crop_dim::make(
+                  b1, b0, 0, {x, y}, crop_dim::make(b2, b0, 0, {x, y}, call_stmt::make(nullptr, {}, {b1, b2}, {})))),
+      matches(crop_dim::make(b1, b0, 0, {x, y}, call_stmt::make(nullptr, {}, {b1, b1}, {}))));
+  ASSERT_THAT(simplify(clone_buffer::make(b1, b0,
+                  crop_buffer::make(b2, b1, {buffer_bounds(b0, 0)},
+                      crop_dim::make(b3, b1, 0, {x, y},
+                          crop_dim::make(b4, b2, 0, {x, y}, call_stmt::make(nullptr, {}, {b3, b4}, {})))))),
+      matches(crop_dim::make(b3, b0, 0, {x, y}, call_stmt::make(nullptr, {}, {b3, b3}, {}))));
 }
 
 TEST(simplify, make_buffer) {


### PR DESCRIPTION
- Substitute no-op crops before mutating the body instead of after
- If two nested crops are the same, just re-use the outer one.