### PR TITLE
Allow padding of copies in pipelines to be a buffer instead of a scalar

### DIFF
--- a/builder/node_mutator.cc
+++ b/builder/node_mutator.cc
@@ -206,7 +206,7 @@ void node_mutator::visit(const copy_stmt* op) {
   if (!changed) {
     set_result(op);
   } else {
-    set_result(copy_stmt::make(op->src, std::move(src_x), op->dst, op->dst_x, op->padding));
+    set_result(copy_stmt::make(op->src, std::move(src_x), op->dst, op->dst_x, op->pad));
   }
 }
 void node_mutator::visit(const allocate* op) {

--- a/builder/optimizations.cc
+++ b/builder/optimizations.cc
@@ -420,13 +420,14 @@ public:
           }
         }
       } else if (!any_stride_defined(target_info->dims)) {
-        assert(target_info->dims.size() == alias.permutation.size());
+        assert(info.dims.size() == alias.permutation.size());
         // The target doesn't have any strides, we might have some strides we assumed we could propagate.
-        for (std::size_t d = 0; d < target_info->dims.size(); ++d) {
+        for (std::size_t d = 0; d < info.dims.size(); ++d) {
           int alias_d = alias.permutation[d];
           if (alias_d >= 0) {
-            assert(!target_info->dims[d].stride.defined());
-            target_info->dims[d].stride = info.dims[alias_d].stride;
+            assert(alias_d < static_cast<int>(target_info->dims.size()));
+            assert(!target_info->dims[alias_d].stride.defined());
+            target_info->dims[alias_d].stride = info.dims[d].stride;
           }
         }
       }

--- a/builder/pipeline.cc
+++ b/builder/pipeline.cc
@@ -64,10 +64,11 @@ buffer_expr_ptr buffer_expr::make(node_context& ctx, const std::string& sym, std
   return buffer_expr_ptr(new buffer_expr(ctx.insert_unique(sym), rank, std::move(elem_size)));
 }
 
-buffer_expr_ptr buffer_expr::make(var sym, const_raw_buffer_ptr constant_buffer) {
+buffer_expr_ptr buffer_expr::make_constant(var sym, const_raw_buffer_ptr constant_buffer) {
   return buffer_expr_ptr(new buffer_expr(sym, std::move(constant_buffer)));
 }
-buffer_expr_ptr buffer_expr::make(node_context& ctx, const std::string& sym, const_raw_buffer_ptr constant_buffer) {
+buffer_expr_ptr buffer_expr::make_constant(
+    node_context& ctx, const std::string& sym, const_raw_buffer_ptr constant_buffer) {
   return buffer_expr_ptr(new buffer_expr(ctx.insert_unique(sym), std::move(constant_buffer)));
 }
 

--- a/builder/pipeline.h
+++ b/builder/pipeline.h
@@ -54,6 +54,14 @@ public:
   // Make a constant buffer_expr. It takes ownership of the buffer from the caller.
   static buffer_expr_ptr make(var sym, const_raw_buffer_ptr constant_buffer);
   static buffer_expr_ptr make(node_context& ctx, const std::string& sym, const_raw_buffer_ptr constant_buffer);
+  template <typename T, typename = typename std::enable_if_t<std::is_trivial_v<T>>>
+  static buffer_expr_ptr make(var sym, const T& value) {
+    return make(sym, raw_buffer::make_scalar<T>(value));
+  }
+  template <typename T, typename = typename std::enable_if_t<std::is_trivial_v<T>>>
+  static buffer_expr_ptr make(node_context& ctx, const std::string& sym, const T& value) {
+    return make(ctx, sym, raw_buffer::make_scalar<T>(value));
+  }
 
   var sym() const { return sym_; }
   expr elem_size() const { return elem_size_; }
@@ -171,11 +179,11 @@ private:
 
   std::vector<input> inputs_;
   std::vector<output> outputs_;
+  // If this is true, `inputs_` must have 2 elements, where the second input is the padding.
+  bool is_padded_copy_ = false;
 
   std::vector<loop_info> loops_;
   std::optional<loop_id> compute_at_;
-
-  std::optional<std::vector<char>> padding_;
 
   void add_this_to_buffers();
   void remove_this_from_buffers();
@@ -185,7 +193,7 @@ public:
   func(call_stmt::callable impl, std::vector<input> inputs, std::vector<output> outputs,
       call_stmt::attributes attrs = {});
   func(std::vector<input> inputs, output out);
-  func(input input, output out, std::optional<std::vector<char>> padding = std::nullopt);
+  func(input src, output dst, input pad);
   func(func&&) noexcept;
   func& operator=(func&&) noexcept;
   ~func();
@@ -290,26 +298,20 @@ public:
   }
 
   // Make a copy from a single input to a single output.
-  static func make_copy(input in, output out) { return func(std::move(in), {std::move(out)}); }
+  static func make_copy(input src, output dst) { return func({std::move(src)}, std::move(dst)); }
   // Make a copy from a single input to a single output, with padding outside the output crop.
-  static func make_copy(input in, output out, std::vector<char> padding) {
-    return func({std::move(in)}, std::move(out), std::move(padding));
-  }
-  template <typename T>
-  static func make_copy(input in, output out, T padding) {
-    std::vector<char> p(sizeof(padding));
-    memcpy(p.data(), &padding, sizeof(T));
-    return make_copy(std::move(in), std::move(out), std::move(p));
+  static func make_copy(input src, output dst, input pad) {
+    return func(std::move(src), std::move(dst), std::move(pad));
   }
   // Make a copy from multiple inputs with undefined padding.
-  static func make_copy(std::vector<input> in, output out) { return func(std::move(in), {std::move(out)}); }
+  static func make_copy(std::vector<input> src, output dst) { return func(std::move(src), std::move(dst)); }
   // Make a concatenation copy. This is a helper function for `make_copy`, where the crop for input i is a `crop_dim` in
   // dimension `dim` on the interval `[bounds[i], bounds[i + 1])`, and the input is translated by `-bounds[i]`.
-  static func make_concat(std::vector<buffer_expr_ptr> in, output out, std::size_t dim, std::vector<expr> bounds);
+  static func make_concat(std::vector<buffer_expr_ptr> src, output dst, std::size_t dim, std::vector<expr> bounds);
   // Make a stack copy. This is a helper function for `make_copy`, where the crop for input i is a `slice_dim` of
   // dimension `dim` at i. If `dim` is greater than the rank of `out` (the default), the new stack dimension will be the
   // last dimension of the output.
-  static func make_stack(std::vector<buffer_expr_ptr> in, output out, std::size_t dim = -1);
+  static func make_stack(std::vector<buffer_expr_ptr> src, output dst, std::size_t dim = -1);
 
   const call_stmt::callable& impl() const { return impl_; }
   const std::vector<input>& inputs() const { return inputs_; }
@@ -317,7 +319,7 @@ public:
   const call_stmt::attributes& attrs() const { return attrs_; }
   const void* user_data() const { return user_data_; }
   void*& user_data() { return user_data_; }
-  const std::optional<std::vector<char>>& padding() const { return padding_; }
+  bool is_padded_copy() const { return is_padded_copy_; }
 
   stmt make_call() const;
 };

--- a/builder/pipeline.h
+++ b/builder/pipeline.h
@@ -52,15 +52,15 @@ public:
   static buffer_expr_ptr make(var sym, std::size_t rank, expr elem_size);
   static buffer_expr_ptr make(node_context& ctx, const std::string& sym, std::size_t rank, expr elem_size);
   // Make a constant buffer_expr. It takes ownership of the buffer from the caller.
-  static buffer_expr_ptr make(var sym, const_raw_buffer_ptr constant_buffer);
-  static buffer_expr_ptr make(node_context& ctx, const std::string& sym, const_raw_buffer_ptr constant_buffer);
+  static buffer_expr_ptr make_constant(var sym, const_raw_buffer_ptr constant_buffer);
+  static buffer_expr_ptr make_constant(node_context& ctx, const std::string& sym, const_raw_buffer_ptr constant_buffer);
   template <typename T, typename = typename std::enable_if_t<std::is_trivial_v<T>>>
-  static buffer_expr_ptr make(var sym, const T& value) {
-    return make(sym, raw_buffer::make_scalar<T>(value));
+  static buffer_expr_ptr make_scalar(var sym, const T& value) {
+    return make_constant(sym, raw_buffer::make_scalar<T>(value));
   }
   template <typename T, typename = typename std::enable_if_t<std::is_trivial_v<T>>>
-  static buffer_expr_ptr make(node_context& ctx, const std::string& sym, const T& value) {
-    return make(ctx, sym, raw_buffer::make_scalar<T>(value));
+  static buffer_expr_ptr make_scalar(node_context& ctx, const std::string& sym, const T& value) {
+    return make_constant(ctx, sym, raw_buffer::make_scalar<T>(value));
   }
 
   var sym() const { return sym_; }

--- a/builder/replica_pipeline.cc
+++ b/builder/replica_pipeline.cc
@@ -163,7 +163,7 @@ public:
       }
       os_ << "  " << const_name << "->allocate();\n";
       os_ << "  std::uint8_t " << const_name << "_fill[" << elem_size << "] = { 0 };\n";
-      os_ << "  fill(*" << const_name << ", " << const_name << "_fill);\n";
+      os_ << "  copy(*raw_buffer::make_scalar(" << elem_size << ", " << const_name << "_fill), *" << const_name << ");\n";
       (void)print_assignment_explicit(name, "buffer_expr::make(ctx, /*sym=*/\"", name, "\", ", const_name, ")");
     } else {
       (void)print_assignment_explicit(

--- a/builder/replica_pipeline.cc
+++ b/builder/replica_pipeline.cc
@@ -332,9 +332,10 @@ public:
 
     if (!f.defined() && f.outputs().size() == 1) {
       std::string func_outputs = print(f.outputs()[0]);
-      if (f.padding()) {
+      if (f.is_padded_copy()) {
+        assert(f.inputs().size() == 2);
         std::string func_inputs = print(f.inputs()[0]);
-        std::string padding = print_vector(*f.padding());
+        std::string padding = print(f.inputs()[1]);
         (void)print_assignment_explicit(
             fn_name, "func::make_copy(", func_inputs, ", ", func_outputs, ", ", padding, ")");
       } else {

--- a/builder/replica_pipeline.cc
+++ b/builder/replica_pipeline.cc
@@ -164,7 +164,7 @@ public:
       os_ << "  " << const_name << "->allocate();\n";
       os_ << "  std::uint8_t " << const_name << "_fill[" << elem_size << "] = { 0 };\n";
       os_ << "  copy(*raw_buffer::make_scalar(" << elem_size << ", " << const_name << "_fill), *" << const_name << ");\n";
-      (void)print_assignment_explicit(name, "buffer_expr::make(ctx, /*sym=*/\"", name, "\", ", const_name, ")");
+      (void)print_assignment_explicit(name, "buffer_expr::make_constant(ctx, /*sym=*/\"", name, "\", ", const_name, ")");
     } else {
       (void)print_assignment_explicit(
           name, "buffer_expr::make(ctx, \"", name, "\", /*rank=*/", bep->rank(), ", /*elem_size=*/", elem_size, ")");

--- a/builder/simplify.cc
+++ b/builder/simplify.cc
@@ -1426,6 +1426,7 @@ public:
   void visit(const copy_stmt* op) override {
     var src = visit_symbol(op->src);
     var dst = visit_symbol(op->dst);
+    var pad = visit_symbol(op->pad);
 
     std::vector<scoped_value_in_symbol_map<expr_info>> decls;
     for (var i : op->dst_x) {
@@ -1440,8 +1441,8 @@ public:
       changed = changed || !src_x.back().same_as(i);
     }
 
-    if (changed || src != op->src || dst != op->dst) {
-      set_result(copy_stmt::make(src, std::move(src_x), dst, op->dst_x, op->padding));
+    if (changed || src != op->src || dst != op->dst || pad != op->pad) {
+      set_result(copy_stmt::make(src, std::move(src_x), dst, op->dst_x, op->pad));
     } else {
       set_result(op);
     }

--- a/builder/simplify.cc
+++ b/builder/simplify.cc
@@ -1442,7 +1442,7 @@ public:
     }
 
     if (changed || src != op->src || dst != op->dst || pad != op->pad) {
-      set_result(copy_stmt::make(src, std::move(src_x), dst, op->dst_x, op->pad));
+      set_result(copy_stmt::make(src, std::move(src_x), dst, op->dst_x, pad));
     } else {
       set_result(op);
     }

--- a/builder/substitute.cc
+++ b/builder/substitute.cc
@@ -231,7 +231,7 @@ public:
     if (!try_match(cs->src_x, op->src_x)) return;
     if (!try_match(cs->dst, op->dst)) return;
     if (!try_match(cs->dst_x, op->dst_x)) return;
-    if (!try_match(cs->padding, op->padding)) return;
+    if (!try_match(cs->pad, op->pad)) return;
   }
 
   void visit(const allocate* op) override {
@@ -647,6 +647,7 @@ void substitutor::visit(const call_stmt* op) {
 void substitutor::visit(const copy_stmt* op) {
   var src = visit_symbol(op->src);
   var dst = visit_symbol(op->dst);
+  var pad = visit_symbol(op->pad);
 
   std::size_t decls_entered = 0;
   // copy_stmt is effectively a declaration of the dst_x symbols for the src_x expressions.
@@ -670,8 +671,8 @@ void substitutor::visit(const copy_stmt* op) {
     changed = changed || !src_x[i].same_as(op->src_x[i]);
   }
   exit_decls(decls_entered);
-  if (changed || src != op->src || dst != op->dst) {
-    set_result(copy_stmt::make(src, std::move(src_x), dst, std::move(dst_x), op->padding));
+  if (changed || src != op->src || dst != op->dst || pad != op->pad) {
+    set_result(copy_stmt::make(src, std::move(src_x), dst, std::move(dst_x), op->pad));
   } else {
     set_result(op);
   }

--- a/builder/substitute.cc
+++ b/builder/substitute.cc
@@ -672,7 +672,7 @@ void substitutor::visit(const copy_stmt* op) {
   }
   exit_decls(decls_entered);
   if (changed || src != op->src || dst != op->dst || pad != op->pad) {
-    set_result(copy_stmt::make(src, std::move(src_x), dst, std::move(dst_x), op->pad));
+    set_result(copy_stmt::make(src, std::move(src_x), dst, std::move(dst_x), pad));
   } else {
     set_result(op);
   }

--- a/builder/test/copy.cc
+++ b/builder/test/copy.cc
@@ -62,7 +62,7 @@ TEST(trivial_1d, copy) {
 
   // Crop the output to the intersection of the input and output buffer.
   box_expr output_crop = in->bounds() & out->bounds();
-  func copy = func::make_copy({in, {point(x)}, output_crop}, {out, {x}}, static_cast<int>(0));
+  func copy = func::make_copy({in, {point(x)}, output_crop}, {out, {x}}, {buffer_expr::make<int>(ctx, "padding", 0)});
 
   pipeline p = build_pipeline(ctx, {in}, {out});
 
@@ -105,7 +105,8 @@ TEST(trivial_2d, copy) {
 
   // Crop the output to the intersection of the input and output buffer.
   box_expr output_crop = in->bounds() & out->bounds();
-  func copy = func::make_copy({in, {point(x), point(y)}, output_crop}, {out, {x, y}}, static_cast<int>(0));
+  func copy = func::make_copy(
+      {in, {point(x), point(y)}, output_crop}, {out, {x, y}}, {buffer_expr::make<int>(ctx, "padding", 0)});
 
   pipeline p = build_pipeline(ctx, {in}, {out});
 
@@ -192,8 +193,8 @@ TEST(padded, copy) {
   int padding_x = 3;
   int padding_y = 2;
 
-  func copy = func::make_copy(
-      {in, {point(x) - padding_x, point(y) - padding_y}, in->bounds()}, {out, {x, y}}, static_cast<int>(0));
+  func copy = func::make_copy({in, {point(x) - padding_x, point(y) - padding_y}, in->bounds()}, {out, {x, y}},
+      {buffer_expr::make<int>(ctx, "padding", 0)});
 
   pipeline p = build_pipeline(ctx, {in}, {out});
 
@@ -238,8 +239,8 @@ TEST(custom_pad, copy) {
   const int x_max = 8;
   const int y_min = 2;
   const int y_max = 4;
-  func copy =
-      func::make_copy({in, {point(x), point(y)}, {{x_min, x_max}, {y_min, y_max}}}, {out, {x, y}}, static_cast<int>(0));
+  func copy = func::make_copy({in, {point(x), point(y)}, {{x_min, x_max}, {y_min, y_max}}}, {out, {x, y}},
+      {buffer_expr::make<int>(ctx, "padding", 0)});
 
   pipeline p = build_pipeline(ctx, {in}, {out});
 

--- a/builder/test/copy.cc
+++ b/builder/test/copy.cc
@@ -62,7 +62,8 @@ TEST(trivial_1d, copy) {
 
   // Crop the output to the intersection of the input and output buffer.
   box_expr output_crop = in->bounds() & out->bounds();
-  func copy = func::make_copy({in, {point(x)}, output_crop}, {out, {x}}, {buffer_expr::make<int>(ctx, "padding", 0)});
+  func copy =
+      func::make_copy({in, {point(x)}, output_crop}, {out, {x}}, {buffer_expr::make_scalar<int>(ctx, "padding", 0)});
 
   pipeline p = build_pipeline(ctx, {in}, {out});
 
@@ -203,7 +204,7 @@ TEST(padded, copy) {
   int padding_y = 2;
 
   func copy = func::make_copy({in, {point(x) - padding_x, point(y) - padding_y}, in->bounds()}, {out, {x, y}},
-      {buffer_expr::make<int>(ctx, "padding", 0)});
+      {buffer_expr::make_scalar<int>(ctx, "padding", 0)});
 
   pipeline p = build_pipeline(ctx, {in}, {out});
 
@@ -249,7 +250,7 @@ TEST(custom_pad, copy) {
   const int y_min = 2;
   const int y_max = 4;
   func copy = func::make_copy({in, {point(x), point(y)}, {{x_min, x_max}, {y_min, y_max}}}, {out, {x, y}},
-      {buffer_expr::make<int>(ctx, "padding", 0)});
+      {buffer_expr::make_scalar<int>(ctx, "padding", 0)});
 
   pipeline p = build_pipeline(ctx, {in}, {out});
 

--- a/builder/test/copy_pipeline.cc
+++ b/builder/test/copy_pipeline.cc
@@ -94,7 +94,7 @@ TEST_P(padded_copy, pipeline) {
   if (compute_padding) {
     padding = buffer_expr::make(ctx, "padding", 2, sizeof(char));
   } else {
-    padding = buffer_expr::make<char>(ctx, "padding", 3);
+    padding = buffer_expr::make_scalar<char>(ctx, "padding", 3);
   }
 
   var x(ctx, "x");
@@ -204,7 +204,7 @@ TEST_P(copy_sequence, pipeline) {
   auto make_copy = [&](int stage, buffer_expr_ptr src, buffer_expr_ptr dst) {
     if (((1 << stage) & pad_mask) != 0) {
       return func::make_copy({src, {point(x + 1)}, {bounds(pad_min(stage), pad_max(stage))}}, {dst, {x}},
-          {buffer_expr::make<char>(ctx, "padding", stage)});
+          {buffer_expr::make_scalar<char>(ctx, "padding", stage)});
     } else {
       return func::make_copy({src, {point(x + 1)}}, {dst, {x}});
     }
@@ -749,7 +749,7 @@ TEST_P(broadcasted_elementwise, constant) {
   init_random(in2_buf);
 
   auto in1 = buffer_expr::make(ctx, "in1", 2, sizeof(int));
-  auto in2 = buffer_expr::make(ctx, "in2", raw_buffer::make_copy(in2_buf));
+  auto in2 = buffer_expr::make_constant(ctx, "in2", raw_buffer::make_copy(in2_buf));
   auto in2_broadcasted = buffer_expr::make(ctx, "in2_broadcasted", 2, sizeof(int));
   auto out = buffer_expr::make(ctx, "out", 2, sizeof(int));
 

--- a/builder/test/copy_pipeline.cc
+++ b/builder/test/copy_pipeline.cc
@@ -83,7 +83,7 @@ TEST_P(padded_copy, pipeline) {
   func copy_in = func::make(copy_2d<char>, {{in, {point(x), point(y)}}}, {{intm, {x, y}}});
   func crop = func::make_copy(
       {intm, permute<interval_expr>(permutation, {point(x + offset_x), point(y + offset_y)}), in->bounds()},
-      {padded_intm, {x, y}}, {3});
+      {padded_intm, {x, y}}, {buffer_expr::make<char>(ctx, "padding", 3)});
   func copy_out = func::make(copy_2d<char>, {{padded_intm, {point(x), point(y)}}}, {{out, {x, y}}});
 
   if (split_y > 0) {
@@ -167,7 +167,8 @@ TEST_P(copy_sequence, pipeline) {
   auto make_copy = [&](int stage, buffer_expr_ptr src, buffer_expr_ptr dst) {
     if (((1 << stage) & pad_mask) != 0) {
       return func::make_copy(
-          {src, {point(x + 1)}, {bounds(pad_min(stage), pad_max(stage))}}, {dst, {x}}, static_cast<char>(stage));
+          {src, {point(x + 1)}, {bounds(pad_min(stage), pad_max(stage))}}, {dst, {x}}, {
+        buffer_expr::make<char>(ctx, "padding", stage)});
     } else {
       return func::make_copy({src, {point(x + 1)}}, {dst, {x}});
     }

--- a/builder/test/copy_pipeline.cc
+++ b/builder/test/copy_pipeline.cc
@@ -51,12 +51,16 @@ TEST(flip_y, pipeline) {
   ASSERT_THAT(eval_ctx.heap.allocs, testing::UnorderedElementsAre(W * H * sizeof(char)));
 }
 
-class padded_copy : public testing::TestWithParam<std::tuple<int, int, bool, int>> {};
+class padded_copy : public testing::TestWithParam<std::tuple<int, int, bool, int, bool>> {};
 
 auto offsets = testing::Values(0, 1, -1, 10, -10);
+auto no_offset = testing::Values(0);
 
-INSTANTIATE_TEST_SUITE_P(offsets, padded_copy,
-    testing::Combine(offsets, offsets, testing::Bool(), testing::Values(0, 1, 2)),
+INSTANTIATE_TEST_SUITE_P(offsets_x, padded_copy,
+    testing::Combine(offsets, no_offset, testing::Bool(), testing::Values(0, 1, 2), testing::Bool()),
+    test_params_to_string<padded_copy::ParamType>);
+INSTANTIATE_TEST_SUITE_P(offsets_y, padded_copy,
+    testing::Combine(no_offset, offsets, testing::Bool(), testing::Values(0, 1, 2), testing::Bool()),
     test_params_to_string<padded_copy::ParamType>);
 
 TEST_P(padded_copy, pipeline) {
@@ -64,6 +68,16 @@ TEST_P(padded_copy, pipeline) {
   int offset_y = std::get<1>(GetParam());
   bool in_bounds = std::get<2>(GetParam());
   int split_y = std::get<3>(GetParam());
+  bool compute_padding = std::get<4>(GetParam());
+
+  auto padding_value = [=](index_t x, index_t y) -> char {
+    if (compute_padding) {
+      return static_cast<char>(y * 2 + x);
+    } else {
+      return 3;
+    }
+  };
+
   std::vector<int> permutation = {0, 1};
   if (std::get<3>(GetParam())) {
     std::swap(permutation[0], permutation[1]);
@@ -76,14 +90,33 @@ TEST_P(padded_copy, pipeline) {
   auto out = buffer_expr::make(ctx, "out", 2, sizeof(char));
   auto intm = buffer_expr::make(ctx, "intm", 2, sizeof(char));
   auto padded_intm = buffer_expr::make(ctx, "padded_intm", 2, sizeof(char));
+  buffer_expr_ptr padding;
+  if (compute_padding) {
+    padding = buffer_expr::make(ctx, "padding", 2, sizeof(char));
+  } else {
+    padding = buffer_expr::make<char>(ctx, "padding", 3);
+  }
 
   var x(ctx, "x");
   var y(ctx, "y");
 
   func copy_in = func::make(copy_2d<char>, {{in, {point(x), point(y)}}}, {{intm, {x, y}}});
+  func padding_func;
+  if (compute_padding) {
+    auto iota2 = [=](const buffer<char>& out) -> slinky::index_t {
+      assert(out.rank == 2);
+      for (index_t y = out.dim(1).begin(); y != out.dim(1).end(); ++y) {
+        for (index_t x = out.dim(0).begin(); x != out.dim(0).end(); ++x) {
+          out(x, y) = padding_value(x, y);
+        }
+      }
+      return 0;
+    };
+    padding_func = func::make(std::move(iota2), {}, {{padding, {x, y}}});
+  }
   func crop = func::make_copy(
       {intm, permute<interval_expr>(permutation, {point(x + offset_x), point(y + offset_y)}), in->bounds()},
-      {padded_intm, {x, y}}, {buffer_expr::make<char>(ctx, "padding", 3)});
+      {padded_intm, {x, y}}, {padding, {point(x), point(y)}});
   func copy_out = func::make(copy_2d<char>, {{padded_intm, {point(x), point(y)}}}, {{out, {x, y}}});
 
   if (split_y > 0) {
@@ -117,12 +150,16 @@ TEST_P(padded_copy, pipeline) {
       if (in_buf.contains(permute<index_t>(permutation, {x + offset_x, y + offset_y}))) {
         ASSERT_EQ(out_buf(x, y), in_buf(permute<index_t>(permutation, {x + offset_x, y + offset_y})));
       } else {
-        ASSERT_EQ(out_buf(x, y), 3);
+        ASSERT_EQ(out_buf(x, y), padding_value(x, y));
       }
     }
   }
 
-  ASSERT_THAT(eval_ctx.heap.allocs, testing::UnorderedElementsAre(W * H * sizeof(char)));
+  if (compute_padding) {
+    ASSERT_THAT(eval_ctx.heap.allocs, testing::UnorderedElementsAre(W * H * sizeof(char), W * H * sizeof(char)));
+  } else {
+    ASSERT_THAT(eval_ctx.heap.allocs, testing::UnorderedElementsAre(W * H * sizeof(char)));
+  }
   ASSERT_EQ(eval_ctx.copy_calls, split_y == 0 ? 1 : ceil_div(H, split_y));
 }
 
@@ -166,9 +203,8 @@ TEST_P(copy_sequence, pipeline) {
   // If the pad mask is one for that stage, we add padding outside the region [1, 4].
   auto make_copy = [&](int stage, buffer_expr_ptr src, buffer_expr_ptr dst) {
     if (((1 << stage) & pad_mask) != 0) {
-      return func::make_copy(
-          {src, {point(x + 1)}, {bounds(pad_min(stage), pad_max(stage))}}, {dst, {x}}, {
-        buffer_expr::make<char>(ctx, "padding", stage)});
+      return func::make_copy({src, {point(x + 1)}, {bounds(pad_min(stage), pad_max(stage))}}, {dst, {x}},
+          {buffer_expr::make<char>(ctx, "padding", stage)});
     } else {
       return func::make_copy({src, {point(x + 1)}}, {dst, {x}});
     }
@@ -224,7 +260,9 @@ TEST_P(copy_sequence, pipeline) {
 
 class copied_output : public testing::TestWithParam<std::tuple<int, int, int>> {};
 
-INSTANTIATE_TEST_SUITE_P(schedule, copied_output, testing::Combine(testing::Range(0, 3), offsets, offsets),
+INSTANTIATE_TEST_SUITE_P(offset_x, copied_output, testing::Combine(testing::Range(0, 3), offsets, no_offset),
+    test_params_to_string<copied_output::ParamType>);
+INSTANTIATE_TEST_SUITE_P(offset_y, copied_output, testing::Combine(testing::Range(0, 3), no_offset, offsets),
     test_params_to_string<copied_output::ParamType>);
 
 TEST_P(copied_output, pipeline) {
@@ -296,7 +334,9 @@ TEST_P(copied_output, pipeline) {
 
 class copied_input : public testing::TestWithParam<std::tuple<int, int, int>> {};
 
-INSTANTIATE_TEST_SUITE_P(schedule, copied_input, testing::Combine(testing::Range(0, 3), offsets, offsets),
+INSTANTIATE_TEST_SUITE_P(offset_x, copied_input, testing::Combine(testing::Range(0, 3), offsets, no_offset),
+    test_params_to_string<copied_input::ParamType>);
+INSTANTIATE_TEST_SUITE_P(offset_y, copied_input, testing::Combine(testing::Range(0, 3), no_offset, offsets),
     test_params_to_string<copied_input::ParamType>);
 
 TEST_P(copied_input, pipeline) {

--- a/builder/test/elementwise.cc
+++ b/builder/test/elementwise.cc
@@ -66,10 +66,7 @@ public:
       dims[d] = dim::broadcast();
     }
 
-    auto value = raw_buffer::make(Rank, sizeof(T), dims);
-    assert(value->size_bytes() == sizeof(T));
-    memcpy(value->base, &c->value, sizeof(T));
-    result = buffer_expr::make(ctx, "c" + std::to_string(c->value), std::move(value));
+    result = buffer_expr::make_scalar<T>(ctx, "c" + std::to_string(c->value), c->value);
     constants.push_back(result);
   }
 

--- a/builder/test/pipeline.cc
+++ b/builder/test/pipeline.cc
@@ -1007,8 +1007,8 @@ TEST_P(padded_stencil, pipeline) {
   var y(ctx, "y");
 
   func add = func::make(add_1<short>, {{in, {point(x), point(y)}}}, {{intm, {x, y}}});
-  func padded = func::make_copy(
-      {intm, {point(x), point(y)}, in->bounds()}, {padded_intm, {x, y}}, {buffer_expr::make<short>(ctx, "padding", 6)});
+  func padded = func::make_copy({intm, {point(x), point(y)}, in->bounds()}, {padded_intm, {x, y}},
+      {buffer_expr::make_scalar<short>(ctx, "padding", 6)});
   func stencil = func::make(sum3x3<short>, {{padded_intm, {bounds(-1, 1) + x, bounds(-1, 1) + y}}}, {{out, {x, y}}});
 
   switch (schedule) {
@@ -1119,7 +1119,7 @@ TEST_P(padded_stencil_separable, pipeline) {
       {{in, {point(x), point(y)}}}, {{intm, {x, y}}}, call_stmt::attributes{.name = "add"});
   // transpose so we compute the stencil in x.
   func padded_t = func::make_copy({intm, {point(x), point(y)}, in->bounds()}, {padded_intm_t, {y, x}},
-      {buffer_expr::make<short>(ctx, "padding", 6)});
+      {buffer_expr::make_scalar<short>(ctx, "padding", 6)});
   func stencil_x = func::make(
       [&](const buffer<const short>& a, const buffer<short>& b) -> index_t {
         if (require_dense_x) {
@@ -1239,7 +1239,7 @@ TEST(constant, pipeline) {
 
   auto out = buffer_expr::make(ctx, "out", 2, sizeof(short));
 
-  auto constant = buffer_expr::make(ctx, "constant", std::move(constant_buf));
+  auto constant = buffer_expr::make_constant(ctx, "constant", std::move(constant_buf));
 
   var x(ctx, "x");
   var y(ctx, "y");

--- a/builder/test/pipeline.cc
+++ b/builder/test/pipeline.cc
@@ -1007,7 +1007,8 @@ TEST_P(padded_stencil, pipeline) {
   var y(ctx, "y");
 
   func add = func::make(add_1<short>, {{in, {point(x), point(y)}}}, {{intm, {x, y}}});
-  func padded = func::make_copy({intm, {point(x), point(y)}, in->bounds()}, {padded_intm, {x, y}}, {{6, 0}});
+  func padded = func::make_copy(
+      {intm, {point(x), point(y)}, in->bounds()}, {padded_intm, {x, y}}, {buffer_expr::make<short>(ctx, "padding", 6)});
   func stencil = func::make(sum3x3<short>, {{padded_intm, {bounds(-1, 1) + x, bounds(-1, 1) + y}}}, {{out, {x, y}}});
 
   switch (schedule) {
@@ -1117,7 +1118,8 @@ TEST_P(padded_stencil_separable, pipeline) {
       },
       {{in, {point(x), point(y)}}}, {{intm, {x, y}}}, call_stmt::attributes{.name = "add"});
   // transpose so we compute the stencil in x.
-  func padded_t = func::make_copy({intm, {point(x), point(y)}, in->bounds()}, {padded_intm_t, {y, x}}, {{6, 0}});
+  func padded_t = func::make_copy({intm, {point(x), point(y)}, in->bounds()}, {padded_intm_t, {y, x}},
+      {buffer_expr::make<short>(ctx, "padding", 6)});
   func stencil_x = func::make(
       [&](const buffer<const short>& a, const buffer<short>& b) -> index_t {
         if (require_dense_x) {

--- a/builder/test/replica_pipeline.cc
+++ b/builder/test/replica_pipeline.cc
@@ -383,7 +383,7 @@ auto p = []() -> ::slinky::pipeline {
   };
   auto _fn_2 = func::make(std::move(_replica_fn_3), {{in, {point(x), point(y)}}}, {{intm, {x, y}}}, {});
   auto _4 = in->sym();
-  auto _fn_1 = func::make_copy({intm, {point(x), point(y)}, {{(buffer_min(_4, 0)), (buffer_max(_4, 0))}, {(buffer_min(_4, 1)), (buffer_max(_4, 1))}}, {}, {}}, {padded_intm, {x, y}}, {6, 0});
+  auto _fn_1 = func::make_copy({intm, {point(x), point(y)}, {{(buffer_min(_4, 0)), (buffer_max(_4, 0))}, {(buffer_min(_4, 1)), (buffer_max(_4, 1))}}, {}, {}}, {padded_intm, {x, y}});
   _fn_1.compute_root();
   auto _replica_fn_5 = [=](const buffer<const void>& i0, const buffer<void>& o0) -> index_t {
     const buffer<const void>* input_buffers[] = {&i0};

--- a/builder/test/replica_pipeline.cc
+++ b/builder/test/replica_pipeline.cc
@@ -362,7 +362,7 @@ auto p = []() -> ::slinky::pipeline {
   ASSERT_EQ(0, p().evaluate(inputs, outputs, eval_ctx));
 }
 
-TEST(replica, padded_stencil) {
+TEST(replica, padded_stencil) {  
   // clang-format off
 // BEGIN define_replica_pipeline() output
 auto p = []() -> ::slinky::pipeline {
@@ -383,7 +383,12 @@ auto p = []() -> ::slinky::pipeline {
   };
   auto _fn_2 = func::make(std::move(_replica_fn_3), {{in, {point(x), point(y)}}}, {{intm, {x, y}}}, {});
   auto _4 = in->sym();
-  auto _fn_1 = func::make_copy({intm, {point(x), point(y)}, {{(buffer_min(_4, 0)), (buffer_max(_4, 0))}, {(buffer_min(_4, 1)), (buffer_max(_4, 1))}}, {}, {}}, {padded_intm, {x, y}});
+  auto padding_const = std::make_shared<buffer<void, 0>>(/*rank=*/0, /*elem_size=*/2);
+  padding_const->allocate();
+  std::uint8_t padding_const_fill[2] = { 0 };
+  copy(*raw_buffer::make_scalar(2, padding_const_fill), *padding_const);
+  auto padding = buffer_expr::make(ctx, /*sym=*/"padding", padding_const);
+  auto _fn_1 = func::make_copy({intm, {point(x), point(y)}, {{(buffer_min(_4, 0)), (buffer_max(_4, 0))}, {(buffer_min(_4, 1)), (buffer_max(_4, 1))}}, {}, {}}, {padded_intm, {x, y}}, {padding, {}});
   _fn_1.compute_root();
   auto _replica_fn_5 = [=](const buffer<const void>& i0, const buffer<void>& o0) -> index_t {
     const buffer<const void>* input_buffers[] = {&i0};

--- a/builder/test/replica_pipeline.cc
+++ b/builder/test/replica_pipeline.cc
@@ -387,7 +387,7 @@ auto p = []() -> ::slinky::pipeline {
   padding_const->allocate();
   std::uint8_t padding_const_fill[2] = { 0 };
   copy(*raw_buffer::make_scalar(2, padding_const_fill), *padding_const);
-  auto padding = buffer_expr::make(ctx, /*sym=*/"padding", padding_const);
+  auto padding = buffer_expr::make_constant(ctx, /*sym=*/"padding", padding_const);
   auto _fn_1 = func::make_copy({intm, {point(x), point(y)}, {{(buffer_min(_4, 0)), (buffer_max(_4, 0))}, {(buffer_min(_4, 1)), (buffer_max(_4, 1))}}, {}, {}}, {padded_intm, {x, y}}, {padding, {}});
   _fn_1.compute_root();
   auto _replica_fn_5 = [=](const buffer<const void>& i0, const buffer<void>& o0) -> index_t {

--- a/builder/test/substitute.cc
+++ b/builder/test/substitute.cc
@@ -18,6 +18,7 @@ var y(symbols, "y");
 var z(symbols, "z");
 var w(symbols, "w");
 var u(symbols, "u");
+var v(symbols, "v");
 
 MATCHER_P(matches, expected, "") { return match(arg, expected); }
 
@@ -60,6 +61,7 @@ TEST(substitute, shadowed) {
       substitute(copy_stmt::make(x, {y, z}, w, {y, z}, {}), y, z), matches(copy_stmt::make(x, {y, z}, w, {y, z}, {})));
   ASSERT_THAT(substitute(copy_stmt::make(x, {y}, w, {y}, {}), y, z), matches(copy_stmt::make(x, {y}, w, {y}, {})));
   ASSERT_THAT(substitute(copy_stmt::make(x, {y}, w, {z}, {}), y, u), matches(copy_stmt::make(x, {u}, w, {z}, {})));
+  ASSERT_THAT(substitute(copy_stmt::make(x, {y}, w, {z}, u), u, v), matches(copy_stmt::make(x, {y}, w, {z}, v)));
 }
 
 TEST(match, basic) {

--- a/builder/test/visualize/padded_stencil_0.html
+++ b/builder/test/visualize/padded_stencil_0.html
@@ -357,26 +357,32 @@ function pipeline(__in, out) {
     let g_1 = buffer_min(__in, 1);
     let g_0 = buffer_max(__in, 0);
     let g_2 = buffer_max(__in, 1);
-    { let padded_intm_intm = allocate('padded_intm/intm', 2, [
-        {bounds:[(buffer_min(out, 0) + -1), (buffer_max(out, 0) + 1)], stride:NaN, fold_factor:NaN},
-        {bounds:[(buffer_min(out, 1) + -1), (buffer_max(out, 1) + 1)], stride:NaN, fold_factor:NaN}
+    { let padding = allocate('padding', 2, [
+        
       ]);
-      { let __intm_3 = crop_buffer(padded_intm_intm, [
-          [g, g_0],
-          [g_1, g_2]
-      ]); {
-        let intm_3 = __intm_3;
-        consume(__in);
-        produce(intm_3);
+      { let padded_intm_intm = allocate('padded_intm/intm', 2, [
+          {bounds:[(buffer_min(out, 0) + -1), (buffer_max(out, 0) + 1)], stride:NaN, fold_factor:NaN},
+          {bounds:[(buffer_min(out, 1) + -1), (buffer_max(out, 1) + 1)], stride:NaN, fold_factor:NaN}
+        ]);
+        { let __intm_3 = crop_buffer(padded_intm_intm, [
+            [g, g_0],
+            [g_1, g_2]
+        ]); {
+          let intm_3 = __intm_3;
+          consume(__in);
+          produce(intm_3);
+          __event_t++;
+          produce(intm_3);
+          produce(padded_intm_intm);
+          produce(padding);
+          __event_t++;
+        }}
+        consume(padded_intm_intm);
+        produce(out);
         __event_t++;
-        produce(intm_3);
-        produce(padded_intm_intm);
-        __event_t++;
-      }}
-      consume(padded_intm_intm);
-      produce(out);
-      __event_t++;
-      free(padded_intm_intm);
+        free(padded_intm_intm);
+      }
+      free(padding);
     }
   }
 }

--- a/builder/test/visualize/padded_stencil_1.html
+++ b/builder/test/visualize/padded_stencil_1.html
@@ -357,26 +357,32 @@ function pipeline(__in, out) {
     let g_1 = buffer_min(__in, 1);
     let g_0 = buffer_max(__in, 0);
     let g_2 = buffer_max(__in, 1);
-    { let padded_intm_intm = allocate('padded_intm/intm', 2, [
-        {bounds:[(buffer_min(out, 0) + -1), (buffer_max(out, 0) + 1)], stride:NaN, fold_factor:NaN},
-        {bounds:[(buffer_min(out, 1) + -1), (buffer_max(out, 1) + 1)], stride:NaN, fold_factor:NaN}
+    { let padding = allocate('padding', 2, [
+        
       ]);
-      { let __intm_3 = crop_buffer(padded_intm_intm, [
-          [g, g_0],
-          [g_1, g_2]
-      ]); {
-        let intm_3 = __intm_3;
-        consume(__in);
-        produce(intm_3);
+      { let padded_intm_intm = allocate('padded_intm/intm', 2, [
+          {bounds:[(buffer_min(out, 0) + -1), (buffer_max(out, 0) + 1)], stride:NaN, fold_factor:NaN},
+          {bounds:[(buffer_min(out, 1) + -1), (buffer_max(out, 1) + 1)], stride:NaN, fold_factor:NaN}
+        ]);
+        { let __intm_3 = crop_buffer(padded_intm_intm, [
+            [g, g_0],
+            [g_1, g_2]
+        ]); {
+          let intm_3 = __intm_3;
+          consume(__in);
+          produce(intm_3);
+          __event_t++;
+          produce(intm_3);
+          produce(padded_intm_intm);
+          produce(padding);
+          __event_t++;
+        }}
+        consume(padded_intm_intm);
+        produce(out);
         __event_t++;
-        produce(intm_3);
-        produce(padded_intm_intm);
-        __event_t++;
-      }}
-      consume(padded_intm_intm);
-      produce(out);
-      __event_t++;
-      free(padded_intm_intm);
+        free(padded_intm_intm);
+      }
+      free(padding);
     }
   }
 }

--- a/builder/test/visualize/padded_stencil_2.html
+++ b/builder/test/visualize/padded_stencil_2.html
@@ -357,40 +357,46 @@ function pipeline(__in, out) {
     let g_1 = buffer_min(__in, 1);
     let g_0 = buffer_max(__in, 0);
     let g_2 = buffer_max(__in, 1);
-    { let padded_intm = allocate('padded_intm', 2, [
-        {bounds:[(buffer_min(out, 0) + -1), (buffer_max(out, 0) + 1)], stride:NaN, fold_factor:NaN},
-        {bounds:[(buffer_min(out, 1) + -1), (buffer_max(out, 1) + 1)], stride:NaN, fold_factor:3}
+    { let padding = allocate('padding', 2, [
+        
       ]);
-      { let intm = allocate('intm', 2, [
-          {bounds:[max(buffer_min(padded_intm, 0), g), min(buffer_max(padded_intm, 0), g_0)], stride:NaN, fold_factor:NaN},
-          {bounds:[max(buffer_min(padded_intm, 1), g_1), min(buffer_max(padded_intm, 1), g_2)], stride:NaN, fold_factor:1}
+      { let padded_intm = allocate('padded_intm', 2, [
+          {bounds:[(buffer_min(out, 0) + -1), (buffer_max(out, 0) + 1)], stride:NaN, fold_factor:NaN},
+          {bounds:[(buffer_min(out, 1) + -1), (buffer_max(out, 1) + 1)], stride:NaN, fold_factor:3}
         ]);
-        let __loop_min = (buffer_min(out, 1) + -2);
-        let __loop_max = buffer_max(out, 1);
-        let __loop_step = 1;
-        for(let out_y = __loop_min; out_y <= __loop_max; out_y += __loop_step) {
-          { let __intm = crop_dim(intm, 1, [(out_y + 1), (out_y + 1)]); {
-            let intm = __intm;
-            consume(__in);
-            produce(intm);
-            __event_t++;
-          }}
-          { let __padded_intm = crop_dim(padded_intm, 1, [(out_y + 1), (out_y + 1)]); {
-            let padded_intm = __padded_intm;
-            produce(intm);
-            produce(padded_intm);
-            __event_t++;
-          }}
-          { let __out_out_y = crop_dim(out, 1, [out_y, out_y]); {
-            let out_out_y = __out_out_y;
-            consume(padded_intm);
-            produce(out_out_y);
-            __event_t++;
-          }}
+        { let intm = allocate('intm', 2, [
+            {bounds:[max(buffer_min(padded_intm, 0), g), min(buffer_max(padded_intm, 0), g_0)], stride:NaN, fold_factor:NaN},
+            {bounds:[max(buffer_min(padded_intm, 1), g_1), min(buffer_max(padded_intm, 1), g_2)], stride:NaN, fold_factor:1}
+          ]);
+          let __loop_min = (buffer_min(out, 1) + -2);
+          let __loop_max = buffer_max(out, 1);
+          let __loop_step = 1;
+          for(let out_y = __loop_min; out_y <= __loop_max; out_y += __loop_step) {
+            { let __intm = crop_dim(intm, 1, [(out_y + 1), (out_y + 1)]); {
+              let intm = __intm;
+              consume(__in);
+              produce(intm);
+              __event_t++;
+            }}
+            { let __padded_intm = crop_dim(padded_intm, 1, [(out_y + 1), (out_y + 1)]); {
+              let padded_intm = __padded_intm;
+              produce(intm);
+              produce(padded_intm);
+              produce(padding);
+              __event_t++;
+            }}
+            { let __out_out_y = crop_dim(out, 1, [out_y, out_y]); {
+              let out_out_y = __out_out_y;
+              consume(padded_intm);
+              produce(out_out_y);
+              __event_t++;
+            }}
+          }
+          free(intm);
         }
-        free(intm);
+        free(padded_intm);
       }
-      free(padded_intm);
+      free(padding);
     }
   }
 }

--- a/runtime/depends_on.cc
+++ b/runtime/depends_on.cc
@@ -170,9 +170,14 @@ public:
     if (depends_on_result* deps = find_deps(op->src)) {
       deps->var = true;
       deps->buffer_src = true;
-      if (op->padding) {
+      if (op->pad.defined()) {
         deps->buffer_bounds = true;
       }
+      deps->buffer_dims = true;
+    }
+    if (depends_on_result* deps = find_deps(op->pad)) {
+      deps->var = true;
+      deps->buffer_src = true;
       deps->buffer_dims = true;
     }
     if (depends_on_result* deps = find_deps(op->dst)) {

--- a/runtime/expr_stmt.cc
+++ b/runtime/expr_stmt.cc
@@ -418,14 +418,13 @@ stmt call_stmt::make(call_stmt::callable target, symbol_list inputs, symbol_list
   return stmt(n);
 }
 
-stmt copy_stmt::make(
-    var src, std::vector<expr> src_x, var dst, std::vector<var> dst_x, std::optional<std::vector<char>> padding) {
+stmt copy_stmt::make(var src, std::vector<expr> src_x, var dst, std::vector<var> dst_x, var pad) {
   auto n = new copy_stmt();
   n->src = src;
   n->src_x = std::move(src_x);
   n->dst = dst;
   n->dst_x = std::move(dst_x);
-  n->padding = std::move(padding);
+  n->pad = pad;
   return stmt(n);
 }
 

--- a/runtime/expr_stmt.cc
+++ b/runtime/expr_stmt.cc
@@ -22,8 +22,10 @@ expr var::operator-() const { return -expr(*this); }
 std::string node_context::name(var v) const {
   if (v.id < sym_to_name.size()) {
     return sym_to_name[v.id];
-  } else {
+  } else if (v.defined()) {
     return "<" + std::to_string(v.id) + ">";
+  } else {
+    return "<>";
   }
 }
 

--- a/runtime/print.cc
+++ b/runtime/print.cc
@@ -142,8 +142,10 @@ public:
   printer& operator<<(var sym) {
     if (context) {
       os << context->name(sym);
-    } else {
+    } else if (sym.defined()) {
       os << "<" + std::to_string(sym.id) << ">";
+    } else {
+      os << "<>";
     }
     return *this;
   }

--- a/runtime/print.cc
+++ b/runtime/print.cc
@@ -322,8 +322,8 @@ public:
 
   void visit(const copy_stmt* n) override {
     *this << indent() << "copy(" << n->src << ", {" << n->src_x << "}, " << n->dst << ", {" << n->dst_x << "}";
-    if (n->padding) {
-      *this << ", {" << *n->padding << "}";
+    if (n->pad.defined()) {
+      *this << ", " << n->pad;
     }
     *this << ")\n";
   }

--- a/runtime/stmt.h
+++ b/runtime/stmt.h
@@ -163,15 +163,12 @@ public:
   std::vector<expr> src_x;
   var dst;
   std::vector<var> dst_x;
-  // padding = nullopt => no padding
-  // padding = {} => padding is uninitialized
-  // padding = <elem_size bytes> => value to put in padding
-  std::optional<std::vector<char>> padding;
+  // If defined, the copy will be padded with the values from this buffer when `src` is out of bounds of `dst`.
+  var pad;
 
   void accept(stmt_visitor* v) const override;
 
-  static stmt make(
-      var src, std::vector<expr> src_x, var dst, std::vector<var> dst_x, std::optional<std::vector<char>> padding);
+  static stmt make(var src, std::vector<expr> src_x, var dst, std::vector<var> dst_x, var pad);
 
   static constexpr stmt_node_type static_type = stmt_node_type::copy_stmt;
 };

--- a/runtime/test/depends_on.cc
+++ b/runtime/test/depends_on.cc
@@ -89,13 +89,15 @@ TEST(depends_on, basic) {
 TEST(depends_on, copy) {
   ASSERT_EQ(depends_on(copy_stmt::make(x, {z}, y, {z}, {}), x),
       (depends_on_result{.var = true, .buffer_src = true, .buffer_dims = true}));
-  ASSERT_EQ(depends_on(copy_stmt::make(x, {z}, y, {z}, {{3}}), x),
+  ASSERT_EQ(depends_on(copy_stmt::make(x, {z}, y, {z}, w), x),
       (depends_on_result{.var = true, .buffer_src = true, .buffer_dims = true, .buffer_bounds = true}));
   ASSERT_EQ(depends_on(copy_stmt::make(x, {z}, y, {z}, {}), y),
       (depends_on_result{.var = true, .buffer_dst = true, .buffer_dims = true, .buffer_bounds = true}));
-  ASSERT_EQ(depends_on(copy_stmt::make(x, {z}, y, {z}, {{3}}), y),
+  ASSERT_EQ(depends_on(copy_stmt::make(x, {z}, y, {z}, w), y),
       (depends_on_result{.var = true, .buffer_dst = true, .buffer_dims = true, .buffer_bounds = true}));
-  ASSERT_EQ(depends_on(copy_stmt::make(x, {z + w}, y, {z}, {}), z), (depends_on_result{}));
+  ASSERT_EQ(depends_on(copy_stmt::make(x, {z}, y, {z}, w), w),
+      (depends_on_result{.var = true, .buffer_src = true, .buffer_dims = true}));
+    ASSERT_EQ(depends_on(copy_stmt::make(x, {z + w}, y, {z}, {}), z), (depends_on_result{}));
   ASSERT_EQ(depends_on(copy_stmt::make(x, {z + w}, y, {z}, {}), w), (depends_on_result{.var = true}));
 }
 


### PR DESCRIPTION
This picks up where #633 left off and enables padding to be buffers in the pipeline API as well.

Padding can now be computed by another stage in the pipeline, and does not need to be a scalar value. It is now essentially the same as any other input to any other pipeline stage.