### PR TITLE
Every task is a loop in the thread pool

### DIFF
--- a/base/thread_pool.cc
+++ b/base/thread_pool.cc
@@ -9,8 +9,6 @@
 
 namespace slinky {
 
-thread_pool::task_id thread_pool::unique_task_id = &thread_pool::unique_task_id;
-
 thread_pool_impl::thread_pool_impl(int workers, task_ref init) : stop_(false) {
   auto worker = [this, init]() {
     if (init) init();
@@ -37,28 +35,32 @@ void thread_pool_impl::run_worker(predicate_ref condition) {
 
 namespace {
 
-thread_local std::vector<thread_pool::task_id> task_stack;
+thread_local std::vector<const void*> task_stack;
 
 }  // namespace
 
-thread_pool::task_id thread_pool_impl::dequeue(task& t) {
-  for (auto i = task_queue_.begin(); i != task_queue_.end(); ++i) {
-    task_id id = std::get<2>(*i);
-    if (id != unique_task_id && std::find(task_stack.begin(), task_stack.end(), id) != task_stack.end()) {
-      // Don't enqueue the same task multiple times on the same thread.
+std::shared_ptr<thread_pool::loop> thread_pool_impl::dequeue(loop_task& t) {
+  for (auto i = task_queue_.begin(); i != task_queue_.end();) {
+    std::shared_ptr<thread_pool::loop> loop = std::get<1>(*i);
+    if (std::find(task_stack.begin(), task_stack.end(), &*loop) != task_stack.end()) {
+      // Don't run the same loop multiple times on the same thread.
+      ++i;
       continue;
     }
-    int& task_count = std::get<0>(*i);
-    if (task_count == 1) {
-      t = std::move(std::get<1>(*i));
-      task_queue_.erase(i);
-      return id;
-    } else {
-      assert(task_count > 1);
-      task_count -= 1;
-      t = std::get<1>(*i);
-      return id;
+    size_t iterations_remaining = loop->count_remaining_iterations();
+    if (iterations_remaining == 0) {
+      // No more threads can start working on this loop.
+      i = task_queue_.erase(i);
+      continue;
     }
+    t = std::get<2>(*i);
+    int& max_workers = std::get<0>(*i);
+    assert(max_workers > 0);
+    if (--max_workers == 0 || iterations_remaining == 1) {
+      // No more workers for this loop.
+      task_queue_.erase(i);
+    }
+    return loop;
   }
   return nullptr;
 }
@@ -70,11 +72,11 @@ void thread_pool_impl::wait_for(predicate_ref condition, std::condition_variable
 
   std::unique_lock l(mutex_);
   while (!condition()) {
-    task t;
-    if (task_id id = dequeue(t)) {
+    loop_task t;
+    if (auto loop = dequeue(t)) {
       l.unlock();
-      task_stack.push_back(id);
-      t();
+      task_stack.push_back(&*loop);
+      loop->run(t);
       task_stack.pop_back();
       l.lock();
       // Notify the helper CV, helpers might be waiting for a condition that the task changed the value of.
@@ -98,37 +100,26 @@ void thread_pool_impl::atomic_call(task_ref t) {
   cv_helper_.notify_all();
 }
 
-void thread_pool_impl::enqueue(int n, task t, task_id id) {
-  if (n <= 0) return;
-  std::unique_lock l(mutex_);
-  task_queue_.push_back({n, std::move(t), id});
-  cv_worker_.notify_all();
-  cv_helper_.notify_all();
-}
 
-void thread_pool_impl::enqueue(task t, task_id id) {
+std::shared_ptr<thread_pool::loop> thread_pool_impl::enqueue(std::size_t n, loop_task t, int max_workers) {
+  auto loop = std::make_shared<thread_pool::loop>(n);
   std::unique_lock l(mutex_);
-  task_queue_.push_back({1, std::move(t), id});
-  cv_worker_.notify_one();
-  cv_helper_.notify_one();
-}
-
-void thread_pool_impl::run(task_ref t, task_id id) {
-  assert(id == unique_task_id || std::find(task_stack.begin(), task_stack.end(), id) == task_stack.end());
-  task_stack.push_back(id);
-  t();
-  task_stack.pop_back();
-}
-
-void thread_pool_impl::cancel(task_id id) {
-  std::unique_lock l(mutex_);
-  for (auto i = task_queue_.begin(); i != task_queue_.end();) {
-    if (std::get<2>(*i) == id) {
-      i = task_queue_.erase(i);
-    } else {
-      ++i;
-    }
+  task_queue_.push_back({max_workers, loop, std::move(t)});
+  if (n == 1 || max_workers == 1) {
+    cv_worker_.notify_one();
+    cv_helper_.notify_one();
+  } else {
+    cv_worker_.notify_all();
+    cv_helper_.notify_all();
   }
+  return loop;
+}
+
+void thread_pool_impl::work_on_loop(loop& l, loop_task body) {
+  assert(std::find(task_stack.begin(), task_stack.end(), &l) == task_stack.end());
+  task_stack.push_back(&l);
+  l.run(body);
+  task_stack.pop_back();
 }
 
 }  // namespace slinky

--- a/base/thread_pool.cc
+++ b/base/thread_pool.cc
@@ -53,12 +53,14 @@ std::shared_ptr<thread_pool::loop> thread_pool_impl::dequeue(loop_task& t) {
       i = task_queue_.erase(i);
       continue;
     }
-    t = std::get<2>(*i);
     int& max_workers = std::get<0>(*i);
     assert(max_workers > 0);
     if (--max_workers == 0 || iterations_remaining == 1) {
       // No more workers for this loop.
+      t = std::move(std::get<2>(*i));
       task_queue_.erase(i);
+    } else {
+      t = std::get<2>(*i);
     }
     return loop;
   }

--- a/base/thread_pool.h
+++ b/base/thread_pool.h
@@ -108,7 +108,8 @@ public:
 
   virtual int thread_count() const = 0;
 
-  // Enqueues a loop task over `n` iterations.
+  // Enqueues a loop task over `n` iterations. The tasks queued in this thread pool are instances of `parallel_for<>`
+  // plus a loop task `t` that executes each iteration. Tasks are complete when all `n` of the iterations are done.
   virtual std::shared_ptr<loop> enqueue(
       std::size_t n, loop_task t, int max_workers = std::numeric_limits<int>::max()) = 0;
   // Run the task on the current thread, and prevents tasks enqueued by `enqueue` from running recursively.

--- a/base/thread_pool.h
+++ b/base/thread_pool.h
@@ -81,6 +81,16 @@ public:
     todo_ -= done;
   }
 
+  // Return the number of loop iterations that have not started yet. This returns an upper bound, by the time the
+  // function returns some of the counted iterations may have already been started by another thread.
+  std::size_t count_remaining_iterations() const {
+    std::size_t result = 0;
+    for (const task& k : tasks_) {
+      result += k.end - k.i;
+    }
+    return result;
+  }
+
   bool done() const { return todo_ == 0; }
 };
 
@@ -88,9 +98,8 @@ public:
 // It is not directly used by anything except for testing.
 class thread_pool {
 public:
-  using task_id = const void*;
-  static task_id unique_task_id;
-  using task = std::function<void()>;
+  using loop = slinky::parallel_for<>;
+  using loop_task = std::function<void(std::size_t)>;
   using task_ref = function_ref<void()>;
   using predicate = std::function<bool()>;
   using predicate_ref = function_ref<bool()>;
@@ -99,19 +108,23 @@ public:
 
   virtual int thread_count() const = 0;
 
-  // Enqueues `n` copies of task `t` on the thread pool queue. This guarantees that `t` will not
-  // be run recursively on the same thread while in `wait_for`.
-  virtual void enqueue(int n, task t, task_id id = unique_task_id) = 0;
-  virtual void enqueue(task t, task_id id = unique_task_id) = 0;
+  // Enqueues a loop task over `n` iterations.
+  virtual std::shared_ptr<loop> enqueue(
+      std::size_t n, loop_task t, int max_workers = std::numeric_limits<int>::max()) = 0;
   // Run the task on the current thread, and prevents tasks enqueued by `enqueue` from running recursively.
-  virtual void run(task_ref t, task_id id = unique_task_id) = 0;
-  // Cancel tasks previously enqueued with the given `id`.
-  virtual void cancel(task_id id) {}
+  virtual void work_on_loop(loop& l, loop_task body) = 0;
   // Waits for `condition` to become true. While waiting, executes tasks on the queue.
   // The condition is executed atomically.
   virtual void wait_for(predicate_ref condition) = 0;
   // Run `t` on the calling thread, but atomically w.r.t. other `atomic_call` and `wait_for` conditions.
   virtual void atomic_call(task_ref t) = 0;
+
+  // Enqueues a singleton task.
+  template <typename Fn>
+  void enqueue(Fn t) {
+    // Make a dummy loop task with one iteration.
+    enqueue(1, [t = std::move(t)](std::size_t) { t(); });
+  }
 
   template <typename Fn>
   void parallel_for(std::size_t n, Fn&& body, int max_workers = std::numeric_limits<int>::max()) {
@@ -122,23 +135,17 @@ public:
       return;
     }
 
-    auto loop = std::make_shared<slinky::parallel_for<>>(n);
-
-    // Capture n by value becuase this may run after the parallel_for call returns.
-    auto worker = [this, loop, body = std::move(body)]() mutable {
-      loop->run(body);
-      // If we get here, there's no more work to start. Cancel any remaining tasks.
-      cancel(loop.get());
-    };
-    int workers = std::min<int>(max_workers, std::min<std::size_t>(thread_count() + 1, n));
-    if (workers > 1) {
-      enqueue(workers - 1, worker, loop.get());
-    }
-    // Running the worker here guarantees forward progress on the loop even if no threads in the thread pool are
+    assert(max_workers > 1);
+    auto loop = enqueue(n, body, max_workers - 1);
+    assert(loop);
+    // Working on the loop here guarantees forward progress on the loop even if no threads in the thread pool are
     // available.
-    run(worker, loop.get());
-    // While the loop still isn't done, work on other tasks.
-    wait_for([&]() { return loop->done(); });
+    work_on_loop(*loop, std::move(body));
+    // While the loop still isn't done, work on other tasks. Checking before calling `wait_for` helps because we
+    // don't need to call `loop->done` atomically.
+    if (!loop->done()) {
+      wait_for([&]() { return loop->done(); });
+    }
   }
 };
 
@@ -151,7 +158,7 @@ private:
   std::vector<std::thread> threads_;
   std::atomic<bool> stop_;
 
-  using queued_task = std::tuple<int, task, task_id>;
+  using queued_task = std::tuple<int, std::shared_ptr<loop>, loop_task>;
   std::deque<queued_task> task_queue_;
   std::mutex mutex_;
   // We have two condition variables in an attempt to minimize unnecessary thread wakeups:
@@ -164,7 +171,7 @@ private:
 
   void wait_for(predicate_ref condition, std::condition_variable& cv);
 
-  task_id dequeue(task& t);
+  std::shared_ptr<loop> dequeue(loop_task& t);
 
 public:
   // `workers` indicates how many worker threads the thread pool will have.
@@ -182,10 +189,8 @@ public:
 
   int thread_count() const override { return std::max<int>(expected_thread_count_, worker_count_); }
 
-  void enqueue(int n, task t, task_id id = unique_task_id) override;
-  void enqueue(task t, task_id id = unique_task_id) override;
-  void run(task_ref t, task_id id = unique_task_id) override;
-  void cancel(task_id id) override;
+  std::shared_ptr<loop> enqueue(std::size_t n, loop_task t, int max_workers) override;
+  void work_on_loop(loop& l, loop_task body) override;
   void wait_for(predicate_ref condition) override { wait_for(condition, cv_helper_); }
   void atomic_call(task_ref t) override;
 };

--- a/builder/test/tile_area.cc
+++ b/builder/test/tile_area.cc
@@ -84,16 +84,6 @@ TEST(tile_area, pipeline) {
   }
 }
 
-class test_thread_pool_impl : public thread_pool_impl {
-public:
-  void run(task_ref t, task_id id = unique_task_id) override {
-    run_called = true;
-    thread_pool_impl::run(t, id);
-  }
-
-  bool run_called = false;
-};
-
 // An example of two 2D elementwise operations in sequence.
 TEST(conditional_parallel, pipeline) {
   // Make the pipeline
@@ -139,8 +129,6 @@ TEST(conditional_parallel, pipeline) {
       const raw_buffer* inputs[] = {&in_buf};
       const raw_buffer* outputs[] = {&out_buf};
       test_context eval_ctx;
-      test_thread_pool_impl tp;
-      eval_ctx.config.thread_pool = &tp;
       p.evaluate(args, inputs, outputs, eval_ctx);
 
       for (int y = 0; y < H; ++y) {
@@ -148,8 +136,6 @@ TEST(conditional_parallel, pipeline) {
           ASSERT_EQ(out_buf(x, y), 2 * (y * W + x) + 1);
         }
       }
-
-      ASSERT_EQ(tp.run_called, max_x != loop::serial || max_y != loop::serial);
     }
   }
 }


### PR DESCRIPTION
This makes every queued task in the thread pool a `parallel_for<>` object instead of a simple task. (Tasks are now loops with `n = 1`.)

This eliminates the need for the `cancel` mechanism, which was clunky and high overhead. Now, we can simply see if any work remains *before* starting to work on a task instead of after, which eliminates a lot of unneeded worker tasks, especially in the case of nested parallel loops.