### PR TITLE
Fix `can_fuse` for broadcast dimensions

### DIFF
--- a/slinky/runtime/buffer.h
+++ b/slinky/runtime/buffer.h
@@ -728,7 +728,7 @@ void pad(const dim* src_bounds, const raw_buffer& dst, const raw_buffer& pad);
 // Returns true if the two dimensions can be fused.
 inline bool can_fuse(const dim& inner, const dim& outer) {
   if (inner.empty()) return false;
-  if (outer.min() == outer.max() && outer.fold_factor() != 0) return true;
+  if (outer.min() == outer.max() && outer.stride() != 0) return true;
 
   index_t next_stride = inner.stride() * (inner.max() - inner.min() + 1);
   if (next_stride != outer.stride()) return false;

--- a/slinky/runtime/test/buffer.cc
+++ b/slinky/runtime/test/buffer.cc
@@ -1017,9 +1017,9 @@ TEST(buffer, copy_empty_src) {
   }
 }
 
-TEST(can_fuse, empty) {
-  ASSERT_FALSE(can_fuse(dim{0, -1, 0}, dim::broadcast()));
-}
+TEST(can_fuse, empty) { ASSERT_FALSE(can_fuse(dim{0, -1, 0}, dim::broadcast())); }
+TEST(can_fuse, non_broadcast_extent_1) { ASSERT_TRUE(can_fuse(dim{0, 3, 1}, dim{0, 0, 4, dim::unfolded})); }
+TEST(can_fuse, broadcast_extent_1) { ASSERT_FALSE(can_fuse(dim{0, 3, 1}, dim{0, 0, 0, dim::unfolded})); }
 
 TEST(fuse_contiguous_dims, fuse0) {
   buffer<int, 1> a({}), b({});


### PR DESCRIPTION
#802 relaxed the check for which dimensions are broadcasts, which exposed `can_fuse` being too lax on what it accepted as a broadcast.