### PR TITLE
Add tests of variable stride/dilation stencils

### DIFF
--- a/builder/optimizations.cc
+++ b/builder/optimizations.cc
@@ -134,7 +134,8 @@ bool is_copy(var src, expr src_x, int src_d, var dst, span<const var> dst_x, int
     scale = simplify(scale);
     offset = simplify(offset);
 
-    if (!is_non_negative(scale)) {
+    std::optional<index_t> scale_bound = evaluate_constant_lower_bound(scale);
+    if (!scale_bound || *scale_bound < 0) {
       // TODO: Maybe we could handle negative stride copies.
       return false;
     }

--- a/builder/test/stencil.cc
+++ b/builder/test/stencil.cc
@@ -144,7 +144,8 @@ TEST_P(stencil, x_y_dx_dy) {
   var dy(ctx, "dy");
   test_context eval_ctx;
 
-  func copy = func::make_copy({in, {point(x * S + dx * D), point(y * S + dy * D)}}, {out, {x, y, dx, dy}}, eval_ctx.copy);
+  func copy =
+      func::make_copy({in, {point(x * S + dx * D), point(y * S + dy * D)}}, {out, {x, y, dx, dy}}, eval_ctx.copy);
 
   pipeline p = build_pipeline(ctx, {in}, {out});
 
@@ -203,7 +204,8 @@ TEST_P(stencil, x_dx_y_dy) {
   var dy(ctx, "dy");
   test_context eval_ctx;
 
-  func copy = func::make_copy({in, {point(x * S + dx * D), point(y * S + dy * D)}}, {out, {x, dx, y, dy}}, eval_ctx.copy);
+  func copy =
+      func::make_copy({in, {point(x * S + dx * D), point(y * S + dy * D)}}, {out, {x, dx, y, dy}}, eval_ctx.copy);
 
   pipeline p = build_pipeline(ctx, {in}, {out});
 
@@ -236,6 +238,59 @@ TEST_P(stencil, x_dx_y_dy) {
                   ASSERT_EQ(out_buf(x, dx, y, dy), in_buf(x * S + dx * D, y * S + dy * D));
                 }
               }
+            }
+          }
+
+          ASSERT_EQ(eval_ctx.copy_calls, 1);
+        }
+      }
+    }
+  }
+}
+
+TEST(stencil_variable, x_dx) {
+  // Make the pipeline
+  node_context ctx;
+
+  auto in = buffer_expr::make(ctx, "in", 1, sizeof(short));
+  auto out = buffer_expr::make(ctx, "out", 2, sizeof(short));
+
+  var x(ctx, "x");
+  var dx(ctx, "dx");
+  var s(ctx, "s");
+  var d(ctx, "d");
+  test_context eval_ctx;
+
+  func copy = func::make_copy({in, {point(x * max(1, s) + dx * max(1, d))}}, {out, {x, dx}}, eval_ctx.copy);
+
+  pipeline p = build_pipeline(ctx, {s, d}, {in}, {out});
+
+  // Run the pipeline.
+  const int N = 10;
+  const int K = 5;
+
+  for (index_t S : {1, 2, 3}) {
+    for (index_t D : {1, 2, 3}) {
+      for (int min_n : offsets) {
+        for (int min_k : offsets) {
+          buffer<short, 2> out_buf({N, K});
+          out_buf.allocate();
+          out_buf.translate(min_n, min_k);
+
+          buffer<short, 1> in_buf({(N - 1) * S + (K - 1) * D + 1});
+          init_random(in_buf);
+          in_buf.translate(min_n * S + min_k * D);
+
+          // Not having span(std::initializer_list<T>) is unfortunate.
+          index_t args[] = {S, D};
+          const raw_buffer* inputs[] = {&in_buf};
+          const raw_buffer* outputs[] = {&out_buf};
+          eval_ctx.copy_calls = 0;
+          p.evaluate(args, inputs, outputs, eval_ctx);
+
+          for (int n = min_n; n < min_n + N; ++n) {
+            for (int k = min_k; k < min_k + K; ++k) {
+              ASSERT_EQ(out_buf(n, k), in_buf(n * S + k * D));
             }
           }
 

--- a/builder/test/stencil.cc
+++ b/builder/test/stencil.cc
@@ -265,14 +265,14 @@ TEST(stencil_variable, x_dx) {
 
   pipeline p = build_pipeline(ctx, {s, d}, {in}, {out});
 
-  // Run the pipeline.
-  const int N = 10;
-  const int K = 5;
-
+  // Run the pipeline with varying stride/dilation parameters.
   for (index_t S : {1, 2, 3}) {
     for (index_t D : {1, 2, 3}) {
       for (int min_n : offsets) {
         for (int min_k : offsets) {
+          const int N = 10;
+          const int K = 5;
+
           buffer<short, 2> out_buf({N, K});
           out_buf.allocate();
           out_buf.translate(min_n, min_k);

--- a/builder/test/stencil_pipeline.cc
+++ b/builder/test/stencil_pipeline.cc
@@ -217,12 +217,11 @@ TEST_P(stencil_variable, 1d) {
 
   pipeline p = build_pipeline(ctx, {s, d}, {in}, {out}, {}, build_options{.no_alias_buffers = no_alias_buffers});
 
-  // Run the pipeline.
-
-  const int N = 10;
-
+  // Run the pipeline with varying stride/dilation parameters.
   for (int S : {1, 2, 3}) {
     for (int D : {1, 2, 3}) {
+      const int N = 10;
+
       buffer<short, 1> out_buf({N});
       out_buf.allocate();
 


### PR DESCRIPTION
And modify `is_copy` to be able to handle this case, by looking for constant bounds, rather than constants.