### PR TITLE
Simplify `make_buffer` with new broadcast dimensions to `transpose`

### DIFF
--- a/slinky/builder/simplify.cc
+++ b/slinky/builder/simplify.cc
@@ -1756,7 +1756,7 @@ public:
         }
 
         // To be a transpose, we need buffer_at to be the base of src_buf, and each dimension to be a dimension of the
-        // original buffer.
+        // original buffer, or a broadcast.
         // TODO: This could probably be built into the slice check above.
         std::vector<int> permutation;
         auto is_transpose = [&]() {
@@ -1766,6 +1766,8 @@ public:
             int dim = is_buffer_dim(info.dims[d], *src_buf);
             if (dim >= 0) {
               permutation.push_back(dim);
+            } else if (prove_constant_true(info.dims[d].is_broadcast())) {
+              permutation.push_back(transpose::new_dim);
             } else {
               return false;
             }

--- a/slinky/builder/test/simplify/simplify.cc
+++ b/slinky/builder/test/simplify/simplify.cc
@@ -1054,16 +1054,6 @@ TEST(simplify, make_buffer) {
                   make_buffer::make(b1, buffer_at(b0), buffer_elem_size(b0), {buffer_dim(b0, 0), buffer_dim(b0, 1)},
                       dummy_call({}, {b1})))),
       matches(allocate::make(b0, memory_type::heap, 4, {{{0, 255}, {}, {}}, {{0, 0}, {}, {}}}, dummy_call({}, {b0}))));
-  ASSERT_THAT(simplify(allocate::make(b0, memory_type::heap, 4, {{{0, 255}, {}, {}}, {{0, 0}, {}, {}}},
-                  make_buffer::make(b1, buffer_at(b0), buffer_elem_size(b0), {buffer_dim(b0, 0), {{0, 0}, 0, {}}},
-                      dummy_call({}, {b1})))),
-      matches(allocate::make(b0, memory_type::heap, 4, {{{0, 255}, {}, {}}, {{0, 0}, {}, {}}}, dummy_call({}, {b0}))));
-  ASSERT_THAT(
-      simplify(allocate::make(b0, memory_type::heap, 4, {{{0, 255}, {}, {}}, {{0, 0}, {}, {}}, {{0, 0}, {}, {}}},
-          make_buffer::make(b1, buffer_at(b0), buffer_elem_size(b0),
-              {buffer_dim(b0, 0), {{0, 0}, 0, {}}, {{0, 0}, 0, {}}}, dummy_call({}, {b1})))),
-      matches(allocate::make(
-          b0, memory_type::heap, 4, {{{0, 255}, {}, {}}, {{0, 0}, {}, {}}, {{0, 0}, {}, {}}}, dummy_call({}, {b0}))));
 }
 
 TEST(simplify, transpose) {

--- a/slinky/builder/test/simplify/simplify.cc
+++ b/slinky/builder/test/simplify/simplify.cc
@@ -672,19 +672,19 @@ TEST(simplify, allocate) {
 
   // Drop trailing broadcast dimensions.
   ASSERT_THAT(simplify(allocate::make(
-                  x, memory_type::heap, 1, {{bounds(2, 3), 4, 5}, {{0, 0}, 0, 0}}, check::make(buffer_at(x)))),
+                  x, memory_type::heap, 1, {{bounds(2, 3), 4, 5}, dim::broadcast()}, check::make(buffer_at(x)))),
       matches(allocate::make(x, memory_type::heap, 1, {{bounds(2, 3), 4, expr()}}, check::make(buffer_at(x)))));
 
   // Drop multiple trailing broadcast dimensions.
-  ASSERT_THAT(simplify(allocate::make(x, memory_type::heap, 1, {{bounds(2, 3), 4, 5}, {{0, 0}, 0, 0}, {{0, 0}, 0, 0}},
-                  check::make(buffer_at(x)))),
+  ASSERT_THAT(simplify(allocate::make(x, memory_type::heap, 1,
+                  {{bounds(2, 3), 4, 5}, dim::broadcast(), dim::broadcast()}, check::make(buffer_at(x)))),
       matches(allocate::make(x, memory_type::heap, 1, {{bounds(2, 3), 4, expr()}}, check::make(buffer_at(x)))));
 
   // A broadcast dimension that is not trailing should not be removed.
   ASSERT_THAT(simplify(allocate::make(
-                  x, memory_type::heap, 1, {{{0, 0}, 0, 0}, {bounds(2, 3), 4, 5}}, check::make(buffer_at(x)))),
+                  x, memory_type::heap, 1, {dim::broadcast(), {bounds(2, 3), 4, 5}}, check::make(buffer_at(x)))),
       matches(allocate::make(
-          x, memory_type::heap, 1, {{{0, 0}, 0, 0}, {bounds(2, 3), 4, expr()}}, check::make(buffer_at(x)))));
+          x, memory_type::heap, 1, {dim::broadcast(), {bounds(2, 3), 4, expr()}}, check::make(buffer_at(x)))));
 }
 
 TEST(simplify, constant_buffer) {
@@ -743,15 +743,15 @@ TEST(simplify, slice_of_crop) {
       matches(allocate::make(b0, memory_type::heap, 1, {{bounds(0, x)}}, dummy_call({b0}, {}))));
 
   // Slicing a dimension known to be broadcast is a no-op.
-  ASSERT_THAT(simplify(allocate::make(b0, memory_type::heap, 1, {{{0, 0}, 0, 0}, {bounds(0, x), 1, expr()}},
+  ASSERT_THAT(simplify(allocate::make(b0, memory_type::heap, 1, {dim::broadcast(), {bounds(0, x), 1, expr()}},
                   slice_dim::make(b1, b0, 0, y, dummy_call({b1}, {})))),
-      matches(
-          allocate::make(b0, memory_type::heap, 1, {{{0, 0}, 0, 0}, {bounds(0, x), 1, expr()}}, dummy_call({b0}, {}))));
+      matches(allocate::make(
+          b0, memory_type::heap, 1, {dim::broadcast(), {bounds(0, x), 1, expr()}}, dummy_call({b0}, {}))));
 
   // Broadcast dim is skipped, non-broadcast dim is kept.
-  ASSERT_THAT(simplify(allocate::make(b0, memory_type::heap, 1, {{{0, 0}, 0, 0}, {bounds(0, x), 1, expr()}},
+  ASSERT_THAT(simplify(allocate::make(b0, memory_type::heap, 1, {dim::broadcast(), {bounds(0, x), 1, expr()}},
                   slice_buffer::make(b1, b0, {y, z}, dummy_call({b1}, {})))),
-      matches(allocate::make(b0, memory_type::heap, 1, {{{0, 0}, 0, 0}, {bounds(0, x), 1, expr()}},
+      matches(allocate::make(b0, memory_type::heap, 1, {dim::broadcast(), {bounds(0, x), 1, expr()}},
           slice_dim::make(b1, b0, 1, z, dummy_call({b1}, {})))));
 }
 
@@ -939,15 +939,15 @@ TEST(simplify, crop) {
       matches(allocate::make(b0, memory_type::heap, 1, {{bounds(0, x)}}, dummy_call({}, {b0}))));
 
   // Cropping a dimension known to be broadcast is a no-op.
-  ASSERT_THAT(simplify(allocate::make(b0, memory_type::heap, 1, {{{0, 0}, 0, 0}, {bounds(0, x), 1, expr()}},
+  ASSERT_THAT(simplify(allocate::make(b0, memory_type::heap, 1, {dim::broadcast(), {bounds(0, x), 1, expr()}},
                   crop_dim::make(b1, b0, 0, {y, z}, dummy_call({}, {b1})))),
-      matches(
-          allocate::make(b0, memory_type::heap, 1, {{{0, 0}, 0, 0}, {bounds(0, x), 1, expr()}}, dummy_call({}, {b0}))));
+      matches(allocate::make(
+          b0, memory_type::heap, 1, {dim::broadcast(), {bounds(0, x), 1, expr()}}, dummy_call({}, {b0}))));
 
   // Cropping broadcast and non-broadcast dimensions only removes the broadcast crop.
-  ASSERT_THAT(simplify(allocate::make(b0, memory_type::heap, 1, {{{0, 0}, 0, 0}, {bounds(0, x), 1, expr()}},
+  ASSERT_THAT(simplify(allocate::make(b0, memory_type::heap, 1, {dim::broadcast(), {bounds(0, x), 1, expr()}},
                   crop_buffer::make(b1, b0, {{y, z}, {w, u}}, dummy_call({}, {b1})))),
-      matches(allocate::make(b0, memory_type::heap, 1, {{{0, 0}, 0, 0}, {bounds(0, x), 1, expr()}},
+      matches(allocate::make(b0, memory_type::heap, 1, {dim::broadcast(), {bounds(0, x), 1, expr()}},
           crop_dim::make(b1, b0, 1, {w, u}, dummy_call({}, {b1})))));
 }
 
@@ -1022,6 +1022,10 @@ TEST(simplify, make_buffer) {
   ASSERT_THAT(simplify(make_buffer::make(
                   b1, buffer_at(b0), buffer_elem_size(b0), {buffer_dim(b0, 0), buffer_dim(b0, 2)}, body)),
       matches(transpose::make(b1, b0, {0, 2}, body)));
+
+  ASSERT_THAT(simplify(make_buffer::make(b1, buffer_at(b0), buffer_elem_size(b0),
+                  {buffer_dim(b0, 0), dim::broadcast(), buffer_dim(b0, 2)}, body)),
+      matches(transpose::make(b1, b0, {0, transpose::new_dim, 2}, body)));
 
   ASSERT_THAT(
       simplify(allocate::make(b0, memory_type::heap, 4, {{{0, 10}, {}, {}}, {{0, 20}, {}, {}}, {{0, 30}, {}, {}}},

--- a/slinky/runtime/buffer.cc
+++ b/slinky/runtime/buffer.cc
@@ -324,7 +324,7 @@ void copy_impl(raw_buffer& src, raw_buffer& dst) {
 void pad_impl(raw_buffer& src, raw_buffer& dst, raw_buffer& pad) {
   for (int d = static_cast<int>(std::min(src.rank, dst.rank)) - 1; d >= 0; --d) {
     const slinky::dim& src_d = src.dim(d);
-    if (src_d == slinky::dim::broadcast()) {
+    if (src_d.is_broadcast()) {
       continue;
     }
     // TODO: Try to implement this without saving and restoring the dst buffer between each crop.

--- a/slinky/runtime/buffer.h
+++ b/slinky/runtime/buffer.h
@@ -137,7 +137,7 @@ public:
   bool is_folded(const dim& other) const { return is_folded(other.min(), other.max()); }
   bool is_folded() const { return is_folded(min(), max()); }
 
-  bool is_broadcast() const { return min() == 0 && max() == 0 && stride() == 0 && fold_factor() == 0; }
+  bool is_broadcast() const { return min() == 0 && max() == 0 && stride() == 0; }
 };
 
 inline constexpr dim dim::broadcast_{0, 0, 0, 0};

--- a/slinky/runtime/buffer.h
+++ b/slinky/runtime/buffer.h
@@ -739,7 +739,7 @@ inline bool can_fuse(const dim& inner, const dim& outer) {
 // Fuse two dimensions of a buffer.
 inline slinky::dim fuse(slinky::dim inner, const slinky::dim& outer) {
   assert(can_fuse(inner, outer));
-  if (outer == dim::broadcast()) {
+  if (outer.is_broadcast()) {
     return outer;
   } else {
     const index_t inner_extent = inner.extent();

--- a/slinky/runtime/expr.h
+++ b/slinky/runtime/expr.h
@@ -549,7 +549,7 @@ struct dim_expr {
   const expr& get_field(buffer_field field) const;
 
   expr is_broadcast() const {
-    return bounds.min == 0 && bounds.max == 0 && stride == 0 && fold_factor == 0;
+    return bounds.min == 0 && bounds.max == 0 && stride == 0;
   }
 };
 

--- a/slinky/runtime/print.cc
+++ b/slinky/runtime/print.cc
@@ -531,7 +531,7 @@ std::ostream& operator<<(std::ostream& os, const raw_buffer& buf) {
 }
 
 std::ostream& operator<<(std::ostream& os, const dim& d) {
-  if (d == dim::broadcast()) {
+  if (d.is_broadcast()) {
     return os << "{}";
   }
   os << "{min=" << d.min() << ", max=" << d.max() << ", extent=" << d.extent() << ", stride=" << d.stride();

--- a/slinky/runtime/print.cc
+++ b/slinky/runtime/print.cc
@@ -446,7 +446,12 @@ public:
   }
 
   void visit(const transpose* n) override {
-    *this << indent() << n->sym << " = transpose(" << n->src << ", {" << n->dims << "}) {";
+    *this << indent() << n->sym << " = transpose(" << n->src << ", {";
+    for (std::size_t i = 0; i < n->dims.size(); ++i) {
+      if (i > 0) *this << ", ";
+      *this << (n->dims[i] == transpose::new_dim ? -1 : n->dims[i]);
+    }
+    *this << "}) {";
     *this << n->body;
     *this << indent() << "}";
   }

--- a/slinky/runtime/stmt.h
+++ b/slinky/runtime/stmt.h
@@ -402,6 +402,8 @@ public:
   std::vector<int> dims;
   stmt body;
 
+  static constexpr int new_dim = std::numeric_limits<int>::max();
+
   static bool is_truncate(span<const int> dims);
   bool is_truncate() const;
 


### PR DESCRIPTION
This change enables the simplifier to rewrite `make_buffer` with new broadcast dimensions to a `transpose` op. The `transpose` op already supports out of bounds dimensions as a broadcast (as the change in #784 implies), so this is just a small change to the simplifier.

It also motivates relaxing what is considered a broadcast dimension, removing the `fold_factor = 0` requirement.