### PR TITLE
Add options to `raw_buffer::slice` to reduce overhead

### DIFF
--- a/slinky/runtime/buffer.h
+++ b/slinky/runtime/buffer.h
@@ -279,21 +279,19 @@ public:
   }
 
   template <typename... Offsets>
-  raw_buffer& translate(index_t o0, Offsets... offsets) {
+  void translate(index_t o0, Offsets... offsets) {
     assert(sizeof...(offsets) + 1 <= rank);
     translate_impl(dims, o0, offsets...);
-    return *this;
   }
-  raw_buffer& translate(span<const index_t> offsets) {
+  void translate(span<const index_t> offsets) {
     assert(offsets.size() <= rank);
     for (std::size_t i = 0; i < offsets.size(); ++i) {
       dims[i].translate(offsets[i]);
     }
-    return *this;
   }
 
   // Remove dimensions `ds`. The dimensions must be sorted in ascending order.
-  raw_buffer& slice(span<const std::size_t> ds) {
+  void slice(span<const std::size_t> ds) {
     if (ds.size() == 1) return slice(ds[0]);
 
     // Handle any slices of leading dimensions by just incrementing the dims pointer.
@@ -325,18 +323,16 @@ public:
 
     dims += slice_leading;
     rank -= slice_total;
-
-    return *this;
   }
-  raw_buffer& slice(std::initializer_list<std::size_t> ds) { return slice({&*ds.begin(), ds.size()}); }
+  void slice(std::initializer_list<std::size_t> ds) { slice({&*ds.begin(), ds.size()}); }
 
   // Remove dimension `d` and move the base pointer to point to `at` in this dimension.
   // `at` is dim(d).min() by default.
   // If `d` is 0 or rank - 1, the slice does not mutate the dims array.
-  raw_buffer& slice(std::size_t d) {
+  void slice(std::size_t d) {
     if (d >= rank) {
       // slicing a broadcast dimension is a no-op.
-      return *this;
+      return;
     }
 
     rank -= 1;
@@ -349,12 +345,11 @@ public:
         dims[i] = dims[i + 1];
       }
     }
-    return *this;
   }
-  raw_buffer& slice(std::size_t d, index_t at) {
+  void slice(std::size_t d, index_t at) {
     if (d >= rank) {
       // slicing a broadcast dimension is a no-op.
-      return *this;
+      return;
     }
 
     if (base != nullptr) {
@@ -370,10 +365,10 @@ public:
 
   // Crop the buffer in dimension `d` to the bounds `[min, max]`. The bounds will be clamped to the existing bounds.
   // Updates the base pointer to point to the new min.
-  raw_buffer& crop(std::size_t d, index_t min, index_t max) {
+  void crop(std::size_t d, index_t min, index_t max) {
     if (d >= rank) {
       // Cropping a broadcast dimension is a no-op.
-      return *this;
+      return;
     }
     slinky::dim& dim_d = dims[d];
     min = std::max(min, dim_d.min());
@@ -391,7 +386,6 @@ public:
     }
 
     dim_d.set_bounds(min, max);
-    return *this;
   }
 
   std::size_t size_bytes() const;

--- a/slinky/runtime/buffer.h
+++ b/slinky/runtime/buffer.h
@@ -154,6 +154,11 @@ using const_raw_buffer_ptr = std::shared_ptr<const raw_buffer>;
 static constexpr struct {
 } slice;
 
+// This wrapper indicates that its value should be assumed to be in bounds.
+struct in_bounds {
+  index_t x;
+};
+
 // We have some difficult requirements for this buffer object:
 // 1. We want type safety in user code, but we also want to be able to treat buffers as generic.
 // 2. We want to store metadata (dimensions) efficiently.
@@ -360,6 +365,21 @@ public:
         base = nullptr;
       }
     }
+    return slice(d);
+  }
+
+  // This overload assumes that `at` is in bounds and that the buffer is non-null.
+  void slice(std::size_t d, in_bounds at) {
+    if (d >= rank) {
+      // slicing a broadcast dimension is a no-op.
+      return;
+    }
+
+    assert(base);
+    const slinky::dim& dim_d = dims[d];
+    assert(dim_d.contains(at.x));
+    base = offset_bytes_non_null(base, dim_d.flat_offset_bytes(at.x));
+
     return slice(d);
   }
 

--- a/slinky/runtime/buffer.h
+++ b/slinky/runtime/buffer.h
@@ -120,9 +120,10 @@ public:
   bool contains(index_t x) const { return contains(x, x); }
   bool contains(const dim& other) const { return contains(other.min(), other.max()); }
 
-  std::ptrdiff_t flat_offset_bytes(index_t i) const {
+  SLINKY_INLINE std::ptrdiff_t flat_offset_bytes(index_t i, bool assert_unfolded = false) const {
     assert(contains(i));
-    if (stride() == 0 || fold_factor() == unfolded) {
+    assert(fold_factor() == unfolded || !assert_unfolded);
+    if (stride() == 0 || fold_factor() == unfolded || assert_unfolded) {
       return (i - min()) * stride();
     } else {
       return euclidean_mod_positive_modulus(i, fold_factor()) * stride();
@@ -351,7 +352,7 @@ public:
       }
     }
   }
-  void slice(std::size_t d, index_t at) {
+  void slice(std::size_t d, index_t at, bool assert_unfolded = false) {
     if (d >= rank) {
       // slicing a broadcast dimension is a no-op.
       return;
@@ -360,7 +361,7 @@ public:
     if (base != nullptr) {
       const slinky::dim& dim_d = dims[d];
       if (dim_d.contains(at)) {
-        base = offset_bytes_non_null(base, dim_d.flat_offset_bytes(at));
+        base = offset_bytes_non_null(base, dim_d.flat_offset_bytes(at, assert_unfolded));
       } else {
         base = nullptr;
       }
@@ -369,7 +370,7 @@ public:
   }
 
   // This overload assumes that `at` is in bounds and that the buffer is non-null.
-  void slice(std::size_t d, in_bounds at) {
+  void slice(std::size_t d, in_bounds at, bool assert_unfolded = false) {
     if (d >= rank) {
       // slicing a broadcast dimension is a no-op.
       return;
@@ -378,7 +379,7 @@ public:
     assert(base);
     const slinky::dim& dim_d = dims[d];
     assert(dim_d.contains(at.x));
-    base = offset_bytes_non_null(base, dim_d.flat_offset_bytes(at.x));
+    base = offset_bytes_non_null(base, dim_d.flat_offset_bytes(at.x, assert_unfolded));
 
     return slice(d);
   }

--- a/slinky/runtime/buffer.h
+++ b/slinky/runtime/buffer.h
@@ -298,7 +298,10 @@ public:
 
   // Remove dimensions `ds`. The dimensions must be sorted in ascending order.
   void slice(span<const std::size_t> ds) {
-    if (ds.size() == 1) return slice(ds[0]);
+    if (ds.size() == 1) {
+      slice(ds[0]);
+      return;
+    }
 
     // Handle any slices of leading dimensions by just incrementing the dims pointer.
     std::size_t slice_leading = 0;
@@ -366,10 +369,10 @@ public:
         base = nullptr;
       }
     }
-    return slice(d);
+    slice(d);
   }
 
-  // This overload assumes that `at` is in bounds and that the buffer is non-null.
+  // This overload assumes that `at` is in bounds and that the buffer is non-null (it was in-bounds before too).
   void slice(std::size_t d, in_bounds at, bool assert_unfolded = false) {
     if (d >= rank) {
       // slicing a broadcast dimension is a no-op.
@@ -381,7 +384,7 @@ public:
     assert(dim_d.contains(at.x));
     base = offset_bytes_non_null(base, dim_d.flat_offset_bytes(at.x, assert_unfolded));
 
-    return slice(d);
+    slice(d);
   }
 
   // Crop the buffer in dimension `d` to the bounds `[min, max]`. The bounds will be clamped to the existing bounds.

--- a/slinky/runtime/test/buffer.cc
+++ b/slinky/runtime/test/buffer.cc
@@ -255,6 +255,9 @@ TEST(buffer, broadcast_slice_crop) {
   sliced.slice(2, 5);
   ASSERT_EQ(sliced.rank, 2);
 
+  sliced.slice(2, in_bounds{5});
+  ASSERT_EQ(sliced.rank, 2);
+
   // Cropping a dimension >= rank is a no-op.
   raw_buffer cropped = buf;
   cropped.crop(2, 0, 5);
@@ -490,7 +493,7 @@ TEST(buffer, slice_at) {
   ASSERT_EQ(sliced.dim(1), buf.dim(2));
   ASSERT_EQ(&sliced(0, 0), &buf(0, 2, 0));
 
-  sliced.slice(/*dim=*/0, /*at=*/1);
+  sliced.slice(/*dim=*/0, /*at=*/in_bounds{1});
   ASSERT_EQ(sliced.rank, 1);
   ASSERT_EQ(sliced.dim(0), buf.dim(2));
   ASSERT_EQ(&sliced(0), &buf(1, 2, 0));


### PR DESCRIPTION
Many users of `raw_buffer` want to use `slice` to get a dimension from a buffer that they will handle with other libraries or tools. These uses likely don't support folding, and often want to assume that the index is in bounds. This change provides the tools to use these assumptions to avoid overhead in slinky code.

This change also removes the ability to chain slice and other buffer operations. This doesn't work well when the user is using `buffer<T>`.