### PR TITLE
Provide option to use absl synchronization primitives for thread pool

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,9 @@ jobs:
         
       - name: Build and test with ASAN
         run: bazel test --config=asan --copt=-Os --test_output=errors ...
+        
+      - name: Build and test thread pool with absl
+        run: bazel test --define slinky_use_absl_synchronization=true base/test:thread_pool
 
       - name: Shut down bazel
         run: bazel shutdown

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,3 +1,4 @@
 bazel_dep(name = "googletest", version = "1.14.0")
 bazel_dep(name = "google_benchmark", version = "1.8.3")
 bazel_dep(name = "rules_license", version = "0.0.7")
+bazel_dep(name = "abseil-cpp", version = "20250512.1")

--- a/base/BUILD
+++ b/base/BUILD
@@ -35,6 +35,11 @@ cc_library(
     visibility = ["//visibility:public"],
 )
 
+config_setting(
+    name = "use_absl_synchronization",
+    define_values = {"slinky_use_absl_synchronization": "true"},
+)
+
 cc_library(
     name = "thread_pool_impl",
     srcs = ["thread_pool_impl.cc"],
@@ -45,7 +50,14 @@ cc_library(
         "thread_synchronization.h",
         "util.h"
     ],
-    deps = [":thread_pool"],
+    defines = select({
+        ":use_absl_synchronization": ["SLINKY_USE_ABSL_SYNCHRONIZATION"],
+        "//conditions:default": [],
+    }),
+    deps = [":thread_pool"] + select({
+        ":use_absl_synchronization": ["@abseil-cpp//absl/synchronization"],
+        "//conditions:default": [],
+    }),
     visibility = ["//visibility:public"],
 )
 

--- a/base/BUILD
+++ b/base/BUILD
@@ -42,6 +42,7 @@ cc_library(
         "function_ref.h",
         "ref_count.h",
         "thread_pool_impl.h",
+        "thread_synchronization.h",
         "util.h"
     ],
     deps = [":thread_pool"],

--- a/base/thread_pool_impl.cc
+++ b/base/thread_pool_impl.cc
@@ -3,9 +3,10 @@
 #include <algorithm>
 #include <cassert>
 #include <functional>
-#include <mutex>
 #include <thread>
 #include <vector>
+
+#include "base/thread_synchronization.h"
 
 namespace slinky {
 
@@ -155,12 +156,12 @@ ref_count<thread_pool_impl::task_impl> thread_pool_impl::dequeue(int& worker) {
   return nullptr;
 }
 
-void thread_pool_impl::wait_for(predicate_ref condition, std::condition_variable& cv) {
+void thread_pool_impl::wait_for(predicate_ref condition, condition_variable& cv) {
   // We want to spin a few times before letting the OS take over.
   const int spin_count = 1000;
   int spins = 0;
 
-  std::unique_lock l(mutex_);
+  unique_lock l(mutex_);
   while (!condition()) {
     int worker;
     if (auto task = dequeue(worker)) {
@@ -189,7 +190,7 @@ void thread_pool_impl::wait_for(predicate_ref condition, std::condition_variable
 }
 
 void thread_pool_impl::work_until_idle() {
-  std::unique_lock l(mutex_);
+  unique_lock l(mutex_);
   int worker;
   while (auto task = dequeue(worker)) {
     l.unlock();
@@ -207,7 +208,7 @@ void thread_pool_impl::work_until_idle() {
 }
 
 void thread_pool_impl::atomic_call(function_ref<void()> t) {
-  std::unique_lock l(mutex_);
+  unique_lock l(mutex_);
   t();
   cv_worker_.notify_all();
   cv_helper_.notify_all();
@@ -225,7 +226,7 @@ ref_count<thread_pool::task> thread_pool_impl::enqueue(std::size_t n, task_body 
   max_workers = std::min<std::size_t>(n, max_workers);
   const std::size_t shard_count = ordered ? 1 : std::min(max_shards, max_workers);
   auto loop = task_impl::make(shard_count, n, std::move(t), max_workers);
-  std::unique_lock l(mutex_);
+  unique_lock l(mutex_);
   task_queue_.push_back(loop);
   if (max_workers == 1) {
     cv_worker_.notify_one();

--- a/base/thread_pool_impl.h
+++ b/base/thread_pool_impl.h
@@ -3,17 +3,16 @@
 
 #include <atomic>
 #include <cassert>
-#include <condition_variable>
 #include <deque>
 #include <functional>
 #include <limits>
-#include <mutex>
 #include <thread>
 #include <vector>
 
 #include "base/function_ref.h"
 #include "base/ref_count.h"
 #include "base/thread_pool.h"
+#include "base/thread_synchronization.h"
 
 namespace slinky {
 
@@ -78,16 +77,16 @@ private:
   std::atomic<bool> stop_;
 
   std::deque<ref_count<task_impl>> task_queue_;
-  std::mutex mutex_;
+  mutex mutex_;
   // We have two condition variables in an attempt to minimize unnecessary thread wakeups:
   // - cv_helper_ is waited on by threads that are helping the worker threads while waiting for a condition.
   // - cv_worker_ is waited on by worker threads.
   // Enqueuing a task wakes up a thread from each condition variable.
   // cv_helper_ is only notified when the state of a condition may change (a task completes, or an `atomic_call` runs).
-  std::condition_variable cv_helper_;
-  std::condition_variable cv_worker_;
+  condition_variable cv_helper_;
+  condition_variable cv_worker_;
 
-  void wait_for(predicate_ref condition, std::condition_variable& cv);
+  void wait_for(predicate_ref condition, condition_variable& cv);
 
   ref_count<task_impl> dequeue(int& worker);
 

--- a/base/thread_synchronization.h
+++ b/base/thread_synchronization.h
@@ -1,0 +1,15 @@
+#ifndef SLINKY_BASE_THREAD_SYNCHRONIZATION_H
+#define SLINKY_BASE_THREAD_SYNCHRONIZATION_H
+
+#include <condition_variable>
+#include <mutex>
+
+namespace slinky {
+
+using mutex = std::mutex;
+using condition_variable = std::condition_variable;
+using unique_lock = std::unique_lock<std::mutex>;
+
+}  // namespace slinky
+
+#endif  // SLINKY_BASE_THREAD_SYNCHRONIZATION_H

--- a/base/thread_synchronization.h
+++ b/base/thread_synchronization.h
@@ -1,14 +1,56 @@
 #ifndef SLINKY_BASE_THREAD_SYNCHRONIZATION_H
 #define SLINKY_BASE_THREAD_SYNCHRONIZATION_H
 
+#ifdef SLINKY_USE_ABSL_SYNCHRONIZATION
+
+#include "absl/synchronization/mutex.h"
+
+#else
+
 #include <condition_variable>
 #include <mutex>
 
+#endif
+
 namespace slinky {
+
+#ifdef SLINKY_USE_ABSL_SYNCHRONIZATION
+
+using mutex = absl::Mutex;
+
+class unique_lock {
+  friend class condition_variable;
+  mutex& m_;
+
+public:
+  unique_lock(mutex& m) : m_(m) { m_.Lock(); }
+  unique_lock(const unique_lock&) = delete;
+  unique_lock(unique_lock&&) = default;
+  ~unique_lock() { m_.Unlock(); }
+
+  unique_lock& operator=(const unique_lock&) = delete;
+  unique_lock& operator=(unique_lock&&) = default;
+
+  void lock() { m_.Lock(); }
+  void unlock() { m_.Unlock(); }
+};
+
+class condition_variable {
+  absl::CondVar impl_;
+
+public:
+  void notify_one() { impl_.Signal(); }
+  void notify_all() { impl_.SignalAll(); }
+  void wait(unique_lock& l) { impl_.Wait(&l.m_); }
+};
+
+#else
 
 using mutex = std::mutex;
 using condition_variable = std::condition_variable;
 using unique_lock = std::unique_lock<std::mutex>;
+
+#endif
 
 }  // namespace slinky
 


### PR DESCRIPTION
This adds an option `--define slinky_use_absl_synchronization=true` to the build, which will use `absl::Mutex` instead of `std::mutex`.