### PR TITLE
Fix crop simplification bug

### DIFF
--- a/slinky/builder/simplify.cc
+++ b/slinky/builder/simplify.cc
@@ -2037,7 +2037,7 @@ public:
         // Substitute the outer crop bounds into this crop's bounds.
         auto c_dims = make_dims_from_bounds(c->bounds);
         for (interval_expr& i : op_bounds) {
-          i = substitute_buffer(i, op_src, c_dims);
+          i = substitute_buffer(i, op_src, c_dims, c->sym);
         }
         // Nested crops of the same buffer, and the crop isn't used.
         op_bounds.resize(std::max(op_bounds.size(), c->bounds.size()));
@@ -2049,7 +2049,7 @@ public:
         // Substitute the outer crop bounds into this crop's bounds.
         auto c_dims = make_dims_from_bounds(c->dim, c->bounds);
         for (interval_expr& i : op_bounds) {
-          i = substitute_buffer(i, op_src, c_dims);
+          i = substitute_buffer(i, op_src, c_dims, c->sym);
         }
         // Nested crops of the same buffer, and the crop isn't used.
         op_bounds.resize(std::max<int>(op_bounds.size(), c->dim + 1));

--- a/slinky/builder/test/simplify/simplify.cc
+++ b/slinky/builder/test/simplify/simplify.cc
@@ -909,6 +909,10 @@ TEST(simplify, crop) {
       simplify(crop_buffer::make(b1, b0, {{x, y}, {z, w}}, crop_buffer::make(b2, b1, {{}, {z, w}, {u, v}}, body))),
       matches(crop_buffer::make(b2, b0, {{x, y}, {z, w}, {u, v}}, body)));
 
+  // The inner crop uses dimensions from the original buffer, and the crop bounds.
+  ASSERT_THAT(simplify(crop_dim::make(b1, b0, 0, {x, y}, crop_dim::make(b2, b1, 1, buffer_bounds(b1, 1), body))),
+      matches(crop_dim::make(b1, b0, 0, {x, y}, crop_buffer::make(b2, b0, {{x, y}, buffer_bounds(b1, 1)}, body))));
+
   // Nested crops of the same buffer.
   ASSERT_THAT(simplify(crop_dim::make(b1, b0, 0, {x, y}, crop_dim::make(b2, b0, 0, {x, y}, dummy_call({}, {b1, b2})))),
       matches(crop_dim::make(b1, b0, 0, {x, y}, dummy_call({}, {b1, b1}))));


### PR DESCRIPTION
A crop that did not crop some dimensions of the buffer needs to use the bounds of the original buffer (the default buffer when substituting the crop bounds).