### PR TITLE
Revert "Remove alignment requirement from `raw_buffer` (#843)"

### DIFF
--- a/slinky/runtime/buffer.h
+++ b/slinky/runtime/buffer.h
@@ -227,7 +227,7 @@ public:
   using element = void;
   using pointer = void*;
 
-  void* base;
+  alignas(16) void* base;
   std::size_t elem_size;
 
   // `rank` is the number of dimensions in the `dims` array. However, conceptually, the buffer has infinite dimensions


### PR DESCRIPTION
This reverts commit d08ba4bb4229e7df4c3401fbaa7539302b8dca3b.