### PR TITLE
Fix aliasing of slices

### DIFF
--- a/builder/optimizations.cc
+++ b/builder/optimizations.cc
@@ -636,9 +636,9 @@ public:
 
     alias_info a;
     a.target = op->src;
-    a.at.resize(op->src_x.size());
+    a.at = op->src_x;
     a.permutation.resize(op->dst_x.size());
-    a.dims = info->dims;
+    a.dims.resize(info->dims.size());
     for (int dst_d = 0; dst_d < static_cast<int>(op->dst_x.size()); ++dst_d) {
       int src_d;
       if (!is_copy_dst_dim(op, dst_d, src_d)) {


### PR DESCRIPTION
This PR fixes a bug where if a copy has a slice of one of the input dimensions, the alias ignores it.

The other change is just a minor tweak for clarity, that none of the original buffer dimensions affect the alias (all of them were overwritten by the alias dimensions).