### PR TITLE
Fix fuse_contiguous_dims case

### DIFF
--- a/runtime/buffer.h
+++ b/runtime/buffer.h
@@ -755,7 +755,7 @@ inline const dim& dim_or_broadcast(const raw_buffer& buf, std::ptrdiff_t d) {
 inline bool same_bounds(std::ptrdiff_t, const raw_buffer&) { return true; }
 template <typename... Bufs>
 bool same_bounds(std::size_t d, const raw_buffer& buf0, const raw_buffer& buf1, const Bufs&... bufs) {
-  return (buf0.rank <= d || buf1.rank <= d || same_bounds(buf0.dim(d), buf1.dim(d))) && same_bounds(d, buf1, bufs...);
+  return (buf0.rank <= d || buf1.rank <= d || same_bounds(buf0.dim(d), buf1.dim(d))) && same_bounds(d, buf0, bufs...);
 }
 
 // Returns true if two dimensions of all buffers can be fused.

--- a/runtime/test/buffer.cc
+++ b/runtime/test/buffer.cc
@@ -1134,4 +1134,18 @@ TEST(fuse_contiguous_dims, cant_fuse_sets) {
   ASSERT_EQ(b.rank, 4);
 }
 
+TEST(fuse_contiguous_dims, cant_fuse_mismatched_bounds) {
+  buffer<int, 2> a({2, 3}), b({2, 3});
+  buffer<int> c, d;
+  a.crop(0, 1, 1);
+  ASSERT_EQ(fuse_contiguous_dims(a, b), 0);
+  ASSERT_EQ(a.rank, 2);
+  ASSERT_EQ(b.rank, 2);
+  // In this case, we have buffers with smaller rank in between the buffers with
+  // mismatched dimensions.
+  ASSERT_EQ(fuse_contiguous_dims(a, c, b, d), 0);
+  ASSERT_EQ(a.rank, 2);
+  ASSERT_EQ(b.rank, 2);
+}
+  
 }  // namespace slinky


### PR DESCRIPTION
When there are broadcasted buffers between the mismatched dimensions, we failed to catch it because we allow the intervening broadcasts to fuse.