### PR TITLE
Fix incorrect canonicalization of a broadcast and extent 1 dimension

### DIFF
--- a/slinky/builder/simplify.cc
+++ b/slinky/builder/simplify.cc
@@ -1632,16 +1632,11 @@ public:
 
   // Returns true if d can be represented as buffer_dim(sym, dim)
   bool is_buffer_dim(const dim_expr& d, const dim_expr& src, var sym, int dim) {
-    if (!is_buffer_meta(d.bounds.min, src.bounds.min, sym, buffer_field::min, dim)) return false;
-    if (!is_buffer_meta(d.bounds.max, src.bounds.max, sym, buffer_field::max, dim)) return false;
-
-    if (prove_true(src.bounds.min == src.bounds.max)) {
-      // The extent is 1, the stride and fold factor don't matter.
-      return true;
-    } else {
-      return is_buffer_meta(d.stride, src.stride, sym, buffer_field::stride, dim, slinky::dim::auto_stride) &&
-             is_buffer_meta(d.fold_factor, src.fold_factor, sym, buffer_field::fold_factor, dim, slinky::dim::unfolded);
-    }
+    return 
+      is_buffer_meta(d.bounds.min, src.bounds.min, sym, buffer_field::min, dim) &&
+      is_buffer_meta(d.bounds.max, src.bounds.max, sym, buffer_field::max, dim) &&
+      is_buffer_meta(d.stride, src.stride, sym, buffer_field::stride, dim, slinky::dim::auto_stride) &&
+      is_buffer_meta(d.fold_factor, src.fold_factor, sym, buffer_field::fold_factor, dim, slinky::dim::unfolded);
   }
 
   // If we know that buffer metadata has some values, rewrite references to that dim to use buffer intrinsics

--- a/slinky/builder/test/simplify/simplify.cc
+++ b/slinky/builder/test/simplify/simplify.cc
@@ -1058,6 +1058,13 @@ TEST(simplify, make_buffer) {
                   make_buffer::make(b1, buffer_at(b0), buffer_elem_size(b0), {buffer_dim(b0, 0), buffer_dim(b0, 1)},
                       dummy_call({}, {b1})))),
       matches(allocate::make(b0, memory_type::heap, 4, {{{0, 255}, {}, {}}, {{0, 0}, {}, {}}}, dummy_call({}, {b0}))));
+
+  // Dims with min=max=0 but different strides (explicit 0 vs auto_stride) must not be canonicalized to the same dim.
+  ASSERT_THAT(simplify(allocate::make(b0, memory_type::heap, 4, {{{0, 0}, 0}, {{0, 0}, {}}},
+                  make_buffer::make(b1, buffer_at(b0), buffer_elem_size(b0),
+                      {{{0, 0}, buffer_stride(b0, 1), {}}, {{0, 0}, buffer_stride(b0, 0)}}, dummy_call({}, {b1})))),
+      matches(allocate::make(
+          b0, memory_type::heap, 4, {{{0, 0}, 0}, {{0, 0}, {}}}, transpose::make(b1, b0, {1}, dummy_call({}, {b1})))));
 }
 
 TEST(simplify, transpose) {


### PR DESCRIPTION
This change fixes a bug: we incorrectly canonicalize dimension `{[0, 0], 0}` to another dimension `{[0, 0], <>}` because we consider the stride (and fold factor) irrelevant for extent 1 dimensions. But, this is not correct after #751.