### PR TITLE
Add `thread_pool_impl::work_until_idle`

### DIFF
--- a/base/test/thread_pool.cc
+++ b/base/test/thread_pool.cc
@@ -79,4 +79,20 @@ TEST(wait_for, barriers) {
   th.join();
 }
 
+TEST(work_until_idle, test) {
+  thread_pool_impl t(/*workers=*/0);
+  for (int n = 0; n < 100; ++n) {
+    std::atomic<int> count = 0;
+    std::atomic<int> sum = 0;
+    t.enqueue(n, [&](size_t i) {
+      count++;
+      sum += i;
+    });
+    t.work_until_idle();
+    ASSERT_EQ(count, n);
+    ASSERT_EQ(sum, sum_arithmetic_sequence(n));
+  }
+
+}
+
 }  // namespace slinky

--- a/base/thread_pool_impl.h
+++ b/base/thread_pool_impl.h
@@ -100,13 +100,17 @@ public:
 
   // Enters the calling thread into the thread pool as a worker. Does not return until `condition` returns true.
   void run_worker(predicate_ref condition);
+
+  // Enters the calling thread into the thread pool as a worker. Returns when there is no work to do.
+  void work_until_idle();
+
   // Because the above API allows adding workers to the thread pool, we might not know how many threads there will be
   // when starting up a task. This allows communicating that information.
   void expect_workers(int n) { expected_thread_count_ = n; }
 
   int thread_count() const override { return std::max<int>(expected_thread_count_, worker_count_); }
 
-  ref_count<task> enqueue(std::size_t n, task_body t, int max_workers) override;
+  ref_count<task> enqueue(std::size_t n, task_body t, int max_workers = std::numeric_limits<int>::max()) override;
   void wait_for(task* t) override;
   void wait_for(predicate_ref condition) override { wait_for(condition, cv_helper_); }
   void atomic_call(function_ref<void()> t) override;


### PR DESCRIPTION
This helper is useful when trying to use `thread_pool_impl` to wrap an existing thread pool. This is similar to `run_worker`, but instead of waiting on the condition variable when there is no work to do, it just returns. This is useful to call from a scheduled task in another thread pool that we want to work on the `thread_pool_impl` queue instead.