### PR TITLE
Add `euclidean_div_positive_divisor` and optimize

### DIFF
--- a/base/arithmetic.h
+++ b/base/arithmetic.h
@@ -19,7 +19,7 @@ T euclidean_div(T a, T b, T define_b_zero = 0) {
     return define_b_zero;
   }
   T q = a / b;
-  T r = a - q * b;
+  T r = a % b;
   T bs = b >> (sizeof(T) * 8 - 1);
   T rs = r >> (sizeof(T) * 8 - 1);
   return q - (rs & bs) + (rs & ~bs);
@@ -38,7 +38,7 @@ template <typename T>
 T euclidean_div_positive_divisor(T a, T b) {
   assert(b > 0);
   T q = a / b;
-  T r = a - q * b;
+  T r = a % b;
   T rs = r >> (sizeof(T) * 8 - 1);
   return q + rs;
 }

--- a/base/arithmetic.h
+++ b/base/arithmetic.h
@@ -26,19 +26,28 @@ T euclidean_div(T a, T b, T define_b_zero = 0) {
 }
 
 template <typename T>
-T euclidean_mod_positive_modulus(T a, T b) {
-  assert(b > 0);
-  T r = a % b;
-  return r >= 0 ? r : r + b;
-}
-
-template <typename T>
 T euclidean_mod(T a, T b, T define_b_zero = 0) {
   if (b == 0) {
     return define_b_zero;
   }
   T r = a % b;
   return r >= 0 ? r : (b < 0 ? r - b : r + b);
+}
+
+template <typename T>
+T euclidean_div_positive_divisor(T a, T b) {
+  assert(b > 0);
+  T q = a / b;
+  T r = a - q * b;
+  T rs = r >> (sizeof(T) * 8 - 1);
+  return q + rs;
+}
+
+template <typename T>
+T euclidean_mod_positive_modulus(T a, T b) {
+  assert(b > 0);
+  T r = a % b;
+  return r >= 0 ? r : r + b;
 }
 
 // Compute a / b, rounding down.

--- a/base/arithmetic.h
+++ b/base/arithmetic.h
@@ -20,8 +20,10 @@ T euclidean_div(T a, T b, T define_b_zero = 0) {
   }
   T q = a / b;
   T r = a % b;
+  // Get the sign of b and r (-1 or 0).
   T bs = b >> (sizeof(T) * 8 - 1);
   T rs = r >> (sizeof(T) * 8 - 1);
+  // Adjust the result (which is rounded towards 0) to be rounded down.
   return q - (rs & bs) + (rs & ~bs);
 }
 
@@ -39,6 +41,7 @@ T euclidean_div_positive_divisor(T a, T b) {
   assert(b > 0);
   T q = a / b;
   T r = a % b;
+  // Get the sign of r (-1 or 0).
   T rs = r >> (sizeof(T) * 8 - 1);
   return q + rs;
 }

--- a/base/test/arithmetic.cc
+++ b/base/test/arithmetic.cc
@@ -33,6 +33,8 @@ TEST(arithmetic, euclidean_div_mod) {
     // 2. (a / b) * b + a % b == a
     ASSERT_EQ(euclidean_div(a, b) * b + euclidean_mod(a, b), a);
     ASSERT_EQ(euclidean_div(-a, b) * b + euclidean_mod(-a, b), -a);
+    ASSERT_EQ(euclidean_div_positive_divisor(a, b) * b + euclidean_mod(a, b), a);
+    ASSERT_EQ(euclidean_div_positive_divisor(-a, b) * b + euclidean_mod(-a, b), -a);
     ASSERT_EQ(euclidean_div(a, -b) * -b + euclidean_mod(a, -b), a);
     ASSERT_EQ(euclidean_div(-a, -b) * -b + euclidean_mod(-a, -b), -a);
     ASSERT_EQ(euclidean_div(a, b) * b + euclidean_mod_positive_modulus(a, b), a);

--- a/base/test/arithmetic_benchmark.cc
+++ b/base/test/arithmetic_benchmark.cc
@@ -6,11 +6,11 @@ namespace slinky {
 
 template <typename Fn>
 void BM_binary(benchmark::State& state, Fn&& fn) {
-  std::vector<std::pair<std::ptrdiff_t, std::ptrdiff_t>> values(1000);
-  std::generate(values.begin(), values.end(), []() { return std::make_pair(rand(), rand()); });
-  while (state.KeepRunningBatch(values.size())) {
-    for (const auto& i : values) {
-      benchmark::DoNotOptimize(fn(i.first, i.second));
+  std::vector<std::ptrdiff_t> values(1000);
+  std::generate(values.begin(), values.end(), []() { return rand(); });
+  while (state.KeepRunningBatch(values.size() - 1)) {
+    for (size_t i = 1; i < values.size(); ++i) {
+      benchmark::DoNotOptimize(fn(values[i - 1], values[i]));
     }
   }
 }
@@ -20,6 +20,9 @@ void BM_euclidean_div(benchmark::State& state) {
 }
 void BM_euclidean_mod(benchmark::State& state) {
   BM_binary(state, [](std::ptrdiff_t a, std::ptrdiff_t b) { return euclidean_mod<std::ptrdiff_t>(a, b); });
+}
+void BM_euclidean_div_positive_divisor(benchmark::State& state) {
+  BM_binary(state, euclidean_div_positive_divisor<std::ptrdiff_t>);
 }
 void BM_euclidean_mod_positive_modulus(benchmark::State& state) {
   BM_binary(state, euclidean_mod_positive_modulus<std::ptrdiff_t>);
@@ -34,6 +37,7 @@ void BM_lcm(benchmark::State& state) { BM_binary(state, lcm<std::ptrdiff_t>); }
 
 BENCHMARK(BM_euclidean_div);
 BENCHMARK(BM_euclidean_mod);
+BENCHMARK(BM_euclidean_div_positive_divisor);
 BENCHMARK(BM_euclidean_mod_positive_modulus);
 BENCHMARK(BM_saturate_add);
 BENCHMARK(BM_saturate_sub);


### PR DESCRIPTION
- Add `euclidean_div_positive_divisor` to simplify some logic
- Use `a % b` instead of computing it. This is a lot faster with clang, but doesn't affect gcc.