### PR TITLE
Allow copy funcs to have a custom copy implementation

### DIFF
--- a/builder/node_mutator.cc
+++ b/builder/node_mutator.cc
@@ -217,7 +217,7 @@ void node_mutator::visit(const copy_stmt* op) {
   if (!changed) {
     set_result(op);
   } else {
-    set_result(copy_stmt::make(op->src, std::move(src_x), op->dst, op->dst_x, op->pad));
+    set_result(copy_stmt::make(op->impl, op->src, std::move(src_x), op->dst, op->dst_x, op->pad));
   }
 }
 void node_mutator::visit(const allocate* op) {

--- a/builder/optimizations.cc
+++ b/builder/optimizations.cc
@@ -1151,15 +1151,16 @@ stmt implement_copy(const copy_stmt* op, node_context& ctx) {
   call_stmt::attributes copy_attrs;
   copy_attrs.name = "copy";
   stmt result = call_stmt::make(
-      [](const call_stmt* op, const eval_context& ctx) -> index_t {
+      [impl = op->impl](const call_stmt* op, const eval_context& ctx) -> index_t {
         // TODO: This passes the src buffer as an output, not an input, because slinky thinks the bounds of inputs
         // don't matter. But in this case, they do...
         const raw_buffer* src_buf = ctx.lookup_buffer(op->outputs[0]);
         const raw_buffer* dst_buf = ctx.lookup_buffer(op->outputs[1]);
-        const raw_buffer* pad_buf = op->outputs[2].defined() ? ctx.lookup_buffer(op->outputs[2]) : nullptr;
+        const raw_buffer* pad_buf = op->outputs[2].defined() ? ctx.lookup_buffer(op->outputs[2]) : &no_padding;
         assert(src_buf);
         assert(dst_buf);
-        ctx.config->copy(*src_buf, *dst_buf, pad_buf);
+        assert(pad_buf);
+        impl(*src_buf, *dst_buf, *pad_buf);
         return 0;
       },
       {}, {op->src, dst, op->pad}, std::move(copy_attrs));

--- a/builder/pipeline.h
+++ b/builder/pipeline.h
@@ -310,6 +310,10 @@ public:
     return make_impl(std::move(impl), std::move(inputs), std::move(outputs), std::move(attrs));
   }
 
+  // The following functions make various forms of copy operations. `impl` is a function that can customize the
+  // implementation of the copy. The function must be equivalent to `slinky::copy`. The `impl` function may not be
+  // called if the copy is aliased.
+
   // Make a copy from a single input to a single output.
   static func make_copy(input src, output dst, copy_stmt::callable impl = slinky::copy) {
     return func(std::move(impl), {std::move(src)}, std::move(dst));
@@ -324,13 +328,13 @@ public:
   }
   // Make a concatenation copy. This is a helper function for `make_copy`, where the crop for input i is a `crop_dim` in
   // dimension `dim` on the interval `[bounds[i], bounds[i + 1])`, and the input is translated by `-bounds[i]`.
-  static func make_concat(std::vector<buffer_expr_ptr> src, output dst, std::size_t dim,
-      std::vector<expr> bounds, copy_stmt::callable impl = slinky::copy);
+  static func make_concat(std::vector<buffer_expr_ptr> src, output dst, std::size_t dim, std::vector<expr> bounds,
+      copy_stmt::callable impl = slinky::copy);
   // Make a stack copy. This is a helper function for `make_copy`, where the crop for input i is a `slice_dim` of
   // dimension `dim` at i. If `dim` is greater than the rank of `out` (the default), the new stack dimension will be the
   // last dimension of the output.
-  static func make_stack(std::vector<buffer_expr_ptr> src, output dst, std::size_t dim = -1,
-      copy_stmt::callable impl = slinky::copy);
+  static func make_stack(
+      std::vector<buffer_expr_ptr> src, output dst, std::size_t dim = -1, copy_stmt::callable impl = slinky::copy);
 
   const call_stmt::callable& impl() const { return impl_; }
   const std::vector<input>& inputs() const { return inputs_; }

--- a/builder/pipeline.h
+++ b/builder/pipeline.h
@@ -186,6 +186,7 @@ public:
 private:
   call_stmt::callable impl_;
   call_stmt::attributes attrs_;
+  copy_stmt::callable copy_impl_;
   // A pointer to the optional user data.
   void* user_data_ = nullptr;
 
@@ -204,8 +205,8 @@ public:
   func() = default;
   func(call_stmt::callable impl, std::vector<input> inputs, std::vector<output> outputs,
       call_stmt::attributes attrs = {});
-  func(std::vector<input> inputs, output out);
-  func(input src, output dst, input pad);
+  func(copy_stmt::callable impl, std::vector<input> inputs, output out);
+  func(copy_stmt::callable impl, input src, output dst, input pad);
   func(func&&) noexcept;
   func& operator=(func&&) noexcept;
   ~func();
@@ -310,20 +311,26 @@ public:
   }
 
   // Make a copy from a single input to a single output.
-  static func make_copy(input src, output dst) { return func({std::move(src)}, std::move(dst)); }
+  static func make_copy(input src, output dst, copy_stmt::callable impl = slinky::copy) {
+    return func(std::move(impl), {std::move(src)}, std::move(dst));
+  }
   // Make a copy from a single input to a single output, with padding outside the output crop.
-  static func make_copy(input src, output dst, input pad) {
-    return func(std::move(src), std::move(dst), std::move(pad));
+  static func make_copy(input src, output dst, input pad, copy_stmt::callable impl = slinky::copy) {
+    return func(std::move(impl), std::move(src), std::move(dst), std::move(pad));
   }
   // Make a copy from multiple inputs with undefined padding.
-  static func make_copy(std::vector<input> src, output dst) { return func(std::move(src), std::move(dst)); }
+  static func make_copy(std::vector<input> src, output dst, copy_stmt::callable impl = slinky::copy) {
+    return func(std::move(impl), std::move(src), std::move(dst));
+  }
   // Make a concatenation copy. This is a helper function for `make_copy`, where the crop for input i is a `crop_dim` in
   // dimension `dim` on the interval `[bounds[i], bounds[i + 1])`, and the input is translated by `-bounds[i]`.
-  static func make_concat(std::vector<buffer_expr_ptr> src, output dst, std::size_t dim, std::vector<expr> bounds);
+  static func make_concat(std::vector<buffer_expr_ptr> src, output dst, std::size_t dim,
+      std::vector<expr> bounds, copy_stmt::callable impl = slinky::copy);
   // Make a stack copy. This is a helper function for `make_copy`, where the crop for input i is a `slice_dim` of
   // dimension `dim` at i. If `dim` is greater than the rank of `out` (the default), the new stack dimension will be the
   // last dimension of the output.
-  static func make_stack(std::vector<buffer_expr_ptr> src, output dst, std::size_t dim = -1);
+  static func make_stack(std::vector<buffer_expr_ptr> src, output dst, std::size_t dim = -1,
+      copy_stmt::callable impl = slinky::copy);
 
   const call_stmt::callable& impl() const { return impl_; }
   const std::vector<input>& inputs() const { return inputs_; }

--- a/builder/simplify.cc
+++ b/builder/simplify.cc
@@ -1505,7 +1505,7 @@ public:
     }
 
     if (changed || src != op->src || dst != op->dst || pad != op->pad) {
-      set_result(copy_stmt::make(src, std::move(src_x), dst, op->dst_x, pad));
+      set_result(copy_stmt::make(op->impl, src, std::move(src_x), dst, op->dst_x, pad));
     } else {
       set_result(op);
     }

--- a/builder/substitute.cc
+++ b/builder/substitute.cc
@@ -278,6 +278,12 @@ public:
     if (!try_match(cs->dst, op->dst)) return;
     if (!try_match(cs->dst_x, op->dst_x)) return;
     if (!try_match(cs->pad, op->pad)) return;
+    if (cs->impl && op->impl) {
+      // If std::function-s are defined we can't compare the functions, compare the pointers instead.
+      if (!try_match(cs, op)) return;
+    } else {
+      if (!try_match(!cs->impl, !op->impl)) return;
+    }
   }
 
   void visit(const allocate* op) override {
@@ -740,7 +746,7 @@ void substitutor::visit(const copy_stmt* op) {
   }
   exit_decls(decls_entered);
   if (changed || src != op->src || dst != op->dst || pad != op->pad) {
-    set_result(copy_stmt::make(src, std::move(src_x), dst, std::move(dst_x), pad));
+    set_result(copy_stmt::make(op->impl, src, std::move(src_x), dst, std::move(dst_x), pad));
   } else {
     set_result(op);
   }

--- a/builder/test/cannot_alias.cc
+++ b/builder/test/cannot_alias.cc
@@ -39,8 +39,9 @@ TEST_P(may_alias, transpose_input) {
 
   var x(ctx, "x");
   var y(ctx, "y");
+  test_context eval_ctx;
 
-  func transposed = func::make_copy({in, {point(y), point(x)}}, {in_t, {x, y}});
+  func transposed = func::make_copy({in, {point(y), point(x)}}, {in_t, {x, y}}, eval_ctx.copy);
   func add1 = func::make(
       [=](const buffer<const int>& a, const buffer<int>& b) -> index_t {
         if (!may_alias && a.dim(0).stride() != 4) return 1;
@@ -62,7 +63,6 @@ TEST_P(may_alias, transpose_input) {
   // Not having span(std::initializer_list<T>) is unfortunate.
   const raw_buffer* inputs[] = {&in_buf};
   const raw_buffer* outputs[] = {&out_buf};
-  test_context eval_ctx;
   ASSERT_EQ(0, p.evaluate(inputs, outputs, eval_ctx));
 
   for (int y = 0; y < H; ++y) {
@@ -97,6 +97,7 @@ TEST_P(may_alias, transpose_output) {
 
   var x(ctx, "x");
   var y(ctx, "y");
+  test_context eval_ctx;
 
   func add1 = func::make(
       [=](const buffer<const int>& a, const buffer<int>& b) -> index_t {
@@ -104,7 +105,7 @@ TEST_P(may_alias, transpose_output) {
         return add_1<int>(a, b);
       },
       {{{in, {point(x), point(y)}}}}, {{{out_t, {x, y}}}}, call_stmt::attributes{.name = "add1"});
-  func transposed = func::make_copy({out_t, {point(y), point(x)}}, {out, {x, y}});
+  func transposed = func::make_copy({out_t, {point(y), point(x)}}, {out, {x, y}}, eval_ctx.copy);
 
   pipeline p = build_pipeline(ctx, {in}, {out});
 
@@ -120,7 +121,6 @@ TEST_P(may_alias, transpose_output) {
   // Not having span(std::initializer_list<T>) is unfortunate.
   const raw_buffer* inputs[] = {&in_buf};
   const raw_buffer* outputs[] = {&out_buf};
-  test_context eval_ctx;
   ASSERT_EQ(0, p.evaluate(inputs, outputs, eval_ctx));
 
   for (int y = 0; y < H; ++y) {
@@ -143,6 +143,7 @@ TEST_P(may_alias, aligned) {
 
   var x(ctx, "x");
   var y(ctx, "y");
+  test_context eval_ctx;
 
   intm->dim(0).bounds = align(intm->dim(0).bounds, 2);
 
@@ -159,7 +160,7 @@ TEST_P(may_alias, aligned) {
   out->dim(1).fold_factor = dim::unfolded;
 
   func add = func::make(add_1<short>, {{in, {point(x), point(y)}}}, {{intm, {x, y}}});
-  func copied = func::make_copy({intm, {point(x), point(y)}}, {out, {x, y}});
+  func copied = func::make_copy({intm, {point(x), point(y)}}, {out, {x, y}}, eval_ctx.copy);
 
   pipeline p = build_pipeline(ctx, {in}, {out});
 
@@ -175,7 +176,6 @@ TEST_P(may_alias, aligned) {
   // Not having span(std::initializer_list<T>) is unfortunate.
   const raw_buffer* inputs[] = {&in_buf};
   const raw_buffer* outputs[] = {&out_buf};
-  test_context eval_ctx;
   p.evaluate(inputs, outputs, eval_ctx);
 
   for (int y = 0; y < H; ++y) {
@@ -200,6 +200,7 @@ TEST_P(may_alias, same_bounds) {
 
   var x(ctx, "x");
   var y(ctx, "y");
+  test_context eval_ctx;
 
   // In this pipeline, the result is copied to two outputs. We can only alias in this case if we know the two outputs
   // have the same bounds.
@@ -217,8 +218,8 @@ TEST_P(may_alias, same_bounds) {
   out2->dim(1).fold_factor = dim::unfolded;
 
   func add = func::make(add_1<short>, {{in, {point(x), point(y)}}}, {{intm, {x, y}}});
-  func copied1 = func::make_copy({intm, {point(x), point(y)}}, {out1, {x, y}});
-  func copied2 = func::make_copy({intm, {point(x), point(y)}}, {out2, {x, y}});
+  func copied1 = func::make_copy({intm, {point(x), point(y)}}, {out1, {x, y}}, eval_ctx.copy);
+  func copied2 = func::make_copy({intm, {point(x), point(y)}}, {out2, {x, y}}, eval_ctx.copy);
 
   pipeline p = build_pipeline(ctx, {in}, {out1, out2});
 
@@ -236,7 +237,6 @@ TEST_P(may_alias, same_bounds) {
   // Not having span(std::initializer_list<T>) is unfortunate.
   const raw_buffer* inputs[] = {&in_buf};
   const raw_buffer* outputs[] = {&out1_buf, &out2_buf};
-  test_context eval_ctx;
   p.evaluate(inputs, outputs, eval_ctx);
 
   for (int y = 0; y < H; ++y) {
@@ -262,6 +262,7 @@ TEST_P(may_alias, unfolded) {
 
   var x(ctx, "x");
   var y(ctx, "y");
+  test_context eval_ctx;
 
   // In this pipeline, the result is copied to the output, and we want to fold the intermediate buffer and alias it to
   // the output. We can only alias it if we know the output is unfolded.
@@ -275,7 +276,7 @@ TEST_P(may_alias, unfolded) {
   out->dim(0).fold_factor = dim::unfolded;
 
   func add = func::make(add_1<short>, {{in, {point(x), point(y)}}}, {{intm, {x, y}}});
-  func copied = func::make_copy({intm, {point(x), point(y)}}, {out, {x, y}});
+  func copied = func::make_copy({intm, {point(x), point(y)}}, {out, {x, y}}, eval_ctx.copy);
 
   // The fold factor must be > 1, so we can't assume that the intermediate fold factor divides the output fold factor.
   copied.loops({{y, 2}});
@@ -294,7 +295,6 @@ TEST_P(may_alias, unfolded) {
   // Not having span(std::initializer_list<T>) is unfortunate.
   const raw_buffer* inputs[] = {&in_buf};
   const raw_buffer* outputs[] = {&out_buf};
-  test_context eval_ctx;
   p.evaluate(inputs, outputs, eval_ctx);
 
   for (int y = 0; y < H; ++y) {
@@ -379,12 +379,13 @@ TEST(split_output, cannot_alias) {
 
   var x(ctx, "x");
   var y(ctx, "y");
+  test_context eval_ctx;
 
   // This pipeline is tempted to alias the intermediate to the output, but it isn't safe because we don't know it's big
   // enough.
   func add = func::make(add_1<short>, {{{in, {point(x), point(y)}}}}, {{{intm, {x, y}}}});
-  func split1 = func::make_copy({intm, {point(x), point(y)}}, {out1, {x, y}});
-  func split2 = func::make_copy({intm, {point(x), point(y) + out1->dim(1).extent()}}, {out2, {x, y}});
+  func split1 = func::make_copy({intm, {point(x), point(y)}}, {out1, {x, y}}, eval_ctx.copy);
+  func split2 = func::make_copy({intm, {point(x), point(y) + out1->dim(1).extent()}}, {out2, {x, y}}, eval_ctx.copy);
   pipeline p = build_pipeline(ctx, {in}, {out1, out2});
 
   // Run the pipeline.
@@ -402,7 +403,6 @@ TEST(split_output, cannot_alias) {
   // Not having span(std::initializer_list<T>) is unfortunate.
   const raw_buffer* inputs[] = {&in_buf};
   const raw_buffer* outputs[] = {&out1_buf, &out2_buf};
-  test_context eval_ctx;
   p.evaluate(inputs, outputs, eval_ctx);
 
   for (int y = 0; y < H1; ++y) {

--- a/builder/test/context.cc
+++ b/builder/test/context.cc
@@ -48,14 +48,10 @@ test_context::test_context() {
     heap.track_free(b->size_bytes());
   };
 
-  config.copy = [this](const raw_buffer& src, const raw_buffer& dst, const raw_buffer* pad) {
+  copy = [this](const raw_buffer& src, const raw_buffer& dst, const raw_buffer& pad) {
     ++copy_calls;
     copy_elements += dst.elem_count();
     slinky::copy(src, dst, pad);
-  };
-  config.pad = [this](const dim* in_bounds, const raw_buffer& dst, const raw_buffer& pad) {
-    ++pad_calls;
-    slinky::pad(in_bounds, dst, pad);
   };
 
   config.thread_pool = &threads;

--- a/builder/test/context.h
+++ b/builder/test/context.h
@@ -35,9 +35,10 @@ public:
   memory_info heap;
   int copy_calls = 0;
   int copy_elements = 0;
-  int pad_calls = 0;
 
   eval_config config;
+
+  copy_stmt::callable copy;
 
   test_context();
 };

--- a/builder/test/optimizations.cc
+++ b/builder/test/optimizations.cc
@@ -250,8 +250,8 @@ TEST(optimizations, deshadow_speed) {
 TEST(optimizations, canonicalize_nodes) {
   ASSERT_THAT(canonicalize_nodes(x + x), unique_node_count_is(2));
   ASSERT_THAT(canonicalize_nodes(x + y), unique_node_count_is(3));
-  ASSERT_THAT(canonicalize_nodes(
-                  block::make({copy_stmt::make(x, {z, w}, y, {z, w}, {}), copy_stmt::make(x, {z, w}, y, {z, w}, {})})),
+  ASSERT_THAT(canonicalize_nodes(block::make({copy_stmt::make(nullptr, x, {z, w}, y, {z, w}, {}),
+                  copy_stmt::make(nullptr, x, {z, w}, y, {z, w}, {})})),
       unique_node_count_is(4));
   ASSERT_THAT(
       canonicalize_nodes(block::make({call_stmt::make(nullptr, {x}, {y}, {}), call_stmt::make(nullptr, {x}, {y}, {})})),

--- a/builder/test/stencil.cc
+++ b/builder/test/stencil.cc
@@ -42,8 +42,9 @@ TEST_P(stencil, x_dx) {
 
   var x(ctx, "x");
   var dx(ctx, "dx");
+  test_context eval_ctx;
 
-  func copy = func::make_copy({in, {point(x * S + dx * D)}}, {out, {x, dx}});
+  func copy = func::make_copy({in, {point(x * S + dx * D)}}, {out, {x, dx}}, eval_ctx.copy);
 
   pipeline p = build_pipeline(ctx, {in}, {out});
 
@@ -63,7 +64,7 @@ TEST_P(stencil, x_dx) {
       // Not having span(std::initializer_list<T>) is unfortunate.
       const raw_buffer* inputs[] = {&in_buf};
       const raw_buffer* outputs[] = {&out_buf};
-      test_context eval_ctx;
+      eval_ctx.copy_calls = 0;
       p.evaluate(inputs, outputs, eval_ctx);
 
       for (int n = min_n; n < min_n + N; ++n) {
@@ -90,8 +91,9 @@ TEST_P(stencil, dx_x) {
 
   var x(ctx, "x");
   var dx(ctx, "dx");
+  test_context eval_ctx;
 
-  func copy = func::make_copy({in, {point(x * S + dx * D)}}, {out, {dx, x}});
+  func copy = func::make_copy({in, {point(x * S + dx * D)}}, {out, {dx, x}}, eval_ctx.copy);
 
   pipeline p = build_pipeline(ctx, {in}, {out});
 
@@ -111,7 +113,7 @@ TEST_P(stencil, dx_x) {
       // Not having span(std::initializer_list<T>) is unfortunate.
       const raw_buffer* inputs[] = {&in_buf};
       const raw_buffer* outputs[] = {&out_buf};
-      test_context eval_ctx;
+      eval_ctx.copy_calls = 0;
       p.evaluate(inputs, outputs, eval_ctx);
 
       for (int n = min_n; n < min_n + N; ++n) {
@@ -140,8 +142,9 @@ TEST_P(stencil, x_y_dx_dy) {
   var y(ctx, "y");
   var dx(ctx, "dx");
   var dy(ctx, "dy");
+  test_context eval_ctx;
 
-  func copy = func::make_copy({in, {point(x * S + dx * D), point(y * S + dy * D)}}, {out, {x, y, dx, dy}});
+  func copy = func::make_copy({in, {point(x * S + dx * D), point(y * S + dy * D)}}, {out, {x, y, dx, dy}}, eval_ctx.copy);
 
   pipeline p = build_pipeline(ctx, {in}, {out});
 
@@ -163,7 +166,7 @@ TEST_P(stencil, x_y_dx_dy) {
           // Not having span(std::initializer_list<T>) is unfortunate.
           const raw_buffer* inputs[] = {&in_buf};
           const raw_buffer* outputs[] = {&out_buf};
-          test_context eval_ctx;
+          eval_ctx.copy_calls = 0;
           p.evaluate(inputs, outputs, eval_ctx);
 
           for (int y = min_y; y < min_y + H; ++y) {
@@ -198,8 +201,9 @@ TEST_P(stencil, x_dx_y_dy) {
   var y(ctx, "y");
   var dx(ctx, "dx");
   var dy(ctx, "dy");
+  test_context eval_ctx;
 
-  func copy = func::make_copy({in, {point(x * S + dx * D), point(y * S + dy * D)}}, {out, {x, dx, y, dy}});
+  func copy = func::make_copy({in, {point(x * S + dx * D), point(y * S + dy * D)}}, {out, {x, dx, y, dy}}, eval_ctx.copy);
 
   pipeline p = build_pipeline(ctx, {in}, {out});
 
@@ -222,7 +226,7 @@ TEST_P(stencil, x_dx_y_dy) {
           // Not having span(std::initializer_list<T>) is unfortunate.
           const raw_buffer* inputs[] = {&in_buf};
           const raw_buffer* outputs[] = {&out_buf};
-          test_context eval_ctx;
+          eval_ctx.copy_calls = 0;
           p.evaluate(inputs, outputs, eval_ctx);
 
           for (int y = min_y; y < min_y + H; ++y) {

--- a/builder/test/substitute.cc
+++ b/builder/test/substitute.cc
@@ -7,8 +7,8 @@
 #include "builder/substitute.h"
 #include "runtime/buffer.h"
 #include "runtime/expr.h"
-#include "runtime/stmt.h"
 #include "runtime/print.h"
+#include "runtime/stmt.h"
 
 namespace slinky {
 
@@ -62,11 +62,14 @@ TEST(substitute, shadowed) {
   ASSERT_THAT(substitute(slice_dim::make(x, u, 2, 0, check::make(y == buffer_min(x, 3))), y, buffer_max(u, 3)),
       matches(slice_dim::make(x, u, 2, 0, check::make(buffer_max(u, 3) == buffer_min(x, 3)))));
 
-  ASSERT_THAT(
-      substitute(copy_stmt::make(x, {y, z}, w, {y, z}, {}), y, z), matches(copy_stmt::make(x, {y, z}, w, {y, z}, {})));
-  ASSERT_THAT(substitute(copy_stmt::make(x, {y}, w, {y}, {}), y, z), matches(copy_stmt::make(x, {y}, w, {y}, {})));
-  ASSERT_THAT(substitute(copy_stmt::make(x, {y}, w, {z}, {}), y, u), matches(copy_stmt::make(x, {u}, w, {z}, {})));
-  ASSERT_THAT(substitute(copy_stmt::make(x, {y}, w, {z}, u), u, v), matches(copy_stmt::make(x, {y}, w, {z}, v)));
+  ASSERT_THAT(substitute(copy_stmt::make(nullptr, x, {y, z}, w, {y, z}, {}), y, z),
+      matches(copy_stmt::make(nullptr, x, {y, z}, w, {y, z}, {})));
+  ASSERT_THAT(substitute(copy_stmt::make(nullptr, x, {y}, w, {y}, {}), y, z),
+      matches(copy_stmt::make(nullptr, x, {y}, w, {y}, {})));
+  ASSERT_THAT(substitute(copy_stmt::make(nullptr, x, {y}, w, {z}, {}), y, u),
+      matches(copy_stmt::make(nullptr, x, {u}, w, {z}, {})));
+  ASSERT_THAT(substitute(copy_stmt::make(nullptr, x, {y}, w, {z}, u), u, v),
+      matches(copy_stmt::make(nullptr, x, {y}, w, {z}, v)));
 }
 
 TEST(match, basic) {

--- a/runtime/buffer.cc
+++ b/runtime/buffer.cc
@@ -356,12 +356,12 @@ void pad_impl(raw_buffer& src, raw_buffer& dst, raw_buffer& pad) {
 
 }  // namespace
 
-SLINKY_NO_STACK_PROTECTOR void copy(const raw_buffer& src, const raw_buffer& dst, const raw_buffer* pad) {
+SLINKY_NO_STACK_PROTECTOR void copy(const raw_buffer& src, const raw_buffer& dst, const raw_buffer& pad) {
   assert(dst.elem_size == src.elem_size);
   assert(dst.base || dst.elem_count() == 0);
   if (dst.rank == 0) {
-    assert(src.base || (pad && pad->base));
-    memcpy(dst.base, !src.base && pad ? pad->base : src.base, dst.elem_size);
+    assert(src.base || pad.base);
+    memcpy(dst.base, !src.base && pad.base ? pad.base : src.base, dst.elem_size);
     return;
   }
 
@@ -375,12 +375,12 @@ SLINKY_NO_STACK_PROTECTOR void copy(const raw_buffer& src, const raw_buffer& dst
   internal::copy_small_n(src.dims, src.rank, src_opt.dims);
 
   // If the src has rank 0, then the padding is irrelevant, nothing is out of bounds.
-  if (src_opt.rank > 0 && pad && pad->base) {
-    assert(dst_opt.elem_size == pad->elem_size);
+  if (src_opt.rank > 0 && pad.base) {
+    assert(dst_opt.elem_size == pad.elem_size);
 
-    raw_buffer pad_opt = *pad;
-    pad_opt.dims = SLINKY_ALLOCA(dim, pad->rank);
-    internal::copy_small_n(pad->dims, pad->rank, pad_opt.dims);
+    raw_buffer pad_opt = pad;
+    pad_opt.dims = SLINKY_ALLOCA(dim, pad.rank);
+    internal::copy_small_n(pad.dims, pad.rank, pad_opt.dims);
 
     optimize_dims(dst_opt, src_opt, pad_opt);
 

--- a/runtime/buffer.h
+++ b/runtime/buffer.h
@@ -649,11 +649,11 @@ const buffer<NewT>& raw_buffer::cast() const {
 }
 
 // Copy the contents of `src` to `dst`.
-// If `padding` is nullptr, every index of `dst` must be in bounds of `src`.
-// If `padding` is not nullptr, `dst` will be copied from `src` if it is in bounds, otherwise it will be copied from
+// If `padding` is `no_padding, every index of `dst` must be in bounds of `src`.
+// If `padding` is not `no_padding`, `dst` will be copied from `src` if it is in bounds, otherwise it will be copied from
 // `padding`, which must be in bounds.
-void copy(const raw_buffer& src, const raw_buffer& dst, const raw_buffer* pad = nullptr);
-inline void copy(const raw_buffer& src, const raw_buffer& dst, const raw_buffer& pad) { copy(src, dst, &pad); }
+static constexpr raw_buffer no_padding = {};
+void copy(const raw_buffer& src, const raw_buffer& dst, const raw_buffer& pad = no_padding);
 
 // Performs only the padding operation of a copy. The region that would have been copied is unmodified.
 void pad(const dim* src_bounds, const raw_buffer& dst, const raw_buffer& pad);

--- a/runtime/evaluate.h
+++ b/runtime/evaluate.h
@@ -28,14 +28,6 @@ struct eval_config {
   // A pointer to a thread pool, required for parallel
   slinky::thread_pool* thread_pool = nullptr;
 
-  // Functions implementing buffer data movement:
-  // - `copy` should copy from `src` to `dst`, filling `dst` with `pad` when out of bounds of `src`.
-  // - `pad` should fill the area out of bounds of `src_dims` with `pad` in `dst`.
-  std::function<void(const raw_buffer& src, const raw_buffer& dst, const raw_buffer* pad)> copy =
-      static_cast<void (*)(const raw_buffer&, const raw_buffer&, const raw_buffer*)>(slinky::copy);
-  std::function<void(const dim* in_bounds, const raw_buffer& dst, const raw_buffer& pad)> pad =
-      static_cast<void (*)(const dim*, const raw_buffer&, const raw_buffer&)>(slinky::pad);
-
   // Functions implementing the `trace_begin` and `trace_end` intrinsics.
   std::function<index_t(const char*)> trace_begin;
   std::function<void(index_t)> trace_end;

--- a/runtime/expr_stmt.cc
+++ b/runtime/expr_stmt.cc
@@ -438,13 +438,14 @@ stmt call_stmt::make(call_stmt::callable target, symbol_list inputs, symbol_list
   return stmt(n);
 }
 
-stmt copy_stmt::make(var src, std::vector<expr> src_x, var dst, std::vector<var> dst_x, var pad) {
+stmt copy_stmt::make(copy_stmt::callable impl, var src, std::vector<expr> src_x, var dst, std::vector<var> dst_x, var pad) {
   auto n = new copy_stmt();
   n->src = src;
   n->src_x = std::move(src_x);
   n->dst = dst;
   n->dst_x = std::move(dst_x);
   n->pad = pad;
+  n->impl = impl;
   return stmt(n);
 }
 

--- a/runtime/stmt.h
+++ b/runtime/stmt.h
@@ -165,6 +165,8 @@ public:
 
 class copy_stmt : public stmt_node<copy_stmt> {
 public:
+  using callable = std::function<void(const raw_buffer&, const raw_buffer&, const raw_buffer& pad)>;
+
   var src;
   std::vector<expr> src_x;
   var dst;
@@ -172,9 +174,13 @@ public:
   // If defined, the copy will be padded with the values from this buffer when `src` is out of bounds of `dst`.
   var pad;
 
+  // This function implements the copy operation. `slinky::copy` is always a suitable implementation of this.
+  // The implementation must only perform a copy and no other operations.
+  callable impl;
+
   void accept(stmt_visitor* v) const override;
 
-  static stmt make(var src, std::vector<expr> src_x, var dst, std::vector<var> dst_x, var pad);
+  static stmt make(callable impl, var src, std::vector<expr> src_x, var dst, std::vector<var> dst_x, var pad);
 
   static constexpr stmt_node_type static_type = stmt_node_type::copy_stmt;
 };

--- a/runtime/test/depends_on.cc
+++ b/runtime/test/depends_on.cc
@@ -91,18 +91,18 @@ TEST(depends_on, basic) {
 }
 
 TEST(depends_on, copy) {
-  ASSERT_EQ(depends_on(copy_stmt::make(x, {z}, y, {z}, {}), x),
+  ASSERT_EQ(depends_on(copy_stmt::make(nullptr, x, {z}, y, {z}, {}), x),
       (depends_on_result{.var = true, .buffer_src = true, .buffer_dims = true}));
-  ASSERT_EQ(depends_on(copy_stmt::make(x, {z}, y, {z}, w), x),
+  ASSERT_EQ(depends_on(copy_stmt::make(nullptr, x, {z}, y, {z}, w), x),
       (depends_on_result{.var = true, .buffer_src = true, .buffer_dims = true, .buffer_bounds = true}));
-  ASSERT_EQ(depends_on(copy_stmt::make(x, {z}, y, {z}, {}), y),
+  ASSERT_EQ(depends_on(copy_stmt::make(nullptr, x, {z}, y, {z}, {}), y),
       (depends_on_result{.var = true, .buffer_dst = true, .buffer_dims = true, .buffer_bounds = true}));
-  ASSERT_EQ(depends_on(copy_stmt::make(x, {z}, y, {z}, w), y),
+  ASSERT_EQ(depends_on(copy_stmt::make(nullptr, x, {z}, y, {z}, w), y),
       (depends_on_result{.var = true, .buffer_dst = true, .buffer_dims = true, .buffer_bounds = true}));
-  ASSERT_EQ(depends_on(copy_stmt::make(x, {z}, y, {z}, w), w),
+  ASSERT_EQ(depends_on(copy_stmt::make(nullptr, x, {z}, y, {z}, w), w),
       (depends_on_result{.var = true, .buffer_src = true, .buffer_dims = true}));
-    ASSERT_EQ(depends_on(copy_stmt::make(x, {z + w}, y, {z}, {}), z), (depends_on_result{}));
-  ASSERT_EQ(depends_on(copy_stmt::make(x, {z + w}, y, {z}, {}), w), (depends_on_result{.var = true}));
+    ASSERT_EQ(depends_on(copy_stmt::make(nullptr, x, {z + w}, y, {z}, {}), z), (depends_on_result{}));
+  ASSERT_EQ(depends_on(copy_stmt::make(nullptr, x, {z + w}, y, {z}, {}), w), (depends_on_result{.var = true}));
 }
 
 TEST(depends_on, is_pure) {
@@ -146,8 +146,8 @@ TEST(find_dependencies, basic) {
   ASSERT_THAT(find_dependencies(crop_dim::make(x, y, 0, {z, z}, call_stmt::make(nullptr, {w}, {u}, {}))),
       testing::ElementsAre(y, z, w, u));
   ASSERT_THAT(find_dependencies(block::make({check::make(x), check::make(y)})), testing::ElementsAre(x, y));
-  ASSERT_THAT(find_dependencies(copy_stmt::make(x, {w}, y, {w}, z)), testing::ElementsAre(x, y, z));
-  ASSERT_THAT(find_dependencies(copy_stmt::make(x, {w + u}, y, {w}, var())), testing::ElementsAre(x, y, u));
+  ASSERT_THAT(find_dependencies(copy_stmt::make(nullptr, x, {w}, y, {w}, z)), testing::ElementsAre(x, y, z));
+  ASSERT_THAT(find_dependencies(copy_stmt::make(nullptr, x, {w + u}, y, {w}, var())), testing::ElementsAre(x, y, u));
 }
 
 }  // namespace slinky


### PR DESCRIPTION
This allows one to define pipelines with copies in them that might alias to another buffer, but if they don't, to call a user defined implementation of copy instead of `slinky::copy`.

This provides a way to optimize special cases of copies, such as transposes that affect dimensions with a small and/or fixed stride.