### PR TITLE
Optimize simplify usages

### DIFF
--- a/builder/optimizations.cc
+++ b/builder/optimizations.cc
@@ -1334,9 +1334,11 @@ class pure_dims_remover : public stmt_mutator {
     return sd;
   }
 
-  static bool is_extent_one(interval_expr interval) { return prove_true(interval.min == interval.max); }
-
-  static bool is_extent_one(dim_expr d) { return is_extent_one(d.bounds); }
+  static bool is_extent_one(const interval_expr& interval) {
+    return interval.min.defined() && interval.max.defined() &&
+           (interval.is_point() || match(interval.min, interval.max));
+  }
+  static bool is_extent_one(const dim_expr& d) { return is_extent_one(d.bounds); }
 
   template <typename T>
   static sliceable_dims find_sliceable(const std::vector<T>& dims) {

--- a/builder/simplify.cc
+++ b/builder/simplify.cc
@@ -1815,7 +1815,6 @@ public:
       }
       return false;
     };
-    if (is_redundant(x)) return def;
     if (const T* t = x.as<T>()) {
       bool a_redundant = is_redundant(t->a);
       bool b_redundant = is_redundant(t->b);
@@ -1826,7 +1825,10 @@ public:
       } else if (b_redundant) {
         return remove_redundant_bounds<T>(t->a, bounds, def);
       }
-    } else if (const add* xa = x.as<add>()) {
+    } else {
+      if (is_redundant(x)) return def;
+    }
+    if (const add* xa = x.as<add>()) {
       if (as_constant(xa->b)) {
         // We have T(x + y, b). We can rewrite to T(x, b - y) + y, and if we can eliminate the bound, the whole
         // bound is redundant.

--- a/builder/simplify.cc
+++ b/builder/simplify.cc
@@ -1900,8 +1900,8 @@ public:
     //   result = simplify(result & x, {{x, buffer}})
     //
     // and then remove the clamps of x. But this is pretty tricky.
-    std::set<expr, node_less> mins = {buffer_min(buf, dim)};
-    std::set<expr, node_less> maxs = {buffer_max(buf, dim)};
+    std::set<expr, node_less> mins;
+    std::set<expr, node_less> maxs;
     enumerate_bounds<class max>(buffer.min, mins);
     enumerate_bounds<class min>(buffer.max, maxs);
     interval_expr deduped = {


### PR DESCRIPTION
- Remove self bounds from `mutate_crop_bounds`. Each thing in this set is expensive, and this one seems to be unnecessary.
- Use `match` instead of `prove_true` in `remove_pure_dims`, `prove_true(x == y)` is likely overkill after simplification
- We don't need to check `min(x, y)`/`max(x, y)`  *and* `x`, `y`, and for redundant-ness