### PR TITLE
Fix `depends_on` for `buffer_at`

### DIFF
--- a/slinky/builder/test/simplify/simplify.cc
+++ b/slinky/builder/test/simplify/simplify.cc
@@ -1049,10 +1049,6 @@ TEST(simplify, make_buffer) {
       matches(allocate::make(b0, memory_type::heap, 4, {{{0, 10}, {}, {}}, {{0, 20}, {}, {}}, {{0, 30}, {}, {}}},
           transpose::make(b1, b0, {0, 1}, dummy_call({}, {b0, b1})))));
 
-  ASSERT_THAT(simplify(transpose::make(b1, b2, {1, 0},
-                  make_buffer::make(b0, buffer_at(b1), buffer_elem_size(b1), {{{0, 10}, 2}}, dummy_call({}, {b0})))),
-      matches(make_buffer::make(b0, buffer_at(b2), buffer_elem_size(b2), {{{0, 10}, 2}}, dummy_call({}, {b0}))));
-
   // Truncating a consant buffer.
   const dim const_dims[] = {dim::broadcast(), dim::broadcast()};
   auto const_buffer = slinky::raw_buffer::make(/*rank=*/2, /*elem_size=*/1, const_dims);

--- a/slinky/runtime/depends_on.cc
+++ b/slinky/runtime/depends_on.cc
@@ -86,6 +86,8 @@ public:
       if (auto buf = as_variable(op->args[0])) {
         if (depends_on_result* deps = find_deps(*buf)) {
           deps->buffer_base = true;
+          deps->buffer_dims = true;
+          deps->buffer_bounds = true;
         }
       }
 

--- a/slinky/runtime/test/depends_on.cc
+++ b/slinky/runtime/test/depends_on.cc
@@ -53,7 +53,8 @@ std::ostream& operator<<(std::ostream& os, const depends_on_result& r) {
 TEST(depends_on, basic) {
   ASSERT_EQ(depends_on(x + y, x), (depends_on_result{.var = true}));
   ASSERT_EQ(depends_on(x + x, x), (depends_on_result{.var = true}));
-  ASSERT_EQ(depends_on(buffer_at(x), x), (depends_on_result{.buffer_base = true}));
+  ASSERT_EQ(depends_on(buffer_at(x), x),
+      (depends_on_result{.buffer_base = true, .buffer_dims = true, .buffer_bounds = true}));
 
   ASSERT_EQ(depends_on(buffer_min(x, 0), x), (depends_on_result{.buffer_dims = true, .buffer_bounds = true}));
   ASSERT_EQ(depends_on(buffer_stride(x, 0), x), (depends_on_result{.buffer_dims = true}));


### PR DESCRIPTION
`buffer_at` uses the buffer's bounds and other dimension metadata to compute the address it returns.