### PR TITLE
Fix not waiting for loops that were not completed by main thread but still not done

### DIFF
--- a/base/thread_pool.h
+++ b/base/thread_pool.h
@@ -59,7 +59,7 @@ public:
   }
 
   // Work on the loop. This returns when work on all items in the loop has started, but may return before all items are
-  // complete. Returns true if this call resulted in the loop being done.
+  // complete. Returns true if this call resulted in the loop being done, but the loop may not be done.
   template <typename Fn>
   bool run(const Fn& body) {
     std::size_t w = K == 1 ? 0 : worker_++;
@@ -78,7 +78,7 @@ public:
         ++done;
       }
     }
-    return (todo_ -= done) == 0 && done > 0;
+    return done > 0 && (todo_ -= done) == 0;
   }
 
   // Return the number of loop iterations that have not started yet. This returns an upper bound, by the time the
@@ -114,7 +114,8 @@ public:
   virtual std::shared_ptr<loop> enqueue(
       std::size_t n, loop_task t, int max_workers = std::numeric_limits<int>::max()) = 0;
   // Run the task on the current thread, and prevents tasks enqueued by `enqueue` from running recursively.
-  virtual bool work_on_loop(loop& l, loop_task body) = 0;
+  // Does not return until the loop is complete.
+  virtual void run(loop& l, loop_task body) = 0;
   // Waits for `condition` to become true. While waiting, executes tasks on the queue.
   // The condition is executed atomically.
   virtual void wait_for(predicate_ref condition) = 0;
@@ -146,11 +147,7 @@ public:
       auto loop = enqueue(n, body, max_workers);
       // Working on the loop here guarantees forward progress on the loop even if no threads in the thread pool are
       // available.
-      if (!work_on_loop(*loop, std::move(body))) {
-        // While the loop still isn't done, work on other tasks. Checking before calling `wait_for` helps because we
-        // don't need to call `loop->done` atomically.
-        wait_for([&]() { return loop->done(); });
-      }
+      run(*loop, std::move(body));
     }
   }
 };
@@ -196,7 +193,7 @@ public:
   int thread_count() const override { return std::max<int>(expected_thread_count_, worker_count_); }
 
   std::shared_ptr<loop> enqueue(std::size_t n, loop_task t, int max_workers) override;
-  bool work_on_loop(loop& l, loop_task body) override;
+  void run(loop& l, loop_task body) override;
   void wait_for(predicate_ref condition) override { wait_for(condition, cv_helper_); }
   void atomic_call(task_ref t) override;
 };


### PR DESCRIPTION
#671 has a theoretical bug, if the main thread working on a parallel for loop does not complete the loop, `work_on_loop` returns false, but the loop might not be done yet and we need to wait for it.

I've never seen it actually cause a test to fail, but it definitely seems like a bug.

This does a related cleanup: by moving all of the loop completion logic to be inside `thread_pool::run`, it eliminates a use of `wait_for` from the thread pool public API, which makes the thread pool API more implementable by other thread pools. There is still a use of `wait_for` in the evaluator logic, but, one step at a time.