### PR TITLE
Fix undefined expressions in crop bounds and closures

### DIFF
--- a/builder/simplify.cc
+++ b/builder/simplify.cc
@@ -1796,7 +1796,7 @@ public:
   }
 
   template <typename T>
-  expr remove_redundant_bounds(expr x, const std::set<expr, node_less>& bounds) {
+  expr remove_redundant_bounds(expr x, const std::set<expr, node_less>& bounds, const expr& def) {
     auto is_redundant = [&](const expr& x) {
       // A bound x is redundant if the bounds already have a value i such that T(x, i) == i
       for (const expr& i : bounds) {
@@ -1805,23 +1805,23 @@ public:
       }
       return false;
     };
-    if (is_redundant(x)) return expr();
+    if (is_redundant(x)) return def;
     if (const T* t = x.as<T>()) {
       bool a_redundant = is_redundant(t->a);
       bool b_redundant = is_redundant(t->b);
       if (a_redundant && b_redundant) {
-        return expr();
+        return def;
       } else if (a_redundant) {
-        return remove_redundant_bounds<T>(t->b, bounds);
+        return remove_redundant_bounds<T>(t->b, bounds, def);
       } else if (b_redundant) {
-        return remove_redundant_bounds<T>(t->a, bounds);
+        return remove_redundant_bounds<T>(t->a, bounds, def);
       }
     } else if (const add* xa = x.as<add>()) {
       if (as_constant(xa->b)) {
         // We have T(x + y, b). We can rewrite to T(x, b - y) + y, and if we can eliminate the bound, the whole
         // bound is redundant.
         for (const expr& i : bounds) {
-          expr removed = remove_redundant_bounds<T>(xa->a, {mutate(i - xa->b)});
+          expr removed = remove_redundant_bounds<T>(xa->a, {mutate(i - xa->b)}, def);
           if (!removed.same_as(xa->a)) {
             return std::move(removed) + xa->b;
           }
@@ -1832,7 +1832,7 @@ public:
         // We have T(x / y, b). We can rewrite to T(x, b * y) / y, and if we can eliminate the bound, the whole
         // bound is redundant.
         for (const expr& i : bounds) {
-          expr removed = remove_redundant_bounds<T>(xa->a, {mutate(i * xa->b)});
+          expr removed = remove_redundant_bounds<T>(xa->a, {mutate(i * xa->b)}, def);
           if (!removed.same_as(xa->a)) {
             return std::move(removed) / xa->b;
           }
@@ -1845,7 +1845,7 @@ public:
         // redundant mins, we should round up, and redundant maxes should round down.
         for (const expr& i : bounds) {
           expr rounded = std::is_same<T, class min>::value ? i + (xa->b - 1) : i;
-          expr removed = remove_redundant_bounds<T>(xa->a, {mutate(rounded / xa->b)});
+          expr removed = remove_redundant_bounds<T>(xa->a, {mutate(rounded / xa->b)}, def);
           if (!removed.same_as(xa->a)) {
             return std::move(removed) * xa->b;
           }
@@ -1857,8 +1857,8 @@ public:
           if (match(xs->condition, bs->condition)) {
             // We have T(select(c, xt, xf), select(c, bt, bf)), rewrite to select(c, T(xt, bt), T(xf, bf)) and attempt
             // to eliminate bounds.
-            expr t = remove_redundant_bounds<T>(xs->true_value, {bs->true_value});
-            expr f = remove_redundant_bounds<T>(xs->false_value, {bs->false_value});
+            expr t = remove_redundant_bounds<T>(xs->true_value, {bs->true_value}, def);
+            expr f = remove_redundant_bounds<T>(xs->false_value, {bs->false_value}, def);
             if (!t.same_as(xs->true_value) || !f.same_as(xs->false_value)) {
               return select(xs->condition, std::move(t), std::move(f));
             }
@@ -1866,8 +1866,8 @@ public:
         }
       }
       // Also try select(x, T(xt, b), T(xf, b))
-      expr t = remove_redundant_bounds<T>(xs->true_value, bounds);
-      expr f = remove_redundant_bounds<T>(xs->false_value, bounds);
+      expr t = remove_redundant_bounds<T>(xs->true_value, bounds, def);
+      expr f = remove_redundant_bounds<T>(xs->false_value, bounds, def);
       if (!t.same_as(xs->true_value) || !f.same_as(xs->false_value)) {
         return select(xs->condition, std::move(t), std::move(f));
       }
@@ -1893,19 +1893,12 @@ public:
     enumerate_bounds<class max>(buffer.min, mins);
     enumerate_bounds<class min>(buffer.max, maxs);
     interval_expr deduped = {
-        remove_redundant_bounds<class max>(result.min, mins),
-        remove_redundant_bounds<class min>(result.max, maxs),
+        remove_redundant_bounds<class max>(result.min, mins, buffer_min(buf, dim)),
+        remove_redundant_bounds<class min>(result.max, maxs, buffer_max(buf, dim)),
     };
     if (!deduped.same_as(result)) {
       result = mutate(deduped);
     }
-
-    if (result.min.defined() && prove_true(result.min <= buffer.min)) result.min = expr();
-    if (result.max.defined() && prove_true(result.max >= buffer.max)) result.max = expr();
-
-    // TODO: I think it might be possible to avoid generating these min/max + mutate in some cases.
-    if (result.min.defined()) buffer.min = mutate(max(buffer.min, result.min));
-    if (result.max.defined()) buffer.max = mutate(min(buffer.max, result.max));
 
     // We might have written a select into an interval that tries to preserve the empty-ness of the interval.
     // But this might be unnecessary. Try to remove unnecessary selects here.
@@ -1930,6 +1923,13 @@ public:
         result.min = mutate(ctx.matched(x) + ctx.matched(y));
       }
     }
+
+    if (result.min.defined() && prove_true(result.min <= buffer.min)) result.min = expr();
+    if (result.max.defined() && prove_true(result.max >= buffer.max)) result.max = expr();
+
+    // TODO: I think it might be possible to avoid generating these min/max + mutate in some cases.
+    if (result.min.defined()) buffer.min = mutate(max(buffer.min, result.min));
+    if (result.max.defined()) buffer.max = mutate(min(buffer.max, result.max));
 
     return result;
   }

--- a/builder/test/simplify/simplify.cc
+++ b/builder/test/simplify/simplify.cc
@@ -653,6 +653,16 @@ TEST(simplify, crop) {
                       crop_dim::make(b3, b1, 0, {x, y},
                           crop_dim::make(b4, b2, 0, {x, y}, call_stmt::make(nullptr, {}, {b3, b4}, {})))))),
       matches(crop_dim::make(b3, b0, 0, {x, y}, call_stmt::make(nullptr, {}, {b3, b3}, {}))));
+
+  ASSERT_THAT(simplify(block::make({
+                  check::make(buffer_min(b0, 0) == 0),
+                  crop_dim::make(b2, b0, 0,
+                      {select(buffer_max(b0, 0) < 0, buffer_max(b0, 0) + 32, 0), buffer_max(b0, 0) + 31}, body),
+              })),
+      matches(block::make({
+          check::make(buffer_min(b0, 0) == 0),
+          crop_dim::make(b2, b0, 0, {select(buffer_max(b0, 0) < 0, buffer_max(b0, 0), -32) + 32, expr()}, body),
+      })));
 }
 
 TEST(simplify, make_buffer) {

--- a/runtime/depends_on.cc
+++ b/runtime/depends_on.cc
@@ -35,6 +35,8 @@ public:
   }
 
   depends_on_result* find_deps(var s) {
+    if (!s.defined()) return nullptr;
+
     // Go in reverse order to handle shadowed declarations properly.
     for (auto i = var_deps.rbegin(); i != var_deps.rend(); ++i) {
       if (i->first == s) return i->second;

--- a/runtime/expr.h
+++ b/runtime/expr.h
@@ -98,9 +98,6 @@ enum class intrinsic {
   and_then,
   or_else,
 
-  // `define_undef(x, def)` means that undefined expressions take the value `def` when evaluating `x`.
-  define_undef,
-
   // Returns the size of a buffer in bytes.
   buffer_size_bytes,
 

--- a/runtime/test/depends_on.cc
+++ b/runtime/test/depends_on.cc
@@ -142,6 +142,8 @@ TEST(find_dependencies, basic) {
   ASSERT_THAT(find_dependencies(crop_dim::make(x, y, 0, {z, z}, call_stmt::make(nullptr, {w}, {u}, {}))),
       testing::ElementsAre(y, z, w, u));
   ASSERT_THAT(find_dependencies(block::make({check::make(x), check::make(y)})), testing::ElementsAre(x, y));
+  ASSERT_THAT(find_dependencies(copy_stmt::make(x, {w}, y, {w}, z)), testing::ElementsAre(x, y, z));
+  ASSERT_THAT(find_dependencies(copy_stmt::make(x, {w + u}, y, {w}, var())), testing::ElementsAre(x, y, u));
 }
 
 }  // namespace slinky

--- a/runtime/test/evaluate.cc
+++ b/runtime/test/evaluate.cc
@@ -14,8 +14,6 @@ node_context ctx;
 var x(ctx, "x");
 var y(ctx, "y");
 
-expr define_undef(const expr& a, const expr& def) { return call::make(intrinsic::define_undef, {a, def}); }
-
 }  // namespace
 
 bool operator!=(const dim& a, const dim& b) {
@@ -63,18 +61,6 @@ TEST(evaluate, arithmetic) {
   ASSERT_EQ(evaluate(or_else(expr(false), expr(true))), true);
   ASSERT_EQ(evaluate(or_else(expr(false), expr(false))), false);
   ASSERT_EQ(evaluate(or_else(expr(true), indeterminate())), true);
-}
-
-TEST(evaluate, undef) {
-  eval_context context;
-  context[x] = 4;
-
-  ASSERT_EQ(evaluate(define_undef(select(true, expr(), x), 0), context), 0);
-  ASSERT_EQ(evaluate(define_undef(select(false, expr(), x), 0), context), 4);
-  ASSERT_EQ(evaluate(define_undef(select(true, expr(), x) + 2, 0), context), 0);
-  ASSERT_EQ(evaluate(define_undef(select(false, expr(), x) + 2, 0), context), 6);
-  ASSERT_EQ(evaluate(define_undef(select(true, expr(), x) + 2, 0) + 1, context), 1);
-  ASSERT_EQ(evaluate(define_undef(select(false, expr(), x) + 2, 0) + 1, context), 7);
 }
 
 TEST(evaluate, call) {


### PR DESCRIPTION
Currently, we allow crops to have undefined bounds, which means there is no crop at that bound.

We also allow things like `select(x, expr(), y)` in crop bounds, and that means that the crop should do nothing in the case `x` is true. This is a headache to support well.  This PR removes this, so `expr()` would need to be a `buffer_min` expression instead.

Also, don't capture undef vars in closures