### PR TITLE
Avoid fuse_siblings breaking due to shadowing after fusing

### DIFF
--- a/slinky/builder/optimizations.cc
+++ b/slinky/builder/optimizations.cc
@@ -1235,7 +1235,8 @@ class sibling_fuser : public stmt_mutator {
   static bool fuse(const T* a, const T* b, stmt& result) {
     if (!a || !b || !can_fuse(a, b)) return false;
 
-    stmt body = block::make({a->body, substitute(b->body, b->sym, a->sym)});
+    // We can't substitute here because it is possible that b declares a and uses it elsewhere.
+    stmt body = block::make({a->body, clone_buffer::make(b->sym, a->sym, b->body)});
     result = clone_with(a, std::move(body));
     return true;
   }

--- a/slinky/builder/pipeline.cc
+++ b/slinky/builder/pipeline.cc
@@ -1591,9 +1591,9 @@ stmt build_pipeline(node_context& ctx, const std::vector<buffer_expr_ptr>& input
   if (options.no_checks) {
     result = recursive_mutate<check>(
         result, [](const check* op) { return has_side_effects(op->condition) ? stmt(op) : stmt(); });
-    // Simplify again, in case there are lets that the checks used that are now dead.
-    result = simplify(result);
   }
+
+  result = simplify(result);
 
   result = insert_early_free(result);
 

--- a/slinky/builder/test/optimizations.cc
+++ b/slinky/builder/test/optimizations.cc
@@ -66,7 +66,8 @@ TEST(optimizations, fuse_siblings) {
                   allocate::make(x, memory_type::heap, 1, {}, use_buffer(x)),
                   allocate::make(y, memory_type::heap, 1, {}, use_buffer(y)),
               })),
-      matches(allocate::make(x, memory_type::heap, 1, {}, block::make({use_buffer(x), use_buffer(x)}))));
+      matches(allocate::make(
+          x, memory_type::heap, 1, {}, block::make({use_buffer(x), clone_buffer::make(y, x, use_buffer(y))}))));
 
   ASSERT_THAT(fuse_siblings(block::make({
                   allocate::make(x, memory_type::heap, 1, {}, use_buffer(x)),
@@ -109,8 +110,9 @@ TEST(optimizations, fuse_siblings) {
                   crop_dim::make(x, y, 0, {0, 10}, crop_dim::make(z, x, 1, {0, 10}, use_buffer(z))),
                   crop_dim::make(z, y, 0, {0, 10}, crop_dim::make(w, z, 1, {0, 10}, use_buffer(w))),
               })),
-      matches(crop_dim::make(
-          x, y, 0, {0, 10}, crop_dim::make(z, x, 1, {0, 10}, block::make({use_buffer(z), use_buffer(z)})))));
+      matches(crop_dim::make(x, y, 0, {0, 10},
+          block::make({crop_dim::make(z, x, 1, {0, 10}, use_buffer(z)),
+              clone_buffer::make(z, x, crop_dim::make(w, z, 1, {0, 10}, use_buffer(w)))}))));
 }
 
 TEST(optimizations, remove_pure_dims) {


### PR DESCRIPTION
This change fixes a bug where before fusing, a symbol was not shadowed, but after fusing, it is. The fix is to insert a `clone_buffer` instead of substituting, and then simplifying again to clean up the clone when possible.

This is a reduction in the strength of `fuse_siblings` because it can't recursively fuse fusable siblings, this would require an intermediate simplification to eliminate the `clone_buffer` (if it weren't needed). See the changes to the test to see an example.

I think two nested siblings being able to fuse is rare, and we can fix this later if needed.