### PR TITLE
Avoid unnecessary body traversals in `depends_on`

### DIFF
--- a/slinky/builder/simplify.cc
+++ b/slinky/builder/simplify.cc
@@ -501,6 +501,10 @@ public:
     node_mutator::set_result(mutate(e, &result_info));
   }
 
+  void mutate_and_set_result(const stmt& s) {
+    node_mutator::set_result(mutate(s));
+  }
+
   interval_expr mutate(const interval_expr& x, expr_info* min_info, expr_info* max_info) {
     if (deep_is_point(x)) {
       expr result = mutate(x.min, min_info);
@@ -1748,7 +1752,7 @@ public:
     // check below could be unnecessary.
     auto deps = depends_on(op->body, op->sym);
     if (!deps.any()) {
-      set_result(mutate(op->body));
+      mutate_and_set_result(op->body);
       return;
     }
 

--- a/slinky/builder/simplify.cc
+++ b/slinky/builder/simplify.cc
@@ -1743,14 +1743,20 @@ public:
   }
 
   void visit(const make_buffer* op) override {
+    // To avoid redundant nested simplifications, try to substitute the buffer both before and after mutating the body.
+    // TODO: It may be impossible for depends_on_result::buffer_data() to change due to simplification, so the second
+    // check below could be unnecessary.
+    auto deps = depends_on(op->body, op->sym);
+    if (!deps.any()) {
+      set_result(mutate(op->body));
+      return;
+    }
+
     expr base = mutate(op->base);
     buffer_info info;
     bool changed = mutate_buffer(op, info);
 
-    // To avoid redundant nested simplifications, try to substitute the buffer both before and after mutating the body.
-    // TODO: It may be impossible for depends_on_result::buffer_data() to change due to simplification, so the second
-    // check below could be unnecessary.
-    if (can_substitute_buffer(depends_on(op->body, op->sym))) {
+    if (can_substitute_buffer(deps)) {
       // We only needed the buffer meta, not the buffer itself.
       set_result(mutate_with_buffer(nullptr, op->body, op->sym, find_buffer_data_dependency(base), std::move(info)));
       return;

--- a/slinky/runtime/depends_on.cc
+++ b/slinky/runtime/depends_on.cc
@@ -1,10 +1,14 @@
 #include "slinky/runtime/depends_on.h"
 
 #include <cassert>
+#include <map>
+#include <utility>
+#include <vector>
 
 #include "slinky/base/chrome_trace.h"
+#include "slinky/base/span.h"
 #include "slinky/runtime/expr.h"
-#include "slinky/runtime/print.h"
+#include "slinky/runtime/stmt.h"
 
 namespace slinky {
 
@@ -75,7 +79,6 @@ public:
       case buffer_field::rank:
       case buffer_field::elem_size:
       case buffer_field::size_bytes: deps->var = true; break;
-      default: SLINKY_UNREACHABLE << "unknown buffer_field " << to_string(op->field);
       }
     }
   }

--- a/slinky/runtime/depends_on.cc
+++ b/slinky/runtime/depends_on.cc
@@ -1,6 +1,7 @@
 #include "slinky/runtime/depends_on.h"
 
 #include <cassert>
+#include <cstddef>
 #include <map>
 #include <utility>
 #include <vector>

--- a/slinky/runtime/depends_on.cc
+++ b/slinky/runtime/depends_on.cc
@@ -122,6 +122,10 @@ public:
       // We have src_deps we want to transitively add to via this declaration.
       var_deps.push_back({sym, src_deps});
     } else if (decl_needs_shadow(sym)) {
+      if (!unknown_deps && var_deps.size() == 1) {
+        // The only dep we are looking for is shadowed by this declaration, so the body cannot depend on it.
+        return;
+      }
       // We are shadowing something we are finding the dependencies of. Point at the dummy instead to avoid
       // contaminating the dependencies.
       var_deps.push_back({sym, &dummy_deps});

--- a/slinky/runtime/depends_on.h
+++ b/slinky/runtime/depends_on.h
@@ -1,6 +1,7 @@
 #ifndef SLINKY_RUNTIME_DEPENDS_ON_H
 #define SLINKY_RUNTIME_DEPENDS_ON_H
 
+#include "slinky/base/span.h"
 #include "slinky/runtime/expr.h"
 #include "slinky/runtime/stmt.h"
 


### PR DESCRIPTION
This contains two optimizations related to the deeply nested `make_buffer` ops we generate:
- In `depends_on`, if the only decl we are interested in is shadowed, we don't need to recurse into the body.
- We can skip simplification of the `make_buffer` buffer exprs if we know the buffer is unused.