### PR TITLE
Fix bugs uncovered by copying from a rank > 0 buffer to a scalar

### DIFF
--- a/slinky/builder/substitute.cc
+++ b/slinky/builder/substitute.cc
@@ -862,9 +862,15 @@ public:
     case buffer_field::max:
     case buffer_field::stride:
     case buffer_field::fold_factor: {
-      expr sub = dim < static_cast<index_t>(dims.size()) ? dims[dim].get_field(field) : expr();
-      if (sub.defined()) return sub;
-      break;
+      if (dim < static_cast<index_t>(dims.size())) {
+        expr sub = dims[dim].get_field(field);
+        if (sub.defined() || !def.defined()) return sub;
+        break;
+      } else if (def.defined()) {
+        break;
+      } else {
+        return 0;
+      }
     }
     default: SLINKY_UNREACHABLE << "got scalar var instead of buffer";
     }

--- a/slinky/builder/test/substitute.cc
+++ b/slinky/builder/test/substitute.cc
@@ -42,7 +42,7 @@ TEST(substitute, basic) {
       matches(crop_dim::make(y, z, 0, {0, 0}, dummy_call({w}, {y}))));
   ASSERT_THAT(substitute(crop_dim::make(y, y, 0, {0, 0}, crop_dim::make(y, y, 0, {0, 0}, dummy_call({x}, {y}))), x, w),
       matches(crop_dim::make(y, y, 0, {0, 0}, crop_dim::make(y, y, 0, {0, 0}, dummy_call({w}, {y})))));
-  ASSERT_THAT(substitute_buffer(buffer_stride(x, 0), x, expr(), {}), matches(expr()));
+  ASSERT_THAT(substitute_buffer(buffer_stride(x, 0), x, expr(), {}), matches(0));
   ASSERT_THAT(substitute_buffer(buffer_stride(x, 0), x, expr(), {}, y), matches(buffer_stride(y, 0)));
   ASSERT_THAT(substitute_buffer(buffer_stride(x, 0), x, expr(), {dim_expr()}), matches(expr()));
   ASSERT_THAT(substitute_buffer(buffer_stride(x, 0), x, expr(), {dim_expr()}, y), matches(buffer_stride(y, 0)));

--- a/slinky/runtime/buffer.cc
+++ b/slinky/runtime/buffer.cc
@@ -261,56 +261,52 @@ void copy_impl(raw_buffer& src, raw_buffer& dst) {
   assert(dst.base || dst.elem_count() == 0);
   index_t elem_size = dst.elem_size;
 
-  if (dst.rank == 0) {
-    memcpy(dst.base, src.base, elem_size);
+  const slinky::dim& dst_dim0 = dst.dim(0);
+  const slinky::dim& src_dim0 = src.dim(0);
+
+  if (dst_dim0.empty()) {
+    // Empty destination, nothing to do.
+  } else if (dst_dim0.fold_factor() > 0 || src_dim0.fold_factor() > 0 || dst_dim0.stride() != elem_size ||
+             (src_dim0.stride() != 0 && src_dim0.stride() != elem_size)) {
+    // There is some complication to the innermost dimension's copy.
+    for_each_contiguous_slice(
+        dst, [elem_size](index_t extent, void* dst, const void* src) { memcpy(dst, src, extent * elem_size); }, src);
   } else {
-    const slinky::dim& dst_dim0 = dst.dim(0);
-    const slinky::dim& src_dim0 = src.dim(0);
+    slice_dim0(dst);
+    slice_dim0(src);
 
-    if (dst_dim0.empty()) {
-      // Empty destination, nothing to do.
-    } else if (dst_dim0.fold_factor() > 0 || src_dim0.fold_factor() > 0 ||
-               dst_dim0.stride() != elem_size || (src_dim0.stride() != 0 && src_dim0.stride() != elem_size)) {
-      // There is some complication to the innermost dimension's copy.
-      for_each_contiguous_slice(
-          dst, [elem_size](index_t extent, void* dst, const void* src) { memcpy(dst, src, extent * elem_size); }, src);
+    const index_t dst_size = dst_dim0.extent() * elem_size;
+
+    if (src_dim0.stride() == 0) {
+      // The inner dimension is a fill call.
+      fill_value_buffer buffer;
+      const void* buffer_value;
+      index_t buffer_elem_size;
+      const void* cached_src = nullptr;
+      for_each_element(
+          [&](void* dst, const void* src) {
+            if (cached_src != src) {
+              cached_src = src;
+              buffer_elem_size = elem_size;
+              buffer_value = src;
+              optimize_fill_value(buffer_value, buffer_elem_size, dst_size, buffer);
+            }
+            fill(dst, buffer_value, buffer_elem_size, dst_size);
+          },
+          dst, src);
     } else {
-      slice_dim0(dst);
-      slice_dim0(src);
+      // The inner dimension is a memcpy.
+      assert(dst_dim0.is_point() || src_dim0.stride() == elem_size);
+      assert(src_dim0.begin() <= dst_dim0.begin());
+      assert(src_dim0.end() >= dst_dim0.end());
 
-      const index_t dst_size = dst_dim0.extent() * elem_size;
-
-      if (src_dim0.stride() == 0) {
-        // The inner dimension is a fill call.
-        fill_value_buffer buffer;
-        const void* buffer_value;
-        index_t buffer_elem_size;
-        const void* cached_src = nullptr;
-        for_each_element(
-            [&](void* dst, const void* src) {
-              if (cached_src != src) {
-                cached_src = src;
-                buffer_elem_size = elem_size;
-                buffer_value = src;
-                optimize_fill_value(buffer_value, buffer_elem_size, dst_size, buffer);
-              }
-              fill(dst, buffer_value, buffer_elem_size, dst_size);
-            },
-            dst, src);
-      } else {
-        // The inner dimension is a memcpy.
-        assert(src_dim0.stride() == elem_size);
-        assert(src_dim0.begin() <= dst_dim0.begin());
-        assert(src_dim0.end() >= dst_dim0.end());
-
-        void* src_base = src.base;
-        src.base = offset_bytes(src.base, src_dim0.flat_offset_bytes(dst_dim0.min()));
-        for_each_element([=](void* dst, const void* src) { memcpy(dst, src, dst_size); }, dst, src);
-        src.base = src_base;
-      }
-      unslice_dim0(dst, dst_dim0);
-      unslice_dim0(src, src_dim0);
+      void* src_base = src.base;
+      src.base = offset_bytes(src.base, src_dim0.flat_offset_bytes(dst_dim0.min()));
+      for_each_element([=](void* dst, const void* src) { memcpy(dst, src, dst_size); }, dst, src);
+      src.base = src_base;
     }
+    unslice_dim0(dst, dst_dim0);
+    unslice_dim0(src, src_dim0);
   }
 }
 
@@ -356,11 +352,6 @@ void pad_impl(raw_buffer& src, raw_buffer& dst, raw_buffer& pad) {
 SLINKY_NO_STACK_PROTECTOR void copy(const raw_buffer& src, const raw_buffer& dst, const raw_buffer& pad) {
   assert(dst.elem_size == src.elem_size);
   assert(dst.base || dst.elem_count() == 0);
-  if (dst.rank == 0) {
-    assert(src.base || pad.base);
-    memcpy(dst.base, !src.base && pad.base ? pad.base : src.base, dst.elem_size);
-    return;
-  }
 
   // Make (shallow) copies of the buffers, so we can optimize the dimensions.
   raw_buffer dst_opt = dst;
@@ -703,21 +694,23 @@ template <bool SkipContiguous, std::size_t BufsSize, typename F>
 SLINKY_NO_STACK_PROTECTOR SLINKY_INLINE void for_each_impl(span<const raw_buffer*, BufsSize> bufs, F f) {
   const raw_buffer& buf = *bufs[0];
 
-  auto* loop = reinterpret_cast<for_each_loop<BufsSize>*>(SLINKY_ALLOCA(char, size_of_plan<F>(bufs.size(), buf.rank)));
-
+  int rank = buf.rank;
   void** bases = SLINKY_ALLOCA(void*, bufs.size());
   bases[0] = buf.base;
   for (std::size_t n = 1; n < bufs.size(); ++n) {
     bases[n] = bufs[n]->base;
+    rank = std::max<int>(rank, bufs[n]->rank);
   }
+
+  auto* loop = reinterpret_cast<for_each_loop<BufsSize>*>(SLINKY_ALLOCA(char, size_of_plan<F>(bufs.size(), rank)));
 
   for_each_loop_impl<BufsSize> inner_impl;
   for_each_loop<BufsSize>* outer_loop = loop;
 
   index_t slice_extent = 1;
   index_t extent = 1;
-  for (std::ptrdiff_t d = static_cast<std::ptrdiff_t>(buf.rank) - 1; d >= 0; --d) {
-    const dim& buf_dim = buf.dims[d];
+  for (int d = rank - 1; d >= 0; --d) {
+    const dim& buf_dim = buf.dim(d);
 
     if (buf_dim.min() == buf_dim.max()) {
       // extent 1, we don't need any of the logic here, skip to below.

--- a/slinky/runtime/buffer.h
+++ b/slinky/runtime/buffer.h
@@ -1015,13 +1015,6 @@ SLINKY_NO_STACK_PROTECTOR void for_each_contiguous_slice(const Buf& buf, const F
 // `nullptr` if `buf` is out of bounds of `bufs`.
 template <typename F, typename Buf, typename... Bufs>
 SLINKY_NO_STACK_PROTECTOR void for_each_element(const F& f, const Buf& buf, const Bufs&... bufs) {
-  if (buf.rank == 0) {
-    // Skip the overhead of our machinery for rank 0 buffers.
-    f(reinterpret_cast<typename Buf::pointer>(buf.raw_buffer::base),
-        reinterpret_cast<typename Bufs::pointer>(bufs.raw_buffer::base)...);
-    return;
-  }
-
   static constexpr std::size_t BufsSize = sizeof...(Bufs) + 1;
   std::array<const raw_buffer*, BufsSize> buf_ptrs = {&buf, &bufs...};
 

--- a/slinky/runtime/buffer.h
+++ b/slinky/runtime/buffer.h
@@ -473,6 +473,9 @@ public:
     rank = 0;
     dims = nullptr;
   }
+
+  T& operator()() { return *reinterpret_cast<T*>(base); }
+  const T& operator()() const { return *reinterpret_cast<T*>(base); }
 };
 
 namespace internal {

--- a/slinky/runtime/test/buffer.cc
+++ b/slinky/runtime/test/buffer.cc
@@ -327,6 +327,17 @@ TEST(buffer, copy_broadcast) {
   }
 }
 
+TEST(buffer, copy_to_broadcast) {
+  buffer<int, 1> src;
+  src.mutable_dim(0) = dim(-2, 2, sizeof(int));
+  int data[] = {0, 1, 2, 3, 4};
+  src.raw_buffer::base = data;
+
+  scalar<int> dst;
+  copy(src, dst);
+  ASSERT_EQ(dst(), 2);
+}
+
 TEST(buffer, pad_scalar) {
   scalar<int> dst(1);
   scalar<int> padding(2);


### PR DESCRIPTION
All of the fixes on this branch involve copies from higher rank buffers to low rank buffers, because of bugs in handling the implicit trailing broadcast dimensions.

- Remove special case for rank 0 buffers in `copy`. It doesn't make sense to optimize the scalar copy case anyways.
- `for_each_element` needs to handle every dimension of any input buffer, not just the dimensions of the "base" buffer. This invalidates the "fast path" recently added in #805.
- Fix substitute for broadcast/implicit dimensions.