### PR TITLE
Fix simplify of nested transposes

### DIFF
--- a/slinky/builder/simplify.cc
+++ b/slinky/builder/simplify.cc
@@ -2313,13 +2313,13 @@ public:
       sym_info.elem_size = (*src_info)->elem_size;
       // This is like `permute`, but we can't guarantee that we know all the dimensions of src_info (it could be a
       // buffer external to the pipeline).
-      sym_info.dims.resize(op->dims.size());
+      sym_info.dims.resize(dims.size());
       sym_info.rank = sym_info.dims.size();
-      for (size_t i = 0; i < op->dims.size(); ++i) {
+      for (size_t i = 0; i < dims.size(); ++i) {
         if (op->dims[i] < static_cast<int>((*src_info)->dims.size())) {
-          sym_info.dims[i] = (*src_info)->dims[op->dims[i]];
+          sym_info.dims[i] = (*src_info)->dims[dims[i]];
         } else {
-          sym_info.dims[i] = buffer_dim(op->src, op->dims[i]);
+          sym_info.dims[i] = buffer_dim(src, dims[i]);
         }
       }
     }

--- a/slinky/builder/test/simplify/simplify.cc
+++ b/slinky/builder/test/simplify/simplify.cc
@@ -1067,6 +1067,17 @@ TEST(simplify, transpose) {
       matches(transpose::make(b2, b0, {2, 3}, dummy_call({}, {b2}))));
 
   ASSERT_THAT(
+      simplify(transpose::make(b1, b0, {2, 3},
+          transpose::make(b2, b1, {0, transpose::new_dim, 1}, check::make(buffer_min(b2, 2) == buffer_min(b0, 3))))),
+      matches(
+          transpose::make(b2, b0, {2, transpose::new_dim, 3}, check::make(buffer_min(b2, 2) == buffer_min(b0, 3)))));
+
+  // Make sure that an intermediate transpose that drops dimensions is not skipped.
+  ASSERT_THAT(simplify(transpose::make(b1, b0, {2, 1, 0},
+                  transpose::make(b2, b1, {}, transpose::make(b3, b2, {0, 1}, dummy_call({}, {b3}))))),
+      matches(transpose::make(b3, b0, {transpose::new_dim, transpose::new_dim}, dummy_call({}, {b3}))));
+
+  ASSERT_THAT(
       simplify(crop_buffer::make(b1, b0, {{x, y}, {z, w}}, transpose::make_truncate(b2, b1, 3, dummy_call({}, {b2})))),
       matches(crop_buffer::make(b1, b0, {{x, y}, {z, w}}, transpose::make_truncate(b2, b1, 3, dummy_call({}, {b2})))));
 


### PR DESCRIPTION
The resulting transpose should use the "collapsed" dimensions from the whole chain, not just the immediate parent.