### PR TITLE
Minor cleanups

### DIFF
--- a/base/thread_pool.h
+++ b/base/thread_pool.h
@@ -125,8 +125,8 @@ public:
     auto loop = std::make_shared<slinky::parallel_for<>>(n);
 
     // Capture n by value becuase this may run after the parallel_for call returns.
-    auto worker = [this, loop, body = std::move(body)]() mutable { 
-      loop->run(body); 
+    auto worker = [this, loop, body = std::move(body)]() mutable {
+      loop->run(body);
       // If we get here, there's no more work to start. Cancel any remaining tasks.
       cancel(loop.get());
     };

--- a/builder/node_mutator.cc
+++ b/builder/node_mutator.cc
@@ -71,7 +71,9 @@ stmt clone_with(const transpose* op, var sym, stmt new_body) {
   return transpose::make(sym, op->src, op->dims, std::move(new_body));
 }
 
-stmt clone_with(const let_stmt* op, stmt new_body) { return let_stmt::make(op->lets, std::move(new_body), op->is_closure); }
+stmt clone_with(const let_stmt* op, stmt new_body) {
+  return let_stmt::make(op->lets, std::move(new_body), op->is_closure);
+}
 
 stmt clone_with(const loop* op, stmt new_body) { return clone_with(op, op->sym, std::move(new_body)); }
 stmt clone_with(const allocate* op, stmt new_body) { return clone_with(op, op->sym, std::move(new_body)); }
@@ -186,7 +188,8 @@ void node_mutator::visit(const loop* op) {
   expr step = mutate(op->step);
   expr max_workers = mutate(op->max_workers);
   stmt body = mutate(op->body);
-  if (bounds.same_as(op->bounds) && step.same_as(op->step) && max_workers.same_as(op->max_workers) && body.same_as(op->body)) {
+  if (bounds.same_as(op->bounds) && step.same_as(op->step) && max_workers.same_as(op->max_workers) &&
+      body.same_as(op->body)) {
     set_result(op);
   } else {
     set_result(loop::make(op->sym, std::move(max_workers), std::move(bounds), std::move(step), std::move(body)));

--- a/builder/optimizations.h
+++ b/builder/optimizations.h
@@ -6,7 +6,8 @@
 
 namespace slinky {
 
-// Where possible, replace `allocate` with `make_buffer` referring to another buffer with appropriate metadata for copies.
+// Where possible, replace `allocate` with `make_buffer` referring to another buffer with appropriate metadata for
+// copies.
 stmt alias_copies(const stmt& s, node_context& ctx, const std::vector<buffer_expr_ptr>& inputs,
     const std::vector<buffer_expr_ptr>& outputs);
 

--- a/builder/pipeline.h
+++ b/builder/pipeline.h
@@ -228,8 +228,9 @@ private:
   template <typename ArgTypes, typename Fn, std::size_t... Indices>
   static SLINKY_ALWAYS_INLINE index_t call_impl_tuple(
       const Fn& impl, eval_context& ctx, const call_stmt* op, std::index_sequence<Indices...>) {
-    return impl(internal::buffer_converter<typename std::tuple_element<Indices, ArgTypes>::type>::convert(ctx.lookup_buffer(
-        Indices < op->inputs.size() ? op->inputs[Indices] : op->outputs[Indices - op->inputs.size()]))...);
+    return impl(
+        internal::buffer_converter<typename std::tuple_element<Indices, ArgTypes>::type>::convert(ctx.lookup_buffer(
+            Indices < op->inputs.size() ? op->inputs[Indices] : op->outputs[Indices - op->inputs.size()]))...);
   }
 
   template <typename Lambda>

--- a/builder/replica_pipeline.cc
+++ b/builder/replica_pipeline.cc
@@ -7,8 +7,8 @@
 #include <string>
 #include <vector>
 
-#include "builder/substitute.h"
 #include "builder/simplify.h"
+#include "builder/substitute.h"
 #include "runtime/print.h"
 
 namespace slinky {

--- a/builder/slide_and_fold_storage.cc
+++ b/builder/slide_and_fold_storage.cc
@@ -244,9 +244,7 @@ public:
   symbol_map<interval_expr>& current_expr_bounds() { return *loops.back().expr_bounds; }
   symbol_map<modulus_remainder<index_t>>& current_expr_alignment() { return *loops.back().expr_alignment; }
 
-  slide_and_fold(node_context& ctx) : ctx(ctx), x(ctx.insert_unique("_x")) {
-    loops.emplace_back(loop_info());
-  }
+  slide_and_fold(node_context& ctx) : ctx(ctx), x(ctx.insert_unique("_x")) { loops.emplace_back(loop_info()); }
 
   stmt mutate(const stmt& s) override {
     stmt result = stmt_mutator::mutate(s);

--- a/builder/substitute.cc
+++ b/builder/substitute.cc
@@ -18,7 +18,7 @@ namespace {
 
 template <typename T, typename... U>
 std::uintptr_t get_target(const std::function<T(U...)>& f) {
-  typedef T(*fn)(U...);
+  typedef T (*fn)(U...);
   return reinterpret_cast<std::uintptr_t>(f.template target<fn>());
 }
 

--- a/builder/test/aligned_producer.cc
+++ b/builder/test/aligned_producer.cc
@@ -11,7 +11,7 @@ namespace slinky {
 class aligned_producer : public testing::TestWithParam<std::tuple<int, int, bool>> {};
 
 INSTANTIATE_TEST_SUITE_P(split_mode, aligned_producer,
-    testing::Combine(testing::Range(2, 4), testing::Range(0, 5), testing::Values(true, false)),
+    testing::Combine(testing::Range(2, 4), testing::Range(0, 5), testing::Bool()),
     test_params_to_string<aligned_producer::ParamType>);
 
 // An example of two 1D elementwise operations in sequence.

--- a/builder/test/cannot_alias.cc
+++ b/builder/test/cannot_alias.cc
@@ -14,7 +14,7 @@ namespace slinky {
 
 class may_alias : public testing::TestWithParam<bool> {};
 
-INSTANTIATE_TEST_SUITE_P(constrain, may_alias, testing::Values(false, true));
+INSTANTIATE_TEST_SUITE_P(constrain, may_alias, testing::Bool());
 
 TEST_P(may_alias, transpose_input) {
   // Make the pipeline
@@ -324,12 +324,12 @@ TEST_P(may_alias, with_fold) {
 
   var x(ctx, "x");
 
-  func mul = func::make(multiply_2<int>, {{in, {point(x)}}}, {{intm, {x}}},
-      call_stmt::attributes{.allow_in_place = 0x1, .name = "mul"});
+  func mul = func::make(
+      multiply_2<int>, {{in, {point(x)}}}, {{intm, {x}}}, call_stmt::attributes{.allow_in_place = 0x1, .name = "mul"});
   func mul2 = func::make(multiply_2<int>, {{intm, {point(x)}}}, {{intm2, {x}}},
       call_stmt::attributes{.allow_in_place = 0x1, .name = "mul2"});
-  func add = func::make(add_1<int>, {{intm2, {point(x)}}}, {{out, {x}}},
-      call_stmt::attributes{.allow_in_place = 0x1, .name = "add"});
+  func add = func::make(
+      add_1<int>, {{intm2, {point(x)}}}, {{out, {x}}}, call_stmt::attributes{.allow_in_place = 0x1, .name = "add"});
 
   add.loops({{x, 1, 1}});
 
@@ -423,8 +423,7 @@ TEST(split_output, cannot_alias) {
 
 class multiple_uses : public testing::TestWithParam<std::tuple<int, bool>> {};
 
-INSTANTIATE_TEST_SUITE_P(alias_split, multiple_uses,
-    testing::Combine(testing::Values(0, 1), testing::Values(false, true)),
+INSTANTIATE_TEST_SUITE_P(alias_split, multiple_uses, testing::Combine(testing::Values(0, 1), testing::Bool()),
     test_params_to_string<multiple_uses::ParamType>);
 
 TEST_P(multiple_uses, cannot_alias) {

--- a/builder/test/context.cc
+++ b/builder/test/context.cc
@@ -60,7 +60,8 @@ test_context::test_context() {
 
   config.thread_pool = &threads;
 
-  // Many tests count the number of allocations that go on the heap, don't let memory_type::automatic corrupt those counts.
+  // Many tests count the number of allocations that go on the heap, don't let memory_type::automatic corrupt those
+  // counts.
   config.auto_stack_threshold = 0;
   // Similarly, alignment makes it hard to know the expected size of allocations.
   config.alignment = 1;

--- a/builder/test/copy.cc
+++ b/builder/test/copy.cc
@@ -810,7 +810,7 @@ TEST(stack, copy) {
 
 class reshape : public testing::TestWithParam<bool> {};
 
-INSTANTIATE_TEST_SUITE_P(opaque, reshape, testing::Values(false, true));
+INSTANTIATE_TEST_SUITE_P(opaque, reshape, testing::Bool());
 
 TEST_P(reshape, copy) {
   const bool opaque = GetParam();
@@ -890,7 +890,7 @@ TEST_P(reshape, copy) {
 
 class batch_reshape : public testing::TestWithParam<bool> {};
 
-INSTANTIATE_TEST_SUITE_P(opaque, batch_reshape, testing::Values(false, true));
+INSTANTIATE_TEST_SUITE_P(opaque, batch_reshape, testing::Bool());
 
 TEST_P(batch_reshape, copy) {
   const bool opaque = GetParam();

--- a/builder/test/copy_pipeline.cc
+++ b/builder/test/copy_pipeline.cc
@@ -56,7 +56,7 @@ class padded_copy : public testing::TestWithParam<std::tuple<int, int, bool, int
 auto offsets = testing::Values(0, 1, -1, 10, -10);
 
 INSTANTIATE_TEST_SUITE_P(offsets, padded_copy,
-    testing::Combine(offsets, offsets, testing::Values(true, false), testing::Values(0, 1, 2)),
+    testing::Combine(offsets, offsets, testing::Bool(), testing::Values(0, 1, 2)),
     test_params_to_string<padded_copy::ParamType>);
 
 TEST_P(padded_copy, pipeline) {
@@ -368,7 +368,7 @@ TEST_P(copied_input, pipeline) {
 
 class concatenated_output : public testing::TestWithParam<bool> {};
 
-INSTANTIATE_TEST_SUITE_P(schedule, concatenated_output, testing::Values(true, false));
+INSTANTIATE_TEST_SUITE_P(schedule, concatenated_output, testing::Bool());
 
 TEST_P(concatenated_output, pipeline) {
   bool no_alias_buffers = GetParam();
@@ -437,8 +437,7 @@ class transposed_output : public testing::TestWithParam<std::tuple<bool, int, in
 
 auto iota3 = testing::Values(0, 1, 2);
 
-INSTANTIATE_TEST_SUITE_P(schedule, transposed_output,
-    testing::Combine(testing::Values(true, false), iota3, iota3, iota3),
+INSTANTIATE_TEST_SUITE_P(schedule, transposed_output, testing::Combine(testing::Bool(), iota3, iota3, iota3),
     test_params_to_string<transposed_output::ParamType>);
 
 TEST_P(transposed_output, pipeline) {
@@ -563,7 +562,7 @@ TEST(stacked_output, pipeline) {
 class broadcasted_elementwise : public testing::TestWithParam<std::tuple<bool, int, int>> {};
 
 INSTANTIATE_TEST_SUITE_P(dim, broadcasted_elementwise,
-    testing::Combine(testing::Values(true, false), testing::Range(0, 2), testing::Values(0, 1)),
+    testing::Combine(testing::Bool(), testing::Range(0, 2), testing::Values(0, 1)),
     test_params_to_string<broadcasted_elementwise::ParamType>);
 
 TEST_P(broadcasted_elementwise, input) {
@@ -759,7 +758,7 @@ TEST_P(broadcasted_elementwise, constant) {
 class constrained_transpose : public testing::TestWithParam<std::tuple<bool, bool, bool>> {};
 
 INSTANTIATE_TEST_SUITE_P(dim, constrained_transpose,
-    testing::Combine(testing::Values(true, false), testing::Values(true, false), testing::Values(true, false)),
+    testing::Combine(testing::Bool(), testing::Bool(), testing::Bool()),
     test_params_to_string<constrained_transpose::ParamType>);
 
 TEST_P(constrained_transpose, pipeline) {

--- a/builder/test/elementwise.cc
+++ b/builder/test/elementwise.cc
@@ -294,7 +294,8 @@ TEST_P(elementwise, exp2_horners) { test_expr_pipeline<int, 1>(ctx, GetParam(), 
 TEST_P(elementwise, exp3_horners) { test_expr_pipeline<int, 1>(ctx, GetParam(), 1 + x * (1 + x * (1 + x))); }
 TEST_P(elementwise, exp4_horners) { test_expr_pipeline<int, 1>(ctx, GetParam(), 1 + x * (1 + x * (1 + x * (1 + x)))); }
 TEST_P(elementwise, exp8_horners) {
-  test_expr_pipeline<int, 1>(ctx, GetParam(), 1 + x * (1 + x * (1 + x * (1 + x * (1 + x * (1 + x * (1 + x * (1 + x))))))));
+  test_expr_pipeline<int, 1>(
+      ctx, GetParam(), 1 + x * (1 + x * (1 + x * (1 + x * (1 + x * (1 + x * (1 + x * (1 + x))))))));
 }
 
 }  // namespace slinky

--- a/builder/test/pipeline.cc
+++ b/builder/test/pipeline.cc
@@ -103,8 +103,7 @@ TEST_P(trivial, pipeline) {
 class elementwise : public testing::TestWithParam<std::tuple<int, int, bool>> {};
 
 INSTANTIATE_TEST_SUITE_P(split_schedule_mode, elementwise,
-    testing::Combine(loop_modes, testing::Range(0, 4), testing::Values(false, true)),
-    test_params_to_string<elementwise::ParamType>);
+    testing::Combine(loop_modes, testing::Range(0, 4), testing::Bool()), test_params_to_string<elementwise::ParamType>);
 
 // An example of two 1D elementwise operations in sequence.
 TEST_P(elementwise, pipeline_1d) {
@@ -254,7 +253,7 @@ TEST_P(elementwise, pipeline_2d) {
 
 class store_at : public testing::TestWithParam<bool> {};
 
-INSTANTIATE_TEST_SUITE_P(alias_in_place, store_at, testing::Values(false, true));
+INSTANTIATE_TEST_SUITE_P(alias_in_place, store_at, testing::Bool());
 
 // An example of two 2D elementwise operations in sequence with intermediate buffer stored at
 // the inner loop level.
@@ -565,8 +564,8 @@ TEST_P(stencil, pipeline) {
 
 class slide_2d : public testing::TestWithParam<std::tuple<int, int, bool>> {};
 
-INSTANTIATE_TEST_SUITE_P(split_split_mode, slide_2d,
-    testing::Combine(loop_modes, loop_modes, testing::Values(false, true)), test_params_to_string<slide_2d::ParamType>);
+INSTANTIATE_TEST_SUITE_P(split_split_mode, slide_2d, testing::Combine(loop_modes, loop_modes, testing::Bool()),
+    test_params_to_string<slide_2d::ParamType>);
 
 TEST_P(slide_2d, pipeline) {
   int max_workers_x = std::get<0>(GetParam());
@@ -753,7 +752,7 @@ TEST_P(multiple_outputs, pipeline) {
   func::callable<const int, int, int> sum_x_xy = [](const buffer<const int>& in, const buffer<int>& sum_x,
                                                      const buffer<int>& sum_xy) -> index_t {
     for (index_t z = std::min(sum_xy.dim(0).min(), sum_x.dim(1).min());
-        z <= std::max(sum_xy.dim(0).max(), sum_x.dim(1).max()); ++z) {
+         z <= std::max(sum_xy.dim(0).max(), sum_x.dim(1).max()); ++z) {
       if (sum_xy.contains(z)) sum_xy(z) = 0;
       for (index_t y = sum_x.dim(0).min(); y <= sum_x.dim(0).max(); ++y) {
         if (sum_x.contains(y, z)) sum_x(y, z) = 0;
@@ -1074,7 +1073,7 @@ interval_expr dilate(interval_expr x, int dx) { return {x.min - dx, x.max + dx};
 class padded_stencil_separable : public testing::TestWithParam<std::tuple<bool, int>> {};
 
 INSTANTIATE_TEST_SUITE_P(alias_schedule, padded_stencil_separable,
-    testing::Combine(testing::Values(true, false), testing::Range(0, 3)),
+    testing::Combine(testing::Bool(), testing::Range(0, 3)),
     test_params_to_string<padded_stencil_separable::ParamType>);
 
 TEST_P(padded_stencil_separable, pipeline) {

--- a/builder/test/simplify/simplify.cc
+++ b/builder/test/simplify/simplify.cc
@@ -609,16 +609,16 @@ TEST(simplify, allocate) {
   // Pull statements that don't use the buffer out of allocate nodes.
   ASSERT_THAT(simplify(allocate::make(x, memory_type::heap, 1, {{bounds(2, 3), 4, 5}},
                   block::make({check::make(y), check::make(buffer_at(x)), check::make(z)}))),
-      matches(block::make(
-          {check::make(y), allocate::make(x, memory_type::heap, 1, {{bounds(2, 3), 4, expr()}}, check::make(buffer_at(x))),
-              check::make(z)})));
+      matches(block::make({check::make(y),
+          allocate::make(x, memory_type::heap, 1, {{bounds(2, 3), 4, expr()}}, check::make(buffer_at(x))),
+          check::make(z)})));
 
   // Make sure clone_buffer doesn't hide uses of buffers or bounds.
   ASSERT_THAT(simplify(allocate::make(x, memory_type::heap, 1, {{bounds(2, 3), 4, 5}},
                   block::make({check::make(y), clone_buffer::make(w, x, check::make(buffer_at(w))), check::make(z)}))),
-      matches(block::make(
-          {check::make(y), allocate::make(x, memory_type::heap, 1, {{bounds(2, 3), 4, expr()}}, check::make(buffer_at(x))),
-              check::make(z)})));
+      matches(block::make({check::make(y),
+          allocate::make(x, memory_type::heap, 1, {{bounds(2, 3), 4, expr()}}, check::make(buffer_at(x))),
+          check::make(z)})));
 }
 
 TEST(simplify, crop) {

--- a/builder/test/softmax.cc
+++ b/builder/test/softmax.cc
@@ -228,11 +228,11 @@ TEST_P(softmax, pipeline) {
     } else {
       if (use_compute_at == 2) {
         // TODO(vksnk): for this to work we need to teach slide_and_fold_storage to take bounds from make_buffer.
-        ASSERT_THAT(eval_ctx.heap.allocs,
-            testing::UnorderedElementsAre(sum_exp_in_size, exp_in_size, B * softmax_in_size / split_b, softmax_out_size));
+        ASSERT_THAT(eval_ctx.heap.allocs, testing::UnorderedElementsAre(sum_exp_in_size, exp_in_size,
+                                              B * softmax_in_size / split_b, softmax_out_size));
       } else {
-        ASSERT_THAT(eval_ctx.heap.allocs,
-            testing::UnorderedElementsAre(sum_exp_in_size, exp_in_size, max_in_size, softmax_in_size, softmax_out_size));
+        ASSERT_THAT(eval_ctx.heap.allocs, testing::UnorderedElementsAre(sum_exp_in_size, exp_in_size, max_in_size,
+                                              softmax_in_size, softmax_out_size));
       }
     }
   } else {

--- a/runtime/depends_on.cc
+++ b/runtime/depends_on.cc
@@ -344,7 +344,8 @@ bool is_pure(expr_ref x) {
 
 namespace {
 
-std::vector<var> keys(const std::map<var, depends_on_result>& m) { std::vector<var> result;
+std::vector<var> keys(const std::map<var, depends_on_result>& m) {
+  std::vector<var> result;
   result.reserve(m.size());
   for (const auto& i : m) {
     result.push_back(i.first);
@@ -373,7 +374,7 @@ std::vector<var> find_buffer_dependencies(stmt_ref s, bool input, bool output) {
   std::map<var, depends_on_result> deps;
   dependencies v(deps);
   if (s.defined()) s.accept(&v);
-  
+
   std::vector<var> result;
   result.reserve(deps.size());
   for (const auto& i : deps) {

--- a/runtime/expr_stmt.cc
+++ b/runtime/expr_stmt.cc
@@ -1,6 +1,6 @@
 #include "runtime/expr.h"
-#include "runtime/stmt.h"
 #include "runtime/print.h"
+#include "runtime/stmt.h"
 
 #include <algorithm>
 #include <cassert>
@@ -124,7 +124,7 @@ expr::expr(std::int64_t x) : expr(make_constant(x)) {}
 expr::expr(var sym) : expr(make_variable(sym)) {}
 
 expr variable::make(var sym) { return expr(make_variable(sym)); }
-expr variable::make(var sym, buffer_field field, int dim) { 
+expr variable::make(var sym, buffer_field field, int dim) {
   variable* n = new variable();
   n->sym = sym;
   n->field = field;
@@ -649,24 +649,20 @@ bool is_variable(expr_ref x, var b, buffer_field field, int dim) {
 expr abs(expr x) { return call::make(intrinsic::abs, {std::move(x)}); }
 expr align_down(expr x, const expr& a) { return (std::move(x) / a) * a; }
 expr align_up(expr x, const expr& a) { return ((std::move(x) + a - 1) / a) * a; }
-interval_expr align(interval_expr x, const expr& a) { return {align_down(std::move(x.min), a), align_up(std::move(x.max) + 1, a) - 1}; }
+interval_expr align(interval_expr x, const expr& a) {
+  return {align_down(std::move(x.min), a), align_up(std::move(x.max) + 1, a) - 1};
+}
 
 expr and_then(expr a, expr b) { return call::make(intrinsic::and_then, {std::move(a), std::move(b)}); }
 expr or_else(expr a, expr b) { return call::make(intrinsic::or_else, {std::move(a), std::move(b)}); }
 
-expr buffer_rank(var buf) {
-  return variable::make(buf, buffer_field::rank);
-}
+expr buffer_rank(var buf) { return variable::make(buf, buffer_field::rank); }
 expr buffer_elem_size(var buf) { return variable::make(buf, buffer_field::elem_size); }
 expr buffer_min(var buf, int dim) { return variable::make(buf, buffer_field::min, dim); }
 expr buffer_max(var buf, int dim) { return variable::make(buf, buffer_field::max, dim); }
 expr buffer_extent(var buf, int dim) { return (buffer_max(buf, dim) - buffer_min(buf, dim)) + 1; }
-expr buffer_stride(var buf, int dim) {
-  return variable::make(buf, buffer_field::stride, dim);
-}
-expr buffer_fold_factor(var buf, int dim) {
-  return variable::make(buf, buffer_field::fold_factor, dim);
-}
+expr buffer_stride(var buf, int dim) { return variable::make(buf, buffer_field::stride, dim); }
+expr buffer_fold_factor(var buf, int dim) { return variable::make(buf, buffer_field::fold_factor, dim); }
 
 interval_expr buffer_bounds(var buf, int dim) { return {buffer_min(buf, dim), buffer_max(buf, dim)}; }
 dim_expr buffer_dim(var buf, int dim) {
@@ -714,7 +710,6 @@ box_expr dims_bounds(span<const dim_expr> dims) {
   }
   return result;
 }
-
 
 const expr& dim_expr::get_field(buffer_field field) const {
   switch (field) {

--- a/runtime/pipeline.cc
+++ b/runtime/pipeline.cc
@@ -23,9 +23,7 @@ void pipeline::setup(scalars args, buffers inputs, buffers outputs, eval_context
   }
 }
 
-void pipeline::setup(buffers inputs, buffers outputs, eval_context& ctx) const {
-  setup({}, inputs, outputs, ctx);
-}
+void pipeline::setup(buffers inputs, buffers outputs, eval_context& ctx) const { setup({}, inputs, outputs, ctx); }
 
 index_t pipeline::evaluate(eval_context& ctx) const { return slinky::evaluate(body, ctx); }
 

--- a/runtime/test/buffer.cc
+++ b/runtime/test/buffer.cc
@@ -1,9 +1,9 @@
 #include <gtest/gtest.h>
 
 #include <algorithm>
+#include <chrono>
 #include <cstddef>
 #include <cstdint>
-#include <chrono>
 #include <iostream>
 #include <numeric>
 #include <random>
@@ -781,8 +781,7 @@ TEST(buffer, for_each_element_fuzz) {
       buf.allocate();
     }
     for_each_element([](const void*, const void*, const void*) {}, bufs[0], bufs[1], bufs[2]);
-    for_each_contiguous_slice(
-        bufs[0], [](index_t, const void*, const void*, const void*) {}, bufs[1], bufs[2]);
+    for_each_contiguous_slice(bufs[0], [](index_t, const void*, const void*, const void*) {}, bufs[1], bufs[2]);
   }
 }
 

--- a/runtime/test/buffer_benchmark.cc
+++ b/runtime/test/buffer_benchmark.cc
@@ -221,8 +221,7 @@ void BM_for_each_contiguous_slice_2x(benchmark::State& state) {
   copy(scalar<char>(42), src);
 
   for (auto _ : state) {
-    for_each_contiguous_slice(
-        dst, [&](index_t, const void*, const void*) {}, src);
+    for_each_contiguous_slice(dst, [&](index_t, const void*, const void*) {}, src);
   }
 }
 

--- a/runtime/test/evaluate.cc
+++ b/runtime/test/evaluate.cc
@@ -147,8 +147,8 @@ TEST(evaluate, crop_dim) {
 
   evaluate(crop_dim::make(x, x, 0, {1, 3}, make_check(x, {3, 20})), ctx);
   evaluate(crop_dim::make(y, x, 0, {1, 3}, block::make({make_check(x, {10, 20}), make_check(y, {3, 20})})), ctx);
-  evaluate(
-      crop_dim::make(y, x, 0, buffer_bounds(y, 0), block::make({make_check(x, {10, 20}), make_check(y, {3, 20})})), ctx);
+  evaluate(crop_dim::make(y, x, 0, buffer_bounds(y, 0), block::make({make_check(x, {10, 20}), make_check(y, {3, 20})})),
+      ctx);
   ASSERT_EQ(buf_before, buf);
 }
 

--- a/runtime/visualize.cc
+++ b/runtime/visualize.cc
@@ -177,9 +177,7 @@ public:
     *this << "select(" << op->condition << ", " << op->true_value << ", " << op->false_value << ")";
   }
 
-  void visit(const call* op) override { 
-    *this << op->intrinsic << "(" << op->args << ")"; 
-  }
+  void visit(const call* op) override { *this << op->intrinsic << "(" << op->args << ")"; }
 
   void visit(const block* b) override {
     for (const auto& s : b->stmts) {


### PR DESCRIPTION
- Replace `testing::Values(false, true)` with `testing::Bool()`
- Run clang-format on everything