### PR TITLE
Fix stride propagation when aliasing

### DIFF
--- a/slinky/builder/optimizations.cc
+++ b/slinky/builder/optimizations.cc
@@ -380,17 +380,20 @@ class copy_aliaser : public stmt_mutator {
     }
 
     // If we plan to propagate strides from the alloc to the target (alloc has strides, target doesn't),
-    // require that alloc and target bounds extents match in all dims (after permutation). Otherwise
-    // the propagated strides may not be valid for target's layout: even if the bounds match for a dim
-    // that has a propagated stride, the un-propagated dims of target could have different extents
-    // that cause overlap with the propagated strides.
+    // the propagated strides must be valid for the target's (possibly different) extents.
     if (alias.assume_in_bounds && alloc_has_stride && !target_has_stride) {
-      for (std::size_t d = 0; d < alloc_dims.size(); ++d) {
-        const int target_d = alias.permutation[d];
-        if (target_d < 0 || target_d >= static_cast<int>(target_info.dims.size())) continue;
-        if (alloc_dims[d].bounds.is_point() || target_info.dims[target_d].bounds.is_point()) continue;
-        if (!prove_true(alloc_dims[d].bounds.extent() == target_info.dims[target_d].bounds.extent())) {
-          return false;
+      if (std::all_of(alloc_dims.begin(), alloc_dims.end(), [&](const dim_expr& d) {
+            return !d.stride.defined() || d.bounds.is_point() || prove_true(d.stride == alloc_info.elem_size);
+          })) {
+        // The only defined stride is elem_size, it can be propagated safely.
+      } else {
+        for (std::size_t d = 0; d < alloc_dims.size(); ++d) {
+          const int target_d = alias.permutation[d];
+          if (target_d < 0 || target_d >= static_cast<int>(target_info.dims.size())) continue;
+          if (alloc_dims[d].bounds.is_point() || target_info.dims[target_d].bounds.is_point()) continue;
+          if (!prove_true(alloc_dims[d].bounds.extent() == target_info.dims[target_d].bounds.extent())) {
+            return false;
+          }
         }
       }
     }

--- a/slinky/builder/optimizations.cc
+++ b/slinky/builder/optimizations.cc
@@ -545,17 +545,18 @@ public:
           assert(info.dims.size() == alias.permutation.size());
           // The target doesn't have any strides, we might have some strides we assumed we could propagate.
           for (std::size_t d = 0; d < info.dims.size(); ++d) {
-            if (!info.dims[d].stride.defined()) continue;
-            int target_d = alias.permutation[d];
-            if (target_d >= static_cast<int>(target_info->dims.size())) {
-              assert(prove_true(info.dims[d].stride == 0 || info.dims[d].bounds.is_point()));
+            const int target_d = alias.permutation[d];
+            if (!info.dims[d].stride.defined() ||
+                is_variable(info.dims[d].stride, target_var, buffer_field::stride, target_d)) {
+              // This alias is asking for the stride of the target buffer.
+            } else if (info.dims[d].bounds.is_point()) {
+              // The alias dimension is extent 1, don't mess with strides.
+            } else if (target_d >= static_cast<int>(target_info->dims.size())) {
+              // This alias is a broadcast.
+              assert(prove_true(info.dims[d].stride == 0));
             } else if (target_info->dims[target_d].stride.defined()) {
-              assert(prove_true(
-                  info.dims[d].stride == target_info->dims[target_d].stride || info.dims[d].bounds.is_point()));
-            } else if (is_constant(info.dims[d].stride, 0)) {
-              // TODO(dsharlet|vksnk): stride 0 has a special meaning (i.e. that dim is broadcasted), so
-              // it might be incorrect to propagate it to the target buffer in some cases (this is an
-              // actual bug we're hitting). This is a workaround and it's possible there is a better solution.
+              // The target has a stride, and the alias wants a specific stride, they need to match.
+              assert(prove_true(info.dims[d].stride == target_info->dims[target_d].stride));
             } else {
               target_info->dims[target_d].stride = info.dims[d].stride;
             }

--- a/slinky/builder/optimizations.cc
+++ b/slinky/builder/optimizations.cc
@@ -379,6 +379,22 @@ class copy_aliaser : public stmt_mutator {
       alias.assume_in_bounds = in_bounds;
     }
 
+    // If we plan to propagate strides from the alloc to the target (alloc has strides, target doesn't),
+    // require that alloc and target bounds extents match in all dims (after permutation). Otherwise
+    // the propagated strides may not be valid for target's layout: even if the bounds match for a dim
+    // that has a propagated stride, the un-propagated dims of target could have different extents
+    // that cause overlap with the propagated strides.
+    if (alias.assume_in_bounds && alloc_has_stride && !target_has_stride) {
+      for (std::size_t d = 0; d < alloc_dims.size(); ++d) {
+        const int target_d = alias.permutation[d];
+        if (target_d < 0 || target_d >= static_cast<int>(target_info.dims.size())) continue;
+        if (alloc_dims[d].bounds.is_point() || target_info.dims[target_d].bounds.is_point()) continue;
+        if (!prove_true(alloc_dims[d].bounds.extent() == target_info.dims[target_d].bounds.extent())) {
+          return false;
+        }
+      }
+    }
+
     // If the target doesn't have strides, we can propagate our strides there, but we need to make sure there are no
     // contradictions when we do so. This tracks what we want the strides to be.
     std::vector<expr> target_stride(target_info.dims.size());

--- a/slinky/builder/test/cannot_alias.cc
+++ b/slinky/builder/test/cannot_alias.cc
@@ -978,7 +978,13 @@ TEST_P(padded_stencil, cannot_alias) {
   ASSERT_EQ(eval_ctx.heap.allocs.size(), 1);
 }
 
-TEST(cannot_alias, padded_stride_propagation) {
+class stride_propagation : public testing::TestWithParam<bool> {};
+
+INSTANTIATE_TEST_SUITE_P(constrain_outer, stride_propagation, testing::Bool());
+
+TEST_P(stride_propagation, padded) {
+  const bool constrain_outer = GetParam();
+
   node_context ctx;
 
   auto in = buffer_expr::make(ctx, "in", 2, sizeof(int));
@@ -987,10 +993,10 @@ TEST(cannot_alias, padded_stride_propagation) {
   auto intm1 = buffer_expr::make(ctx, "intm1", 2, sizeof(int));
   auto intm2 = buffer_expr::make(ctx, "intm2", 2, sizeof(int));
 
-  // Constrain intm1 to its natural strides. If these strides are propagated to intm2 (which is larger),
-  // the resulting strides would be too small for intm2, causing memory overlap.
   intm1->dim(0).stride = sizeof(int);
-  intm1->dim(1).stride = sizeof(int) * in->dim(0).extent();
+  if (constrain_outer) {
+    intm1->dim(1).stride = sizeof(int) * in->dim(0).extent();
+  }
 
   var x(ctx, "x");
   var y(ctx, "y");
@@ -1030,15 +1036,17 @@ TEST(cannot_alias, padded_stride_propagation) {
     }
   }
 
-  // We should NOT have aliased intm1 to intm2.
-  ASSERT_GE(eval_ctx.heap.allocs.size(), 1);
+  ASSERT_EQ(eval_ctx.heap.allocs.size(), constrain_outer ? 2 : 1);
 }
 
-TEST(cannot_alias, cropped_stride_propagation) {
+TEST_P(stride_propagation, cropped) {
+  const bool constrain_outer = GetParam();
+
   node_context ctx;
 
   auto in = buffer_expr::make(ctx, "in", 2, sizeof(int));
   auto out = buffer_expr::make(ctx, "out", 2, sizeof(int));
+  auto out_full = buffer_expr::make(ctx, "out_full", 2, sizeof(int));
 
   auto intm1 = buffer_expr::make(ctx, "intm1", 2, sizeof(int));
   auto intm2 = buffer_expr::make(ctx, "intm2", 2, sizeof(int));
@@ -1046,14 +1054,10 @@ TEST(cannot_alias, cropped_stride_propagation) {
   const int W = 8;
   const int H = 8;
 
-  // Force intm1 to be the full size of the input, even though intm2 only consumes a crop of it.
-  intm1->dim(0).bounds = in->dim(0).bounds;
-  intm1->dim(1).bounds = in->dim(1).bounds;
-
-  // intm2 (smaller, a crop of intm1) has explicit strides matching its natural W x H layout.
-  // If these strides are propagated to intm1 (which is larger), the resulting layout would overlap.
   intm2->dim(0).stride = sizeof(int);
-  intm2->dim(1).stride = sizeof(int) * intm2->dim(0).extent();
+  if (constrain_outer) {
+    intm2->dim(1).stride = sizeof(int) * intm2->dim(0).extent();
+  }
 
   var x(ctx, "x");
   var y(ctx, "y");
@@ -1066,7 +1070,10 @@ TEST(cannot_alias, cropped_stride_propagation) {
 
   func copy_out = func::make_copy({intm2, {point(x), point(y)}}, {out, {x, y}}, eval_ctx.copy);
 
-  pipeline p = build_pipeline(ctx, {in}, {out});
+  // A second consumer of intm1 that requires its full bounds. This requires intm1 to be larger than intm2.
+  func copy_full = func::make_copy({intm1, {point(x), point(y)}}, {out_full, {x, y}}, eval_ctx.copy);
+
+  pipeline p = build_pipeline(ctx, {in}, {out, out_full});
 
   buffer<int, 2> in_buf({W + 2, H + 2});
   init_random(in_buf);
@@ -1074,8 +1081,11 @@ TEST(cannot_alias, cropped_stride_propagation) {
   buffer<int, 2> out_buf({W, H});
   out_buf.allocate();
 
+  buffer<int, 2> out_full_buf({W + 2, H + 2});
+  out_full_buf.allocate();
+
   const raw_buffer* inputs[] = {&in_buf};
-  const raw_buffer* outputs[] = {&out_buf};
+  const raw_buffer* outputs[] = {&out_buf, &out_full_buf};
   ASSERT_EQ(0, p.evaluate(inputs, outputs, eval_ctx));
 
   for (int y = 0; y < H; ++y) {
@@ -1083,6 +1093,13 @@ TEST(cannot_alias, cropped_stride_propagation) {
       ASSERT_EQ(out_buf(x, y), in_buf(x + 1, y + 1) + 1);
     }
   }
+  for (int y = 0; y < H + 2; ++y) {
+    for (int x = 0; x < W + 2; ++x) {
+      ASSERT_EQ(out_full_buf(x, y), in_buf(x, y) + 1);
+    }
+  }
+
+  ASSERT_EQ(eval_ctx.heap.allocs.size(), constrain_outer ? 2 : 1);
 }
 
 }  // namespace slinky

--- a/slinky/builder/test/cannot_alias.cc
+++ b/slinky/builder/test/cannot_alias.cc
@@ -978,4 +978,111 @@ TEST_P(padded_stencil, cannot_alias) {
   ASSERT_EQ(eval_ctx.heap.allocs.size(), 1);
 }
 
+TEST(cannot_alias, padded_stride_propagation) {
+  node_context ctx;
+
+  auto in = buffer_expr::make(ctx, "in", 2, sizeof(int));
+  auto out = buffer_expr::make(ctx, "out", 2, sizeof(int));
+
+  auto intm1 = buffer_expr::make(ctx, "intm1", 2, sizeof(int));
+  auto intm2 = buffer_expr::make(ctx, "intm2", 2, sizeof(int));
+
+  // Constrain intm1 to its natural strides. If these strides are propagated to intm2 (which is larger),
+  // the resulting strides would be too small for intm2, causing memory overlap.
+  intm1->dim(0).stride = sizeof(int);
+  intm1->dim(1).stride = sizeof(int) * in->dim(0).extent();
+
+  var x(ctx, "x");
+  var y(ctx, "y");
+  test_context eval_ctx;
+
+  func add1 = func::make(add_1<int>, {{in, {point(x), point(y)}}}, {{intm1, {x, y}}});
+
+  auto padding = buffer_expr::make_scalar<int>(ctx, "padding", 0);
+  func pad = func::make_copy({intm1, {point(x - 1), point(y - 1)}, in->bounds()}, {intm2, {x, y}},
+      {padding, {point(x), point(y)}}, eval_ctx.copy);
+
+  func copy_out = func::make_copy({intm2, {point(x), point(y)}}, {out, {x, y}}, eval_ctx.copy);
+
+  pipeline p = build_pipeline(ctx, {in}, {out});
+
+  // Run the pipeline.
+  const int W = 8;
+  const int H = 8;
+  buffer<int, 2> in_buf({W, H});
+  init_random(in_buf);
+
+  buffer<int, 2> out_buf({W + 2, H + 2});
+  out_buf.allocate();
+
+  const raw_buffer* inputs[] = {&in_buf};
+  const raw_buffer* outputs[] = {&out_buf};
+  ASSERT_EQ(0, p.evaluate(inputs, outputs, eval_ctx));
+
+  // Verify results.
+  for (int y = 0; y < H + 2; ++y) {
+    for (int x = 0; x < W + 2; ++x) {
+      if (x >= 1 && x < W + 1 && y >= 1 && y < H + 1) {
+        ASSERT_EQ(out_buf(x, y), in_buf(x - 1, y - 1) + 1);
+      } else {
+        ASSERT_EQ(out_buf(x, y), 0);  // Padding
+      }
+    }
+  }
+
+  // We should NOT have aliased intm1 to intm2.
+  ASSERT_GE(eval_ctx.heap.allocs.size(), 1);
+}
+
+TEST(cannot_alias, cropped_stride_propagation) {
+  node_context ctx;
+
+  auto in = buffer_expr::make(ctx, "in", 2, sizeof(int));
+  auto out = buffer_expr::make(ctx, "out", 2, sizeof(int));
+
+  auto intm1 = buffer_expr::make(ctx, "intm1", 2, sizeof(int));
+  auto intm2 = buffer_expr::make(ctx, "intm2", 2, sizeof(int));
+
+  const int W = 8;
+  const int H = 8;
+
+  // Force intm1 to be the full size of the input, even though intm2 only consumes a crop of it.
+  intm1->dim(0).bounds = in->dim(0).bounds;
+  intm1->dim(1).bounds = in->dim(1).bounds;
+
+  // intm2 (smaller, a crop of intm1) has explicit strides matching its natural W x H layout.
+  // If these strides are propagated to intm1 (which is larger), the resulting layout would overlap.
+  intm2->dim(0).stride = sizeof(int);
+  intm2->dim(1).stride = sizeof(int) * intm2->dim(0).extent();
+
+  var x(ctx, "x");
+  var y(ctx, "y");
+  test_context eval_ctx;
+
+  func add1 = func::make(add_1<int>, {{in, {point(x), point(y)}}}, {{intm1, {x, y}}});
+
+  // Crop copy (no padding): intm2[x, y] = intm1[x + 1, y + 1]. intm2 is smaller than intm1.
+  func crop = func::make_copy({intm1, {point(x + 1), point(y + 1)}}, {intm2, {x, y}}, eval_ctx.copy);
+
+  func copy_out = func::make_copy({intm2, {point(x), point(y)}}, {out, {x, y}}, eval_ctx.copy);
+
+  pipeline p = build_pipeline(ctx, {in}, {out});
+
+  buffer<int, 2> in_buf({W + 2, H + 2});
+  init_random(in_buf);
+
+  buffer<int, 2> out_buf({W, H});
+  out_buf.allocate();
+
+  const raw_buffer* inputs[] = {&in_buf};
+  const raw_buffer* outputs[] = {&out_buf};
+  ASSERT_EQ(0, p.evaluate(inputs, outputs, eval_ctx));
+
+  for (int y = 0; y < H; ++y) {
+    for (int x = 0; x < W; ++x) {
+      ASSERT_EQ(out_buf(x, y), in_buf(x + 1, y + 1) + 1);
+    }
+  }
+}
+
 }  // namespace slinky

--- a/slinky/builder/test/cannot_alias.cc
+++ b/slinky/builder/test/cannot_alias.cc
@@ -778,7 +778,7 @@ class constrained_stencil : public testing::TestWithParam<int> {};
 
 INSTANTIATE_TEST_SUITE_P(alias_split, constrained_stencil, testing::Values(1, 5));
 
-TEST_P(constrained_stencil, may_alias) {
+TEST_P(constrained_stencil, cannot_alias) {
   const int S = GetParam();
   const int D = 1;
   const int K = 5;
@@ -795,7 +795,7 @@ TEST_P(constrained_stencil, may_alias) {
   auto stencil = buffer_expr::make(ctx, "stencil", 2, sizeof(short));
 
   stencil->dim(0).stride = sizeof(short);
-  stencil->dim(1).stride = sizeof(short) * S;
+  stencil->dim(1).stride = sizeof(short) * K;
 
   var x(ctx, "x");
   var dx(ctx, "dx");
@@ -839,14 +839,9 @@ TEST_P(constrained_stencil, may_alias) {
     }
   }
 
-  if (S == 1) {
-    // When S is 1, both stencil dimensions can be aliased without violating the stride constraint for either dimension.
-    ASSERT_EQ(eval_ctx.heap.allocs.size(), 1);
-    ASSERT_EQ(eval_ctx.copy_calls, 0);
-  } else {
-    ASSERT_EQ(eval_ctx.heap.allocs.size(), 2);
-    ASSERT_EQ(eval_ctx.copy_calls, 1);
-  }
+  // We can't alias the copy because the stencil is required to be contiguous.
+  ASSERT_EQ(eval_ctx.heap.allocs.size(), 2);
+  ASSERT_EQ(eval_ctx.copy_calls, 1);
 }
 
 TEST(padded_reshape, cannot_alias_pad) {


### PR DESCRIPTION
If an alias requires particular strides, we try to propagate them to the allocation being aliased (instead of giving up on the alias).

If an alias was aliasing only a subset of the allocation, the strides it requested may not be large enough.

This is a difficult case to verify in general. To avoid this problem, we require that *all* extents match, which is a conservative but safe check. We can make one exception: if all defined strides are equal to the `elem_size`, we know that we won't have this problem. (We could further generalize this check to try to verify that all defined strides form a contiguous block of memory with their extents.)

This change does cause some performance regressions in some cases I've seen due to newly rejected aliases, but I think it is a necessary change to avoid correctness problems. We might be able to find subsequent improvements that allow aliasing in these cases.