### PR TITLE
Treat constants as inputs, so we don't try to reallocate them

### DIFF
--- a/builder/optimizations.cc
+++ b/builder/optimizations.cc
@@ -415,7 +415,9 @@ public:
   }
 
   void visit(const constant_buffer* op) override {
-    auto s = set_value_in_scope(buffers, op->sym, buffer_info(buffer_dims(*op->value), op->value->elem_size));
+    // Constants are similar to inputs in that they cannot be mutated.
+    auto s = set_value_in_scope(
+        buffers, op->sym, buffer_info(buffer_dims(*op->value), op->value->elem_size, /*is_input=*/true));
     stmt_mutator::visit(op);
 
     // When an allocation goes out of scope, we should remove it as an aliasing candidate.

--- a/builder/test/cannot_alias.cc
+++ b/builder/test/cannot_alias.cc
@@ -667,4 +667,52 @@ TEST(multiple_producers, cannot_alias) {
   }
 }
 
+TEST(cannot_alias, padded_constant) {
+  const int padding_value = 3;
+
+  // Make the pipeline
+  node_context ctx;
+
+  const int W = 10;
+  const int H = 7;
+  buffer<char, 2> in_buf({W - 2, H - 2});
+  init_random(in_buf);
+
+  auto in = buffer_expr::make_constant(ctx, "in", raw_buffer::make_copy(in_buf));
+  auto out = buffer_expr::make(ctx, "out", 2, sizeof(char));
+  auto padded_in = buffer_expr::make(ctx, "padded_intm", 2, sizeof(char));
+  auto padding = buffer_expr::make_scalar<char>(ctx, "padding", padding_value);
+
+  var x(ctx, "x");
+  var y(ctx, "y");
+
+  func crop =
+      func::make_copy({in, {point(x), point(y)}, in->bounds()}, {padded_in, {x, y}}, {padding, {point(x), point(y)}});
+  func copy_out = func::make(copy_2d<char>, {{padded_in, {point(x), point(y)}}}, {{out, {x, y}}});
+
+  pipeline p = build_pipeline(ctx, {in}, {out});
+
+  // Run the pipeline
+  buffer<char, 2> out_buf({W, H});
+  out_buf.allocate();
+
+  const raw_buffer* inputs[] = {&in_buf};
+  const raw_buffer* outputs[] = {&out_buf};
+  test_context eval_ctx;
+  p.evaluate(inputs, outputs, eval_ctx);
+
+  for (int y = 0; y < H; ++y) {
+    for (int x = 0; x < W; ++x) {
+      if (in_buf.contains(x, y)) {
+        ASSERT_EQ(out_buf(x, y), in_buf(x, y));
+      } else {
+        ASSERT_EQ(out_buf(x, y), padding_value);
+      }
+    }
+  }
+
+  ASSERT_EQ(eval_ctx.heap.allocs.size(), 1);
+  ASSERT_EQ(eval_ctx.copy_calls, 1);
+}
+
 }  // namespace slinky


### PR DESCRIPTION
We can't reallocate constants with padding like we can intermediate allocations.