### PR TITLE
Set expected workers in thread pool's constructor

### DIFF
--- a/base/test/thread_pool.cc
+++ b/base/test/thread_pool.cc
@@ -92,7 +92,14 @@ TEST(work_until_idle, test) {
     ASSERT_EQ(count, n);
     ASSERT_EQ(sum, sum_arithmetic_sequence(n));
   }
+}
 
+TEST(thread_count, delayed_workers) {
+  // Start a thread pool with workers that are slow to start.
+  thread_pool_impl t(/*workers=*/2, []() { std::this_thread::sleep_for(std::chrono::milliseconds(100)); });
+
+  // We should have two threads even if the workers haven't started yet.
+  ASSERT_EQ(t.thread_count(), 2);
 }
 
 }  // namespace slinky

--- a/base/thread_pool_impl.cc
+++ b/base/thread_pool_impl.cc
@@ -88,6 +88,7 @@ bool thread_pool_impl::task_impl::all_work_started() const {
 }
 
 thread_pool_impl::thread_pool_impl(int workers, function_ref<void()> init) : stop_(false) {
+  expect_workers(workers);
   auto worker = [this, init]() {
     if (init) init();
     run_worker([this]() -> bool { return stop_; });


### PR DESCRIPTION
Not all of the workers may be started when `thread_count` is called, leading to an incorrect number of threads being reported.