### PR TITLE
Remove alignment requirement from `raw_buffer`

### DIFF
--- a/slinky/runtime/buffer.h
+++ b/slinky/runtime/buffer.h
@@ -227,7 +227,7 @@ public:
   using element = void;
   using pointer = void*;
 
-  alignas(16) void* base;
+  void* base;
   std::size_t elem_size;
 
   // `rank` is the number of dimensions in the `dims` array. However, conceptually, the buffer has infinite dimensions


### PR DESCRIPTION
This requirement is hard to satisfy, and I don't think it is that helpful.