### PR TITLE
Add optional pattern matching in the rewriter

### DIFF
--- a/builder/simplify_rules.h
+++ b/builder/simplify_rules.h
@@ -23,6 +23,8 @@ rewrite::pattern_constant<4> c4;
 rewrite::pattern_constant<5> c5;
 rewrite::pattern_constant<6> c6;
 
+using rewrite::may_be;
+
 }  // namespace
 
 // clang-format off
@@ -35,14 +37,14 @@ bool apply_min_rules(Fn&& apply) {
       apply(min(x, rewrite::positive_infinity()), x) ||
       apply(min(x, std::numeric_limits<index_t>::min()), std::numeric_limits<index_t>::min()) ||
       apply(min(x, rewrite::negative_infinity()), rewrite::negative_infinity()) ||
-      apply(min(x, x + c0), 
+      apply(min(x, x + c0),
         x, c0 > 0,
         x + c0 /*c0 < 0*/) ||
       apply(min(x, x), x) ||
       apply(min(x, y), x && y, is_boolean(x) && is_boolean(y)) ||
 
       // This might be the only rule that doesn't have an analogous max rule.
-      apply(min(max(x, c0), c1), 
+      apply(min(max(x, c0), c1),
         c0, c0 == c1,
         max(min(x, c1), c0), c0 < c1) ||
 
@@ -141,10 +143,7 @@ bool apply_min_rules(Fn&& apply) {
       apply(min(max(x, c0), max(y, c1)),
         max(min(x, max(y, c1)), c0), c0 < c1,
         max(min(y, max(x, c0)), c1), c0 > c1) ||
-      apply(min(x + c0, select(y, z + c1, w + c2)), min(x, select(y, z + eval(c1 - c0), w + eval(c2 - c0))) + c0) ||
-      apply(min(x + c0, select(y, c1, w + c2)), min(x, select(y, eval(c1 - c0), w + eval(c2 - c0))) + c0) ||
-      apply(min(x + c0, select(y, z + c1, c2)), min(x, select(y, z + eval(c1 - c0), eval(c2 - c0))) + c0) ||
-      apply(min(x + c0, select(y, c1, c2)), min(x, select(y, eval(c1 - c0), eval(c2 - c0))) + c0) ||
+      apply(min(x + c0, select(y, may_be<0>(z) + c1, may_be<0>(w) + c2)), min(x, select(y, z + eval(c1 - c0), w + eval(c2 - c0))) + c0) ||
       apply(min(select(y, c1, c2), c0), select(y, eval(min(c0, c1)), eval(min(c0, c2)))) ||
 
       // https://github.com/halide/Halide/blob/7994e7030976f9fcd321a4d1d5f76f4582e01905/src/Simplify_Min.cpp#L276-L311
@@ -152,26 +151,22 @@ bool apply_min_rules(Fn&& apply) {
         min(x, eval(c1/c0))*c0, c0 > 0 && c1%c0 == 0,
         max(x, eval(c1/c0))*c0, c0 < 0 && c1%c0 == 0) ||
 
-      apply(min(x*c0, y*c1), 
+      apply(min(x*c0, y*c1),
         min(x, y*eval(c1/c0))*c0, c0 > 0 && c1%c0 == 0,
         max(x, y*eval(c1/c0))*c0, c0 < 0 && c1%c0 == 0,
         min(y, x*eval(c0/c1))*c1, c1 > 0 && c0%c1 == 0,
         max(y, x*eval(c0/c1))*c1, c1 < 0 && c0%c1 == 0) ||
-      apply(min(y*c0 + c1, x*c0), 
+      apply(min(y*c0 + c1, x*c0),
         min(x, y + eval(c1/c0))*c0, c0 > 0 && c1%c0 == 0,
         max(x, y + eval(c1/c0))*c0, c0 < 0 && c1%c0 == 0) ||
 
-      apply(min(x/c0, y/c0),
-        min(x, y)/c0, c0 > 0,
-        max(x, y)/c0, c0 < 0) ||
+      apply(min(y/c0 + may_be<0>(c1), x/c0),
+        min(x, y + eval(c1*c0))/c0, c0 > 0,
+        max(x, y + eval(c1*c0))/c0, c0 < 0) ||
 
       apply(min(x/c0, c1),
         min(x, eval(c1*c0))/c0, c0 > 0,
         max(x, eval(c1*c0))/c0, c0 < 0) ||
-
-      apply(min(y/c0 + c1, x/c0),
-        min(x, y + eval(c1*c0))/c0, c0 > 0,
-        max(x, y + eval(c1*c0))/c0, c0 < 0) ||
 
       apply(min(staircase(x, c0, c1, c2), staircase(x, c3, c4, c5) + c6),
         staircase(x, c0, c1, c2), 0 <= staircase_sum_min(c0, c1, -c2, c3, c4, c5) + c6,
@@ -207,7 +202,7 @@ bool apply_max_rules(Fn&& apply) {
       apply(max(x, max(y, max(z, max(x, w)))), max(x, max(y, max(z, w)))) ||
       apply(max(x, max(y, max(z, max(w, max(x, u))))), max(x, max(y, max(z, max(w, u))))) ||
       apply(max(x, max(y, max(z, max(w, max(u, max(x, v)))))), max(x, max(y, max(z, max(w, max(u, v)))))) ||
-    
+
       // Similar rules but with mixes of min and max.
       apply(max(min(x, y), max(x, z)), max(x, z)) ||
       apply(max(x, max(y, min(x, z))), max(x, y)) ||
@@ -262,7 +257,7 @@ bool apply_max_rules(Fn&& apply) {
       apply(max(w + select(x, y, z), select(x, u, v)), select(x, max(u, w + y), max(v, w + z))) ||
       apply(max(w - select(x, y, z), select(x, u, v)), select(x, max(u, w - y), max(v, w - z))) ||
       apply(max(select(x, y, z) - w, select(x, u, v)), select(x, max(u, y - w), max(v, z - w))) ||
-    
+
       apply(max(select(x, y, select(z, w, u)), select(z, v, t)), select(z, max(v, select(x, y, w)), max(t, select(x, y, u)))) ||
       apply(max(select(x, select(z, w, u), y), select(z, v, t)), select(z, max(v, select(x, w, y)), max(t, select(x, u, y)))) ||
 
@@ -294,12 +289,9 @@ bool apply_max_rules(Fn&& apply) {
       apply(max(min(x, c0), min(y, c1)),
         min(max(x, min(y, c1)), c0), c0 > c1,
         min(max(y, min(x, c0)), c1), c0 < c1) ||
-      apply(max(x + c0, select(y, z + c1, w + c2)), max(x, select(y, z + eval(c1 - c0), w + eval(c2 - c0))) + c0) ||
-      apply(max(x + c0, select(y, c1, w + c2)), max(x, select(y, eval(c1 - c0), w + eval(c2 - c0))) + c0) ||
-      apply(max(x + c0, select(y, z + c1, c2)), max(x, select(y, z + eval(c1 - c0), eval(c2 - c0))) + c0) ||
-      apply(max(x + c0, select(y, c1, c2)), max(x, select(y, eval(c1 - c0), eval(c2 - c0))) + c0) ||
+      apply(max(x + c0, select(y, may_be<0>(z) + c1, may_be<0>(w) + c2)), max(x, select(y, z + eval(c1 - c0), w + eval(c2 - c0))) + c0) ||
       apply(max(select(y, c1, c2), c0), select(y, eval(max(c0, c1)), eval(max(c0, c2)))) ||
-      
+
       // https://github.com/halide/Halide/blob/7994e7030976f9fcd321a4d1d5f76f4582e01905/src/Simplify_Max.cpp#L271-L300
       apply(max(x*c0, c1),
         max(x, eval(c1/c0))*c0, c0 > 0 && c1%c0 == 0,
@@ -314,18 +306,14 @@ bool apply_max_rules(Fn&& apply) {
         max(x, y + eval(c1/c0))*c0, c0 > 0 && c1%c0 == 0,
         min(x, y + eval(c1/c0))*c0, c0 < 0 && c1%c0 == 0) ||
 
-      apply(max(x/c0, y/c0),
-        max(x, y)/c0, c0 > 0,
-        min(x, y)/c0, c0 < 0) ||
+      apply(max(y/c0 + may_be<0>(c1), x/c0),
+        max(x, y + eval(c1*c0))/c0, c0 > 0,
+        min(x, y + eval(c1*c0))/c0, c0 < 0) ||
 
       apply(max(x/c0, c1),
         max(x, eval(c1*c0))/c0, c0 > 0,
         min(x, eval(c1*c0))/c0, c0 < 0) ||
 
-      apply(max(y/c0 + c1, x/c0),
-        max(x, y + eval(c1*c0))/c0, c0 > 0,
-        min(x, y + eval(c1*c0))/c0, c0 < 0) ||
- 
       apply(max(staircase(x, c0, c1, c2), staircase(x, c3, c4, c5) + c6),
         staircase(x, c0, c1, c2), 0 >= staircase_sum_max(c0, c1, -c2, c3, c4, c5) + c6,
         staircase(x, c3, c4, c5) + c6, 0 <= staircase_sum_min(c0, c1, -c2, c3, c4, c5) + c6) ||
@@ -361,11 +349,9 @@ bool apply_add_rules(Fn&& apply) {
       apply((y - x) + (z - x), (y + z) + x*-2) ||
 
       apply(x + (c0 - y), (x - y) + c0) ||
-      apply(x + (y + c0), (x + y) + c0) ||
-      apply((x + c0) + (y + c1), (x + y) + eval(c0 + c1)) ||
+      apply((x + may_be<0>(c0)) + (y + may_be<0>(c1)), (x + y) + eval(c0 + c1), c0 != 0 || c1 != 0) ||
 
-      apply(((x + c0)/c1)*c2 + c3, ((x + eval((c3/c2)*c1 + c0))/c1)*c2, c1 != 0 && c2 != 0 && c3%c2 == 0) ||
-      apply((x + c0)/c1 + c3, (x + eval(c3*c1 + c0))/c1, c1 != 0) ||
+      apply(staircase(x, c0, c1, c2) + c3, ((x + eval((c3/c2)*c1 + c0))/c1)*c2, c0 != 0 && c1 != 0 && c2 != 0 && c3%c2 == 0) ||
 
       apply(min(x, y + c1) + c2, min(y, x + c2), c1 == -c2) ||
       apply(max(x, y + c1) + c2, max(y, x + c2), c1 == -c2) ||
@@ -373,7 +359,7 @@ bool apply_add_rules(Fn&& apply) {
       apply(z + max(x, y - (z - w)), max(x + z, y + w)) ||
       apply(z + min(x, y - z), min(y, x + z)) ||
       apply(z + max(x, y - z), max(y, x + z)) ||
-    
+
       apply(w + select(x, y, z - w), select(x, y + w, z)) ||
       apply(w + select(x, y - w, z), select(x, y, z + w)) ||
 
@@ -390,9 +376,7 @@ bool apply_sub_rules(Fn&& apply) {
       apply(x - y*c0, x + y*eval(-c0)) ||
       apply(x - (c0 - y), (x + y) + eval(-c0)) ||
       apply(c0 - (x - y), (y - x) + c0) ||
-      apply(x - (y + c0), (x - y) + eval(-c0)) ||
       apply((c0 - x) - y, c0 - (x + y)) ||
-      apply((x + c0) - y, (x - y) + c0) ||
       apply((x + y) - x, y) ||
       apply((x - y) - x, -y) ||
       apply(x - (x + y), -y) ||
@@ -401,23 +385,17 @@ bool apply_sub_rules(Fn&& apply) {
       apply((x - y) - (z - y), x - z) ||
       apply((x - y) - (x - z), z - y) ||
       apply((c0 - x) - (y - z), ((z - x) - y) + c0) ||
-      apply((x + c0) - (y + c1), (x - y) + eval(c0 - c1)) ||
+      apply((x + may_be<0>(c0)) - (y + may_be<0>(c1)), (x - y) + eval(c0 - c1), c0 != 0 || c1 != 0) ||
 
-      // These rules taken from 
+      // These rules taken from
       // https://github.com/halide/Halide/blob/e3d3c8cacfe6d664a8994166d0998f362bf55ce8/src/Simplify_Sub.cpp#L411-L421
-      apply((x + y)/c0 - (x + c1)/c0, ((y - c1) + ((x + eval(c1%c0))%c0))/c0, c0 > 0) ||
-      apply((x + c1)/c0 - (x + y)/c0, ((eval(c0 + c1 - 1) - y) - ((x + eval(c1%c0))%c0))/c0, c0 > 0) ||
-      apply((x - y)/c0 - (x + c1)/c0, (((x + eval(c1%c0))%c0) - y - c1)/c0, c0 > 0) ||
-      apply((x + c1)/c0 - (x - y)/c0, ((y + eval(c0 + c1 - 1)) - ((x + eval(c1%c0))%c0))/c0, c0 > 0) ||
-      apply(x/c0 - (x + y)/c0, ((eval(c0 - 1) - y) - (x%c0))/c0, c0 > 0) ||
-      apply((x + y)/c0 - x/c0, (y + (x%c0))/c0, c0 > 0) ||
-      apply(x/c0 - (x - y)/c0, ((y + eval(c0 - 1)) - (x%c0))/c0, c0 > 0) ||
-      apply((x - y)/c0 - x/c0, ((x%c0) - y)/c0, c0 > 0) ||
-      apply((x + y)/c0 - x/c0, (y + (x%c0))/c0, c0 > 0) ||
-
+      apply((x + y)/c0 - (x + may_be<0>(c1))/c0, ((y - c1) + ((x + eval(c1%c0))%c0))/c0, c0 > 0) ||
+      apply((x + may_be<0>(c1))/c0 - (x + y)/c0, ((eval(c0 + c1 - 1) - y) - ((x + eval(c1%c0))%c0))/c0, c0 > 0) ||
+      apply((x - y)/c0 - (x + may_be<0>(c1))/c0, (((x + eval(c1%c0))%c0) - y - c1)/c0, c0 > 0) ||
+      apply((x + may_be<0>(c1))/c0 - (x - y)/c0, ((y + eval(c0 + c1 - 1)) - ((x + eval(c1%c0))%c0))/c0, c0 > 0) ||
       apply(x - (x/c0)*c0, x%c0, c0 > 0) ||
       apply((x/c0)*c0 - x, -(x%c0), c0 > 0) ||
-    
+
       apply(c2 - min(x + c0, y + c1), max(eval(c2 - c0) - x, eval(c2 - c1) - y)) ||
       apply(c2 - max(x + c0, y + c1), min(eval(c2 - c0) - x, eval(c2 - c1) - y)) ||
       apply(c2 - min(x + c0, c1 - y), max(y + eval(c2 - c1), eval(c2 - c0) - x)) ||
@@ -432,14 +410,9 @@ bool apply_sub_rules(Fn&& apply) {
       apply(x - min(x, y), max(x - y, 0), !is_constant(x)) ||
       apply(x - max(x, y), min(x - y, 0), !is_constant(x)) ||
 
-      apply(c2 - select(x, c0, c1), select(x, eval(c2 - c0), eval(c2 - c1))) ||
-      apply(c2 - select(x, y + c0, c1), select(x, eval(c2 - c0) - y, eval(c2 - c1))) ||
-      apply(c2 - select(x, c0 - y, c1), select(x, y + eval(c2 - c0), eval(c2 - c1))) ||
-      apply(c2 - select(x, c0, y + c1), select(x, eval(c2 - c0), eval(c2 - c1) - y)) ||
-      apply(c2 - select(x, c0, c1 - y), select(x, eval(c2 - c0), y + eval(c2 - c1))) ||
-      apply(c2 - select(x, y + c0, z + c1), select(x, eval(c2 - c0) - y, eval(c2 - c1) - z)) ||
-      apply(c2 - select(x, c0 - y, z + c1), select(x, y + eval(c2 - c0), eval(c2 - c1) - z)) ||
-      apply(c2 - select(x, y + c0, c1 - z), select(x, eval(c2 - c0) - y, z + eval(c2 - c1))) ||
+      apply(c2 - select(x, may_be<0>(y) + c0, may_be<0>(z) + c1), select(x, eval(c2 - c0) - y, eval(c2 - c1) - z)) ||
+      apply(c2 - select(x, may_be<0>(y) + c0, c1 - z), select(x, eval(c2 - c0) - y, z + eval(c2 - c1))) ||
+      apply(c2 - select(x, c0 - y, may_be<0>(z) + c1), select(x, y + eval(c2 - c0), eval(c2 - c1) - z)) ||
       apply(c2 - select(x, c0 - y, c1 - z), select(x, y + eval(c2 - c0), z + eval(c2 - c1))) ||
 
       apply(max(x, y)/c0 - min(x, y)/c0, abs(x/c0 - y/c0), c0 > 0) ||
@@ -447,19 +420,15 @@ bool apply_sub_rules(Fn&& apply) {
       apply(max(x, y) - min(x, y), abs(x - y)) ||
       apply(min(x, y) - max(x, y), -abs(x - y)) ||
       apply(select(x, y, z) - select(x, w, u), select(x, y - w, z - u)) ||
-    
-      apply(select(x, y, z + w) - w, select(x, y - w, z)) ||
-      apply(select(x, y + w, z) - w, select(x, y, z - w)) ||
+
+      apply(select(x, y, may_be<0>(z) + w) - w, select(x, y - w, z)) ||
+      apply(select(x, may_be<0>(y) + w, z) - w, select(x, y, z - w)) ||
       apply(select(x, y, w - z) - w, select(x, y - w, -z)) ||
       apply(select(x, w - y, z) - w, select(x, -y, z - w)) ||
-      apply(w - select(x, y, z + w), select(x, w - y, -z)) ||
-      apply(w - select(x, y + w, z), select(x, -y, w - z)) ||
+      apply(w - select(x, y, may_be<0>(z) + w), select(x, w - y, -z)) ||
+      apply(w - select(x, may_be<0>(y) + w, z), select(x, -y, w - z)) ||
       apply(w - select(x, y, w - z), select(x, w - y, z)) ||
       apply(w - select(x, w - y, z), select(x, y, w - z)) ||
-      apply(select(x, y, z) - y, select(x, 0, z - y)) ||
-      apply(select(x, y, z) - z, select(x, y - z, 0)) ||
-      apply(y - select(x, y, z), select(x, 0, y - z)) ||
-      apply(z - select(x, y, z), select(x, z - y, 0)) ||
 
       false;
 }
@@ -479,7 +448,7 @@ bool apply_mul_rules(Fn&& apply) {
       apply((x + c0)*c1, x*c1 + eval(c0*c1)) ||
       apply((c0 - x)*c1, x*eval(-c1) + eval(c0*c1)) ||
       apply(y*(x*c0), (x*y)*c0) ||
-    
+
       apply(select(x, c0, c1)*c2, select(x, eval(c0*c2), eval(c1*c2))) ||
       apply(select(x, y, c1)*c2, select(x, y*c2, eval(c1*c2))) ||
       apply(select(x, c0, y)*c2, select(x, eval(c0*c2), y*c2)) ||
@@ -510,18 +479,14 @@ bool apply_div_rules(Fn&& apply) {
       apply((x*c0)/c1, x/eval(c1/c0), c0 > 0 && c1 > 0 && c1%c0 == 0) ||
       apply((x*y)/x, y*(x != 0)) ||
 
-      apply((x + y*c0)/c1, y*eval(c0/c1) + x/c1, c0%c1 == 0) ||
-      apply((x + c0)/c1, x/c1 + eval(c0/c1), c0%c1 == 0) ||
-      apply((y*c0 - x)/c1, y*eval(c0/c1) + (-x)/c1, c0%c1 == 0 && c0 != 0) ||
-      apply((c0 - x)/c1, (-x)/c1 + eval(c0/c1), c0%c1 == 0 && c0 != 0) ||
-    
-      apply(min(y, z + x*c0)/c1, min(x*eval(c0/c1) + z/c1, y/c1), c1 > 0 && c0%c1 == 0) ||
-      apply(max(y, z + x*c0)/c1, max(x*eval(c0/c1) + z/c1, y/c1), c1 > 0 && c0%c1 == 0) ||
+      apply((x + may_be<1>(y)*c0)/c1, y*eval(c0/c1) + x/c1, c0%c1 == 0) ||
+      apply((may_be<1>(y)*c0 - x)/c1, y*eval(c0/c1) + (-x)/c1, c0%c1 == 0 && c0 != 0) ||
+
+      apply(min(y, may_be<0>(z) + x*c0)/c1, min(x*eval(c0/c1) + z/c1, y/c1), c1 > 0 && c0%c1 == 0) ||
+      apply(max(y, may_be<0>(z) + x*c0)/c1, max(x*eval(c0/c1) + z/c1, y/c1), c1 > 0 && c0%c1 == 0) ||
       apply(min(y, x*c0 - z)/c1, min(x*eval(c0/c1) + (-z)/c1, y/c1), c1 > 0 && c0%c1 == 0) ||
       apply(max(y, x*c0 - z)/c1, max(x*eval(c0/c1) + (-z)/c1, y/c1), c1 > 0 && c0%c1 == 0) ||
-      apply(min(y, x*c0)/c1, min(x*eval(c0/c1), y/c1), c1 > 0 && c0%c1 == 0) ||
-      apply(max(y, x*c0)/c1, max(x*eval(c0/c1), y/c1), c1 > 0 && c0%c1 == 0) ||
-    
+
       apply(select(x, c0, c1)/c2, select(x, eval(c0/c2), eval(c1/c2))) ||
       apply(select(x, y, c1)/c2, select(x, y/c2, eval(c1/c2))) ||
       apply(select(x, c0, y)/c2, select(x, eval(c0/c2), y/c2)) ||
@@ -532,12 +497,12 @@ bool apply_div_rules(Fn&& apply) {
 template <typename Fn>
 bool apply_mod_rules(Fn&& apply) {
   return
-      apply(x%1, 0) || 
-      apply(x%0, 0) || 
+      apply(x%1, 0) ||
+      apply(x%0, 0) ||
       apply(x%x, 0) ||
 
       apply((x + c0)%c1, (x + eval(c0%c1))%c1, c0%c1 != c0) ||
-    
+
       apply(select(x, c0, c1)%c2, select(x, eval(c0%c2), eval(c1%c2))) ||
       apply(select(x, y, c1)%c2, select(x, y%c2, eval(c1%c2))) ||
       apply(select(x, c0, y)%c2, select(x, eval(c0%c2), y%c2)) ||
@@ -558,7 +523,7 @@ bool apply_less_rules(Fn&& apply) {
       // These rules taken from:
       // https://github.com/halide/Halide/blob/e9f8b041f63a1a337ce3be0b07de5a1cfa6f2f65/src/Simplify_LT.cpp#L87-L169
       // with adjustments for the simplifier implementation here.
- 
+
       // Normalize subtractions to additions to cut down on cases to consider
       apply(x - y < z, x < z + y) ||
       apply(z < x - y, z + y < x) ||
@@ -584,17 +549,13 @@ bool apply_less_rules(Fn&& apply) {
 
       // These rules taken from:
       // https://github.com/halide/Halide/blob/e3d3c8cacfe6d664a8994166d0998f362bf55ce8/src/Simplify_LT.cpp#L340-L397
-      apply(w + staircase(x, c0, c1, c1) < x + z, w + c0 < z + (x + c0)%c1, c1 > 0) ||
-      apply(x + z < w + staircase(x, c0, c1, c1), z + (x + c0)%c1 < w + c0, c1 > 0) ||
-      apply(staircase(x, c0, c1, c1) < x + z, c0 < z + (x + c0)%c1, c1 > 0) ||
-      apply(x + z < staircase(x, c0, c1, c1), z + (x + c0)%c1 < c0, c1 > 0) ||
-      apply(w + staircase(x, c0, c1, c1) < x, w + c0 < (x + c0)%c1, c1 > 0) ||
-      apply(x < w + staircase(x, c0, c1, c1), (x + c0)%c1 < w + c0, c1 > 0) ||
+      apply(may_be<0>(w) + staircase(x, c0, c1, c1) < x + may_be<0>(z), w + c0 < z + (x + c0)%c1, c1 > 1) ||
+      apply(x + may_be<0>(z) < may_be<0>(w) + staircase(x, c0, c1, c1), z + (x + c0)%c1 < w + c0, c1 > 1) ||
       apply(staircase(x, c0, c1, c1) < x,
-        c0 < (x + c0)%c1, c1 > 0 && c0 != 0,
+        c0 < (x + c0)%c1, c1 > 1 && c0 != 0,
         x%c1 != 0, c1 > 0 /*&& c0 == 0*/) ||
-      apply(x < staircase(x, c0, c1, c1), 
-        (x + c0)%c1 < c0, c1 > 0 && c0 != 0,
+      apply(x < staircase(x, c0, c1, c1),
+        (x + c0)%c1 < c0, c1 > 1 && c0 != 0,
         false, c1 > 0 /*&& c0 == 0*/) ||
 
       apply(x%c0 < c1,
@@ -604,21 +565,15 @@ bool apply_less_rules(Fn&& apply) {
         true, c1 > 0 && c0 < 0,
         false, c1 > 0 && c0 >= c1 - 1,
         boolean(x%c1), c1 > 0 && c0 == 0) ||
-    
-      apply(staircase(x, c0, c1, c2) < staircase(x, c3, c4, c5) + c6,
+
+      apply(staircase(x, c0, c1, c2) < staircase(x, c3, c4, c5) + may_be<0>(c6),
         true, 0 < staircase_sum_min(c0, c1, -c2, c3, c4, c5) + c6,
         false, 0 >= staircase_sum_max(c0, c1, -c2, c3, c4, c5) + c6) ||
-      apply(staircase(x, c0, c1, c2) + c6 < staircase(x, c3, c4, c5),
-        true, c6 < staircase_sum_min(c0, c1, -c2, c3, c4, c5),
-        false, c6 >= staircase_sum_max(c0, c1, -c2, c3, c4, c5)) ||
-      apply(staircase(x, c0, c1, c2) < staircase(x, c3, c4, c5),
-        true, 0 < staircase_sum_min(c0, c1, -c2, c3, c4, c5),
-        false, 0 >= staircase_sum_max(c0, c1, -c2, c3, c4, c5)) ||
 
       apply(x*c0 < y*c0,
         x < y, c0 > 0,
         y < x, c0 < 0) ||
-        
+
       // The following rules are taken from
       // https://github.com/halide/Halide/blob/7636c44acc2954a7c20275618093973da6767359/src/Simplify_LT.cpp#L186-L263
       // with adjustments for the simplifier implementation here.
@@ -626,28 +581,10 @@ bool apply_less_rules(Fn&& apply) {
       // We want to break max(x, y) < z into x < z && y <
       // z in cases where one of those two terms is going
       // to eval.
-      apply(min(y, x + c0) < x + c1, y < x + c1 || eval(c0 < c1)) ||
-      apply(max(y, x + c0) < x + c1, y < x + c1 && eval(c0 < c1)) ||
-      apply(x < min(y, x + c0) + c1, x < y + c1 && eval(0 < c0 + c1)) ||
-      apply(x < max(y, x + c0) + c1, x < y + c1 || eval(0 < c0 + c1)) ||
-
-      // Special cases where c0 == 0
-      apply(min(x, y) < x + c1, y < x + c1 || eval(0 < c1)) ||
-      apply(max(x, y) < x + c1, y < x + c1 && eval(0 < c1)) ||
-      apply(x < min(x, y) + c1, x < y + c1 && eval(0 < c1)) ||
-      apply(x < max(x, y) + c1, x < y + c1 || eval(0 < c1)) ||
-
-      // Special cases where c1 == 0
-      apply(min(y, x + c0) < x, y < x || eval(c0 < 0)) ||
-      apply(max(y, x + c0) < x, y < x && eval(c0 < 0)) ||
-      apply(x < min(y, x + c0), x < y && eval(0 < c0)) ||
-      apply(x < max(y, x + c0), x < y || eval(0 < c0)) ||
-
-      // Special cases where c0 == c1 == 0
-      apply(min(x, y) < x, y < x) ||
-      apply(max(x, y) < x, false) ||
-      apply(x < max(x, y), x < y) ||
-      apply(x < min(x, y), false) ||
+      apply(min(y, x + may_be<0>(c0)) < x + may_be<0>(c1), y < x + c1 || eval(c0 < c1)) ||
+      apply(max(y, x + may_be<0>(c0)) < x + may_be<0>(c1), y < x + c1 && eval(c0 < c1)) ||
+      apply(x < min(y, x + may_be<0>(c0)) + may_be<0>(c1), x < y + c1 && eval(0 < c0 + c1)) ||
+      apply(x < max(y, x + may_be<0>(c0)) + may_be<0>(c1), x < y + c1 || eval(0 < c0 + c1)) ||
 
       // Special case where x is constant
       apply(min(y, c0) < c1, y < c1 || eval(c0 < c1)) ||
@@ -670,30 +607,20 @@ bool apply_less_rules(Fn&& apply) {
       apply(min(x, min(y, z)) < y, min(x, z) < y) ||
       apply(min(x, y) < max(x, y), x != y) ||
       apply(max(x, y) < min(x, y), false) ||
-        
-      apply(min(x, y + c0) < max(z, y + c1), true, c0 < c1) ||
-      apply(min(x, y + c0) < max(z, y), true, c0 < 0) ||
-      apply(min(x, y) < max(z, y + c1), true, 0 < c1) ||
-      apply(min(x, y + c0) < max(z, y) + c1, true, c0 < c1) ||
-      apply(min(x, y) < max(z, y) + c1, true, 0 < c1) ||
+
+      apply(min(x, y + may_be<0>(c0)) < max(z, y + may_be<0>(c1)), true, c0 < c1) ||
 
       // Subtract terms from both sides within a min/max.
       // These are only enabled for non-constants because they loop with rules that pull constants out of min/max.
-      apply(min(x, y) < x + z, min(y - x, 0) < z, !is_constant(x)) ||
-      apply(max(x, y) < x + z, max(y - x, 0) < z, !is_constant(x)) ||
+      apply(may_be<0>(z) + min(y, x + may_be<0>(u)) < x + may_be<0>(w), min(y - x, u) + z < w, !is_constant(x)) ||
+      apply(may_be<0>(z) + max(y, x + may_be<0>(u)) < x + may_be<0>(w), max(y - x, u) + z < w, !is_constant(x)) ||
+      apply(may_be<0>(z) + min(y, x - u) < x + may_be<0>(w), z < w + max(x - y, u), !is_constant(x)) ||
+      apply(may_be<0>(z) + max(y, x - u) < x + may_be<0>(w), z < w + min(x - y, u), !is_constant(x)) ||
 
-      apply(x + z < min(x, y), z < min(y - x, 0), !is_constant(x)) ||
-      apply(x + z < max(x, y), z < max(y - x, 0), !is_constant(x)) ||
-
-      apply(min(z, x + y) < x + w, min(y, z - x) < w, !is_constant(x)) ||
-      apply(min(z, x - y) < x + w, 0 < w + max(y, x - z), !is_constant(x)) ||
-      apply(max(z, x + y) < x + w, max(y, z - x) < w, !is_constant(x)) ||
-      apply(max(z, x - y) < x + w, 0 < w + min(y, x - z), !is_constant(x)) ||
-
-      apply(x + y < max(w, x + z), y < max(z, w - x), !is_constant(x)) ||
-      apply(x + y < max(w, x - z), y + min(z, x - w) < 0, !is_constant(x)) ||
-      apply(x + y < min(w, x + z), y < min(z, w - x), !is_constant(x)) ||
-      apply(x + y < min(w, x - z), y + max(z, x - w) < 0, !is_constant(x)) ||
+      apply(x + may_be<0>(z) < may_be<0>(w) + min(y, x + may_be<0>(u)), z < min(y - x, u) + w, !is_constant(x)) ||
+      apply(x + may_be<0>(z) < may_be<0>(w) + max(y, x + may_be<0>(u)), z < max(y - x, u) + w, !is_constant(x)) ||
+      apply(x + may_be<0>(z) < may_be<0>(w) + min(y, x - u), z + max(x - y, u) < w, !is_constant(x)) ||
+      apply(x + may_be<0>(z) < may_be<0>(w) + max(y, x - u), z + min(x - y, u) < w, !is_constant(x)) ||
 
       // Selects
       apply(select(x, c0, y) < c1, select(x, eval(c0 < c1), y < c1)) ||
@@ -705,9 +632,7 @@ bool apply_less_rules(Fn&& apply) {
       apply(select(x, y, z) < z, select(x, y < z, false)) ||
       apply(y < select(x, y, w), select(x, false, y < w)) ||
       apply(w < select(x, y, w), select(x, w < y, false)) ||
-      apply(select(x, y, z) < select(x, w, u), select(x, y < w, z < u)) ||
-      apply(select(x, y, z) < v + select(x, w, u), select(x, y < v + w, z < v + u)) ||
-      apply(v + select(x, y, z) < select(x, w, u), select(x, v + y < w, v + z < u)) ||
+      apply(may_be<0>(t) + select(x, y, z) < may_be<0>(v) + select(x, w, u), select(x, y + t < v + w, z + t < v + u)) ||
 
       // Nested logicals
       apply(x < y, y && !x, is_boolean(x) && is_boolean(y)) ||
@@ -719,7 +644,7 @@ bool apply_less_rules(Fn&& apply) {
 
 template <typename Fn>
 bool apply_equal_rules(Fn&& apply) {
-  return 
+  return
       apply(x == x, true) ||
       apply(x*y == x*z, y == z || x == 0) ||
       apply(x == x*y, y == 1 || x == 0) ||
@@ -737,26 +662,20 @@ bool apply_equal_rules(Fn&& apply) {
       apply(x + z == w + (x + y), z == y + w) ||
       apply(w + (x + y) == u + (x + z), y + w == z + u) ||
 
-      apply(x*c0 == y*c1, x == y*eval(c1/c0), c0 != 0 && c1%c0 == 0) ||
-      apply(x*c0 == y*c1, y == x*eval(c0/c1), c1 != 0 && c0%c1 == 0) ||
+      apply(x*c0 == y*c1,
+        x == y*eval(c1/c0), c0 != 0 && c1%c0 == 0,
+        y == x*eval(c0/c1), c1 != 0 && c0%c1 == 0) ||
       apply(x*c0 == c1, x == eval(c1/c0), c0 != 0 && c1%c0 == 0) ||
-      apply(x + c0 == y + c1, x == y + eval(c1 - c0)) ||
-      apply(x + c0 == c1, x == eval(c1 - c0)) ||
-      apply(x + c0 == c1 - y, x + y == eval(c1 - c0)) ||
-      apply(c0 - x == c1, x == eval(c0 - c1)) ||
-      apply(select(x, y, z) == select(x, w, u), select(x, y == w, z == u)) ||
+      apply(x + c0 == may_be<0>(y) + c1, x == y + eval(c1 - c0)) ||
+      apply(may_be<0>(x) + c0 == c1 - y, x + y == eval(c1 - c0)) ||
       apply(x == 0, !x, is_boolean(x)) ||
       apply(x == 1, boolean(x), is_boolean(x)) ||
 
-      apply(x + y == z + (x/c0)*c0, z == y + x%c0, c0 > 0) ||
-      apply(x + y == (x/c0)*c0, y + x%c0 == 0, c0 > 0) ||
-      apply(x == z + (x/c0)*c0, z == x%c0, c0 > 0) ||
-      apply(x == (x/c0)*c0, x%c0 == 0, c0 > 0) ||
+      apply(x + may_be<0>(y) == may_be<0>(z) + (x/c0)*c0, z == y + x%c0, c0 > 0) ||
 
       apply(x%c0 == c1, false, c0 > 0 && (c1 >= c0 || c1 < 0)) ||
-    
-      apply(select(x, y, z) == select(x, w, u), select(x, y == w, z == u)) ||
-      apply(v + select(x, y, z) == select(x, w, u), select(x, w == v + y, u == v + z)) ||
+
+      apply(may_be<0>(v) + select(x, y, z) == select(x, w, u), select(x, w == v + y, u == v + z)) ||
       apply(select(x, c0, y) == c1, select(x, eval(c0 == c1), y == c1)) ||
       apply(select(x, y, c0) == c1, select(x, y == c1, eval(c0 == c1))) ||
       apply(y == select(x == y, x, z), x == y || y == z) ||
@@ -792,7 +711,7 @@ bool apply_logical_and_rules(Fn&& apply) {
       apply(x && (x && y), x && y) ||
       apply(x && (y && (x && z)), x && (y && z)) ||
       apply(x && (y && (z && (x && w))), x && (y && (z && w))) ||
-    
+
       apply(x && (x || y), boolean(x)) ||
       apply(x && (y || (x && z)), x && (y || z)) ||
       apply(x && (y && (x || z)), x && y) ||
@@ -808,7 +727,7 @@ bool apply_logical_and_rules(Fn&& apply) {
       apply(x != y && (z && x == y), false) ||
       apply(x == c1 && x != c0, x == c1, c0 != c1) ||
       apply(x == c0 && x == c1, false, c0 != c1) ||
-    
+
       // These rules taken from:
       // https://github.com/halide/Halide/blob/e9f8b041f63a1a337ce3be0b07de5a1cfa6f2f65/src/Simplify_And.cpp#L67-L76
       apply(c0 <= x && x <= c1, false, c1 < c0) ||
@@ -821,20 +740,10 @@ bool apply_logical_and_rules(Fn&& apply) {
       apply(x <= c0 && x <= c1, x <= eval(min(c0, c1))) ||
 
       // The way we implement <= and < means that constants will be on the LHS for <=, and on the RHS for <
-      apply(x + c0 <= y && y + c1 <= x, false, -c1 < c0) ||
-      apply(x + c0 <= y && y <= x, false, 0 < c0) ||
-      apply(x <= y && y + c1 <= x, false, 0 < c1) ||
       apply(x <= y && y <= x, x == y) ||
-
-      apply(x < y + c0 && y + c1 <= x, false, c0 < c1 + 1) ||
-      apply(x < y + c0 && y <= x, false, c0 < 1) ||
-      apply(x < y && y + c1 <= x, false, -c1 < 1) ||
-      apply(x < y && y <= x, false) ||
-
-      apply(x < y + c0 && y < x + c1, false, c1 + c0 < 2) ||
-      apply(x < y + c0 && y < x, false, c0 < 2) ||
-      apply(x < y && y < x + c1, false, c1 < 2) ||
-      apply(x < y && y < x, false) ||
+      apply(x + may_be<0>(c0) <= y && y + may_be<0>(c1) <= x, false, -c1 < c0) ||
+      apply(x < y + may_be<0>(c0) && y + may_be<0>(c1) <= x, false, c0 < c1 + 1) ||
+      apply(x < y + may_be<0>(c0) && y < x + may_be<0>(c1), false, c1 + c0 < 2) ||
 
       // Above, we have rules for combinations of < and <=, or == and !=. Here, we have a mix of both.
       apply(x != c0 && x <= c1, x <= c1, c0 > c1) ||
@@ -865,7 +774,7 @@ bool apply_logical_or_rules(Fn&& apply) {
       apply(x || c0, true, c0 != 0) ||
       apply(x || false, boolean(x)) ||
       apply(x || x, boolean(x)) ||
-    
+
       // Canonicalize trees and find redundant terms.
       apply((x || y) || (z || w), x || (y || (z || w))) ||
       apply(x || (x || y), x || y) ||
@@ -873,10 +782,10 @@ bool apply_logical_or_rules(Fn&& apply) {
       apply(x || (y || (z || (x || w))), x || (y || (z || w))) ||
 
       apply(x || (x && y), boolean(x)) ||
-      apply(x || (y && (x || z)), x || (y && z)) || 
+      apply(x || (y && (x || z)), x || (y && z)) ||
       apply(x || (y || (x && z)), x || y) ||
-      apply((x && y) || (x && z), x && (y || z)) || 
-    
+      apply((x && y) || (x && z), x && (y || z)) ||
+
       // These rules taken from:
       // https://github.com/halide/Halide/blob/e9f8b041f63a1a337ce3be0b07de5a1cfa6f2f65/src/Simplify_Or.cpp#L59-L68
       apply(x || !x, true) ||
@@ -897,21 +806,11 @@ bool apply_logical_or_rules(Fn&& apply) {
       apply(c1 < x || x <= c0, true, c1 <= c0) ||
 
       // The way we implement <= and < means that constants will be on the LHS for <=, and on the RHS for <
-      apply(x + c0 <= y || y + c1 <= x, true, c0 + c1 < 1) ||
-      apply(x + c0 <= y || y <= x, true, c0 < 1) ||
-      apply(x <= y || y + c1 <= x, true, c1 < 1) ||
-      apply(x <= y || y <= x, true) ||
-
-      apply(x < y + c0 || y + c1 <= x, true, c1 < c0) ||
-      apply(x < y + c0 || y <= x, true, 0 < c0) ||
-      apply(x < y || y + c1 <= x, true, c1 < 0) ||
-      apply(x < y || y <= x, true) ||
-
-      apply(x < y + c0 || y < x + c1, true, 1 < c1 + c0) ||
-      apply(x < y + c0 || y < x, true, 1 < c0) ||
-      apply(x < y || y < x + c1, true, 1 < c1) ||
+      apply(x + may_be<0>(c0) <= y || y + may_be<0>(c1) <= x, true, c0 + c1 < 1) ||
+      apply(x < y + may_be<0>(c0) || y + may_be<0>(c1) <= x, true, c1 < c0) ||
+      apply(x < y + may_be<0>(c0) || y < x + may_be<0>(c1), true, 1 < c1 + c0) ||
       apply(x < y || y < x, x != y) ||
-    
+
       // Above, we have rules for combinations of < and <=, or == and !=. Here, we have a mix of both.
       apply(x != c0 || x <= c1,
         true, c0 <= c1,
@@ -962,9 +861,7 @@ bool apply_select_rules(Fn&& apply) {
       apply(select(!x, y, z), select(x, z, y)) ||
 
       // Pull common expressions out
-      apply(select(x, y, y + z), y + select(x, 0, z)) ||
-      apply(select(x, y + z, y), y + select(x, z, 0)) ||
-      apply(select(x, y + z, y + w), y + select(x, z, w)) ||
+      apply(select(x, y + may_be<0>(z), y + may_be<0>(w)), y + select(x, z, w)) ||
       apply(select(x, z - y, w - y), select(x, z, w) - y) ||
       apply(select(x, w - y, w - z), w - select(x, y, z)) ||
       apply(select(x, max(y, w), max(z, w)), max(w, select(x, y, z))) ||
@@ -972,10 +869,10 @@ bool apply_select_rules(Fn&& apply) {
       apply(select(x, y + c0, c1), select(x, y, eval(c1 - c0)) + c0) ||
       apply(select(x, c0, y + c1), select(x, eval(c0 - c1), y) + c1) ||
 
-      apply(select(x, select(y, z, w), select(y, u, w + c0) + c1), select(y, select(x, z, u + c1), w), c0 + c1 == 0) ||
-      apply(select(x, select(y, z, w), select(y, z + c0, u) + c1), select(y, z, select(x, w, u + c1)), c0 + c1 == 0) ||
-      apply(select(x, select(y, z, w), select(y, u, w)), select(y, select(x, z, u), w)) ||
-      apply(select(x, select(y, z, w), select(y, z, u)), select(y, z, select(x, w, u))) ||
+      apply(select(x, select(y, z, w), select(y, u, w + may_be<0>(c0)) + may_be<0>(c1)), select(y, select(x, z, u + c1), w), c0 + c1 == 0) ||
+      apply(select(x, select(y, z, w), select(y, z + may_be<0>(c0), u) + may_be<0>(c1)), select(y, z, select(x, w, u + c1)), c0 + c1 == 0) ||
+      apply(select(x, select(y, z, w + may_be<0>(c0)) + may_be<0>(c1), select(y, u, w)), select(y, select(x, z + c1, u), w), c0 + c1 == 0) ||
+      apply(select(x, select(y, z + may_be<0>(c0), w) + may_be<0>(c1), select(y, z, u)), select(y, z, select(x, w + c1, u)), c0 + c1 == 0) ||
       apply(select(x, select(y, z, w), w), select(x && y, z, w)) ||
       apply(select(x, select(y, z, w), z), select(x && !y, w, z)) ||
       apply(select(x, z, select(y, z, w)), select(x || y, z, w)) ||
@@ -986,7 +883,7 @@ bool apply_select_rules(Fn&& apply) {
       apply(select(x, y, false), x && y, is_boolean(y)) ||
       apply(select(x, true, y), x || y, is_boolean(y)) ||
       apply(select(x, false, y), y && !x, is_boolean(y)) ||
-    
+
       // Simplifications of min/max
       apply(select(x < y, min(x, y), z), select(x < y, x, z)) ||
       apply(select(x < y, max(x, y), z), select(x < y, y, z)) ||
@@ -1012,7 +909,7 @@ bool apply_select_rules(Fn&& apply) {
 
 template <typename Fn>
 bool apply_call_rules(Fn&& apply) {
-  return 
+  return
       apply(and_then(x, c0), boolean(x), c0 != 0) ||
       apply(and_then(c0, x), boolean(x), c0 != 0) ||
       apply(and_then(false, x), false) ||

--- a/builder/test/BUILD
+++ b/builder/test/BUILD
@@ -242,3 +242,13 @@ cc_test(
     ],
     size = "small",
 )
+
+cc_test(
+    name = "rewrite",
+    srcs = ["rewrite.cc"],
+    deps = [
+        "//builder",
+        "@googletest//:gtest_main",
+    ],
+    size = "small",
+)

--- a/builder/test/rewrite.cc
+++ b/builder/test/rewrite.cc
@@ -1,0 +1,140 @@
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <map>
+#include <tuple>
+
+#include "builder/rewrite.h"
+
+namespace slinky {
+
+// Hackily get at this function in print.cc that we don't want to put in the public API.
+const node_context* set_default_print_context(const node_context* ctx);
+
+namespace rewrite {
+
+pattern_wildcard<0> x;
+pattern_wildcard<1> y;
+pattern_wildcard<2> z;
+pattern_wildcard<3> w;
+
+pattern_constant<0> c0;
+pattern_constant<1> c1;
+pattern_constant<2> c2;
+
+node_context symbols;
+var a(symbols, "a");
+var b(symbols, "b");
+var c(symbols, "c");
+var d(symbols, "d");
+
+// Make test failures easier to read.
+auto _ = []() {
+  set_default_print_context(&symbols);
+  return 0;
+}();
+
+MATCHER_P(matches, x, "") { return match(arg, x); }
+
+// It's a bit tricky to test this. `match_context` doesn't extend the lifetime of the things it matches, so we can't
+// return it from a function that takes an expr we target in a match. To fix this, we make a map from the context, and
+// to do that, we need to make this helper type.
+class context_item {
+  bool is_wildcard;
+  int idx;
+  expr value;
+
+public:
+  template <int N>
+  context_item(pattern_wildcard<N> p, expr value) : is_wildcard(true), idx(N), value(value) {}
+  template <int N>
+  context_item(pattern_constant<N> p, expr value) : is_wildcard(false), idx(N), value(value) {}
+
+  bool operator==(const context_item& r) const {
+    return is_wildcard == r.is_wildcard && idx == r.idx && match(value, r.value);
+  }
+
+  std::string to_string() const {
+    static const char names[] = "xyzwuv";
+    std::stringstream result;
+    if (is_wildcard) {
+      result << names[idx];
+    } else {
+      result << "c" << idx;
+    }
+    result << " -> " << value;
+    return result.str();
+  }
+};
+
+std::ostream& operator<<(std::ostream& os, const context_item& i) { return os << i.to_string(); }
+
+template <typename Pattern>
+std::vector<context_item> test_match(const Pattern& pattern, expr target) {
+  match_context ctx;
+  memset(&ctx, 0, sizeof(ctx));
+  if (!match(ctx, pattern, target)) {
+    return {};
+  }
+
+  std::vector<context_item> result;
+  if (ctx.matched(x).defined()) result.push_back({x, ctx.matched(x)});
+  if (ctx.matched(y).defined()) result.push_back({y, ctx.matched(y)});
+  if (ctx.matched(z).defined()) result.push_back({z, ctx.matched(z)});
+  if (ctx.matched(w).defined()) result.push_back({w, ctx.matched(w)});
+
+  result.push_back({c0, ctx.matched(c0)});
+  result.push_back({c1, ctx.matched(c1)});
+  result.push_back({c2, ctx.matched(c2)});
+
+  return result;
+}
+
+// We can't detect when constants are matched or not. So, we can only check that the match result is a superset of what
+// we think it should be.
+auto matches(std::vector<context_item> values) { return testing::IsSupersetOf(values); }
+auto does_not_match() { return testing::IsEmpty(); }
+
+TEST(match, basic) {
+  // Wildcards
+  ASSERT_THAT(test_match(x, a), matches({{x, a}}));
+  ASSERT_THAT(test_match(x, a), matches({{x, a}}));
+  ASSERT_THAT(test_match(x, a + 2), matches({{x, a + 2}}));
+
+  // add
+  ASSERT_THAT(test_match(x + y, a + b), matches({{x, a}, {y, b}}));
+  ASSERT_THAT(test_match(x + y, a + 3), matches({{x, a}, {y, 3}}));
+  ASSERT_THAT(test_match(x + c0, a + 3), matches({{x, a}, {c0, 3}}));
+  ASSERT_THAT(test_match(x + c0, a), does_not_match());
+
+  // sub
+  ASSERT_THAT(test_match(x - y, a - b), matches({{x, a}, {y, b}}));
+  ASSERT_THAT(test_match(x - y, a + b), does_not_match());
+
+  // mul
+  ASSERT_THAT(test_match(x * y, a * b), matches({{x, a}, {y, b}}));
+  ASSERT_THAT(test_match(x * y, a * 2), matches({{x, a}, {y, 2}}));
+  ASSERT_THAT(test_match(x * y, a / b), does_not_match());
+
+  // staircase
+  ASSERT_THAT(test_match(staircase(x, c0, c1, c2), ((a + 3) / 5) * 7), matches({{x, a}, {c0, 3}, {c1, 5}, {c2, 7}}));
+  ASSERT_THAT(test_match(staircase(x, c0, c1, c2), (a + 3) / 5), matches({{x, a}, {c0, 3}, {c1, 5}, {c2, 1}}));
+  ASSERT_THAT(test_match(staircase(x, c0, c1, c2), (a + 3) * 7), matches({{x, a}, {c0, 3}, {c1, 1}, {c2, 7}}));
+  ASSERT_THAT(test_match(staircase(x, c0, c1, c2), (a / 5) * 7), matches({{x, a}, {c0, 0}, {c1, 5}, {c2, 7}}));
+  ASSERT_THAT(test_match(staircase(x, c0, c1, c2), a * 7), matches({{x, a}, {c0, 0}, {c1, 1}, {c2, 7}}));
+  ASSERT_THAT(test_match(staircase(x, c0, c1, c2), a / 5), matches({{x, a}, {c0, 0}, {c1, 5}, {c2, 1}}));
+  ASSERT_THAT(test_match(staircase(x, c0, c1, c2), a + 3), matches({{x, a}, {c0, 3}, {c1, 1}, {c2, 1}}));
+  ASSERT_THAT(test_match(staircase(x, c0, c1, c2), a), matches({{x, a}, {c0, 0}, {c1, 1}, {c2, 1}}));
+}
+
+TEST(match, optional) {
+  ASSERT_THAT(test_match(may_be<0>(x) + c1, a + 3), matches({{x, a}, {c1, 3}}));
+  ASSERT_THAT(test_match(may_be<0>(x) + c1, 3), matches({{x, 0}, {c1, 3}}));
+  ASSERT_THAT(test_match(may_be<0>(x) + c1, a), does_not_match());
+  ASSERT_THAT(test_match(min(x, y + may_be<0>(c0)), min(a, b + 2)), matches({{x, a}, {y, b}, {c0, 2}}));
+  ASSERT_THAT(test_match(min(x, y + may_be<0>(c0)) < max(z, y + may_be<0>(c1)), min(a, b + 2) < max(c, b + 5)),
+      matches({{x, a}, {y, b}, {c0, 2}, {z, c}, {c1, 5}}));
+}
+
+}  // namespace rewrite
+}  // namespace slinky

--- a/builder/test/simplify/rule_tester.h
+++ b/builder/test/simplify/rule_tester.h
@@ -43,6 +43,11 @@ SLINKY_UNIQUE index_t substitute(const pattern_constant<N>&, const match_context
   return ctx.constants[N];
 }
 
+template <typename A, index_t Default>
+SLINKY_UNIQUE auto substitute(const pattern_optional<A, Default>& p, const match_context& ctx) {
+  return substitute(p.a, ctx);
+}
+
 template <typename T, typename A, typename B>
 SLINKY_UNIQUE auto substitute(const pattern_binary<T, A, B>& p, const match_context& ctx) {
   return make_binary<T>(substitute(p.a, ctx), substitute(p.b, ctx));

--- a/builder/test/simplify/rule_tester.h
+++ b/builder/test/simplify/rule_tester.h
@@ -28,6 +28,93 @@ bool contains_infinity(expr x) {
 
 }  // namespace
 
+namespace rewrite {
+
+// We need a version of substitute from rewrite.h that does not eagerly apply optimization.
+SLINKY_UNIQUE index_t substitute(index_t p, const match_context&) { return p; }
+
+template <int N>
+SLINKY_UNIQUE expr_ref substitute(const pattern_wildcard<N>&, const match_context& ctx) {
+  return ctx.vars[N];
+}
+
+template <int N>
+SLINKY_UNIQUE index_t substitute(const pattern_constant<N>&, const match_context& ctx) {
+  return ctx.constants[N];
+}
+
+template <typename T, typename A, typename B>
+SLINKY_UNIQUE auto substitute(const pattern_binary<T, A, B>& p, const match_context& ctx) {
+  return make_binary<T>(substitute(p.a, ctx), substitute(p.b, ctx));
+}
+
+template <typename T, typename A>
+SLINKY_UNIQUE auto substitute(const pattern_unary<T, A>& p, const match_context& ctx) {
+  return make_unary<T>(substitute(p.a, ctx));
+}
+
+template <typename C, typename T, typename F>
+SLINKY_UNIQUE expr substitute(const pattern_select<C, T, F>& p, const match_context& ctx) {
+  return select::make(substitute(p.c, ctx), substitute(p.t, ctx), substitute(p.f, ctx));
+}
+
+SLINKY_UNIQUE expr substitute(const pattern_call<>& p, const match_context& ctx) { return call::make(p.fn, {}); }
+template <typename A>
+SLINKY_UNIQUE expr substitute(const pattern_call<A>& p, const match_context& ctx) {
+  return call::make(p.fn, {substitute(std::get<0>(p.args), ctx)});
+}
+template <typename A, typename B>
+SLINKY_UNIQUE expr substitute(const pattern_call<A, B>& p, const match_context& ctx) {
+  return call::make(p.fn, {substitute(std::get<0>(p.args), ctx), substitute(std::get<1>(p.args), ctx)});
+}
+
+template <typename X, typename A, typename B, typename C>
+SLINKY_UNIQUE auto substitute(const pattern_staircase<X, A, B, C>& p, const match_context& ctx) {
+  expr x = substitute(p.x, ctx);
+  index_t a = substitute(p.a, ctx);
+  index_t b = substitute(p.b, ctx);
+  index_t c = substitute(p.c, ctx);
+
+  if (a != 0) x += a;
+  if (b != 1) x /= b;
+  if (c != 1) x *= c;
+  return x;
+}
+
+template <typename T, typename Fn>
+SLINKY_UNIQUE bool substitute(const replacement_predicate<T, Fn>& r, const match_context& ctx) {
+  return r.fn(substitute(r.a, ctx));
+}
+
+template <typename T>
+SLINKY_UNIQUE index_t substitute(const replacement_eval<T>& r, const match_context& ctx) {
+  return substitute(r.a, ctx);
+}
+
+template <typename T>
+SLINKY_UNIQUE auto substitute(const replacement_boolean<T>& r, const match_context& ctx) {
+  return boolean(substitute(r.a, ctx));
+}
+
+template <typename A1, typename B1, typename C1, typename A2, typename B2, typename C2>
+SLINKY_UNIQUE index_t substitute(
+    const replacement_staircase_sum_bound<A1, B1, C1, A2, B2, C2>& r, const match_context& ctx) {
+  index_t a1 = substitute(r.a1, ctx);
+  index_t b1 = substitute(r.b1, ctx);
+  index_t c1 = substitute(r.c1, ctx);
+  index_t a2 = substitute(r.a2, ctx);
+  index_t b2 = substitute(r.b2, ctx);
+  index_t c2 = substitute(r.c2, ctx);
+  auto bounds = staircase_sum_bounds(a1, b1, c1, a2, b2, c2);
+  if (r.bound_sign < 0) {
+    return bounds.min ? *bounds.min : std::numeric_limits<index_t>::min();
+  } else {
+    return bounds.max ? *bounds.max : std::numeric_limits<index_t>::max();
+  }
+}
+
+}  // namespace rewrite
+
 class rule_tester {
   static constexpr std::size_t var_count = 6;
 
@@ -65,7 +152,7 @@ public:
         ctx[var(i)] = expr_gen_.random_constant();
       }
 
-      auto dump_ctx = [&]() { 
+      auto dump_ctx = [&]() {
         std::stringstream ss;
         for (std::size_t i = 0; i < var_count; ++i) {
           ss << ", " << var(i) << "=" << ctx[var(i)];
@@ -89,9 +176,8 @@ public:
     std::stringstream rule_str;
     rule_str << p << " -> " << r;
 
+    expr pattern = expr(substitute(p, m));
     bool overflowed = false;
-    expr pattern = expr(substitute(p, m, overflowed));
-    assert(!overflowed);
     expr replacement = expr(substitute(r, m, overflowed));
     assert(!overflowed);
 
@@ -114,8 +200,7 @@ public:
       init_match_context();
       bool overflowed = false;
       if (substitute(pr, m, overflowed) && !overflowed) {
-        expr pattern = expr(substitute(p, m, overflowed));
-        assert(!overflowed);
+        expr pattern = expr(substitute(p, m));
         expr replacement = expr(substitute(r, m, overflowed));
         assert(!overflowed);
 

--- a/builder/test/simplify/simplify.cc
+++ b/builder/test/simplify/simplify.cc
@@ -80,8 +80,8 @@ TEST(simplify, basic) {
   ASSERT_THAT(simplify(max(x, y)), matches(max(x, y)));
   ASSERT_THAT(simplify(min(x, x)), matches(x));
   ASSERT_THAT(simplify(max(x, x)), matches(x));
-  ASSERT_THAT(simplify(min(x / 2, y / 2)), matches(min(x, y) / 2));
-  ASSERT_THAT(simplify(max(x / 2, y / 2)), matches(max(x, y) / 2));
+  ASSERT_THAT(simplify(min(x / 2, y / 2)), matches(min(y, x) / 2));
+  ASSERT_THAT(simplify(max(x / 2, y / 2)), matches(max(y, x) / 2));
   ASSERT_THAT(simplify(min(negative_infinity(), x)), matches(negative_infinity()));
   ASSERT_THAT(simplify(max(negative_infinity(), x)), matches(x));
   ASSERT_THAT(simplify(min(positive_infinity(), x)), matches(x));
@@ -145,6 +145,7 @@ TEST(simplify, basic) {
       matches((min(y, select((1 < x), max(x, 118), 1)) + -1)));
 
   ASSERT_THAT(simplify(min(y, z) <= y + 1), matches(true));
+  ASSERT_THAT(simplify((min(x, y + -1) <= min(x, y))), matches(true));
 
   ASSERT_THAT(simplify(and_then(expr(false), x)), matches(false));
   ASSERT_THAT(simplify(and_then(expr(true), x)), matches(boolean(x)));

--- a/runtime/expr.h
+++ b/runtime/expr.h
@@ -619,6 +619,13 @@ SLINKY_ALWAYS_INLINE SLINKY_UNIQUE bool is_true(expr_ref x) {
 }
 SLINKY_ALWAYS_INLINE SLINKY_UNIQUE bool is_false(expr_ref x) { return is_zero(x); }
 
+// These overloads of the above make templates work transparently.
+SLINKY_ALWAYS_INLINE SLINKY_UNIQUE bool is_constant(index_t x, index_t value) { return x == value; }
+SLINKY_ALWAYS_INLINE SLINKY_UNIQUE bool is_zero(index_t x) { return x == 0; }
+SLINKY_ALWAYS_INLINE SLINKY_UNIQUE bool is_one(index_t x) { return x == 1; }
+SLINKY_ALWAYS_INLINE SLINKY_UNIQUE bool is_true(index_t x) { return x != 0; }
+SLINKY_ALWAYS_INLINE SLINKY_UNIQUE bool is_false(index_t x) { return x == 0; }
+
 // Check if `x` is a call to the intrinsic `fn`.
 SLINKY_ALWAYS_INLINE SLINKY_UNIQUE const call* as_intrinsic(expr_ref x, intrinsic fn) {
   const call* c = x.as<call>();

--- a/runtime/expr.h
+++ b/runtime/expr.h
@@ -395,6 +395,7 @@ public:
 
   void accept(expr_visitor* v) const override;
 
+  static expr_ref get(index_t value);
   static expr make(index_t value);
   static expr make(const void* value);
 

--- a/runtime/expr_stmt.cc
+++ b/runtime/expr_stmt.cc
@@ -104,7 +104,7 @@ const variable* make_variable(var sym) {
   return n;
 }
 
-const constant* make_constant(std::int64_t value) {
+const constant* get_constant(std::int64_t value) {
   static const constant* zero = make_static_constant<0>();
   static const constant* one = make_static_constant<1>();
   if (value == 0) {
@@ -112,12 +112,18 @@ const constant* make_constant(std::int64_t value) {
   } else if (value == 1) {
     return one;
   } else {
-    assert(value <= std::numeric_limits<index_t>::max());
-    assert(value >= std::numeric_limits<index_t>::min());
-    auto n = new constant();
-    n->value = value;
-    return n;
+    return nullptr;
   }
+}
+
+const constant* make_constant(std::int64_t value) {
+  if (const constant* n = get_constant(value)) return n;
+
+  assert(value <= std::numeric_limits<index_t>::max());
+  assert(value >= std::numeric_limits<index_t>::min());
+  auto n = new constant();
+  n->value = value;
+  return n;
 }
 
 }  // namespace
@@ -134,6 +140,7 @@ expr variable::make(var sym, buffer_field field, int dim) {
   return expr(n);
 }
 
+expr_ref constant::get(index_t value) { return get_constant(value); }
 expr constant::make(index_t value) { return expr(make_constant(value)); }
 expr constant::make(const void* value) { return make(reinterpret_cast<index_t>(value)); }
 


### PR DESCRIPTION
This PR makes it possible to optionally match something in a pattern, with a default value if not matched. This allows reducing the duplication in many simplifier rules, which makes the simplifier faster and smaller.

This PR is a subset of #662, removing many of the optional rule rewrites for a later PR.