### PR TITLE
Remove extent 1 dimensions in `optimize_dims`

### DIFF
--- a/slinky/runtime/buffer.h
+++ b/slinky/runtime/buffer.h
@@ -138,6 +138,9 @@ public:
   bool is_folded() const { return is_folded(min(), max()); }
 
   bool is_broadcast() const { return min() == 0 && max() == 0 && stride() == 0; }
+
+  bool is_point() const { return min() == max(); }
+  bool is_point(index_t x) const { return min() == x && max() == x; }
 };
 
 inline constexpr dim dim::broadcast_{0, 0, 0, 0};
@@ -848,6 +851,11 @@ void swap_dims(std::size_t i, std::size_t j, raw_buffer& buf, Bufs&... bufs) {
   swap_dims(i, j, bufs...);
 }
 
+template <typename... Args>
+bool all(Args... args) {
+  return (... && args);
+}
+
 }  // namespace internal
 
 // Jointly sort the dimensions of all buffers such that the strides of the first buffer are in ascending order.
@@ -916,10 +924,31 @@ int optimize_dims(span<const int> dim_sets, raw_buffer& buf, Bufs&... bufs) {
 }
 template <typename... Bufs>
 int optimize_dims(raw_buffer& buf, Bufs&... bufs) {
-  int fused = fuse_contiguous_dims(buf, bufs...);
+  int fused = 0;
+
+  // Remove dimensions of extent 1 from all dimensions in the same position.
+  // TODO: It would be nice to find a way to do this with `fuse_contiguous_dims` and avoid the extra pass over the dimensions.
+  int max_rank = std::max({buf.rank, bufs.rank...});
+  for (int d = 0; d < max_rank;) {
+    const dim& buf_d = buf.dim(d);
+    const index_t at = buf_d.min();
+    if (at == buf_d.max() && internal::all(bufs.dim(d).is_point(at)...)) {
+      buf.slice(d, at);
+      (bufs.slice(d, at), ...);
+      ++fused;
+      --max_rank;
+    } else {
+      ++d;
+    }
+  }
+
+  // The order of operations here is for performance: It's a lot faster to fuse dimensions than sort them. So we fuse
+  // what we can before sorting, then if the sorting changed the order of the dimensions, attempt to fuse again.
+  fused += fuse_contiguous_dims(buf, bufs...);
   if (sort_dims(buf, bufs...)) {
     fused += fuse_contiguous_dims(buf, bufs...);
   }
+
   return fused;
 }
 

--- a/slinky/runtime/buffer.h
+++ b/slinky/runtime/buffer.h
@@ -63,7 +63,7 @@ class dim {
   index_t fold_factor_;
 
   static const dim broadcast_;
-  
+
 public:
   static constexpr index_t auto_stride = std::numeric_limits<index_t>::max();
   static constexpr index_t unfolded = -1;
@@ -842,9 +842,7 @@ SLINKY_INLINE bool attempt_fuse(
   return attempt_fuse(inner, outer, buf, bufs...);
 }
 
-inline void swap_dims(std::size_t i, std::size_t j, raw_buffer& buf) {
-  std::swap(buf.dims[i], buf.dims[j]);
-}
+inline void swap_dims(std::size_t i, std::size_t j, raw_buffer& buf) { std::swap(buf.dims[i], buf.dims[j]); }
 template <typename... Bufs>
 void swap_dims(std::size_t i, std::size_t j, raw_buffer& buf, Bufs&... bufs) {
   swap_dims(i, j, buf);
@@ -924,23 +922,22 @@ int optimize_dims(span<const int> dim_sets, raw_buffer& buf, Bufs&... bufs) {
 }
 template <typename... Bufs>
 int optimize_dims(raw_buffer& buf, Bufs&... bufs) {
-  int fused = 0;
-
   // Remove dimensions of extent 1 from all dimensions in the same position.
-  // TODO: It would be nice to find a way to do this with `fuse_contiguous_dims` and avoid the extra pass over the dimensions.
-  int max_rank = std::max({buf.rank, bufs.rank...});
-  for (int d = 0; d < max_rank;) {
-    const dim& buf_d = buf.dim(d);
-    const index_t at = buf_d.min();
-    if (at == buf_d.max() && internal::all(bufs.dim(d).is_point(at)...)) {
+  // We go from the trailing dimensions first, assuming that extent 1 dimensions are more common there, so it should be
+  // faster to slice them first.
+  // TODO: Find a way to do this with `fuse_contiguous_dims` and avoid the extra pass over the dimensions.
+  const int max_rank = std::max({buf.rank, bufs.rank...});
+  int fused = 0;
+  for (int d = max_rank - 1; d >= 0; --d) {
+    index_t at = buf.dim(d).min();
+    if (internal::all(buf.dim(d).is_point(), bufs.dim(d).is_point(at)...)) {
       buf.slice(d, at);
       (bufs.slice(d, at), ...);
       ++fused;
-      --max_rank;
-    } else {
-      ++d;
     }
   }
+
+  fused += fuse_contiguous_dims(buf, bufs...);
 
   // The order of operations here is for performance: It's a lot faster to fuse dimensions than sort them. So we fuse
   // what we can before sorting, then if the sorting changed the order of the dimensions, attempt to fuse again.

--- a/slinky/runtime/test/buffer.cc
+++ b/slinky/runtime/test/buffer.cc
@@ -1257,4 +1257,16 @@ TEST(fuse_contiguous_dims, cant_fuse_mismatched_bounds) {
   ASSERT_EQ(b.rank, 2);
 }
 
+TEST(optimize_dims, fuse_broadcasted) {
+  buffer<int, 3> a({1, 4, 1}), b({1, 6, 1});
+
+  ASSERT_EQ(optimize_dims(a, b), 2);
+  ASSERT_EQ(a.rank, 1);
+  ASSERT_EQ(b.rank, 1);
+  ASSERT_EQ(a.dim(0).extent(), 4);
+  ASSERT_EQ(a.dim(0).stride(), 4);
+  ASSERT_EQ(b.dim(0).extent(), 6);
+  ASSERT_EQ(b.dim(0).stride(), 4);
+}
+
 }  // namespace slinky

--- a/slinky/runtime/test/buffer.cc
+++ b/slinky/runtime/test/buffer.cc
@@ -1257,16 +1257,44 @@ TEST(fuse_contiguous_dims, cant_fuse_mismatched_bounds) {
   ASSERT_EQ(b.rank, 2);
 }
 
-TEST(optimize_dims, fuse_broadcasted) {
-  buffer<int, 3> a({1, 4, 1}), b({1, 6, 1});
+TEST(optimize_dims, trailing_extent_1) {
+  buffer<int, 3> a({6, 1, 1}), b({3});
 
   ASSERT_EQ(optimize_dims(a, b), 2);
   ASSERT_EQ(a.rank, 1);
   ASSERT_EQ(b.rank, 1);
-  ASSERT_EQ(a.dim(0).extent(), 4);
+  ASSERT_EQ(a.dim(0).extent(), 6);
   ASSERT_EQ(a.dim(0).stride(), 4);
-  ASSERT_EQ(b.dim(0).extent(), 6);
+  ASSERT_EQ(b.dim(0).extent(), 3);
   ASSERT_EQ(b.dim(0).stride(), 4);
+}
+
+TEST(optimize_dims, leading_extent_1) {
+  buffer<int, 3> a({1, 1, 6}), b({1, 1, 3});
+
+  ASSERT_EQ(optimize_dims(a, b), 2);
+  ASSERT_EQ(a.rank, 1);
+  ASSERT_EQ(b.rank, 1);
+  ASSERT_EQ(a.dim(0).extent(), 6);
+  ASSERT_EQ(a.dim(0).stride(), 4);
+  ASSERT_EQ(b.dim(0).extent(), 3);
+  ASSERT_EQ(b.dim(0).stride(), 4);
+}
+
+TEST(optimize_dims, extent_1) {
+  buffer<int, 3> a({2, 1, 6}), b({3, 1, 3});
+
+  ASSERT_EQ(optimize_dims(a, b), 1);
+  ASSERT_EQ(a.rank, 2);
+  ASSERT_EQ(b.rank, 2);
+  ASSERT_EQ(a.dim(0).extent(), 2);
+  ASSERT_EQ(a.dim(0).stride(), 4);
+  ASSERT_EQ(b.dim(0).extent(), 3);
+  ASSERT_EQ(b.dim(0).stride(), 4);
+  ASSERT_EQ(a.dim(1).extent(), 6);
+  ASSERT_EQ(a.dim(1).stride(), 8);
+  ASSERT_EQ(b.dim(1).extent(), 3);
+  ASSERT_EQ(b.dim(1).stride(), 12);
 }
 
 }  // namespace slinky


### PR DESCRIPTION
Currently we fuse dimensions that can be fused, but that doesn't permit fusing extent one broadcasts into non-broadcast dimensions