### PR TITLE
Fix crop handling for aliasing

### DIFF
--- a/builder/optimizations.cc
+++ b/builder/optimizations.cc
@@ -711,11 +711,11 @@ public:
     merge_buffer_info(old_buffers, op->sym, op->src, handler);
   }
 
-  void substitute_alloc_dims(var sym, const std::vector<dim_expr>& dims) {
+  void substitute_crop_into_allocs(var sym, var src, const std::vector<dim_expr>& dims) {
     for (std::optional<buffer_info>& i : buffers) {
       if (!i) continue;
       for (dim_expr& d : i->dims) {
-        d.bounds = substitute_buffer(d.bounds, sym, dims);
+        d.bounds = substitute_buffer(d.bounds, sym, dims, src);
       }
     }
   }
@@ -740,7 +740,7 @@ public:
     for (std::size_t i = 0; i < subs.size(); ++i) {
       subs[i].bounds = op->bounds[i] & buffer_bounds(op->src, i);
     }
-    substitute_alloc_dims(op->sym, subs);
+    substitute_crop_into_allocs(op->sym, op->src, subs);
   }
 
   void visit(const crop_dim* op) override {
@@ -748,7 +748,7 @@ public:
 
     std::vector<dim_expr> subs(op->dim + 1);
     subs[op->dim].bounds = op->bounds & buffer_bounds(op->src, op->dim);
-    substitute_alloc_dims(op->sym, subs);
+    substitute_crop_into_allocs(op->sym, op->src, subs);
   }
 
   void visit(const clone_buffer* op) override {

--- a/builder/substitute.h
+++ b/builder/substitute.h
@@ -76,11 +76,14 @@ stmt substitute(const stmt& s, var target, const expr& replacement);
 
 // Substitute `elem_size` in for buffer_elem_size(buffer) and the other buffer metadata in `dims` for per-dimension
 // metadata.
-expr substitute_buffer(const expr& e, var buffer, const std::vector<dim_expr>& dims);
-expr substitute_buffer(const expr& e, var buffer, const expr& elem_size, const std::vector<dim_expr>& dims);
-interval_expr substitute_buffer(const interval_expr& e, var buffer, const std::vector<dim_expr>& dims);
+// If `def` is defined, then buffer metadata that is undefined in `dims` will be replaced with a read of `def`'s
+// metadata.
+expr substitute_buffer(const expr& e, var buffer, const std::vector<dim_expr>& dims, var def = var());
+expr substitute_buffer(
+    const expr& e, var buffer, const expr& elem_size, const std::vector<dim_expr>& dims, var def = var());
+interval_expr substitute_buffer(const interval_expr& e, var buffer, const std::vector<dim_expr>& dims, var def = var());
 interval_expr substitute_buffer(
-    const interval_expr& e, var buffer, const expr& elem_size, const std::vector<dim_expr>& dims);
+    const interval_expr& e, var buffer, const expr& elem_size, const std::vector<dim_expr>& dims, var def = var());
 
 // Helpers to make dims for use with `substitute_buffer` for bounds.
 std::vector<dim_expr> make_dims_from_bounds(const box_expr& bounds);

--- a/builder/test/substitute.cc
+++ b/builder/test/substitute.cc
@@ -38,9 +38,11 @@ TEST(substitute, basic) {
                   x, w),
       matches(
           crop_dim::make(y, y, 0, {0, 0}, crop_dim::make(y, y, 0, {0, 0}, call_stmt::make(nullptr, {w}, {y}, {})))));
-  ASSERT_THAT(substitute_buffer(buffer_stride(x, 0), x, expr(), {}), matches(buffer_stride(x, 0)));
-  ASSERT_THAT(substitute_buffer(buffer_stride(x, 0), x, expr(), {{{0, 1}, 2, 3}}), matches(2));
+  ASSERT_THAT(substitute_buffer(buffer_stride(x, 0), x, expr(), {}), matches(expr()));
+  ASSERT_THAT(substitute_buffer(buffer_stride(x, 0), x, expr(), {}, y), matches(buffer_stride(y, 0)));
   ASSERT_THAT(substitute_buffer(buffer_stride(x, 0), x, expr(), {dim_expr()}), matches(expr()));
+  ASSERT_THAT(substitute_buffer(buffer_stride(x, 0), x, expr(), {dim_expr()}, y), matches(buffer_stride(y, 0)));
+  ASSERT_THAT(substitute_buffer(buffer_stride(x, 0), x, expr(), {{{0, 1}, 2, 3}}), matches(2));
   ASSERT_THAT(substitute_buffer(buffer_rank(x), x, expr(), {dim_expr(), dim_expr()}), matches(2));
 }
 


### PR DESCRIPTION
`substitute_buffer` would replace buffer values with undef if the value wasn't defined, which is incorrect for the way the crop visitors were using it in aliasing.

This adds an optional parameter to `substitute_buffer` that indicates unspecified values should be taken from a different buffer, instead of left as undef.

At first I tried to fix this by just substituting the buffer values we want in the crop handler. However, this doesn't work, because crop doesn't know how many dimensions the buffer has, so it can't fully populate the `dims` with the correct values.