### PR TITLE
Fix simplify rules and associated test coverage hole

### DIFF
--- a/slinky/builder/rewrite.h
+++ b/slinky/builder/rewrite.h
@@ -350,7 +350,7 @@ std::ostream& operator<<(std::ostream& os, const pattern_binary<T, A, B>& p) {
   case not_equal::static_type: return os << '(' << p.a << " != " << p.b << ')';
   case logical_and::static_type: return os << '(' << p.a << " && " << p.b << ')';
   case logical_or::static_type: return os << '(' << p.a << " || " << p.b << ')';
-  default: SLINKY_UNREACHABLE << "unknown binary operator " << to_string(T::static_type);
+  default: SLINKY_UNREACHABLE << "unknown binary operator " << to_string(T::static_type); return os;
   }
 }
 
@@ -382,7 +382,7 @@ template <typename T, typename A>
 SLINKY_UNIQUE std::ostream& operator<<(std::ostream& os, const pattern_unary<T, A>& p) {
   switch (T::static_type) {
   case logical_not::static_type: return os << '!' << p.a;
-  default: SLINKY_UNREACHABLE << "unknown unary operator " << to_string(T::static_type);
+  default: SLINKY_UNREACHABLE << "unknown unary operator " << to_string(T::static_type); return os;
   }
 }
 

--- a/slinky/builder/simplify_rules.h
+++ b/slinky/builder/simplify_rules.h
@@ -297,7 +297,7 @@ bool apply_add_rules(Fn&& apply) {
       apply((x + may_be<0>(c0)) + (y + may_be<0>(c1)), (x + y) + eval(c0 + c1), c0 != 0 || c1 != 0) ||
 
       apply(staircase(x, c0, c1, c2) + c3, ((x + eval((c3/c2)*c1 + c0))/c1)*c2, c0 != 0 && c1 != 0 && c2 != 0 && c3%c2 == 0) ||
-      apply(staircase(x, 0, c0, c0) + x%c0, x) ||
+      apply(staircase(x, 0, c0, c0) + x%c0, x, c0 != 0) ||
 
       apply(min(x, y + c1) + c2, min(y, x + c2), c1 == -c2) ||
       apply(max(x, y + c1) + c2, max(y, x + c2), c1 == -c2) ||
@@ -416,8 +416,8 @@ bool apply_div_rules(Fn&& apply) {
       apply(x/-1, -x) ||
       apply(x/x, x != 0) ||
 
-      apply((y + x/c0)/c1, (x + y*c0)/eval(c0*c1)) ||
-      apply((y - x/c0)/c1, (y*c0 - x + eval(c0 - 1))/eval(c0*c1)) ||
+      apply((y + x/c0)/c1, (x + y*c0)/eval(c0*c1), c0 > 0) ||
+      apply((y - x/c0)/c1, (y*c0 - x + eval(c0 - 1))/eval(c0*c1), c0 > 0) ||
       apply((x*c0)/(y*c1), (x*eval(c0/c1))/y, c1 > 0 && c0%c1 == 0) ||
       apply((x*c0)/(y*c1), x/(y*eval(c1/c0)), c0 > 0 && c1%c0 == 0) ||
       apply((x*c0)/c1, x*eval(c0/c1), c0%c1 == 0) ||
@@ -491,10 +491,10 @@ bool apply_less_rules(Fn&& apply) {
       apply(x + may_be<0>(z) < may_be<0>(w) + staircase(x, c0, c1, c1), z + (x + c0)%c1 < w + c0, c1 > 1) ||
       apply(staircase(x, c0, c1, c1) < x,
         c0 < (x + c0)%c1, c1 > 1 && c0 != 0,
-        x%c1 != 0, c1 > 0 /*&& c0 == 0*/) ||
+        x%c1 != 0, c1 > 0 && c0 == 0) ||
       apply(x < staircase(x, c0, c1, c1),
         (x + c0)%c1 < c0, c1 > 1 && c0 != 0,
-        false, c1 > 0 /*&& c0 == 0*/) ||
+        false, c1 > 0 && c0 == 0) ||
 
       apply(x%c0 < c1,
         true, c0 > 0 && c0 <= c1,
@@ -633,11 +633,11 @@ bool apply_equal_rules(Fn&& apply) {
       apply(max(x, c0)/c1 == c2,
         x/c1 == c2, c1 > 0 && c0/c1 < c2,
         x < (c2 + 1)*c1, c1 > 0 && c0/c1 == c2,
-        false) ||
+        false, c1 > 0) ||
       apply(min(x, c0)/c1 == c2,
         x/c1 == c2, c1 > 0 && c0/c1 > c2,
-        x > (c2 + 1)*c1, c1 > 0 && c0/c1 == c2,
-        false) ||
+        x >= c2*c1, c1 > 0 && c0/c1 == c2,
+        false, c1 > 0) ||
 
       apply(max(x, c0) == max(x, c1), x >= eval(max(c0, c1)), c0 != c1) ||
       apply(min(x, c0) == min(x, c1), x <= eval(min(c0, c1)), c0 != c1) ||

--- a/slinky/builder/test/simplify/rule_tester.h
+++ b/slinky/builder/test/simplify/rule_tester.h
@@ -127,9 +127,8 @@ class rule_tester {
   expr_generator<gtest_seeded_mt19937> expr_gen_;
 
   std::array<expr, rewrite::symbol_count> exprs;
-  rewrite::match_context m;
 
-  void init_match_context() {
+  void init_match_context(rewrite::match_context& m) {
     for (std::size_t i = 0; i < m.constants.size(); ++i) {
       m.constants[i] = expr_gen_.random_constant();
     }
@@ -140,7 +139,7 @@ class rule_tester {
   }
 
 public:
-  rule_tester() : expr_gen_(rng_, var_count) { init_match_context(); }
+  rule_tester() : expr_gen_(rng_, var_count) {}
 
   SLINKY_NO_INLINE void test_expr(expr pattern, expr replacement, const std::string& rule_str) {
     if (contains_infinity(pattern)) {
@@ -181,6 +180,9 @@ public:
     std::stringstream rule_str;
     rule_str << p << " -> " << r;
 
+    rewrite::match_context m;
+    init_match_context(m);
+
     expr pattern = expr(substitute(p, m));
     bool overflowed = false;
     expr replacement = expr(substitute(r, m, overflowed));
@@ -201,8 +203,9 @@ public:
 
     // Some rules are very picky about a large number of constants, which makes it very unlikely to generate an
     // expression that the rule applies to.
+    rewrite::match_context m;
     for (int test = 0; test < 100000; ++test) {
-      init_match_context();
+      init_match_context(m);
       bool overflowed = false;
       if (substitute(pr, m, overflowed) && !overflowed) {
         expr pattern = expr(substitute(p, m));

--- a/slinky/builder/test/simplify/simplify.cc
+++ b/slinky/builder/test/simplify/simplify.cc
@@ -96,6 +96,10 @@ TEST(simplify, basic) {
   ASSERT_THAT(simplify(min(min(7, x), min(y, 7))), matches(min(min(x, y), 7)));
   ASSERT_THAT(simplify(min(min(7, x), min(7, y))), matches(min(min(x, y), 7)));
 
+  ASSERT_THAT(simplify(min(x, 3) / 2 == 1), matches(2 <= x));
+  ASSERT_THAT(simplify(max(x, 0) / -1 == 0), matches(x <= 0));
+  ASSERT_THAT(simplify(min(x, 0) / -1 == 0), matches(x >= 0));
+
   ASSERT_THAT(simplify(x + 0), matches(x));
   ASSERT_THAT(simplify(x - 0), matches(x));
   ASSERT_THAT(simplify(0 + x + 0), matches(x));
@@ -107,6 +111,8 @@ TEST(simplify, basic) {
 
   ASSERT_THAT(simplify(x / x), matches(x != 0));
   ASSERT_THAT(simplify(0 / x), matches(0));
+
+  ASSERT_THAT(simplify((y + x / -2) / 3), matches((y + x / -2) / 3));
 
   ASSERT_THAT(simplify(((x + 1) - (y - 1)) + 1), matches(x - y + 3));
 


### PR DESCRIPTION
For rules without predicates, we didn't call `init_match_context`, so it used the match context from the previous rule. We just want one random case anyways, so this doesn't seem so bad... except when the previous rule is a conditional rule, it will re-randomize the context until it gets a context that satisfies the condition. So if the previous rule is a rule that requires `c0 > 0`, then any subsequent non-conditional rules will only be tested with `c0 > 0`!