### PR TITLE
Fix multiple padding aliases of the same buffer

### DIFF
--- a/slinky/builder/optimizations.cc
+++ b/slinky/builder/optimizations.cc
@@ -309,6 +309,7 @@ class copy_aliaser : public stmt_mutator {
     // If we decided to alias this buffer, we might have grown the bounds. If so, we need to make a new allocation with
     // this symbol, but make a crop of it for the original bounds.
     var shared_alloc_sym;
+    std::vector<var> intermediate_syms;
 
     buffer_info(std::vector<dim_expr> dims, expr elem_size, bool is_input = false, bool is_output = false)
         : dims(std::move(dims)), elem_size(std::move(elem_size)), is_input(is_input), is_output(is_output) {}
@@ -528,8 +529,11 @@ public:
           assert(!target_info->is_output);
           assert(!target_info->is_input);  // We shouldn't be trying to write to an input anyways.
           // We allocated this buffer, make it big enough to share with this buffer.
-          std::string old_name =
-              ctx.name(target_info->shared_alloc_sym.defined() ? target_info->shared_alloc_sym : target_var);
+          var old_sym = target_info->shared_alloc_sym.defined() ? target_info->shared_alloc_sym : target_var;
+          if (old_sym != target_var) {
+            target_info->intermediate_syms.push_back(old_sym);
+          }
+          std::string old_name = ctx.name(old_sym);
           target_info->shared_alloc_sym = ctx.insert_unique(old_name + "/" + ctx.name(sym));
           alloc_var = target_info->shared_alloc_sym;
           for (std::size_t d = 0; d < alias.permutation.size(); ++d) {
@@ -591,6 +595,13 @@ public:
         // This allocation's bounds were expanded to accommodate aliases. Make a new expanded allocation, and make the
         // original allocation a crop of the expanded allocation.
         body = crop_buffer::make(op->sym, info.shared_alloc_sym, dims_bounds(op->dims), std::move(body));
+        const std::vector<var>& chain = info.intermediate_syms;
+        if (!chain.empty()) {
+          for (std::size_t i = 0; i < chain.size(); ++i) {
+            var next = i + 1 < chain.size() ? chain[i + 1] : info.shared_alloc_sym;
+            body = make_buffer::make(chain[i], buffer_at(next), op->elem_size, info.dims, std::move(body));
+          }
+        }
       }
       stmt result = allocate::make(sym, op->storage, op->elem_size, std::move(info.dims), std::move(body));
       // Wrap with the original buffer in case we want to use the metadata in the construction of the buffer.
@@ -841,6 +852,9 @@ public:
         assert(!old_info->shared_alloc_sym.defined() || old_info->shared_alloc_sym == info->shared_alloc_sym);
         old_info->shared_alloc_sym = info->shared_alloc_sym;
       }
+      if (!info->intermediate_syms.empty()) {
+        old_info->intermediate_syms = std::move(info->intermediate_syms);
+      }
       for (alias_info& a : info->aliases) {
         if (a.target == sym) {
           a.target = src;
@@ -862,6 +876,7 @@ public:
         buffers[i] = buffer_info(
             old_buffers[i]->dims, old_buffers[i]->elem_size, old_buffers[i]->is_input, old_buffers[i]->is_output);
         buffers[i]->shared_alloc_sym = old_buffers[i]->shared_alloc_sym;
+        buffers[i]->intermediate_syms = old_buffers[i]->intermediate_syms;
       }
     }
 

--- a/slinky/builder/optimizations.cc
+++ b/slinky/builder/optimizations.cc
@@ -308,8 +308,7 @@ class copy_aliaser : public stmt_mutator {
 
     // If we decided to alias this buffer, we might have grown the bounds. If so, we need to make a new allocation with
     // this symbol, but make a crop of it for the original bounds.
-    var shared_alloc_sym;
-    std::vector<var> intermediate_syms;
+    std::vector<var> shared_alloc_syms;
 
     buffer_info(std::vector<dim_expr> dims, expr elem_size, bool is_input = false, bool is_output = false)
         : dims(std::move(dims)), elem_size(std::move(elem_size)), is_input(is_input), is_output(is_output) {}
@@ -334,7 +333,7 @@ class copy_aliaser : public stmt_mutator {
     if (alias.is_contiguous_copy) {
       assert(alias.assume_in_bounds);
       // Don't alias if the allocation was grown by another alias, a contiguous copy is likely incorrect.
-      if (alloc_info.shared_alloc_sym.defined()) {
+      if (!alloc_info.shared_alloc_syms.empty()) {
         return false;
       }
       return true;
@@ -361,7 +360,7 @@ class copy_aliaser : public stmt_mutator {
 
     // If the allocation was grown to accommodate another alias, we can't trust assume_in_bounds
     // and need to re-check whether the (possibly grown) allocation fits within the target.
-    bool assume_in_bounds = alias.assume_in_bounds && !alloc_info.shared_alloc_sym.defined();
+    bool assume_in_bounds = alias.assume_in_bounds && alloc_info.shared_alloc_syms.empty();
     if (!assume_in_bounds) {
       bool in_bounds = true;
       for (std::size_t d = 0; d < alloc_dims.size(); ++d) {
@@ -479,7 +478,7 @@ public:
 
     scoped_trace trace("visit(const allocate*)");
     buffer_info info = std::move(*buffers[op->sym]);
-    var sym = info.shared_alloc_sym.defined() ? info.shared_alloc_sym : op->sym;
+    var sym = !info.shared_alloc_syms.empty() ? info.shared_alloc_syms.back() : op->sym;
 
     // When an allocation goes out of scope, we should remove it as an aliasing candidate.
     for (std::optional<buffer_info>& i : buffers) {
@@ -529,13 +528,10 @@ public:
           assert(!target_info->is_output);
           assert(!target_info->is_input);  // We shouldn't be trying to write to an input anyways.
           // We allocated this buffer, make it big enough to share with this buffer.
-          var old_sym = target_info->shared_alloc_sym.defined() ? target_info->shared_alloc_sym : target_var;
-          if (old_sym != target_var) {
-            target_info->intermediate_syms.push_back(old_sym);
-          }
+          var old_sym = !target_info->shared_alloc_syms.empty() ? target_info->shared_alloc_syms.back() : target_var;
           std::string old_name = ctx.name(old_sym);
-          target_info->shared_alloc_sym = ctx.insert_unique(old_name + "/" + ctx.name(sym));
-          alloc_var = target_info->shared_alloc_sym;
+          alloc_var = ctx.insert_unique(old_name + "/" + ctx.name(sym));
+          target_info->shared_alloc_syms.push_back(alloc_var);
           for (std::size_t d = 0; d < alias.permutation.size(); ++d) {
             // TODO: We may have proven this is unnecessary in alias_compatible, we can avoid this in such cases.
             // We need the bounds of the alias, as it exists in the target buffer. `alias.at` tells us where this alias
@@ -591,15 +587,15 @@ public:
       }
     }
     if (!body.same_as(op->body)) {
-      if (info.shared_alloc_sym.defined()) {
+      if (!info.shared_alloc_syms.empty()) {
         // This allocation's bounds were expanded to accommodate aliases. Make a new expanded allocation, and make the
         // original allocation a crop of the expanded allocation.
-        body = crop_buffer::make(op->sym, info.shared_alloc_sym, dims_bounds(op->dims), std::move(body));
-        const std::vector<var>& chain = info.intermediate_syms;
-        if (!chain.empty()) {
-          for (std::size_t i = 0; i < chain.size(); ++i) {
-            var next = i + 1 < chain.size() ? chain[i + 1] : info.shared_alloc_sym;
-            body = make_buffer::make(chain[i], buffer_at(next), op->elem_size, info.dims, std::move(body));
+        body = crop_buffer::make(op->sym, info.shared_alloc_syms.back(), dims_bounds(op->dims), std::move(body));
+        if (info.shared_alloc_syms.size() > 1) {
+          for (std::size_t i = 0; i < info.shared_alloc_syms.size() - 1; ++i) {
+            var next = info.shared_alloc_syms[i + 1];
+            body = make_buffer::make(
+                info.shared_alloc_syms[i], buffer_at(next), op->elem_size, info.dims, std::move(body));
           }
         }
       }
@@ -848,12 +844,10 @@ public:
         old_info->elem_size = std::move(info->elem_size);
         old_info->producers += info->producers;
       }
-      if (info->shared_alloc_sym.defined()) {
-        assert(!old_info->shared_alloc_sym.defined() || old_info->shared_alloc_sym == info->shared_alloc_sym);
-        old_info->shared_alloc_sym = info->shared_alloc_sym;
-      }
-      if (!info->intermediate_syms.empty()) {
-        old_info->intermediate_syms = std::move(info->intermediate_syms);
+      if (!info->shared_alloc_syms.empty()) {
+        assert(old_info->shared_alloc_syms.empty() ||
+               old_info->shared_alloc_syms.back() == info->shared_alloc_syms.back());
+        old_info->shared_alloc_syms = std::move(info->shared_alloc_syms);
       }
       for (alias_info& a : info->aliases) {
         if (a.target == sym) {
@@ -875,8 +869,7 @@ public:
       if (old_buffers[i]) {
         buffers[i] = buffer_info(
             old_buffers[i]->dims, old_buffers[i]->elem_size, old_buffers[i]->is_input, old_buffers[i]->is_output);
-        buffers[i]->shared_alloc_sym = old_buffers[i]->shared_alloc_sym;
-        buffers[i]->intermediate_syms = old_buffers[i]->intermediate_syms;
+        buffers[i]->shared_alloc_syms = old_buffers[i]->shared_alloc_syms;
       }
     }
 

--- a/slinky/builder/optimizations.cc
+++ b/slinky/builder/optimizations.cc
@@ -590,13 +590,10 @@ public:
       if (!info.shared_alloc_syms.empty()) {
         // This allocation's bounds were expanded to accommodate aliases. Make a new expanded allocation, and make the
         // original allocation a crop of the expanded allocation.
-        body = crop_buffer::make(op->sym, info.shared_alloc_syms.back(), dims_bounds(op->dims), std::move(body));
-        if (info.shared_alloc_syms.size() > 1) {
-          for (std::size_t i = 0; i < info.shared_alloc_syms.size() - 1; ++i) {
-            var next = info.shared_alloc_syms[i + 1];
-            body = make_buffer::make(
-                info.shared_alloc_syms[i], buffer_at(next), op->elem_size, info.dims, std::move(body));
-          }
+        const std::vector<var>& syms = info.shared_alloc_syms;
+        body = crop_buffer::make(op->sym, syms.back(), dims_bounds(op->dims), std::move(body));
+        for (std::size_t i = 0; i + 1 < syms.size(); ++i) {
+          body = clone_buffer::make(syms[i], syms[i + 1], std::move(body));
         }
       }
       stmt result = allocate::make(sym, op->storage, op->elem_size, std::move(info.dims), std::move(body));

--- a/slinky/builder/test/copy_pipeline.cc
+++ b/slinky/builder/test/copy_pipeline.cc
@@ -1267,4 +1267,54 @@ TEST(broadcast_new_dim, pipeline) {
   }
 }
 
+TEST(multiple_shared_aliases, pipeline) {
+  node_context ctx;
+
+  auto in = buffer_expr::make(ctx, "in", 1, sizeof(int));
+  auto intm = buffer_expr::make(ctx, "intm", 1, sizeof(int));
+  auto intm1 = buffer_expr::make(ctx, "intm1", 1, sizeof(int));
+  auto intm2 = buffer_expr::make(ctx, "intm2", 1, sizeof(int));
+  auto out = buffer_expr::make(ctx, "out", 1, sizeof(int));
+
+  var x(ctx, "x");
+  test_context eval_ctx;
+
+  func producer = func::make(add_1<int>, {{in, {point(x)}}}, {{intm, {x}}});
+  producer.loops({{x, 1}});
+
+  // We need padding to force bounds expansion and alias sharing.
+  auto pad_val = buffer_expr::make_scalar<int>(ctx, "pad", 0);
+
+  // intm1 = copy(intm) with shift -6, pad outside [0, 1] of intm
+  func copy1 = func::make_copy({intm, {point(x - 6)}, {bounds(0, 1)}}, {intm1, {x}}, {pad_val}, eval_ctx.copy);
+
+  // intm2 = copy(intm) with shift -4, pad outside [0, 1] of intm
+  func copy2 = func::make_copy({intm, {point(x - 4)}, {bounds(0, 1)}}, {intm2, {x}}, {pad_val}, eval_ctx.copy);
+
+  func consumer = func::make(subtract<int>, {{intm1, {point(x)}}, {intm2, {point(x)}}}, {{out, {x}}});
+  consumer.loops({{x, 1}});
+
+  copy1.compute_at({&consumer, x});
+  copy2.compute_at({&consumer, x});
+  intm1->store_at({&consumer, x});
+  intm2->store_at({&consumer, x});
+
+  pipeline p = build_pipeline(ctx, {in}, {out});
+
+  buffer<int, 1> in_buf({2});
+  init_random(in_buf);
+  buffer<int, 1> out_buf({12});
+  out_buf.allocate();
+
+  const raw_buffer* inputs[] = {&in_buf};
+  const raw_buffer* outputs[] = {&out_buf};
+  p.evaluate(inputs, outputs, eval_ctx);
+
+  for (int i = 0; i < 12; ++i) {
+    int val1 = (i - 6 >= 0 && i - 6 <= 1) ? in_buf(i - 6) + 1 : 0;
+    int val2 = (i - 4 >= 0 && i - 4 <= 1) ? in_buf(i - 4) + 1 : 0;
+    ASSERT_EQ(out_buf(i), val1 - val2);
+  }
+}
+
 }  // namespace slinky


### PR DESCRIPTION
When multiple buffers alias the same shared buffer with padding, we need to keep track of multiple shared alloc symbols, not just one.