### PR TITLE
Try alias_compatible with and without substitution of the target

### DIFF
--- a/builder/optimizations.cc
+++ b/builder/optimizations.cc
@@ -322,7 +322,6 @@ class copy_aliaser : public stmt_mutator {
     const bool alloc_has_stride = any_stride_defined(alloc_info.dims);
 
     // Figure out what the actual alias dimension will be by substituting the target into it.
-    std::vector<dim_expr> alias_dims = alias.dims;
     std::vector<dim_expr> alloc_dims = alloc_info.dims;
 
     for (dim_expr& i : alloc_dims) {
@@ -330,6 +329,8 @@ class copy_aliaser : public stmt_mutator {
       i.stride = substitute_buffer(i.stride, target, target_info.dims);
       i.fold_factor = substitute_buffer(i.fold_factor, target, target_info.dims);
     }
+
+    std::vector<dim_expr> alias_dims = alias.dims;
 
     for (dim_expr& i : alias_dims) {
       i.bounds = substitute_buffer(i.bounds, target, target_info.dims);

--- a/builder/test/visualize/padded_stencil_0.html
+++ b/builder/test/visualize/padded_stencil_0.html
@@ -365,11 +365,11 @@ function pipeline(__in, out) {
     { let padding = allocate('padding', 2, [
         
       ]);
-      { let padded_intm_intm = allocate('padded_intm/intm', 2, [
+      { let padded_intm = allocate('padded_intm', 2, [
           {bounds:[(buffer_min(out, 0) + -1), (buffer_max(out, 0) + 1)], stride:NaN, fold_factor:NaN},
           {bounds:[(buffer_min(out, 1) + -1), (buffer_max(out, 1) + 1)], stride:NaN, fold_factor:NaN}
         ]);
-        { let __intm_3 = crop_buffer(padded_intm_intm, [
+        { let __intm_3 = crop_buffer(padded_intm, [
             [g, g_0],
             [g_1, g_2]
         ]); {
@@ -378,14 +378,14 @@ function pipeline(__in, out) {
           produce(intm_3);
           __event_t++;
           produce(intm_3);
-          produce(padded_intm_intm);
+          produce(padded_intm);
           produce(padding);
           __event_t++;
         }}
-        consume(padded_intm_intm);
+        consume(padded_intm);
         produce(out);
         __event_t++;
-        free(padded_intm_intm);
+        free(padded_intm);
       }
       free(padding);
     }

--- a/builder/test/visualize/padded_stencil_1.html
+++ b/builder/test/visualize/padded_stencil_1.html
@@ -365,11 +365,11 @@ function pipeline(__in, out) {
     { let padding = allocate('padding', 2, [
         
       ]);
-      { let padded_intm_intm = allocate('padded_intm/intm', 2, [
+      { let padded_intm = allocate('padded_intm', 2, [
           {bounds:[(buffer_min(out, 0) + -1), (buffer_max(out, 0) + 1)], stride:NaN, fold_factor:NaN},
           {bounds:[(buffer_min(out, 1) + -1), (buffer_max(out, 1) + 1)], stride:NaN, fold_factor:NaN}
         ]);
-        { let __intm_3 = crop_buffer(padded_intm_intm, [
+        { let __intm_3 = crop_buffer(padded_intm, [
             [g, g_0],
             [g_1, g_2]
         ]); {
@@ -378,14 +378,14 @@ function pipeline(__in, out) {
           produce(intm_3);
           __event_t++;
           produce(intm_3);
-          produce(padded_intm_intm);
+          produce(padded_intm);
           produce(padding);
           __event_t++;
         }}
-        consume(padded_intm_intm);
+        consume(padded_intm);
         produce(out);
         __event_t++;
-        free(padded_intm_intm);
+        free(padded_intm);
       }
       free(padding);
     }


### PR DESCRIPTION
A specific case I was looking at was a transpose which could have been aliased to the output, but output had min explicitly set to 0, so after substituion the call to alias_compatible would fail despite both target and source having bounds expressed in terms of output bounds.