### PR TITLE
Add rules and logic to handle negative division numerators

### DIFF
--- a/base/BUILD
+++ b/base/BUILD
@@ -15,6 +15,9 @@ cc_library(
         "span.h",
         "util.h",
     ],
+    srcs = [
+        "arithmetic.cc",
+    ],
     visibility = ["//visibility:public"],
 )
 

--- a/base/arithmetic.cc
+++ b/base/arithmetic.cc
@@ -31,9 +31,4 @@ std::optional<std::pair<int, int>> staircase_sum_bounds(int a1, int b1, int c1, 
   return {{min, max}};
 }
 
-int staircase_sum_max(int a1, int b1, int c1, int a2, int b2, int c2) {
-  auto bounds = staircase_sum_bounds(a1, b1, c1, a2, b2, c2);
-  return bounds ? bounds->second : std::numeric_limits<int>::max();
-}
-
 }  // namespace slinky

--- a/base/arithmetic.cc
+++ b/base/arithmetic.cc
@@ -5,20 +5,20 @@
 
 namespace slinky {
 
-std::optional<std::pair<int, int>> staircase_sum_bounds(int a1, int b1, int c1, int a2, int b2, int c2) {
+interval<int> staircase_sum_bounds(int a1, int b1, int c1, int a2, int b2, int c2) {
   if (b1 == 0 && b2 == 0) {
-    return {{0, 0}};
+    return {0, 0};
   } else if (c1 * b2 != -c2 * b1) {
-    return std::nullopt;
+    return {};
   } else if (b1 == 0 || b2 == 0) {
-    return std::nullopt;
+    return {};
   }
 
   // The ratios of the two sides are equal. The value of this expression is a periodic pattern.
   // We need to search the period for the min and max.
   // If these constants get so big, we need to revisit this algorithm.
   if (abs(b1) > 1024 || abs(b2) > 1024) {
-    return std::nullopt;
+    return {};
   }
   int min = std::numeric_limits<int>::max();
   int max = std::numeric_limits<int>::min();
@@ -28,7 +28,7 @@ std::optional<std::pair<int, int>> staircase_sum_bounds(int a1, int b1, int c1, 
     min = std::min(min, y);
     max = std::max(max, y);
   }
-  return {{min, max}};
+  return {min, max};
 }
 
 }  // namespace slinky

--- a/base/arithmetic.cc
+++ b/base/arithmetic.cc
@@ -1,0 +1,39 @@
+#include <algorithm>
+#include <limits>
+
+#include "base/arithmetic.h"
+
+namespace slinky {
+
+std::optional<std::pair<int, int>> staircase_sum_bounds(int a1, int b1, int c1, int a2, int b2, int c2) {
+  if (b1 == 0 && b2 == 0) {
+    return {{0, 0}};
+  } else if (c1 * b2 != -c2 * b1) {
+    return std::nullopt;
+  } else if (b1 == 0 || b2 == 0) {
+    return std::nullopt;
+  }
+
+  // The ratios of the two sides are equal. The value of this expression is a periodic pattern.
+  // We need to search the period for the min and max.
+  // If these constants get so big, we need to revisit this algorithm.
+  if (abs(b1) > 1024 || abs(b2) > 1024) {
+    return std::nullopt;
+  }
+  int min = std::numeric_limits<int>::max();
+  int max = std::numeric_limits<int>::min();
+  const int period = lcm(abs(b1), abs(b2));
+  for (int x = 0; x < period; ++x) {
+    const int y = euclidean_div(x + a1, b1) * c1 + euclidean_div(x + a2, b2) * c2;
+    min = std::min(min, y);
+    max = std::max(max, y);
+  }
+  return {{min, max}};
+}
+
+int staircase_sum_max(int a1, int b1, int c1, int a2, int b2, int c2) {
+  auto bounds = staircase_sum_bounds(a1, b1, c1, a2, b2, c2);
+  return bounds ? bounds->second : std::numeric_limits<int>::max();
+}
+
+}  // namespace slinky

--- a/base/arithmetic.h
+++ b/base/arithmetic.h
@@ -219,9 +219,27 @@ T staircase(T x, T a, T b, T c) {
   return euclidean_div(x + a, b) * c;
 }
 
+template <typename T>
+struct interval {
+  // The interval is unbounded if the min or max is missing.
+  std::optional<T> min, max;
+
+  interval() = default;
+  explicit interval(T x) : min(x), max(x) {}
+  interval(T min, T max) : min(min), max(max) {}
+
+  bool operator==(const interval<T>& r) const {
+    if (!min != !r.min) return false;
+    if (!max != !r.max) return false;
+    if (min && *min != *r.min) return false;
+    if (max && *max != *r.max) return false;
+    return true;
+  }
+};
+
 // Returns the [min, max] interval over all x of ((x + a1)/b1)*c1 + ((x + a2)/b2)*c2
 // Returns std::nullopt if unbounded.
-std::optional<std::pair<int, int>> staircase_sum_bounds(int a1, int b1, int c1, int a2, int b2, int c2);
+interval<int> staircase_sum_bounds(int a1, int b1, int c1, int a2, int b2, int c2);
 
 }  // namespace slinky
 

--- a/base/arithmetic.h
+++ b/base/arithmetic.h
@@ -5,6 +5,7 @@
 #include <cmath>
 #include <cstddef>
 #include <limits>
+#include <optional>
 #include <utility>
 
 namespace slinky {
@@ -211,6 +212,16 @@ template <typename T>
 T lcm(T a, T b) {
   return (a * b) / gcd(a, b);
 }
+
+// Computes ((x + a)/b)*c
+template <typename T>
+T staircase(T x, T a, T b, T c) {
+  return euclidean_div(x + a, b) * c;
+}
+
+// Returns the [min, max] interval over all x of ((x + a1)/b1)*c1 + ((x + a2)/b2)*c2
+// Returns std::nullopt if unbounded.
+std::optional<std::pair<int, int>> staircase_sum_bounds(int a1, int b1, int c1, int a2, int b2, int c2);
 
 }  // namespace slinky
 

--- a/base/test/BUILD
+++ b/base/test/BUILD
@@ -24,6 +24,7 @@ cc_test(
     srcs = ["arithmetic.cc"],
     deps = [
         "//base",
+        ":util",
         "@googletest//:gtest_main",
     ],
     size = "small",

--- a/base/test/arithmetic.cc
+++ b/base/test/arithmetic.cc
@@ -85,12 +85,12 @@ TEST(arithmetic, gcd) {
 
 TEST(arithmetic, staircase_sum_bounds) {
   // Not the same slope
-  ASSERT_EQ(staircase_sum_bounds(0, 1, 1, 0, 1, 1), std::nullopt);
-  ASSERT_EQ(staircase_sum_bounds(0, 2, 1, 0, 1, -1), std::nullopt);
+  ASSERT_EQ(staircase_sum_bounds(0, 1, 1, 0, 1, 1), interval<int>{});
+  ASSERT_EQ(staircase_sum_bounds(0, 2, 1, 0, 1, -1), interval<int>{});
 
-  ASSERT_EQ(staircase_sum_bounds(0, 1, 1, 0, 1, -1), std::make_pair(0, 0));
-  ASSERT_EQ(staircase_sum_bounds(0, 1, 3, 0, 1, -3), std::make_pair(0, 0));
-  ASSERT_EQ(staircase_sum_bounds(0, 4, 1, 0, -4, 1), std::make_pair(0, 0));
+  ASSERT_EQ(staircase_sum_bounds(0, 1, 1, 0, 1, -1), interval<int>(0));
+  ASSERT_EQ(staircase_sum_bounds(0, 1, 3, 0, 1, -3), interval<int>(0));
+  ASSERT_EQ(staircase_sum_bounds(0, 4, 1, 0, -4, 1), interval<int>(0));
 
   // Generate random staircases, check against brute force.
   const int max_abs_bc = 16;
@@ -115,11 +115,13 @@ TEST(arithmetic, staircase_sum_bounds) {
 
     auto bounds = staircase_sum_bounds(a1, b1, c1, a2, b2, c2);
     if (b1 * c2 == -b2 * c1 && ((b1 != 0) == (b2 != 0))) {
-      ASSERT_TRUE(bounds);
-      ASSERT_EQ(min, bounds->first);
-      ASSERT_EQ(max, bounds->second);
+      ASSERT_TRUE(bounds.min);
+      ASSERT_TRUE(bounds.max);
+      ASSERT_EQ(min, *bounds.min);
+      ASSERT_EQ(max, *bounds.max);
     } else {
-      ASSERT_FALSE(bounds);
+      ASSERT_FALSE(bounds.min);
+      ASSERT_FALSE(bounds.max);
     }
   }
 }

--- a/base/test/arithmetic.cc
+++ b/base/test/arithmetic.cc
@@ -1,8 +1,10 @@
 #include <gtest/gtest.h>
 
 #include <cstdlib>
+#include <random>
 
 #include "base/arithmetic.h"
+#include "base/test/seeded_test.h"
 
 namespace slinky {
 
@@ -79,6 +81,47 @@ TEST(arithmetic, gcd) {
   ASSERT_EQ(gcd(3, 5), 1);
   ASSERT_EQ(gcd(4, 8), 4);
   ASSERT_EQ(gcd(15, 25), 5);
+}
+
+TEST(arithmetic, staircase_sum_bounds) {
+  // Not the same slope
+  ASSERT_EQ(staircase_sum_bounds(0, 1, 1, 0, 1, 1), std::nullopt);
+  ASSERT_EQ(staircase_sum_bounds(0, 2, 1, 0, 1, -1), std::nullopt);
+
+  ASSERT_EQ(staircase_sum_bounds(0, 1, 1, 0, 1, -1), std::make_pair(0, 0));
+  ASSERT_EQ(staircase_sum_bounds(0, 1, 3, 0, 1, -3), std::make_pair(0, 0));
+  ASSERT_EQ(staircase_sum_bounds(0, 4, 1, 0, -4, 1), std::make_pair(0, 0));
+
+  // Generate random staircases, check against brute force.
+  const int max_abs_bc = 16;
+  gtest_seeded_mt19937 rng;
+  std::uniform_int_distribution<int> a_dist{-1000, 1000};
+  std::uniform_int_distribution<int> bc_dist{-max_abs_bc, max_abs_bc};
+  for (auto _ : fuzz_test(std::chrono::seconds(1))) {
+    const int a1 = a_dist(rng);
+    const int a2 = a_dist(rng);
+    const int b1 = bc_dist(rng);
+    const int c1 = bc_dist(rng);
+    const int b2 = bc_dist(rng);
+    const int c2 = -euclidean_div(c1 * b2, b1);
+
+    int min = std::numeric_limits<int>::max();
+    int max = std::numeric_limits<int>::min();
+    for (int x = -max_abs_bc * max_abs_bc; x < max_abs_bc * max_abs_bc; ++x) {
+      const int y = euclidean_div(x + a1, b1) * c1 + euclidean_div(x + a2, b2) * c2;
+      min = std::min(y, min);
+      max = std::max(y, max);
+    }
+
+    auto bounds = staircase_sum_bounds(a1, b1, c1, a2, b2, c2);
+    if (b1 * c2 == -b2 * c1 && ((b1 != 0) == (b2 != 0))) {
+      ASSERT_TRUE(bounds);
+      ASSERT_EQ(min, bounds->first);
+      ASSERT_EQ(max, bounds->second);
+    } else {
+      ASSERT_FALSE(bounds);
+    }
+  }
 }
 
 }  // namespace slinky

--- a/builder/rewrite.h
+++ b/builder/rewrite.h
@@ -579,11 +579,11 @@ SLINKY_UNIQUE index_t substitute(
   index_t a2 = substitute(r.a2, ctx, overflowed);
   index_t b2 = substitute(r.b2, ctx, overflowed);
   index_t c2 = substitute(r.c2, ctx, overflowed);
-  auto bounds = staircase_sum_bounds(a1, b1, c1, a2, b2, c2);
+  interval<int> bounds = staircase_sum_bounds(a1, b1, c1, a2, b2, c2);
   if (r.bound_sign < 0) {
-    return bounds ? bounds->first : std::numeric_limits<index_t>::min();
+    return bounds.min ? *bounds.min : std::numeric_limits<index_t>::min();
   } else {
-    return bounds ? bounds->second : std::numeric_limits<index_t>::max();
+    return bounds.max ? *bounds.max : std::numeric_limits<index_t>::max();
   }
 }
 

--- a/builder/rewrite.h
+++ b/builder/rewrite.h
@@ -39,6 +39,10 @@ struct match_context {
 };
 
 template <int matched>
+SLINKY_UNIQUE bool match(index_t p, index_t x, match_context&) {
+  return p == x;
+}
+template <int matched>
 SLINKY_UNIQUE bool match(index_t p, expr_ref x, match_context&) {
   return is_constant(x, p);
 }

--- a/builder/simplify_bounds.cc
+++ b/builder/simplify_bounds.cc
@@ -58,8 +58,8 @@ interval_expr bounds_of_less(const T* op, interval_expr a, interval_expr b) {
 // like ((x + c0) / c1) * c2.
 void tighten_correlated_bounds_stairs(interval_expr& bounds, const expr& a, const expr& b, int sign_b) {
   match_context lhs, rhs;
-  if (!match(lhs, staircase(x, c2, c0, c1), a, eval(c0 > 0)) ||
-      !match(rhs, staircase(x, c2, c0, c1), b, eval(c0 > 0))) {
+  if (!match(lhs, staircase(x, c0, c1, c2), a) ||
+      !match(rhs, staircase(x, c0, c1, c2), b)) {
     return;
   }
   if (!match(lhs.matched(x), rhs.matched(x))) {
@@ -68,33 +68,18 @@ void tighten_correlated_bounds_stairs(interval_expr& bounds, const expr& a, cons
   }
 
   // We have a sum of two such rational expressions.
-  index_t l_c0 = lhs.matched(c0);
-  index_t l_c1 = lhs.matched(c1);
-  index_t r_c0 = rhs.matched(c0);
-  index_t r_c1 = rhs.matched(c1) * sign_b;
-  index_t l_c2 = lhs.matched(c2);
-  index_t r_c2 = rhs.matched(c2);
+  index_t la = lhs.matched(c0);
+  index_t lb = lhs.matched(c1);
+  index_t lc = lhs.matched(c2);
+  index_t ra = rhs.matched(c0);
+  index_t rb = rhs.matched(c1);
+  index_t rc = rhs.matched(c2) * sign_b;
 
-  if (l_c1 * r_c0 != -r_c1 * l_c0) {
-    // The ratios of the two sides aren't the same, we can't tighten the bounds.
-    return;
+  std::optional<std::pair<int, int>> constant_bounds = staircase_sum_bounds(la, lb, lc, ra, rb, rc);
+  if (constant_bounds) {
+    bounds.min = simplify(static_cast<const class max*>(nullptr), bounds.min, constant_bounds->first);
+    bounds.max = simplify(static_cast<const class min*>(nullptr), bounds.max, constant_bounds->second);
   }
-
-  // The ratios of the two sides are equal. The value of this expression is a periodic pattern.
-  // We need to search the period for the min and max.
-  // If these constants get so big, we need to revisit this algorithm.
-  assert(l_c0 < 1024);
-  assert(r_c0 < 1024);
-  index_t min = std::numeric_limits<index_t>::max();
-  index_t max = std::numeric_limits<index_t>::min();
-  index_t period = lcm(std::abs(l_c0), std::abs(r_c0));
-  for (index_t x = 0; x < period; ++x) {
-    index_t y = floor_div(x + l_c2, l_c0) * l_c1 + floor_div(x + r_c2, r_c0) * r_c1;
-    min = std::min(min, y);
-    max = std::max(max, y);
-  }
-  bounds.min = simplify(static_cast<const class max*>(nullptr), bounds.min, min);
-  bounds.max = simplify(static_cast<const class min*>(nullptr), bounds.max, max);
 }
 
 // We can tighten the upper bounds of expressions like min(x, y) - max(z, w) when x or y is correlated to z or w in a

--- a/builder/simplify_bounds.cc
+++ b/builder/simplify_bounds.cc
@@ -58,8 +58,7 @@ interval_expr bounds_of_less(const T* op, interval_expr a, interval_expr b) {
 // like ((x + c0) / c1) * c2.
 void tighten_correlated_bounds_stairs(interval_expr& bounds, const expr& a, const expr& b, int sign_b) {
   match_context lhs, rhs;
-  if (!match(lhs, staircase(x, c0, c1, c2), a) ||
-      !match(rhs, staircase(x, c0, c1, c2), b)) {
+  if (!match(lhs, staircase(x, c0, c1, c2), a) || !match(rhs, staircase(x, c0, c1, c2), b)) {
     return;
   }
   if (!match(lhs.matched(x), rhs.matched(x))) {
@@ -75,11 +74,9 @@ void tighten_correlated_bounds_stairs(interval_expr& bounds, const expr& a, cons
   index_t rb = rhs.matched(c1);
   index_t rc = rhs.matched(c2) * sign_b;
 
-  std::optional<std::pair<int, int>> constant_bounds = staircase_sum_bounds(la, lb, lc, ra, rb, rc);
-  if (constant_bounds) {
-    bounds.min = simplify(static_cast<const class max*>(nullptr), bounds.min, constant_bounds->first);
-    bounds.max = simplify(static_cast<const class min*>(nullptr), bounds.max, constant_bounds->second);
-  }
+  interval<int> sb = staircase_sum_bounds(la, lb, lc, ra, rb, rc);
+  if (sb.min) bounds.min = simplify(static_cast<const class max*>(nullptr), bounds.min, *sb.min);
+  if (sb.max) bounds.max = simplify(static_cast<const class min*>(nullptr), bounds.max, *sb.max);
 }
 
 // We can tighten the upper bounds of expressions like min(x, y) - max(z, w) when x or y is correlated to z or w in a

--- a/builder/simplify_rules.h
+++ b/builder/simplify_rules.h
@@ -542,6 +542,7 @@ bool apply_div_rules(Fn&& apply) {
       apply(x/x, x != 0) ||
 
       apply((y + x/c0)/c1, (x + y*c0)/eval(c0*c1), c0 > 0 && c1 > 0) ||
+      apply((y - x/c0)/c1, (y*c0 - x + eval(c0 - 1))/eval(c0*c1), c0 > 0 && c1 > 0) ||
       apply((x/c0)/c1, x/eval(c0*c1), c0 > 0 && c1 > 0) ||
       apply((x*c0)/c1, x*eval(c0/c1), c1 > 0 && c0%c1 == 0) ||
       apply((x*c0)/c1, x/eval(c1/c0), c0 > 0 && c1 > 0 && c1%c0 == 0) ||

--- a/builder/simplify_rules.h
+++ b/builder/simplify_rules.h
@@ -170,34 +170,14 @@ bool apply_min_rules(Fn&& apply) {
       apply(min(y/c0 + c1, x/c0),
         min(x, y + eval(c1*c0))/c0, c0 > 0,
         max(x, y + eval(c1*c0))/c0, c0 < 0) ||
-
-      apply(min(((x + c2)/c3)*c4, (x + c0)/c1),
-        (x + c0)/c1, c0 + c3 - c1 <= c2 && c1 > 0 && c3 > 0 && c1*c4 == c3,
-        ((x + c2)/c3)*c4, c2 <= c0 && c1 > 0 && c3 > 0 && c1*c4 == c3) ||
-      apply(min(((x + c2)/c3)*c4, x/c1),
-        x/c1, c3 - c1 <= c2 && c1 > 0 && c3 > 0 && c1*c4 == c3,
-        ((x + c2)/c3)*c4, c2 <= 0 && c1 > 0 && c3 > 0 && c1*c4 == c3) ||
-      apply(min((x/c3)*c4, (x + c0)/c1),
-        (x + c0)/c1, c0 + c3 - c1 <= 0 && c1 > 0 && c3 > 0 && c1*c4 == c3,
-        (x/c3)*c4, 0 <= c0 && c1 > 0 && c3 > 0 && c1*c4 == c3) ||
-      apply(min(x/c1 + c0, (x/c3)*c4), (x/c3)*c4, c0 > 0 && c1 > 0 && c3 > 0 && c1*c4 == c3) ||
-      apply(min((x/c3)*c4, x/c1), (x/c3)*c4, c1 > 0 && c3 > 0 && c1*c4 == c3) ||
-
+        
       // https://github.com/halide/Halide/blob/f4c78317887b6df4d2486e1f81e81f9012943f0f/src/Simplify_Min.cpp#L115-L129
-      // Compare x to a stair-step function in x
-      apply(min(x, ((x + c0)/c1)*c1 + c2),
+      apply(min(staircase(x, c2, c3, c4), (x + c0)/c1),
+        (x + c0)/c1, c0 + c3 - c1 <= c2 && c1 > 0 && c3 > 0 && c1*c4 == c3,
+        staircase(x, c2, c3, c4), c2 <= c0 && c1 > 0 && c3 > 0 && c1*c4 == c3) ||
+      apply(min(x, staircase(x, c0, c1, c1) + c2),
         x, c1 > 0 && c0 + c2 >= c1 - 1,
-        ((x + c0)/c1)*c1 + c2, c1 > 0 && c0 + c2 <= 0) ||
-      apply(min((x/c1)*c1 + c2, (x/c0)*c0), (x/c0)*c0, c1 > 0 && c2 >= c1 && c0 != 0) ||
-      // Special cases where c0 or c2 is zero
-      apply(min(x, (x/c1)*c1 + c2),
-        x, c1 > 0 && c2 >= c1 - 1,
-        (x/c1)*c1 + c2, c1 > 0 && c2 <= 0) ||
-      apply(min(x, ((x + c0)/c1)*c1),
-        x, c1 > 0 && c0 >= c1 - 1,
-        ((x + c0)/c1)*c1, c1 > 0 && c0 <= 0) ||
-
-      apply(min(x, (x/c0)*c0), (x/c0)*c0, c0 > 0) ||
+        staircase(x, c0, c1, c1) + c2, c1 > 0 && c0 + c2 <= 0) ||
 
       apply(min(x, abs(x)), x) ||
 
@@ -345,34 +325,14 @@ bool apply_max_rules(Fn&& apply) {
         max(x, y + eval(c1*c0))/c0, c0 > 0,
         min(x, y + eval(c1*c0))/c0, c0 < 0) ||
  
-      apply(max(((x + c2)/c3)*c4, (x + c0)/c1),
-        (x + c0)/c1, c2 <= c0 && c1 > 0 && c3 > 0 && c1*c4 == c3,
-        ((x + c2)/c3)*c4, c0 + c3 - c1 <= c2 && c1 > 0 && c3 > 0 && c1*c4 == c3) ||
-      apply(max(((x + c2)/c3)*c4, x/c1),
-        x/c1, c2 <= 0 && c1 > 0 && c3 > 0 && c1*c4 == c3,
-        ((x + c2)/c3)*c4, c3 - c1 <= c2 && c1 > 0 && c3 > 0 && c1*c4 == c3) ||
-      apply(max((x/c3)*c4, (x + c0)/c1),
-        (x + c0)/c1, 0 <= c0 && c1 > 0 && c3 > 0 && c1*c4 == c3,
-        (x/c3)*c4, c0 + c3 - c1 <= 0 && c1 > 0 && c3 > 0 && c1*c4 == c3) ||
-      apply(max(x/c1 + c0, (x/c3)*c4), x/c1 + c0, c0 > 0 && c1 > 0 && c3 > 0 && c1*c4 == c3) ||
-      apply(max((x/c3)*c4, x/c1), x/c1, c1 > 0 && c3 > 0 && c1*c4 == c3) ||
-
       // https://github.com/halide/Halide/blob/f4c78317887b6df4d2486e1f81e81f9012943f0f/src/Simplify_Max.cpp#L115-L129
-      // Compare x to a stair-step function in x
-      apply(max(x, ((x + c0)/c1)*c1 + c2),
-        ((x + c0)/c1)*c1 + c2, c1 > 0 && c0 + c2 >= c1 - 1,
+      apply(max(staircase(x, c2, c3, c4), (x + c0)/c1),
+        (x + c0)/c1, c2 <= c0 && c1 > 0 && c3 > 0 && c1*c4 == c3,
+        staircase(x, c2, c3, c4), c0 + c3 - c1 <= c2 && c1 > 0 && c3 > 0 && c1*c4 == c3) ||
+      apply(max(x, staircase(x, c0, c1, c1) + c2),
+        staircase(x, c0, c1, c1) + c2, c1 > 0 && c0 + c2 >= c1 - 1,
         x, c1 > 0 && c0 + c2 <= 0) ||
-      apply(max((x/c1)*c1 + c2, (x/c0)*c0), (x/c1)*c1 + c2, c2 >= c1 && c1 > 0 && c0 != 0) ||
-      // Special cases where c0 or c2 is zero
-      apply(max(x, (x/c1)*c1 + c2),
-        (x/c1)*c1 + c2, c1 > 0 && c2 >= c1 - 1,
-        x, c1 > 0 && c2 <= 0) ||
-      apply(max(x, ((x + c0)/c1)*c1),
-        x, c1 > 0 && c0 <= 0,
-        ((x + c0)/c1)*c1, c1 > 0 && c0 >= c1 - 1) ||
 
-      apply(max(x, (x/c0)*c0), x, c0 > 0) ||
-        
       apply(max(x, abs(x)), abs(x)) ||
 
       false;
@@ -624,22 +584,18 @@ bool apply_less_rules(Fn&& apply) {
 
       // These rules taken from:
       // https://github.com/halide/Halide/blob/e3d3c8cacfe6d664a8994166d0998f362bf55ce8/src/Simplify_LT.cpp#L340-L397
-      apply(w + ((x + c0)/c1)*c1 < x + z, w + c0 < z + (x + c0)%c1, c1 > 0) ||
-      apply(x + z < w + ((x + c0)/c1)*c1, z + (x + c0)%c1 < w + c0, c1 > 0) ||
-      apply(((x + c0)/c1)*c1 < x + z, c0 < z + (x + c0)%c1, c1 > 0) ||
-      apply(x + z < ((x + c0)/c1)*c1, z + (x + c0)%c1 < c0, c1 > 0) ||
-      apply(w + ((x + c0)/c1)*c1 < x, w + c0 < (x + c0)%c1, c1 > 0) ||
-      apply(x < w + ((x + c0)/c1)*c1, (x + c0)%c1 < w + c0, c1 > 0) ||
-      apply(w + (x/c1)*c1 < x + z, w < z + x%c1, c1 > 0) ||
-      apply(x + z < w + (x/c1)*c1, z + x%c1 < w, c1 > 0) ||
-      apply(((x + c0)/c1)*c1 < x, c0 < (x + c0)%c1, c1 > 0) ||
-      apply(x < ((x + c0)/c1)*c1, (x + c0)%c1 < c0, c1 > 0) ||
-      apply((x/c1)*c1 < x + z, 0 < z + x%c1, c1 > 0) ||
-      apply(x + z < (x/c1)*c1, z + x%c1 < 0, c1 > 0) ||
-      apply(w + (x/c1)*c1 < x, w < x%c1, c1 > 0) ||
-      apply(x < w + (x/c1)*c1, x%c1 < w, c1 > 0) ||
-      apply((x/c1)*c1 < x, x%c1 != 0, c1 > 0) ||
-      apply(x < (x/c1)*c1, false, c1 > 0) ||
+      apply(w + staircase(x, c0, c1, c1) < x + z, w + c0 < z + (x + c0)%c1, c1 > 0) ||
+      apply(x + z < w + staircase(x, c0, c1, c1), z + (x + c0)%c1 < w + c0, c1 > 0) ||
+      apply(staircase(x, c0, c1, c1) < x + z, c0 < z + (x + c0)%c1, c1 > 0) ||
+      apply(x + z < staircase(x, c0, c1, c1), z + (x + c0)%c1 < c0, c1 > 0) ||
+      apply(w + staircase(x, c0, c1, c1) < x, w + c0 < (x + c0)%c1, c1 > 0) ||
+      apply(x < w + staircase(x, c0, c1, c1), (x + c0)%c1 < w + c0, c1 > 0) ||
+      apply(staircase(x, c0, c1, c1) < x,
+        c0 < (x + c0)%c1, c1 > 0 && c0 != 0,
+        x%c1 != 0, c1 > 0 /*&& c0 == 0*/) ||
+      apply(x < staircase(x, c0, c1, c1), 
+        (x + c0)%c1 < c0, c1 > 0 && c0 != 0,
+        false, c1 > 0 /*&& c0 == 0*/) ||
 
       apply(x%c0 < c1,
         true, c0 > 0 && c0 <= c1,

--- a/builder/simplify_rules.h
+++ b/builder/simplify_rules.h
@@ -61,6 +61,7 @@ bool apply_min_rules(Fn&& apply) {
       apply(min(x, max(x, y)), x) ||
 
       // Similar rules but with added constants.
+      apply(min(max(y, x + c0) + c1, max(z, x + c2)), max(x + c2, min(z, y + c1)), eval(c0 + c1 == c2)) ||
       apply(min(x, min(y, x + c0) + c1),
         min(x, y + c1), c0 + c1 >= 0,
         min(y, x + c0) + c1 /*c0 + c1 < 0*/) ||
@@ -234,6 +235,7 @@ bool apply_max_rules(Fn&& apply) {
       apply(max(x, min(x, y)), x) ||
 
       // Similar rules but with added constants.
+      apply(max(min(y, x + c0) + c1, min(z, x + c2)), min(x + c2, max(z, y + c1)), eval(c0 + c1 == c2)) ||
       apply(max(x, max(y, x + c0) + c1),
         max(x, y + c1), c0 + c1 <= 0,
         max(y, x + c0) + c1 /*c0 + c1 > 0)*/) ||

--- a/builder/test/simplify/simplify.cc
+++ b/builder/test/simplify/simplify.cc
@@ -223,6 +223,14 @@ TEST(simplify, basic) {
   ASSERT_THAT(simplify(min(min(x / 16 + -2, y) + 1, min(y + 1, x / 16)) + 2), matches(min(y, x / 16 + -2) + 3));
 }
 
+TEST(simplify, staircase) {
+  ASSERT_THAT(simplify(min(((x + 7) / 8) * 8, x)), matches(x));
+  ASSERT_THAT(simplify(max(((x + 7) / 8) * 8, x)), matches(((x + 7) / 8) * 8));
+
+  ASSERT_THAT(simplify(max((x / 8) * 8, x)), matches(x));
+  ASSERT_THAT(simplify(min((x / 8) * 8, x)), matches((x / 8) * 8));
+}
+
 TEST(simplify, let) {
   // lets that should be removed
   ASSERT_THAT(simplify(let::make(x, y, z)), matches(z));                      // Dead let


### PR DESCRIPTION
This PR adds the `staircase` pattern helper, which makes it a lot less annoying to handle the various special cases for rules that want to match things like `((x + a)/b)*c`, where a could be 0, and b or c could be 1. 