### PR TITLE
Refactor `call_stmt::make` calls uses in tests

### DIFF
--- a/builder/test/optimizations.cc
+++ b/builder/test/optimizations.cc
@@ -257,9 +257,7 @@ TEST(optimizations, canonicalize_nodes) {
   ASSERT_THAT(canonicalize_nodes(block::make({copy_stmt::make(nullptr, x, {z, w}, y, {z, w}, {}),
                   copy_stmt::make(nullptr, x, {z, w}, y, {z, w}, {})})),
       unique_node_count_is(4));
-  ASSERT_THAT(
-      canonicalize_nodes(block::make({dummy_call({x}, {y}), dummy_call({x}, {y})})),
-      unique_node_count_is(3));
+  ASSERT_THAT(canonicalize_nodes(block::make({dummy_call({x}, {y}), dummy_call({x}, {y})})), unique_node_count_is(3));
 }
 
 TEST(optimizations, parallelize_tasks) {
@@ -331,8 +329,7 @@ TEST(optimizations, parallelize_tasks) {
               })),
       matches(block::make({
           dummy_call({x}, {y}),
-          async::make(var(), dummy_call({y}, {z}),
-              async::make(var(), dummy_call({y}, {w}), dummy_call({y}, {u}))),
+          async::make(var(), dummy_call({y}, {z}), async::make(var(), dummy_call({y}, {w}), dummy_call({y}, {u}))),
       })));
 
   // A check that both independent consumers depends on.

--- a/builder/test/substitute.cc
+++ b/builder/test/substitute.cc
@@ -40,11 +40,8 @@ TEST(substitute, basic) {
       matches(crop_dim::make(x, z, 0, interval_expr{0, 0}, dummy_call({}, {x}))));
   ASSERT_THAT(substitute(crop_dim::make(y, z, 0, {0, 0}, dummy_call({x}, {y})), x, w),
       matches(crop_dim::make(y, z, 0, {0, 0}, dummy_call({w}, {y}))));
-  ASSERT_THAT(substitute(crop_dim::make(
-                             y, y, 0, {0, 0}, crop_dim::make(y, y, 0, {0, 0}, dummy_call({x}, {y}))),
-                  x, w),
-      matches(
-          crop_dim::make(y, y, 0, {0, 0}, crop_dim::make(y, y, 0, {0, 0}, dummy_call({w}, {y})))));
+  ASSERT_THAT(substitute(crop_dim::make(y, y, 0, {0, 0}, crop_dim::make(y, y, 0, {0, 0}, dummy_call({x}, {y}))), x, w),
+      matches(crop_dim::make(y, y, 0, {0, 0}, crop_dim::make(y, y, 0, {0, 0}, dummy_call({w}, {y})))));
   ASSERT_THAT(substitute_buffer(buffer_stride(x, 0), x, expr(), {}), matches(expr()));
   ASSERT_THAT(substitute_buffer(buffer_stride(x, 0), x, expr(), {}, y), matches(buffer_stride(y, 0)));
   ASSERT_THAT(substitute_buffer(buffer_stride(x, 0), x, expr(), {dim_expr()}), matches(expr()));

--- a/builder/test/substitute.cc
+++ b/builder/test/substitute.cc
@@ -25,6 +25,10 @@ var v(symbols, "v");
 
 MATCHER_P(matches, expected, "") { return match(arg, expected); }
 
+stmt dummy_call(std::vector<var> inputs, std::vector<var> outputs, call_stmt::attributes attrs = {}) {
+  return call_stmt::make(nullptr, std::move(inputs), std::move(outputs), std::move(attrs));
+}
+
 }  // namespace
 
 TEST(substitute, basic) {
@@ -32,15 +36,15 @@ TEST(substitute, basic) {
   ASSERT_THAT(substitute(buffer_min(x, 2), x, y), matches(buffer_min(y, 2)));
   ASSERT_THAT(substitute(buffer_min(x, 2), buffer_min(x, 2), buffer_max(x, 2)), matches(buffer_max(x, 2)));
   ASSERT_THAT(substitute(buffer_at(x), x, expr()), matches(buffer_at(expr())));
-  ASSERT_THAT(substitute(crop_dim::make(x, y, 0, {0, 0}, call_stmt::make(nullptr, {}, {x}, {})), y, z),
-      matches(crop_dim::make(x, z, 0, interval_expr{0, 0}, call_stmt::make(nullptr, {}, {x}, {}))));
-  ASSERT_THAT(substitute(crop_dim::make(y, z, 0, {0, 0}, call_stmt::make(nullptr, {x}, {y}, {})), x, w),
-      matches(crop_dim::make(y, z, 0, {0, 0}, call_stmt::make(nullptr, {w}, {y}, {}))));
+  ASSERT_THAT(substitute(crop_dim::make(x, y, 0, {0, 0}, dummy_call({}, {x})), y, z),
+      matches(crop_dim::make(x, z, 0, interval_expr{0, 0}, dummy_call({}, {x}))));
+  ASSERT_THAT(substitute(crop_dim::make(y, z, 0, {0, 0}, dummy_call({x}, {y})), x, w),
+      matches(crop_dim::make(y, z, 0, {0, 0}, dummy_call({w}, {y}))));
   ASSERT_THAT(substitute(crop_dim::make(
-                             y, y, 0, {0, 0}, crop_dim::make(y, y, 0, {0, 0}, call_stmt::make(nullptr, {x}, {y}, {}))),
+                             y, y, 0, {0, 0}, crop_dim::make(y, y, 0, {0, 0}, dummy_call({x}, {y}))),
                   x, w),
       matches(
-          crop_dim::make(y, y, 0, {0, 0}, crop_dim::make(y, y, 0, {0, 0}, call_stmt::make(nullptr, {w}, {y}, {})))));
+          crop_dim::make(y, y, 0, {0, 0}, crop_dim::make(y, y, 0, {0, 0}, dummy_call({w}, {y})))));
   ASSERT_THAT(substitute_buffer(buffer_stride(x, 0), x, expr(), {}), matches(expr()));
   ASSERT_THAT(substitute_buffer(buffer_stride(x, 0), x, expr(), {}, y), matches(buffer_stride(y, 0)));
   ASSERT_THAT(substitute_buffer(buffer_stride(x, 0), x, expr(), {dim_expr()}), matches(expr()));

--- a/runtime/test/depends_on.cc
+++ b/runtime/test/depends_on.cc
@@ -105,7 +105,7 @@ TEST(depends_on, copy) {
       (depends_on_result{.var = true, .buffer_dst = true, .buffer_dims = true, .buffer_bounds = true}));
   ASSERT_EQ(depends_on(copy_stmt::make(nullptr, x, {z}, y, {z}, w), w),
       (depends_on_result{.var = true, .buffer_src = true, .buffer_dims = true}));
-    ASSERT_EQ(depends_on(copy_stmt::make(nullptr, x, {z + w}, y, {z}, {}), z), (depends_on_result{}));
+  ASSERT_EQ(depends_on(copy_stmt::make(nullptr, x, {z + w}, y, {z}, {}), z), (depends_on_result{}));
   ASSERT_EQ(depends_on(copy_stmt::make(nullptr, x, {z + w}, y, {z}, {}), w), (depends_on_result{.var = true}));
 }
 
@@ -124,8 +124,7 @@ TEST(find_buffer_dependencies, basic) {
   ASSERT_EQ(find_buffer_data_dependency(buffer_at(x, buffer_min(y, 0))), x);
   ASSERT_EQ(find_buffer_data_dependency(buffer_at(x) + buffer_at(y)), var());
 
-  ASSERT_THAT(find_buffer_dependencies(crop_buffer::make(x, y, {}, dummy_call({y}, {x}))),
-      testing::ElementsAre(y));
+  ASSERT_THAT(find_buffer_dependencies(crop_buffer::make(x, y, {}, dummy_call({y}, {x}))), testing::ElementsAre(y));
   ASSERT_THAT(find_buffer_dependencies(crop_buffer::make(z, y, {}, dummy_call({x}, {z})),
                   /*input=*/true, /*output=*/false),
       testing::ElementsAre(x));
@@ -147,8 +146,8 @@ TEST(find_dependencies, basic) {
   ASSERT_THAT(find_dependencies(buffer_at(x)), testing::ElementsAre(x));
   ASSERT_THAT(find_dependencies(x + y), testing::ElementsAre(x, y));
   ASSERT_THAT(find_dependencies(let::make(x, y, x + z)), testing::ElementsAre(y, z));
-  ASSERT_THAT(find_dependencies(crop_dim::make(x, y, 0, {z, z}, dummy_call({w}, {u}))),
-      testing::ElementsAre(y, z, w, u));
+  ASSERT_THAT(
+      find_dependencies(crop_dim::make(x, y, 0, {z, z}, dummy_call({w}, {u}))), testing::ElementsAre(y, z, w, u));
   ASSERT_THAT(find_dependencies(block::make({check::make(x), check::make(y)})), testing::ElementsAre(x, y));
   ASSERT_THAT(find_dependencies(copy_stmt::make(nullptr, x, {w}, y, {w}, z)), testing::ElementsAre(x, y, z));
   ASSERT_THAT(find_dependencies(copy_stmt::make(nullptr, x, {w + u}, y, {w}, var())), testing::ElementsAre(x, y, u));


### PR DESCRIPTION
This makes subsequent changes to `call_stmt::make` less noisy