### PR TITLE
Make init_strides overflow safe.

### DIFF
--- a/slinky/runtime/buffer.cc
+++ b/slinky/runtime/buffer.cc
@@ -97,14 +97,14 @@ struct init_stride_dim {
   index_t dim_stride;
 
   init_stride_dim() : stride(0), dim_stride(0) {}
-  init_stride_dim(index_t stride, index_t dim_stride) : stride(stride), dim_stride(dim_stride) {}
+  init_stride_dim(index_t stride, index_t dim_stride)
+      : stride(stride), dim_stride(dim_stride) {}
 
   bool operator<(const init_stride_dim& r) const { return dim_stride < r.dim_stride; }
 };
 
-SLINKY_INLINE bool is_stride_ok(index_t stride, 
-                                index_t extent, 
-                                span<const init_stride_dim> dims, 
+SLINKY_INLINE bool is_stride_ok(index_t stride, index_t extent,
+                                span<const init_stride_dim> dims,
                                 bool& overflow) {
   index_t dim_stride;
   if (mul_with_overflow(stride, extent, dim_stride)) {
@@ -191,12 +191,12 @@ std::optional<std::size_t> raw_buffer::init_strides_impl(index_t alignment) {
     // Loop through all the dimensions and see if a stride that is just outside any dimension is OK.
     for (const init_stride_dim& dim_j : known_dims) {
       index_t padded_candidate = 0;
-      overflow = overflow || add_with_overflow(
-          dim_j.dim_stride, alignment - 1, padded_candidate);
+      overflow = overflow || add_with_overflow(dim_j.dim_stride, alignment - 1,
+                                               padded_candidate);
       index_t candidate = padded_candidate & ~(alignment - 1);
 
-      if (&dim_j == &known_dims.back() || is_stride_ok(
-              candidate, alloc_extent_i, known_dims, overflow)) {
+      if (&dim_j == &known_dims.back() ||
+          is_stride_ok(candidate, alloc_extent_i, known_dims, overflow)) {
         dim_i.set_stride(candidate);
         learn_dim(candidate, alloc_extent_i);
         // The dims are sorted, so no subsequent candidate will be better.
@@ -207,11 +207,12 @@ std::optional<std::size_t> raw_buffer::init_strides_impl(index_t alignment) {
   }
 
   index_t unaligned_size = 0;
-  overflow = overflow || add_with_overflow(
-      flat_max, static_cast<index_t>(elem_size), unaligned_size);
+  overflow =
+      overflow || add_with_overflow(flat_max, static_cast<index_t>(elem_size),
+                                    unaligned_size);
   index_t padded_size = 0;
-  overflow = overflow || add_with_overflow(
-      unaligned_size, alignment - 1, padded_size);
+  overflow =
+      overflow || add_with_overflow(unaligned_size, alignment - 1, padded_size);
   index_t final_size = padded_size & ~(alignment - 1);
 
   if (overflow || final_size < 0) {

--- a/slinky/runtime/buffer.cc
+++ b/slinky/runtime/buffer.cc
@@ -102,7 +102,10 @@ struct init_stride_dim {
   bool operator<(const init_stride_dim& r) const { return dim_stride < r.dim_stride; }
 };
 
-SLINKY_INLINE bool is_stride_ok(index_t stride, index_t extent, span<const init_stride_dim> dims, bool& overflow) {
+SLINKY_INLINE bool is_stride_ok(index_t stride, 
+                                index_t extent, 
+                                span<const init_stride_dim> dims, 
+                                bool& overflow) {
   index_t dim_stride;
   if (mul_with_overflow(stride, extent, dim_stride)) {
     overflow = true;
@@ -188,10 +191,12 @@ std::optional<std::size_t> raw_buffer::init_strides_impl(index_t alignment) {
     // Loop through all the dimensions and see if a stride that is just outside any dimension is OK.
     for (const init_stride_dim& dim_j : known_dims) {
       index_t padded_candidate = 0;
-      overflow = overflow || add_with_overflow(dim_j.dim_stride, alignment - 1, padded_candidate);
+      overflow = overflow || add_with_overflow(
+          dim_j.dim_stride, alignment - 1, padded_candidate);
       index_t candidate = padded_candidate & ~(alignment - 1);
 
-      if (&dim_j == &known_dims.back() || is_stride_ok(candidate, alloc_extent_i, known_dims, overflow)) {
+      if (&dim_j == &known_dims.back() || is_stride_ok(
+              candidate, alloc_extent_i, known_dims, overflow)) {
         dim_i.set_stride(candidate);
         learn_dim(candidate, alloc_extent_i);
         // The dims are sorted, so no subsequent candidate will be better.
@@ -202,9 +207,11 @@ std::optional<std::size_t> raw_buffer::init_strides_impl(index_t alignment) {
   }
 
   index_t unaligned_size = 0;
-  overflow = overflow || add_with_overflow(flat_max, static_cast<index_t>(elem_size), unaligned_size);
+  overflow = overflow || add_with_overflow(
+      flat_max, static_cast<index_t>(elem_size), unaligned_size);
   index_t padded_size = 0;
-  overflow = overflow || add_with_overflow(unaligned_size, alignment - 1, padded_size);
+  overflow = overflow || add_with_overflow(
+      unaligned_size, alignment - 1, padded_size);
   index_t final_size = padded_size & ~(alignment - 1);
 
   if (overflow || final_size < 0) {
@@ -444,8 +451,6 @@ void pad(const dim* in_bounds, const raw_buffer& dst, const raw_buffer& pad) {
   // Implement the padding in all but the first dimension.
   pad_impl(src, dst_opt, pad_opt);
 }
-
-
 
 namespace internal {
 

--- a/slinky/runtime/buffer.cc
+++ b/slinky/runtime/buffer.cc
@@ -97,15 +97,12 @@ struct init_stride_dim {
   index_t dim_stride;
 
   init_stride_dim() : stride(0), dim_stride(0) {}
-  init_stride_dim(index_t stride, index_t dim_stride)
-      : stride(stride), dim_stride(dim_stride) {}
+  init_stride_dim(index_t stride, index_t dim_stride) : stride(stride), dim_stride(dim_stride) {}
 
   bool operator<(const init_stride_dim& r) const { return dim_stride < r.dim_stride; }
 };
 
-SLINKY_INLINE bool is_stride_ok(index_t stride, index_t extent,
-                                span<const init_stride_dim> dims,
-                                bool& overflow) {
+SLINKY_INLINE bool is_stride_ok(index_t stride, index_t extent, span<const init_stride_dim> dims, bool& overflow) {
   index_t dim_stride;
   if (mul_with_overflow(stride, extent, dim_stride)) {
     overflow = true;
@@ -191,12 +188,10 @@ std::optional<std::size_t> raw_buffer::init_strides_impl(index_t alignment) {
     // Loop through all the dimensions and see if a stride that is just outside any dimension is OK.
     for (const init_stride_dim& dim_j : known_dims) {
       index_t padded_candidate = 0;
-      overflow = overflow || add_with_overflow(dim_j.dim_stride, alignment - 1,
-                                               padded_candidate);
+      overflow = overflow || add_with_overflow(dim_j.dim_stride, alignment - 1, padded_candidate);
       index_t candidate = padded_candidate & ~(alignment - 1);
 
-      if (&dim_j == &known_dims.back() ||
-          is_stride_ok(candidate, alloc_extent_i, known_dims, overflow)) {
+      if (&dim_j == &known_dims.back() || is_stride_ok(candidate, alloc_extent_i, known_dims, overflow)) {
         dim_i.set_stride(candidate);
         learn_dim(candidate, alloc_extent_i);
         // The dims are sorted, so no subsequent candidate will be better.
@@ -207,12 +202,9 @@ std::optional<std::size_t> raw_buffer::init_strides_impl(index_t alignment) {
   }
 
   index_t unaligned_size = 0;
-  overflow =
-      overflow || add_with_overflow(flat_max, static_cast<index_t>(elem_size),
-                                    unaligned_size);
+  overflow = overflow || add_with_overflow(flat_max, static_cast<index_t>(elem_size), unaligned_size);
   index_t padded_size = 0;
-  overflow =
-      overflow || add_with_overflow(unaligned_size, alignment - 1, padded_size);
+  overflow = overflow || add_with_overflow(unaligned_size, alignment - 1, padded_size);
   index_t final_size = padded_size & ~(alignment - 1);
 
   if (overflow || final_size < 0) {

--- a/slinky/runtime/buffer.cc
+++ b/slinky/runtime/buffer.cc
@@ -8,6 +8,7 @@
 #include <functional>
 #include <limits>
 
+#include "slinky/base/arithmetic.h"
 #include "slinky/base/util.h"
 
 namespace slinky {
@@ -92,15 +93,20 @@ namespace {
 // any other dimension's memory.
 struct init_stride_dim {
   index_t stride;
-  index_t dim_stride;  // stride * extent
+  index_t dim_stride;
 
-  init_stride_dim(index_t stride, index_t extent) : stride(stride), dim_stride(stride * extent) {}
+  init_stride_dim() : stride(0), dim_stride(0) {}
+  init_stride_dim(index_t stride, index_t dim_stride) : stride(stride), dim_stride(dim_stride) {}
 
   bool operator<(const init_stride_dim& r) const { return dim_stride < r.dim_stride; }
 };
 
-SLINKY_INLINE bool is_stride_ok(index_t stride, index_t extent, span<const init_stride_dim> dims) {
-  const index_t dim_stride = stride * extent;
+SLINKY_INLINE bool is_stride_ok(index_t stride, index_t extent, span<const init_stride_dim> dims, bool& overflow) {
+  index_t dim_stride;
+  if (mul_with_overflow(stride, extent, dim_stride)) {
+    overflow = true;
+    return false;
+  }
   for (const init_stride_dim& d : dims) {
     if (d.stride >= dim_stride) {
       // The dim is completely outside the proposed stride.
@@ -120,12 +126,22 @@ std::size_t raw_buffer::init_strides_impl(index_t alignment) {
   init_stride_dim* dims = SLINKY_ALLOCA(init_stride_dim, rank);
   init_stride_dim* dims_end = dims;
   // Insert d into dims, sorted by dim_stride. Also track the flat max index of the buffer, to compute the size.
-  std::size_t flat_max = 0;
-  auto learn_dim = [&](const init_stride_dim& d) {
+  index_t flat_max = 0;
+  bool overflow = false;
+
+  auto learn_dim = [&](index_t stride, index_t extent) {
+    index_t dim_stride = 0;
+    overflow = overflow || mul_with_overflow(stride, extent, dim_stride);
+
+    init_stride_dim d(stride, dim_stride);
     init_stride_dim* at = std::lower_bound(dims, dims_end, d);
     internal::copy_small_n_backward(dims_end, dims_end - at, dims_end + 1);
     *at = d;
-    flat_max += d.dim_stride - d.stride;
+
+    index_t diff;
+    overflow = overflow || sub_with_overflow(d.dim_stride, d.stride, diff);
+    overflow = overflow || add_with_overflow(flat_max, diff, flat_max);
+
     ++dims_end;
   };
 
@@ -140,7 +156,12 @@ std::size_t raw_buffer::init_strides_impl(index_t alignment) {
       // The buffer is empty or has extent 1, we don't care about the stride.
       if (dim_i.stride() == dim::auto_stride) dim_i.set_stride(elem_size);
     } else if (dim_i.stride() != dim::auto_stride) {
-      learn_dim(init_stride_dim(std::abs(dim_i.stride()), alloc_extent_i));
+      index_t stride_val = dim_i.stride();
+      if (stride_val == std::numeric_limits<index_t>::min()) {
+        overflow = true;
+        stride_val = 0;
+      }
+      learn_dim(std::abs(stride_val), alloc_extent_i);
     } else {
       // Track the range of dimensions we need to find the stride of.
       unknown_begin = std::min(unknown_begin, i);
@@ -156,19 +177,22 @@ std::size_t raw_buffer::init_strides_impl(index_t alignment) {
     assert(alloc_extent_i > 1);
 
     span<const init_stride_dim> known_dims{dims, dims_end};
-    if (is_stride_ok(elem_size, alloc_extent_i, known_dims)) {
+    if (is_stride_ok(elem_size, alloc_extent_i, known_dims, overflow)) {
       // This dimension can have stride elem_size, no other stride could be better.
       dim_i.set_stride(elem_size);
-      learn_dim(init_stride_dim(elem_size, alloc_extent_i));
+      learn_dim(elem_size, alloc_extent_i);
       continue;
     }
 
     // Loop through all the dimensions and see if a stride that is just outside any dimension is OK.
     for (const init_stride_dim& dim_j : known_dims) {
-      const index_t candidate = (dim_j.dim_stride + (alignment - 1)) & ~(alignment - 1);
-      if (&dim_j == &known_dims.back() || is_stride_ok(candidate, alloc_extent_i, known_dims)) {
+      index_t padded_candidate = 0;
+      overflow = overflow || add_with_overflow(dim_j.dim_stride, alignment - 1, padded_candidate);
+      index_t candidate = padded_candidate & ~(alignment - 1);
+
+      if (&dim_j == &known_dims.back() || is_stride_ok(candidate, alloc_extent_i, known_dims, overflow)) {
         dim_i.set_stride(candidate);
-        learn_dim(init_stride_dim(candidate, alloc_extent_i));
+        learn_dim(candidate, alloc_extent_i);
         // The dims are sorted, so no subsequent candidate will be better.
         break;
       }
@@ -176,11 +200,21 @@ std::size_t raw_buffer::init_strides_impl(index_t alignment) {
     assert(dim_i.stride() != dim::auto_stride);
   }
 
-  return (flat_max + elem_size + (alignment - 1)) & ~(alignment - 1);
+  index_t unaligned_size = 0;
+  overflow = overflow || add_with_overflow(flat_max, static_cast<index_t>(elem_size), unaligned_size);
+  index_t padded_size = 0;
+  overflow = overflow || add_with_overflow(unaligned_size, alignment - 1, padded_size);
+  index_t final_size = padded_size & ~(alignment - 1);
+
+  if (overflow || final_size < 0) {
+    return 0;
+  }
+  return static_cast<std::size_t>(final_size);
 }
 
 void* raw_buffer::allocate(index_t base_alignment, index_t stride_alignment) {
   std::size_t size = init_strides(stride_alignment);
+  if (size == 0) return nullptr;
   void* allocation = malloc(size + base_alignment - 1);
   base = align_up(allocation, base_alignment);
   return allocation;
@@ -409,6 +443,8 @@ void pad(const dim* in_bounds, const raw_buffer& dst, const raw_buffer& pad) {
   // Implement the padding in all but the first dimension.
   pad_impl(src, dst_opt, pad_opt);
 }
+
+
 
 namespace internal {
 

--- a/slinky/runtime/buffer.cc
+++ b/slinky/runtime/buffer.cc
@@ -7,6 +7,7 @@
 #include <cstring>
 #include <functional>
 #include <limits>
+#include <optional>
 
 #include "slinky/base/arithmetic.h"
 #include "slinky/base/util.h"
@@ -121,7 +122,7 @@ SLINKY_INLINE bool is_stride_ok(index_t stride, index_t extent, span<const init_
 
 }  // namespace
 
-std::size_t raw_buffer::init_strides_impl(index_t alignment) {
+std::optional<std::size_t> raw_buffer::init_strides_impl(index_t alignment) {
   // We remember the strides of the dims we know about, in sorted order.
   init_stride_dim* dims = SLINKY_ALLOCA(init_stride_dim, rank);
   init_stride_dim* dims_end = dims;
@@ -207,15 +208,15 @@ std::size_t raw_buffer::init_strides_impl(index_t alignment) {
   index_t final_size = padded_size & ~(alignment - 1);
 
   if (overflow || final_size < 0) {
-    return 0;
+    return std::nullopt;
   }
   return static_cast<std::size_t>(final_size);
 }
 
 void* raw_buffer::allocate(index_t base_alignment, index_t stride_alignment) {
-  std::size_t size = init_strides(stride_alignment);
-  if (size == 0) return nullptr;
-  void* allocation = malloc(size + base_alignment - 1);
+  std::optional<std::size_t> size = init_strides(stride_alignment);
+  if (!size) return nullptr;
+  void* allocation = malloc(*size + base_alignment - 1);
   base = align_up(allocation, base_alignment);
   return allocation;
 }

--- a/slinky/runtime/buffer.h
+++ b/slinky/runtime/buffer.h
@@ -223,7 +223,7 @@ protected:
 
   std::optional<std::size_t> init_strides_impl(index_t alignment);
 
-public:
+ public:
   using element = void;
   using pointer = void*;
 
@@ -424,8 +424,8 @@ public:
   std::optional<std::size_t> init_strides(index_t alignment = 1) {
     if (rank == 0) {
       std::size_t final_sum;
-      if (add_with_overflow(
-              elem_size, static_cast<std::size_t>(alignment - 1), final_sum)) {
+      if (add_with_overflow(elem_size, static_cast<std::size_t>(alignment - 1),
+                            final_sum)) {
         return std::nullopt;
       }
       return final_sum & ~static_cast<std::size_t>(alignment - 1);
@@ -736,8 +736,6 @@ void copy(const raw_buffer& src, const raw_buffer& dst, const raw_buffer& pad = 
 
 // Performs only the padding operation of a copy. The region that would have been copied is unmodified.
 void pad(const dim* src_bounds, const raw_buffer& dst, const raw_buffer& pad);
-
-
 
 // Returns true if the two dimensions can be fused.
 inline bool can_fuse(const dim& inner, const dim& outer) {

--- a/slinky/runtime/buffer.h
+++ b/slinky/runtime/buffer.h
@@ -424,7 +424,8 @@ public:
   std::optional<std::size_t> init_strides(index_t alignment = 1) {
     if (rank == 0) {
       std::size_t final_sum;
-      if (add_with_overflow(elem_size, static_cast<std::size_t>(alignment - 1), final_sum)) {
+      if (add_with_overflow(
+              elem_size, static_cast<std::size_t>(alignment - 1), final_sum)) {
         return std::nullopt;
       }
       return final_sum & ~static_cast<std::size_t>(alignment - 1);

--- a/slinky/runtime/buffer.h
+++ b/slinky/runtime/buffer.h
@@ -422,7 +422,11 @@ public:
   // `alignment` must be a power of 2.
   std::size_t init_strides(index_t alignment = 1) {
     if (rank == 0) {
-      return (elem_size + alignment - 1) & ~(alignment - 1);
+      std::size_t final_sum;
+      if (add_with_overflow(elem_size, static_cast<std::size_t>(alignment - 1), final_sum)) {
+        return 0;
+      }
+      return final_sum & ~static_cast<std::size_t>(alignment - 1);
     } else {
       return init_strides_impl(alignment);
     }
@@ -730,6 +734,8 @@ void copy(const raw_buffer& src, const raw_buffer& dst, const raw_buffer& pad = 
 
 // Performs only the padding operation of a copy. The region that would have been copied is unmodified.
 void pad(const dim* src_bounds, const raw_buffer& dst, const raw_buffer& pad);
+
+
 
 // Returns true if the two dimensions can be fused.
 inline bool can_fuse(const dim& inner, const dim& outer) {

--- a/slinky/runtime/buffer.h
+++ b/slinky/runtime/buffer.h
@@ -223,7 +223,7 @@ protected:
 
   std::optional<std::size_t> init_strides_impl(index_t alignment);
 
- public:
+public:
   using element = void;
   using pointer = void*;
 
@@ -424,8 +424,7 @@ protected:
   std::optional<std::size_t> init_strides(index_t alignment = 1) {
     if (rank == 0) {
       std::size_t final_sum;
-      if (add_with_overflow(elem_size, static_cast<std::size_t>(alignment - 1),
-                            final_sum)) {
+      if (add_with_overflow(elem_size, static_cast<std::size_t>(alignment - 1), final_sum)) {
         return std::nullopt;
       }
       return final_sum & ~static_cast<std::size_t>(alignment - 1);

--- a/slinky/runtime/buffer.h
+++ b/slinky/runtime/buffer.h
@@ -8,6 +8,7 @@
 #include <cstring>
 #include <limits>
 #include <memory>
+#include <optional>
 #include <type_traits>
 
 #include "slinky/base/arithmetic.h"
@@ -220,7 +221,7 @@ protected:
     translate_impl(dims + 1, offsets...);
   }
 
-  std::size_t init_strides_impl(index_t alignment);
+  std::optional<std::size_t> init_strides_impl(index_t alignment);
 
 public:
   using element = void;
@@ -420,11 +421,11 @@ public:
 
   // If any strides are `auto_stride`, replace them with automatically determined strides.
   // `alignment` must be a power of 2.
-  std::size_t init_strides(index_t alignment = 1) {
+  std::optional<std::size_t> init_strides(index_t alignment = 1) {
     if (rank == 0) {
       std::size_t final_sum;
       if (add_with_overflow(elem_size, static_cast<std::size_t>(alignment - 1), final_sum)) {
-        return 0;
+        return std::nullopt;
       }
       return final_sum & ~static_cast<std::size_t>(alignment - 1);
     } else {

--- a/slinky/runtime/evaluate.cc
+++ b/slinky/runtime/evaluate.cc
@@ -599,11 +599,13 @@ public:
     if (op->storage == memory_type::heap) {
       buffer.allocation = context.config->allocate(op->sym, &buffer);
     } else {
-      std::optional<std::size_t> size = buffer.init_strides(context.config->stride_alignment);
+      std::optional<std::size_t> size = buffer.init_strides(
+          context.config->stride_alignment);
       if (!size) {
         return -1;
       }
-      if (op->storage == memory_type::stack || *size <= context.config->auto_stack_threshold) {
+      if (op->storage == memory_type::stack ||
+          *size <= context.config->auto_stack_threshold) {
         std::size_t alignment = context.config->base_alignment;
         buffer.base = SLINKY_ALLOCA(char, *size + alignment - 1);
         buffer.base = align_up(buffer.base, alignment);

--- a/slinky/runtime/evaluate.cc
+++ b/slinky/runtime/evaluate.cc
@@ -599,8 +599,8 @@ public:
     if (op->storage == memory_type::heap) {
       buffer.allocation = context.config->allocate(op->sym, &buffer);
     } else {
-      std::optional<std::size_t> size = buffer.init_strides(
-          context.config->stride_alignment);
+      std::optional<std::size_t> size =
+          buffer.init_strides(context.config->stride_alignment);
       if (!size) {
         return -1;
       }

--- a/slinky/runtime/evaluate.cc
+++ b/slinky/runtime/evaluate.cc
@@ -599,13 +599,11 @@ public:
     if (op->storage == memory_type::heap) {
       buffer.allocation = context.config->allocate(op->sym, &buffer);
     } else {
-      std::optional<std::size_t> size =
-          buffer.init_strides(context.config->stride_alignment);
+      std::optional<std::size_t> size = buffer.init_strides(context.config->stride_alignment);
       if (!size) {
         return -1;
       }
-      if (op->storage == memory_type::stack ||
-          *size <= context.config->auto_stack_threshold) {
+      if (op->storage == memory_type::stack || *size <= context.config->auto_stack_threshold) {
         std::size_t alignment = context.config->base_alignment;
         buffer.base = SLINKY_ALLOCA(char, *size + alignment - 1);
         buffer.base = align_up(buffer.base, alignment);

--- a/slinky/runtime/evaluate.cc
+++ b/slinky/runtime/evaluate.cc
@@ -7,6 +7,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <iostream>
+#include <optional>
 #include <string>
 #include <utility>
 
@@ -598,10 +599,13 @@ public:
     if (op->storage == memory_type::heap) {
       buffer.allocation = context.config->allocate(op->sym, &buffer);
     } else {
-      std::size_t size = buffer.init_strides(context.config->stride_alignment);
-      if (op->storage == memory_type::stack || size <= context.config->auto_stack_threshold) {
+      std::optional<std::size_t> size = buffer.init_strides(context.config->stride_alignment);
+      if (!size) {
+        return -1;
+      }
+      if (op->storage == memory_type::stack || *size <= context.config->auto_stack_threshold) {
         std::size_t alignment = context.config->base_alignment;
-        buffer.base = SLINKY_ALLOCA(char, size + alignment - 1);
+        buffer.base = SLINKY_ALLOCA(char, *size + alignment - 1);
         buffer.base = align_up(buffer.base, alignment);
         buffer.allocation = nullptr;
       } else {

--- a/slinky/runtime/test/buffer.cc
+++ b/slinky/runtime/test/buffer.cc
@@ -6,6 +6,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <numeric>
+#include <optional>
 
 #include "slinky/base/test/seeded_test.h"
 #include "slinky/runtime/buffer.h"
@@ -1319,8 +1320,8 @@ TEST(buffer, init_strides_overflow_multiplication) {
   buf.mutable_dim(1).set_min_extent(0, 2);
   buf.mutable_dim(1).set_stride(max_val - 5);
 
-  std::size_t size = buf.init_strides();
-  ASSERT_EQ(size, 0);
+  std::optional<std::size_t> size = buf.init_strides();
+  ASSERT_EQ(size, std::nullopt);
 }
 
 TEST(buffer, init_strides_overflow_accumulation) {
@@ -1336,16 +1337,16 @@ TEST(buffer, init_strides_overflow_accumulation) {
   buf.mutable_dim(1).set_min_extent(0, 2);
   buf.mutable_dim(1).set_stride(safe_large_stride);
 
-  std::size_t size = buf.init_strides();
-  ASSERT_EQ(size, 0);
+  std::optional<std::size_t> size = buf.init_strides();
+  ASSERT_EQ(size, std::nullopt);
 }
 
 TEST(buffer, init_strides_overflow_rank0_alignment) {
   buffer<int, 0> buf;
   buf.elem_size = std::numeric_limits<std::size_t>::max() - 10;
 
-  std::size_t size = buf.init_strides(16);
-  ASSERT_EQ(size, 0);
+  std::optional<std::size_t> size = buf.init_strides(16);
+  ASSERT_EQ(size, std::nullopt);
 }
 
 }  // namespace slinky

--- a/slinky/runtime/test/buffer.cc
+++ b/slinky/runtime/test/buffer.cc
@@ -1308,4 +1308,47 @@ TEST(optimize_dims, extent_1) {
   ASSERT_EQ(b.dim(1).stride(), 12);
 }
 
+TEST(buffer, init_strides_overflow_multiplication) {
+  buffer<int, 2> buf;
+  buf.elem_size = sizeof(int);
+
+  buf.mutable_dim(0).set_min_extent(0, 10);
+  buf.mutable_dim(0).set_stride(sizeof(int));
+
+  index_t max_val = std::numeric_limits<index_t>::max();
+  buf.mutable_dim(1).set_min_extent(0, 2);
+  buf.mutable_dim(1).set_stride(max_val - 5);
+
+  std::size_t size = buf.init_strides();
+  ASSERT_EQ(size, 0);
+}
+
+TEST(buffer, init_strides_overflow_accumulation) {
+  buffer<int, 2> buf;
+  buf.elem_size = sizeof(int);
+
+  index_t max_val = std::numeric_limits<index_t>::max();
+  // Each footprint is max_val * 2/3 (fits in index_t), but their sum will exceed max_val!
+  index_t safe_large_stride = max_val / 3 * 2;
+
+  buf.mutable_dim(0).set_min_extent(0, 2);
+  buf.mutable_dim(0).set_stride(safe_large_stride);
+
+  buf.mutable_dim(1).set_min_extent(0, 2);
+  buf.mutable_dim(1).set_stride(safe_large_stride);
+
+  std::size_t size = buf.init_strides();
+  ASSERT_EQ(size, 0);
+}
+
+TEST(buffer, init_strides_overflow_rank0_alignment) {
+  buffer<int, 0> buf;
+  // Set a huge elem_size close to max_size_t, so even alignment 16 will overflow it!
+  buf.elem_size = std::numeric_limits<std::size_t>::max() - 10;
+
+  // Alignment 16 (valid power of 2)
+  std::size_t size = buf.init_strides(16);
+  ASSERT_EQ(size, 0);
+}
+
 }  // namespace slinky

--- a/slinky/runtime/test/buffer.cc
+++ b/slinky/runtime/test/buffer.cc
@@ -1,3 +1,5 @@
+#include "slinky/runtime/buffer.h"
+
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
@@ -9,7 +11,6 @@
 #include <optional>
 
 #include "slinky/base/test/seeded_test.h"
-#include "slinky/runtime/buffer.h"
 
 namespace slinky {
 

--- a/slinky/runtime/test/buffer.cc
+++ b/slinky/runtime/test/buffer.cc
@@ -1328,7 +1328,6 @@ TEST(buffer, init_strides_overflow_accumulation) {
   buf.elem_size = sizeof(int);
 
   index_t max_val = std::numeric_limits<index_t>::max();
-  // Each footprint is max_val * 2/3 (fits in index_t), but their sum will exceed max_val!
   index_t safe_large_stride = max_val / 3 * 2;
 
   buf.mutable_dim(0).set_min_extent(0, 2);
@@ -1343,10 +1342,8 @@ TEST(buffer, init_strides_overflow_accumulation) {
 
 TEST(buffer, init_strides_overflow_rank0_alignment) {
   buffer<int, 0> buf;
-  // Set a huge elem_size close to max_size_t, so even alignment 16 will overflow it!
   buf.elem_size = std::numeric_limits<std::size_t>::max() - 10;
 
-  // Alignment 16 (valid power of 2)
   std::size_t size = buf.init_strides(16);
   ASSERT_EQ(size, 0);
 }


### PR DESCRIPTION
This came up in https://github.com/dsharlet/slinky/pull/828.

A follow up change after this one will allow us to simplify the logic in allocate in runtime/evaluate.cc