### PR TITLE
Minor buffer improvements

### DIFF
--- a/slinky/base/arithmetic.h
+++ b/slinky/base/arithmetic.h
@@ -206,6 +206,11 @@ T lcm(T a, T b) {
   return (a * b) / gcd(a, b);
 }
 
+template <typename T>
+bool is_power_of_two(T x) {
+  return x > 0 && (x & (x - 1)) == 0;
+}
+
 // Computes ((x + a)/b)*c
 template <typename T>
 T staircase(T x, T a, T b, T c) {

--- a/slinky/runtime/buffer.cc
+++ b/slinky/runtime/buffer.cc
@@ -165,7 +165,8 @@ std::optional<std::size_t> raw_buffer::init_strides_impl(index_t alignment) {
   init_stride_dim* dims_end = dims;
   // Insert d into dims, sorted by dim_stride. Also track the flat max index of the buffer, to compute the size.
   index_t flat_max = 0;
-  bool overflow = false;
+  // elem_size is unsigned; a value that doesn't fit in a (signed) index_t is an overflow.
+  bool overflow = static_cast<index_t>(elem_size) < 0;
 
   auto learn_dim = [&](index_t stride, index_t extent) {
     index_t dim_stride = 0;
@@ -238,16 +239,13 @@ std::optional<std::size_t> raw_buffer::init_strides_impl(index_t alignment) {
     assert(dim_i.stride() != dim::auto_stride);
   }
 
-  index_t unaligned_size = 0;
-  overflow = overflow || add_with_overflow(flat_max, static_cast<index_t>(elem_size), unaligned_size);
-  index_t padded_size = 0;
-  overflow = overflow || add_with_overflow(unaligned_size, alignment - 1, padded_size);
-  index_t final_size = padded_size & ~(alignment - 1);
+  index_t size = 0;
+  overflow = overflow || add_with_overflow(flat_max, static_cast<index_t>(elem_size), size);
+  overflow = overflow || add_with_overflow(size, alignment - 1, size);
+  if (overflow) return std::nullopt;
 
-  if (overflow || final_size < 0) {
-    return std::nullopt;
-  }
-  return static_cast<std::size_t>(final_size);
+  assert(size >= 0);
+  return static_cast<std::size_t>(size & ~(alignment - 1));
 }
 
 void* raw_buffer::allocate(index_t base_alignment, index_t stride_alignment) {

--- a/slinky/runtime/buffer.h
+++ b/slinky/runtime/buffer.h
@@ -422,15 +422,35 @@ public:
   // If any strides are `auto_stride`, replace them with automatically determined strides.
   // `alignment` must be a power of 2.
   std::optional<std::size_t> init_strides(index_t alignment = 1) {
-    if (rank == 0) {
-      std::size_t final_sum;
-      if (add_with_overflow(elem_size, static_cast<std::size_t>(alignment - 1), final_sum)) {
-        return std::nullopt;
+    assert(alignment > 0);
+    assert(is_power_of_two(alignment));
+    static_assert(dim::auto_stride >= 0, "");
+    if (rank == 0 || (rank == 1 && dims[0].fold_factor() == dim::unfolded && dims[0].stride() >= 0)) {
+      // Fast path for rank 0 or simple (unfolded, non-negative stride) buffers.
+      // elem_size is unsigned; a value that doesn't fit in a (signed) index_t is an overflow.
+      const index_t elem_size = static_cast<index_t>(this->elem_size);
+      bool overflow = elem_size < 0;
+      index_t size = 0;
+      if (rank == 1) {
+        slinky::dim& d = dims[0];
+        index_t stride = d.stride();
+        if (stride == dim::auto_stride) {
+          stride = elem_size;
+          d.set_stride(stride);
+        }
+        // `std::max` guards empty buffers (max < min).
+        overflow = overflow || sub_with_overflow(d.max(), d.min(), size);
+        overflow = overflow || mul_with_overflow(std::max<index_t>(size, 0), stride, size);
       }
-      return final_sum & ~static_cast<std::size_t>(alignment - 1);
-    } else {
-      return init_strides_impl(alignment);
+
+      overflow = overflow || add_with_overflow(size, elem_size, size);
+      overflow = overflow || add_with_overflow(size, alignment - 1, size);
+      if (overflow) return std::nullopt;
+
+      assert(size >= 0);
+      return static_cast<std::size_t>(size & ~(alignment - 1));
     }
+    return init_strides_impl(alignment);
   }
 
   // Allocate and set the base pointer using `malloc`. Returns a pointer to the allocated memory, which should

--- a/slinky/runtime/evaluate.cc
+++ b/slinky/runtime/evaluate.cc
@@ -591,19 +591,27 @@ public:
     allocated_buffer buffer;
     buffer.elem_size = eval(op->elem_size);
     std::size_t rank = op->dims.size();
-    buffer.rank = rank;
     buffer.dims = SLINKY_ALLOCA(dim, rank);
 
-    for (std::size_t d = 0; d < rank; ++d) {
+    // Evaluate the dims in reverse, so we can drop trailing broadcast dims as we encounter them, avoiding a separate
+    // `remove_trailing_broadcasts` pass.
+    buffer.rank = rank;
+    bool trailing = true;
+    for (std::size_t d = rank; d-- > 0;) {
       const dim_expr& op_d = op->dims[d];
       dim& buf_d = buffer.dims[d];
       interval bounds = eval(op_d.bounds);
       buf_d.set_bounds(bounds.min, bounds.max);
       buf_d.set_stride(eval(op_d.stride, dim::auto_stride));
       buf_d.set_fold_factor(eval(op_d.fold_factor, dim::unfolded));
+      if (trailing) {
+        if (buf_d.is_broadcast()) {
+          buffer.rank = d;
+        } else {
+          trailing = false;
+        }
+      }
     }
-
-    remove_trailing_broadcasts(buffer);
 
     if (op->storage == memory_type::heap) {
       buffer.allocation = context.config->allocate(op->sym, &buffer);
@@ -649,19 +657,26 @@ public:
       buffer.base = reinterpret_cast<void*>(eval(op->base, 0));
     }
     std::size_t rank = op->dims.size();
-    buffer.rank = rank;
     buffer.dims = SLINKY_ALLOCA(dim, rank);
 
-    for (std::size_t d = 0; d < rank; ++d) {
+    // Evaluate dimensions in reverse, removing trailing broadcasts as we go.
+    buffer.rank = rank;
+    bool trailing = true;
+    for (std::size_t d = rank; d-- > 0;) {
       const dim_expr& op_d = op->dims[d];
       dim& buf_d = buffer.dims[d];
       interval bounds = eval(op_d.bounds);
       buf_d.set_bounds(bounds.min, bounds.max);
       buf_d.set_stride(eval(op_d.stride));
       buf_d.set_fold_factor(eval(op_d.fold_factor, dim::unfolded));
+      if (trailing) {
+        if (buf_d.is_broadcast()) {
+          buffer.rank = d;
+        } else {
+          trailing = false;
+        }
+      }
     }
-
-    remove_trailing_broadcasts(buffer);
 
     if (!validate_buffer(buffer)) {
       std::cerr << "make_buffer of " << op->sym << " failed." << std::endl;

--- a/slinky/runtime/test/evaluate_benchmark.cc
+++ b/slinky/runtime/test/evaluate_benchmark.cc
@@ -190,7 +190,7 @@ void BM_allocate(benchmark::State& state) {
   state.SetItemsProcessed(calls);
 }
 
-BENCHMARK(BM_allocate)->DenseRange(1, 4);
+BENCHMARK(BM_allocate)->DenseRange(0, 4);
 
 enum class dim_type {
   constant,


### PR DESCRIPTION
- Add a fast path for rank 1 buffers in `init_strides`. We had a fast path for rank 0, this extends it to "simple" (unfolded, non-negative stride) rank 1 buffers.
- Some minor tweaks to improve overflow checking
- A minor tweak to optimize removing trailing broadcasts