### PR TITLE
Rewrite copy, pad, fill to always take buffers instead of scalar values

### DIFF
--- a/builder/optimizations.cc
+++ b/builder/optimizations.cc
@@ -1057,8 +1057,12 @@ stmt implement_copy(const copy_stmt* op, node_context& ctx) {
         // don't matter. But in this case, they do...
         const raw_buffer* src_buf = ctx.lookup_buffer(op->outputs[0]);
         const raw_buffer* dst_buf = ctx.lookup_buffer(op->outputs[1]);
-        const void* pad_value = (!padding || padding->empty()) ? nullptr : padding->data();
-        ctx.config->copy(*src_buf, *dst_buf, pad_value);
+        raw_buffer pad_buf;
+        pad_buf.base = (!padding || padding->empty()) ? nullptr : const_cast<char*>(padding->data());
+        pad_buf.rank = 0;
+        pad_buf.elem_size = dst_buf->elem_size;
+        pad_buf.dims = nullptr;
+        ctx.config->copy(*src_buf, *dst_buf, &pad_buf);
         return 0;
       },
       {}, {op->src, dst}, std::move(copy_attrs));

--- a/builder/optimizations.cc
+++ b/builder/optimizations.cc
@@ -1057,11 +1057,8 @@ stmt implement_copy(const copy_stmt* op, node_context& ctx) {
         // don't matter. But in this case, they do...
         const raw_buffer* src_buf = ctx.lookup_buffer(op->outputs[0]);
         const raw_buffer* dst_buf = ctx.lookup_buffer(op->outputs[1]);
-        raw_buffer pad_buf;
-        pad_buf.base = (!padding || padding->empty()) ? nullptr : const_cast<char*>(padding->data());
-        pad_buf.rank = 0;
-        pad_buf.elem_size = dst_buf->elem_size;
-        pad_buf.dims = nullptr;
+        raw_buffer pad_buf = raw_buffer::make_scalar_ref(
+            dst_buf->elem_size, (!padding || padding->empty()) ? nullptr : const_cast<char*>(padding->data()));
         ctx.config->copy(*src_buf, *dst_buf, &pad_buf);
         return 0;
       },
@@ -1278,7 +1275,8 @@ public:
     in_loop = sym;
     stmt body = mutate(op->body);
     in_loop = old_in_loop;
-    if (sym == op->sym && bounds.same_as(op->bounds) && step.same_as(op->step) && max_workers.same_as(op->max_workers) && body.same_as(op->body)) {
+    if (sym == op->sym && bounds.same_as(op->bounds) && step.same_as(op->step) &&
+        max_workers.same_as(op->max_workers) && body.same_as(op->body)) {
       set_result(op);
     } else {
       set_result(loop::make(sym, std::move(max_workers), std::move(bounds), std::move(step), std::move(body)));

--- a/builder/test/checks.cc
+++ b/builder/test/checks.cc
@@ -37,8 +37,7 @@ TEST(pipeline, checks) {
   buffer<int, 1> in_buf({N});
   buffer<int, 1> out_buf({N});
   in_buf.allocate();
-  const int zero = 0;
-  fill(in_buf, &zero);
+  copy(scalar<int>(0), in_buf);
   out_buf.allocate();
 
   const raw_buffer* inputs[] = {&in_buf};
@@ -82,7 +81,7 @@ TEST(pipeline, unused_input) {
   buffer<int, 1> out_buf({N});
   in_buf.allocate();
   out_buf.allocate();
-  fill(in_buf, 2);
+  copy(scalar<int>(2), in_buf);
   // Leave unused uninitialized so we know if something accesses it (via msan).
 
   const raw_buffer* inputs[] = {&in_buf, &unused_buf};

--- a/builder/test/context.cc
+++ b/builder/test/context.cc
@@ -48,14 +48,14 @@ test_context::test_context() {
     heap.track_free(b->size_bytes());
   };
 
-  config.copy = [this](const raw_buffer& src, const raw_buffer& dst, const void* padding) {
+  config.copy = [this](const raw_buffer& src, const raw_buffer& dst, const raw_buffer* pad) {
     ++copy_calls;
     copy_elements += dst.elem_count();
-    slinky::copy(src, dst, padding);
+    slinky::copy(src, dst, pad);
   };
-  config.pad = [this](const dim* in_bounds, const raw_buffer& dst, const void* padding) {
+  config.pad = [this](const dim* in_bounds, const raw_buffer& dst, const raw_buffer& pad) {
     ++pad_calls;
-    slinky::pad(in_bounds, dst, padding);
+    slinky::pad(in_bounds, dst, pad);
   };
 
   config.thread_pool = &threads;

--- a/runtime/buffer.cc
+++ b/runtime/buffer.cc
@@ -59,9 +59,7 @@ std::size_t raw_buffer::elem_count() const {
 
 raw_buffer_ptr raw_buffer::make(std::size_t rank, std::size_t elem_size, const class dim* dims) {
   std::size_t size = sizeof(raw_buffer) + sizeof(slinky::dim) * rank;
-  if (rank == 0) {
-    size += elem_size;
-  } else if (dims) {
+  if (rank == 0 || dims) {
     size += alloc_size(rank, elem_size, dims);
   }
   char* mem = reinterpret_cast<char*>(malloc(size));

--- a/runtime/buffer.h
+++ b/runtime/buffer.h
@@ -383,11 +383,22 @@ public:
   // Make a deep copy of another buffer, including allocating and copying the data.
   static raw_buffer_ptr make_copy(const raw_buffer& src);
 
-  // Make a buffer around a scalar value. The resulting buffer will have rank 0.
+  // Make a buffer around a scalar value. The resulting buffer will have rank 0. The result is a heap allocated
+  // buffer that contains a copy of the scalar value.
   static raw_buffer_ptr make_scalar(std::size_t elem_size, const void* value);
   template <typename T, typename = typename std::enable_if_t<std::is_trivial_v<T>>>
   static raw_buffer_ptr make_scalar(const T& value) {
     return make_scalar(sizeof(T), &value);
+  }
+
+  // Make a buffer around a scalar value. The resulting buffer will have rank 0. The result is a buffer that contains a
+  // pointer to the value.
+  static raw_buffer make_scalar_ref(std::size_t elem_size, void* value) {
+    return raw_buffer{value, elem_size, 0, nullptr};
+  }
+  template <typename T>
+  static raw_buffer make_scalar_ref(const T& value) {
+    return make_scalar_ref(sizeof(T), &value);
   }
 };
 
@@ -397,7 +408,7 @@ class scalar : public raw_buffer {
 public:
   T value;
 
-  scalar(const T& value = T()) : value(value) { 
+  scalar(const T& value = T()) : value(value) {
     base = &this->value;
     elem_size = sizeof(T);
     rank = 0;

--- a/runtime/buffer.h
+++ b/runtime/buffer.h
@@ -7,6 +7,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <memory>
+#include <type_traits>
 
 #include "base/arithmetic.h"
 #include "base/function_ref.h"
@@ -165,12 +166,8 @@ static constexpr struct {
 // - Provides storage for DimsSize dims (default is 0).
 class raw_buffer {
 protected:
-  static std::ptrdiff_t flat_offset_bytes_impl(const dim* dims, index_t i0) {
-    return dims->flat_offset_bytes(i0);
-  }
-  static std::ptrdiff_t flat_offset_bytes_impl(const dim* dims, decltype(slinky::slice)) {
-    return 0;
-  }
+  static std::ptrdiff_t flat_offset_bytes_impl(const dim* dims, index_t i0) { return dims->flat_offset_bytes(i0); }
+  static std::ptrdiff_t flat_offset_bytes_impl(const dim* dims, decltype(slinky::slice)) { return 0; }
 
   template <typename... Indices>
   static std::ptrdiff_t flat_offset_bytes_impl(const dim* dims, index_t i0, Indices... indices) {
@@ -385,6 +382,27 @@ public:
 
   // Make a deep copy of another buffer, including allocating and copying the data.
   static raw_buffer_ptr make_copy(const raw_buffer& src);
+
+  // Make a buffer around a scalar value. The resulting buffer will have rank 0.
+  static raw_buffer_ptr make_scalar(std::size_t elem_size, const void* value);
+  template <typename T, typename = typename std::enable_if_t<std::is_trivial_v<T>>>
+  static raw_buffer_ptr make_scalar(const T& value) {
+    return make_scalar(sizeof(T), &value);
+  }
+};
+
+// This is a wrapper for a raw_buffer that represents a scalar value, with storage for the scalar value.
+template <typename T>
+class scalar : public raw_buffer {
+public:
+  T value;
+
+  scalar(const T& value = T()) : value(value) { 
+    base = &this->value;
+    elem_size = sizeof(T);
+    rank = 0;
+    dims = nullptr;
+  }
 };
 
 namespace internal {
@@ -613,27 +631,15 @@ const buffer<NewT>& raw_buffer::cast() const {
 }
 
 // Copy the contents of `src` to `dst`.
-// If `padding` is null, `src` must contain every index that `dst` contains.
-// If `padding` is non-null, `dst` is filled with the padding when it is out of bounds of `src`.
-void copy(const raw_buffer& src, const raw_buffer& dst, const void* padding = nullptr);
-template <typename T, typename = typename std::enable_if<!std::is_pointer<T>::value>::type>
-void copy(const raw_buffer& src, const raw_buffer& dst, const T& padding) {
-  copy(src, dst, &padding);
-}
+// If `padding` is nullptr, every index of `dst` must be in bounds of `src`.
+// If `padding` is not nullptr, `dst` will be copied from `src` if it is in bounds, otherwise it will be copied from
+// `padding`, which must be in bounds.
+void copy(const raw_buffer& src, const raw_buffer& dst, const raw_buffer* pad = nullptr);
+inline void copy(const raw_buffer& src, const raw_buffer& dst, const raw_buffer& pad) { copy(src, dst, &pad); }
 
 // Performs only the padding operation of a copy. The region that would have been copied is unmodified.
-void pad(const dim* in_bounds, const raw_buffer& dst, const void* padding);
-template <typename T, typename = typename std::enable_if<!std::is_pointer<T>::value>::type>
-void pad(const dim* in_bounds, const raw_buffer& dst, const T& padding) {
-  pad(in_bounds, dst, &padding);
-}
+void pad(const dim* src_bounds, const raw_buffer& dst, const raw_buffer& pad);
 
-// Fill `dst` with `value`. `value` should point to `dst.elem_size` bytes.
-void fill(const raw_buffer& dst, const void* value);
-template <typename T, typename = typename std::enable_if<!std::is_pointer<T>::value>::type>
-void fill(const raw_buffer& dst, const T& padding) {
-  fill(dst, &padding);
-}
 // Returns true if the two dimensions can be fused.
 inline bool can_fuse(const dim& inner, const dim& outer) {
   if (outer.min() == outer.max()) return true;
@@ -661,36 +667,52 @@ enum class fuse_type {
 // Fuse two dimensions of a buffer.
 template <fuse_type type>
 inline void fuse(index_t inner, index_t outer, raw_buffer& buf) {
-  dim& id = buf.dim(inner);
-  dim& od = buf.dim(outer);
-  assert(can_fuse(id, od));
-  if (id.min() == id.max()) {
-    if (type == fuse_type::remove) {
-      buf.slice(inner);
-      return;
+  if (outer >= static_cast<index_t>(buf.rank)) {
+    // Fusing an implicit broadcast, nothing to do.
+    assert(inner >= static_cast<index_t>(buf.rank) || can_fuse(buf.dim(inner), dim::broadcast()));
+  } else if (inner >= static_cast<index_t>(buf.rank)) {
+    // The inner dimension is an implicit broadcast.
+    dim& od = buf.dim(outer);
+    assert(can_fuse(dim::broadcast(), od));
+    if (type == fuse_type::keep) {
+      od.set_point(0);
+    } else if (type == fuse_type::remove) {
+      buf.slice(outer);
     } else {
-      id = od;
+      assert(type == fuse_type::undef);
     }
-  } else if (id.unbounded()) {
-    // Already fused
   } else {
-    const index_t id_extent = id.extent();
-    if (od.min() != od.max() && od.fold_factor() != dim::unfolded) {
-      assert(id.fold_factor() == dim::unfolded);
-      id.set_fold_factor(od.fold_factor() * id_extent);
-    }
-    if (od.unbounded()) {
-      id.set_unbounded();
+    dim& id = buf.dim(inner);
+    dim& od = buf.dim(outer);
+    assert(can_fuse(id, od));
+    if (id.min() == id.max()) {
+      if (type == fuse_type::remove) {
+        buf.slice(inner);
+        return;
+      } else {
+        id = od;
+      }
+    } else if (id.unbounded()) {
+      // Already fused
     } else {
-      id.set_range(od.begin() * id_extent, od.end() * id_extent);
+      const index_t id_extent = id.extent();
+      if (od.min() != od.max() && od.fold_factor() != dim::unfolded) {
+        assert(id.fold_factor() == dim::unfolded);
+        id.set_fold_factor(od.fold_factor() * id_extent);
+      }
+      if (od.unbounded()) {
+        id.set_unbounded();
+      } else {
+        id.set_range(od.begin() * id_extent, od.end() * id_extent);
+      }
     }
-  }
-  if (type == fuse_type::keep) {
-    od.set_point(0);
-  } else if (type == fuse_type::remove) {
-    buf.slice(outer);
-  } else {
-    assert(type == fuse_type::undef);
+    if (type == fuse_type::keep) {
+      od.set_point(0);
+    } else if (type == fuse_type::remove) {
+      buf.slice(outer);
+    } else {
+      assert(type == fuse_type::undef);
+    }
   }
 }
 
@@ -708,21 +730,22 @@ inline bool same_bounds(const dim& a, const dim& b) {
   return a.min() == b.min() && a.max() == b.max() && a.fold_factor() == b.fold_factor();
 }
 
+inline const dim& dim_or_broadcast(const raw_buffer& buf, std::ptrdiff_t d) {
+  return d < static_cast<std::ptrdiff_t>(buf.rank) ? buf.dim(d) : dim::broadcast();
+}
+
 // Returns true if all buffers have the same bounds in dimension d.
 inline bool same_bounds(std::ptrdiff_t, const raw_buffer&) { return true; }
-inline bool same_bounds(std::ptrdiff_t d, const raw_buffer& buf0, const raw_buffer& buf1) {
-  return same_bounds(buf0.dim(d), buf1.dim(d));
-}
 template <typename... Bufs>
 bool same_bounds(std::ptrdiff_t d, const raw_buffer& buf0, const raw_buffer& buf1, const Bufs&... bufs) {
-  return same_bounds(buf0.dim(d), buf1.dim(d)) && same_bounds(d, buf1, bufs...);
+  return same_bounds(dim_or_broadcast(buf0, d), dim_or_broadcast(buf1, d)) && same_bounds(d, buf1, bufs...);
 }
 
 // Returns true if two dimensions of all buffers can be fused.
 inline bool can_fuse(std::ptrdiff_t, std::ptrdiff_t) { return true; }
 template <typename... Bufs>
 bool can_fuse(std::ptrdiff_t inner, std::ptrdiff_t outer, const raw_buffer& buf, const Bufs&... bufs) {
-  return can_fuse(buf.dim(inner), buf.dim(outer)) && can_fuse(inner, outer, bufs...);
+  return can_fuse(dim_or_broadcast(buf, inner), dim_or_broadcast(buf, outer)) && can_fuse(inner, outer, bufs...);
 }
 
 // Fuse two dimensions of all buffers.
@@ -766,14 +789,16 @@ void swap_dims(std::size_t i, std::size_t j, raw_buffer& buf, Bufs&... bufs) {
 // Returns true if the sort changed the ordering of the dimensions.
 template <typename... Bufs>
 bool sort_dims(span<const int> dim_sets, raw_buffer& buf, Bufs&... bufs) {
-  assert(internal::same_rank(buf, bufs...));
+  // We only attempt to sort the dimensions that exist in all buffers. We could do better here, sometimes we can
+  // swap implicit broadcast dimensions with another broadcast dimension.
+  const size_t rank = std::min({buf.rank, bufs.rank...});
   bool modified = false;
   // A bubble sort is appropriate here, because:
   // - Typically, buffer ranks are very small.
   // - To use std::sort or similar, we need to copy the buffer dimensions into a temporary, sort, and copy them back.
   // - This template will be instantiated very frequently, it's worth attempting to minimize code size.
-  for (std::size_t i = 0; i < buf.rank; ++i) {
-    for (std::size_t j = i + 1; j < buf.rank; ++j) {
+  for (std::size_t i = 0; i < rank; ++i) {
+    for (std::size_t j = i + 1; j < rank; ++j) {
       if (j < dim_sets.size() && dim_sets[i] != dim_sets[j]) continue;
       if (buf.dim(i).stride() > buf.dim(j).stride()) {
         internal::swap_dims(i, j, buf, bufs...);
@@ -795,14 +820,12 @@ bool sort_dims(raw_buffer& buf, Bufs&... bufs) {
 // eligible for fusion. By default, all dimensions are considered to be part of the same set.
 template <typename... Bufs>
 void fuse_contiguous_dims(span<const int> dim_sets, raw_buffer& buf, Bufs&... bufs) {
-  assert(internal::same_rank(buf, bufs...));
   for (std::ptrdiff_t d = static_cast<std::ptrdiff_t>(buf.rank) - 1; d > 0; --d) {
     internal::attempt_fuse(d - 1, d, dim_sets, buf, bufs...);
   }
 }
 template <typename... Bufs>
 void fuse_contiguous_dims(raw_buffer& buf, Bufs&... bufs) {
-  assert(internal::same_rank(buf, bufs...));
   for (std::ptrdiff_t d = static_cast<std::ptrdiff_t>(buf.rank) - 1; d > 0; --d) {
     internal::attempt_fuse(d - 1, d, buf, bufs...);
   }

--- a/runtime/evaluate.h
+++ b/runtime/evaluate.h
@@ -29,12 +29,12 @@ struct eval_config {
   slinky::thread_pool* thread_pool = nullptr;
 
   // Functions implementing buffer data movement:
-  // - `copy` should copy from `src` to `dst`, filling `dst` with `padding` when out of bounds of `src`.
-  // - `pad` should fill the area out of bounds of `src_dims` with `padding` in `dst`.
-  std::function<void(const raw_buffer& src, const raw_buffer& dst, const void* padding)> copy =
-      static_cast<void (*)(const raw_buffer&, const raw_buffer&, const void*)>(slinky::copy);
-  std::function<void(const dim* in_bounds, const raw_buffer& dst, const void* padding)> pad =
-      static_cast<void (*)(const dim*, const raw_buffer&, const void*)>(slinky::pad);
+  // - `copy` should copy from `src` to `dst`, filling `dst` with `pad` when out of bounds of `src`.
+  // - `pad` should fill the area out of bounds of `src_dims` with `pad` in `dst`.
+  std::function<void(const raw_buffer& src, const raw_buffer& dst, const raw_buffer* pad)> copy =
+      static_cast<void (*)(const raw_buffer&, const raw_buffer&, const raw_buffer*)>(slinky::copy);
+  std::function<void(const dim* in_bounds, const raw_buffer& dst, const raw_buffer& pad)> pad =
+      static_cast<void (*)(const dim*, const raw_buffer&, const raw_buffer&)>(slinky::pad);
 
   // Functions implementing the `trace_begin` and `trace_end` intrinsics.
   std::function<index_t(const char*)> trace_begin;

--- a/runtime/test/buffer.cc
+++ b/runtime/test/buffer.cc
@@ -207,18 +207,21 @@ bool test_fill(int elem_size, int size) {
   buf.allocate();
   std::vector<uint8_t> value(elem_size);
   std::iota(value.begin(), value.end(), 0);
-  fill(buf, value.data());
-  for (int i = 0; i < size * elem_size; ++i) {
-    if (reinterpret_cast<const uint8_t*>(buf.base())[i] != i % elem_size) {
-      return false;
+  copy(*raw_buffer::make_scalar(value.size(), value.data()), buf);
+  const uint8_t* data = reinterpret_cast<const uint8_t*>(buf.base());
+  for (int i = 0; i < size; ++i) {
+    for (int j = 0; j < elem_size; ++j) {
+      if (*data++ != j) {
+        return false;
+      }
     }
   }
   return true;
 }
 
 TEST(buffer, fill) {
-  for (int size = 0; size < 100; ++size) {
-    for (int elem_size : {1, 2, 3, 4, 8, 12, 16, 63, 64, 65}) {
+  for (int elem_size : {1, 2, 3, 4, 8, 12, 16, 63, 64, 65}) {
+    for (int size : {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 100, 1024 / elem_size, 1024 * 1024 / elem_size}) {
       ASSERT_TRUE(test_fill(elem_size, size)) << elem_size << " " << size;
     }
   }
@@ -372,7 +375,7 @@ TEST(buffer, for_each_element_cropped) {
   src.crop(0, 2, 6);
   dst.allocate();
   src.allocate();
-  fill(src, 7);
+  copy(scalar<char>(7), src);
   int total = 0;
   int in_bounds = 0;
   for_each_element(
@@ -470,7 +473,7 @@ TEST(buffer, for_each_contiguous_cropped) {
   src.crop(0, 2, 6);
   dst.allocate();
   src.allocate();
-  fill(src, 7);
+  copy(scalar<char>(7), src);
   int slices = 0;
   int total = 0;
   int in_bounds = 0;
@@ -791,39 +794,42 @@ TEST(buffer, copy) {
     int rank = random(rng, 0, max_rank);
     int elem_size = random(rng, 1, 12);
 
-    std::vector<char> padding(elem_size);
-    std::fill(padding.begin(), padding.end(), 7);
-
-    buffer<void, max_rank> src(rank, elem_size);
     buffer<void, max_rank> dst(rank, elem_size);
-    for (std::size_t d = 0; d < src.rank; ++d) {
-      src.dim(d).set_min_extent(0, 5);
+    for (std::size_t d = 0; d < rank; ++d) {
       dst.dim(d).set_min_extent(0, 5);
     }
-    randomize_strides_and_padding(rng, src, {-1, 1, true, false});
-    randomize_strides_and_padding(rng, dst, {-1, 1, false, false});
+    buffer<void, max_rank> src = dst;
+    randomize_strides_and_padding(rng, src, {-1, 1, true, true});
     init_random(rng, src);
+
+    // The padding can't be out of bounds, add one extra padding.
+    buffer<void, max_rank> padding1 = dst;
+    buffer<void, max_rank> padding2 = dst;
+    randomize_strides_and_padding(rng, padding1, {1, 3, true, true});
+    randomize_strides_and_padding(rng, padding2, {1, 3, true, true});
+    init_random(rng, padding1);
+    init_random(rng, padding2);
+
+    randomize_strides_and_padding(rng, dst, {-1, 1, false, false});
     dst.allocate();
 
-    slinky::copy(src, dst, padding.data());
+    slinky::copy(src, dst, padding1);
     for_each_index(dst, [&](auto i) {
       if (src.contains(i)) {
         ASSERT_EQ(memcmp(dst.address_at(i), src.address_at(i), elem_size), 0);
       } else {
-        ASSERT_EQ(memcmp(dst.address_at(i), padding.data(), elem_size), 0);
+        ASSERT_EQ(memcmp(dst.address_at(i), padding1.address_at(i), elem_size), 0);
       }
     });
 
-    std::vector<char> new_padding(elem_size);
-    std::fill(new_padding.begin(), new_padding.end(), 3);
-    pad(src.dims, dst, new_padding.data());
+    pad(src.dims, dst, padding2);
     for_each_index(dst, [&](auto i) {
       if (src.contains(i)) {
         // The src should not have been modified.
         ASSERT_EQ(memcmp(dst.address_at(i), src.address_at(i), elem_size), 0);
       } else {
         // But we should have new padding.
-        ASSERT_EQ(memcmp(dst.address_at(i), new_padding.data(), elem_size), 0);
+        ASSERT_EQ(memcmp(dst.address_at(i), padding2.address_at(i), elem_size), 0);
       }
     });
   }
@@ -848,9 +854,9 @@ TEST(buffer, copy_empty_src) {
       dst.dim(0).set_min_extent(0, D);
     }
     dst.allocate();
-    fill(dst, 7);
+    copy(scalar<int>(7), dst);
     // The result of copying an empty buffer should be entirely padding.
-    slinky::copy(src, dst, 3);
+    slinky::copy(src, dst, scalar<int>(3));
     ASSERT_TRUE(is_filled_buffer(dst, 3));
   }
 }
@@ -928,6 +934,21 @@ TEST(fuse_contiguous_dims, fuse_broadcasted) {
   ASSERT_EQ(b.dim(0).extent(), 6);
   ASSERT_EQ(b.dim(0).stride(), 4);
   ASSERT_EQ(b.dim(1).stride(), 0);
+}
+
+TEST(fuse_contiguous_dims, fuse_implicit_broadcasted) {
+  buffer<int, 3> a({6, 1, 1}), b({6});
+  a.dim(1) = dim::broadcast();
+  a.dim(2) = dim::broadcast();
+
+  fuse_contiguous_dims(a, b);
+  ASSERT_EQ(a.rank, 2);
+  ASSERT_EQ(b.rank, 1);
+  ASSERT_EQ(a.dim(0).extent(), 6);
+  ASSERT_EQ(a.dim(0).stride(), 4);
+  ASSERT_EQ(a.dim(1).stride(), 0);
+  ASSERT_EQ(b.dim(0).extent(), 6);
+  ASSERT_EQ(b.dim(0).stride(), 4);
 }
 
 TEST(fuse_contiguous_dims, fuse_extent1) {

--- a/runtime/test/buffer.cc
+++ b/runtime/test/buffer.cc
@@ -795,7 +795,7 @@ TEST(buffer, copy) {
     int elem_size = random(rng, 1, 12);
 
     buffer<void, max_rank> dst(rank, elem_size);
-    for (std::size_t d = 0; d < rank; ++d) {
+    for (int d = 0; d < rank; ++d) {
       dst.dim(d).set_min_extent(0, 5);
     }
     buffer<void, max_rank> src = dst;

--- a/runtime/test/buffer_benchmark.cc
+++ b/runtime/test/buffer_benchmark.cc
@@ -55,14 +55,16 @@ BENCHMARK(BM_memset)->Arg(1024);
 
 void BM_fill(benchmark::State& state) {
   std::vector<index_t> extents = state_to_vector(4, state);
+
+  scalar<int> five(5);
+  five.elem_size = extents[0];
+
   buffer<void, 3> dst(3, extents[0]);
   extents.erase(extents.begin());
   allocate_buffer(dst, extents);
 
-  int five = 5;
-
   for (auto _ : state) {
-    fill(dst, &five);
+    copy(five, dst);
   }
 }
 
@@ -77,10 +79,10 @@ void BM_fill_padded(benchmark::State& state) {
   buffer<char, 3> dst;
   allocate_buffer(dst, state_to_vector(3, state), padding_size);
 
-  char five = 5;
+  scalar<char> five(5);
 
   for (auto _ : state) {
-    fill(dst, &five);
+    copy(five, dst);
   }
 }
 
@@ -97,10 +99,10 @@ void BM_pad(benchmark::State& state) {
     src.dim(d).set_bounds(1, extents[d] - 2);
   }
 
-  char five = 0;
+  scalar<char> five(5);
 
   for (auto _ : state) {
-    pad(src.dims, dst, &five);
+    pad(src.dims, dst, five);
   }
 }
 
@@ -199,8 +201,7 @@ void BM_for_each_element_2x(benchmark::State& state) {
   buffer<char, 3> src;
   allocate_buffer(src, extents);
 
-  char x = 42;
-  fill(src, &x);
+  copy(scalar<char>(42), src);
 
   dst.slice(0);
   src.slice(0);
@@ -217,8 +218,7 @@ void BM_for_each_contiguous_slice_2x(benchmark::State& state) {
   buffer<char, 3> src;
   allocate_buffer(src, extents);
 
-  char x = 42;
-  fill(src, &x);
+  copy(scalar<char>(42), src);
 
   for (auto _ : state) {
     for_each_contiguous_slice(
@@ -238,10 +238,10 @@ void BM_fill_batch_dims(benchmark::State& state) {
   buffer<char, 8> dst;
   allocate_buffer(dst, {64, 1, 1, 1, 1, 1, 1, 1});
 
-  char five = 5;
+  scalar<char> five(5);
 
   for (auto _ : state) {
-    fill(dst, &five);
+    copy(five, dst);
   }
 }
 


### PR DESCRIPTION
- Remove `fill`, because it is equivalent to `copy` with a scalar buffer as the `src`.
- Change the padding argument of `copy` and `pad` to be a buffer instead of a scalar value. This allows the padding to vary across the output.

This PR is a fairly significant performance regression for some cases of `fill` and `copy` (`fill`/`copy` is 1.2-2x slower for broadcasting copies, only slightly slower for dense copies). It is also an improvement in some cases (copying from folded dense dimensions).

However, we need the extra flexibility enabled by this, and I believe we could recover the performance loss, but it would require handling quite a few cases ({padding, no padding} x {src broadcast, src dense, src strided} x {pad broadcast, pad dense, pad strided}). I think this is reasonably doable, but a bit messy. We can wait until we see the performance of the current approach is an issue before addressing this.

This PR is part 1 of at least 2. The next step will be to change the `padding` argument of `func` to also be a buffer. That argument is unchanged by this PR (the implementation wraps that scalar argument with a buffer to use the new `copy`/`pad` implementation).