### PR TITLE
Allow custom `call` exprs to implement their own logic

### DIFF
--- a/builder/test/copy.cc
+++ b/builder/test/copy.cc
@@ -1088,7 +1088,8 @@ TEST_P(tile, param) {
   var param(ctx, "N");
   test_context eval_ctx;
 
-  expr N = max(1, call::make(intrinsic::none, [](span<const index_t> args) { return args[0] + 1; }, {param}));
+  expr N = max(1, call::make(intrinsic::none,
+                      [](const call* op, eval_context& ctx) { return evaluate(op->args[0], ctx) + 1; }, {param}));
 
   func copy = func::make_copy({in, {point(xo * N + xi), point(yo * N + yi)}}, {out, {xi, yi, xo, yo}}, eval_ctx.copy);
 

--- a/runtime/evaluate.cc
+++ b/runtime/evaluate.cc
@@ -306,11 +306,8 @@ public:
   }
 
   index_t eval_call(const call* op) {
-    index_t* args = SLINKY_ALLOCA(index_t, op->args.size());
-    for (size_t i = 0; i < op->args.size(); ++i) {
-      args[i] = eval(op->args[i]);
-    }
-    return op->target({args, op->args.size()});
+    assert(op->target);
+    return op->target(op, context);
   }
 
   SLINKY_NO_INLINE index_t eval(const call* op) {

--- a/runtime/expr.h
+++ b/runtime/expr.h
@@ -503,9 +503,11 @@ public:
   static constexpr expr_node_type static_type = expr_node_type::select;
 };
 
+class eval_context;
+
 class call : public expr_node<call> {
 public:
-  using callable = std::function<index_t(span<const index_t>)>;
+  using callable = std::function<index_t(const call*, eval_context&)>;
 
   // If the call is an intrinsic operation, which intrinsic it is.
   slinky::intrinsic intrinsic;

--- a/runtime/test/evaluate.cc
+++ b/runtime/test/evaluate.cc
@@ -77,7 +77,11 @@ TEST(evaluate, buffer_fields) {
 }
 
 TEST(evaluate, user_defined_call) {
-  auto fn = [](span<const index_t> args) { return args[0] * args[1]; };
+  auto fn = [](const call* op, eval_context& ctx) {
+    index_t x = evaluate(op->args[0], ctx);
+    index_t y = evaluate(op->args[1], ctx);
+    return x * y; 
+  };
 
   eval_context context;
   context[x] = 3;


### PR DESCRIPTION
This generalizes `call` to allow the callback to handle unpacking the arguments. This is more consistent with how `call_stmt` works, and enables some functionality that wasn't previously possible (e.g. a call that it is a function of a buffer argument).