### PR TITLE
Fix simplify issues for pyramid heavy pipelines

### DIFF
--- a/builder/simplify_rules.h
+++ b/builder/simplify_rules.h
@@ -545,8 +545,15 @@ bool apply_div_rules(Fn&& apply) {
 
       apply((x + y*c0)/c1, y*eval(c0/c1) + x/c1, c0%c1 == 0) ||
       apply((x + c0)/c1, x/c1 + eval(c0/c1), c0%c1 == 0) ||
-      apply((y*c0 - x)/c1, y*eval(c0/c1) + (-x/c1), c0%c1 == 0 && c0 != 0) ||
-      apply((c0 - x)/c1, (-x/c1) + eval(c0/c1), c0%c1 == 0 && c0 != 0) ||
+      apply((y*c0 - x)/c1, y*eval(c0/c1) + (-x)/c1, c0%c1 == 0 && c0 != 0) ||
+      apply((c0 - x)/c1, (-x)/c1 + eval(c0/c1), c0%c1 == 0 && c0 != 0) ||
+    
+      apply(min(y, z + x*c0)/c1, min(x*eval(c0/c1) + z/c1, y/c1), c1 > 0 && c0%c1 == 0) ||
+      apply(max(y, z + x*c0)/c1, max(x*eval(c0/c1) + z/c1, y/c1), c1 > 0 && c0%c1 == 0) ||
+      apply(min(y, x*c0 - z)/c1, min(x*eval(c0/c1) + (-z)/c1, y/c1), c1 > 0 && c0%c1 == 0) ||
+      apply(max(y, x*c0 - z)/c1, max(x*eval(c0/c1) + (-z)/c1, y/c1), c1 > 0 && c0%c1 == 0) ||
+      apply(min(y, x*c0)/c1, min(x*eval(c0/c1), y/c1), c1 > 0 && c0%c1 == 0) ||
+      apply(max(y, x*c0)/c1, max(x*eval(c0/c1), y/c1), c1 > 0 && c0%c1 == 0) ||
     
       apply(select(x, c0, c1)/c2, select(x, eval(c0/c2), eval(c1/c2))) ||
       apply(select(x, y, c1)/c2, select(x, y/c2, eval(c1/c2))) ||

--- a/builder/simplify_rules.h
+++ b/builder/simplify_rules.h
@@ -123,7 +123,9 @@ bool apply_min_rules(Fn&& apply) {
       apply(min(min(x, c0), c1), min(x, eval(min(c0, c1)))) ||
       apply(min(x, min(y, c0)), min(min(x, y), c0)) ||
       apply(min(x + c0, (y + c1)/c2), min(x, (y + eval(c1 - c0*c2))/c2) + c0, c2 != 0) ||
-      apply(min(x + c0, y + c1), min(x, y + eval(c1 - c0)) + c0) ||
+      apply(min(x + c0, y + c1),
+        min(x, y + eval(c1 - c0)) + c0, c0 >= c1,  // Canonicalize to pulling bigger constants out.
+        min(y, x + eval(c0 - c1)) + c1) ||
       apply(min(x + c0, c1 - y), c1 - max(y, eval(c1 - c0) - x)) ||
       apply(min(x + c0, c1), min(x, eval(c1 - c0)) + c0) ||
       apply(min(c0 - x, c1 - y), c0 - max(x, y + eval(c0 - c1))) ||
@@ -294,7 +296,9 @@ bool apply_max_rules(Fn&& apply) {
       apply(max(max(x, c0), c1), max(x, eval(max(c0, c1)))) ||
       apply(max(x, max(y, c0)), max(max(x, y), c0)) ||
       apply(max(x + c0, (y + c1)/c2), max(x, (y + eval(c1 - c0*c2))/c2) + c0, c2 != 0) ||
-      apply(max(x + c0, y + c1), max(x, y + eval(c1 - c0)) + c0) ||
+      apply(max(x + c0, y + c1),
+        max(x, y + eval(c1 - c0)) + c0, c0 >= c1,  // Canonicalize to pulling bigger constants out.
+        max(y, x + eval(c0 - c1)) + c1) ||
       apply(max(x + c0, c1 - y), c1 - min(y, eval(c1 - c0) - x)) ||
       apply(max(x + c0, c1), max(x, eval(c1 - c0)) + c0) ||
       apply(max(c0 - x, c1 - y), c0 - min(x, y + eval(c0 - c1))) ||

--- a/builder/test/simplify/rule_tester.h
+++ b/builder/test/simplify/rule_tester.h
@@ -65,13 +65,21 @@ public:
         ctx[var(i)] = expr_gen_.random_constant();
       }
 
+      auto dump_ctx = [&]() { 
+        std::stringstream ss;
+        for (std::size_t i = 0; i < var_count; ++i) {
+          ss << ", " << var(i) << "=" << ctx[var(i)];
+        }
+        return ss.str();
+      };
+
       index_t value = evaluate(pattern, ctx);
       index_t replacement_value = evaluate(replacement, ctx);
       index_t simplified_value = evaluate(simplified, ctx);
       ASSERT_EQ(value, replacement_value) << "Incorrect rule: " << rule_str << "\n"
-                                          << pattern << " -> " << replacement << "\n";
+                                          << pattern << " -> " << replacement << dump_ctx() << "\n";
       ASSERT_EQ(value, simplified_value) << "Incorrect simplification: " << rule_str << "\n"
-                                         << pattern << " -> " << simplified << "\n";
+                                         << pattern << " -> " << simplified << dump_ctx() << "\n";
     }
   }
 

--- a/builder/test/simplify/simplify.cc
+++ b/builder/test/simplify/simplify.cc
@@ -206,7 +206,7 @@ TEST(simplify, basic) {
 
   ASSERT_THAT(simplify(select(x, (y - 4), 2) + 4), matches(select(x, y, 6)));
   ASSERT_THAT(simplify(select(x, y + 3, 5) - 1), matches(select(x, y, 2) + 2));
-  ASSERT_THAT(simplify(min(x + 2, select(y, 3, z + 4)) - 1), matches(min(x, select(y, -1, z) + 2) + 1));
+  ASSERT_THAT(simplify(min(x + 2, select(y, 3, z + 4)) - 1), matches((min(x + -2, select(y, -1, z)) + 3)));
 
   ASSERT_THAT(simplify(select((y <= 0), select((x <= 0), z, x), z)), matches(select(0 < x && y <= 0, x, z)));
 
@@ -219,6 +219,8 @@ TEST(simplify, basic) {
 
   ASSERT_THAT(simplify(max(select(z <= 0, -1, select(1 <= y, min(x, z + -1), 0)) + 1, select((1 <= y), z, 0))),
       matches(select((1 <= y), max(z, 0), (0 < z))));
+
+  ASSERT_THAT(simplify(min(min(x / 16 + -2, y) + 1, min(y + 1, x / 16)) + 2), matches(min(y, x / 16 + -2) + 3));
 }
 
 TEST(simplify, let) {


### PR DESCRIPTION
- Canonicalize which constant we pull from both sides of a min/max. This fixes an infinite loop bug.
- Add some rules that simplify expressions from pyramid pipelines.