### PR TITLE
Include immintrin.h only on x86_64

### DIFF
--- a/apps/performance.cc
+++ b/apps/performance.cc
@@ -6,7 +6,9 @@
 #include <cassert>
 #include <cstdlib>
 #include <cstring>
+#if defined(__x86_64__)
 #include <immintrin.h>
+#endif
 #include <iomanip>
 #include <iostream>
 


### PR DESCRIPTION
Include immintrin.h only on x86_64.
This fixes the build on arm64.