### PR TITLE
Negate `can_evaluate`

### DIFF
--- a/builder/simplify.cc
+++ b/builder/simplify.cc
@@ -2669,10 +2669,10 @@ public:
 
 bool can_evaluate(intrinsic fn) {
   switch (fn) {
-  case intrinsic::abs:
-  case intrinsic::and_then:
-  case intrinsic::or_else: return true;
-  default: return false;
+  case intrinsic::negative_infinity:
+  case intrinsic::positive_infinity:
+  case intrinsic::indeterminate: return false;
+  default: return true;
   }
 }
 


### PR DESCRIPTION
This allows user defined functions to be constant folded.

I think this also makes more sense: we only need to disallow evaluating functions that otherwise appear evaluatable (no non-constant arguments).