### PR TITLE
Replace `new_dim` in transpose with the original dim if the original dim is a broadcast

### DIFF
--- a/slinky/builder/simplify.cc
+++ b/slinky/builder/simplify.cc
@@ -501,9 +501,7 @@ public:
     node_mutator::set_result(mutate(e, &result_info));
   }
 
-  void mutate_and_set_result(const stmt& s) {
-    node_mutator::set_result(mutate(s));
-  }
+  void mutate_and_set_result(const stmt& s) { node_mutator::set_result(mutate(s)); }
 
   interval_expr mutate(const interval_expr& x, expr_info* min_info, expr_info* max_info) {
     if (deep_is_point(x)) {
@@ -865,9 +863,7 @@ public:
     return x;
   }
 
-  void visit(const constant* op) override {
-    set_result(op, {point(expr(op)), {0, op->value}});
-  }
+  void visit(const constant* op) override { set_result(op, {point(expr(op)), {0, op->value}}); }
 
   template <typename T>
   void visit_min_max(const T* op) {
@@ -2396,17 +2392,27 @@ public:
 
     buffer_info sym_info{expr_info{}};
     if (src_info && *src_info) {
-      while (dims.size() > 0 && (*src_info)->rank >= 0 && dims.back() >= (*src_info)->rank) {
-        // The last dimension would be an implicit broadcast.
-        dims.pop_back();
-      }
+      const int src_rank = (*src_info)->rank;
+      if (src_rank >= 0) {
+        for (std::size_t i = 0; i < dims.size(); ++i) {
+          if (dims[i] >= src_rank && prove_constant_true((*src_info)->dim(i).value().is_broadcast())) {
+            // A new broadcast dimension is the same as the dimension it replaces in src, which is also a broadcast.
+            // Using the src dimension can make this transpose a no-op.
+            dims[i] = static_cast<int>(i);
+          }
+        }
 
-      if (transpose::is_truncate(dims) && (*src_info)->rank >= 0 &&
-          (*src_info)->rank <= static_cast<int>(dims.size())) {
-        // This truncate is a no-op.
-        auto s = set_value_in_scope(vars, op->sym, expr_info::substitution(variable::make(src)));
-        set_result(mutate(op->body));
-        return;
+        while (dims.size() > 0 && dims.back() >= src_rank) {
+          // The last dimension would be an implicit broadcast.
+          dims.pop_back();
+        }
+
+        if (transpose::is_truncate(dims) && src_rank <= static_cast<int>(dims.size())) {
+          // This truncate is a no-op.
+          auto s = set_value_in_scope(vars, op->sym, expr_info::substitution(variable::make(src)));
+          set_result(mutate(op->body));
+          return;
+        }
       }
 
       sym_info.elem_size = (*src_info)->elem_size;

--- a/slinky/builder/test/simplify/simplify.cc
+++ b/slinky/builder/test/simplify/simplify.cc
@@ -1113,6 +1113,28 @@ TEST(simplify, transpose) {
   ASSERT_THAT(simplify(transpose::make(b1, b0, {1, 0}, transpose::make(b2, b1, {0, 2, 1}, dummy_call({}, {b2})))),
       matches(transpose::make(b2, b0, {1, transpose::new_dim, 0}, dummy_call({}, {b2}))));
 
+  // A new_dim where the src dimension is provably a broadcast can use the src dimension instead, which makes this
+  // transpose a no-op.
+  ASSERT_THAT(
+      simplify(allocate::make(b0, memory_type::heap, 4, {{{0, 10}, {}, {}}, {{0, 0}, 0, {}}, {{0, 30}, {}, {}}},
+          transpose::make(b1, b0, {0, transpose::new_dim, 2}, dummy_call({}, {b1})))),
+      matches(allocate::make(b0, memory_type::heap, 4, {{{0, 10}, {}, {}}, {{0, 0}, 0, {}}, {{0, 30}, {}, {}}},
+          dummy_call({}, {b0}))));
+
+  // The same, but the new_dim is the last dimension, so the transpose is a no-op instead of a truncate. The allocate
+  // then drops the trailing broadcast dimension it no longer needs.
+  ASSERT_THAT(simplify(allocate::make(b0, memory_type::heap, 4, {{{0, 10}, {}, {}}, {{0, 0}, 0, {}}},
+                  transpose::make(b1, b0, {0, transpose::new_dim}, dummy_call({}, {b1})))),
+      matches(allocate::make(b0, memory_type::heap, 4, {{{0, 10}, {}, {}}}, dummy_call({}, {b0}))));
+
+  // The src dimension is not provably a broadcast, so the new_dim must be kept.
+  ASSERT_THAT(
+      simplify(allocate::make(b0, memory_type::heap, 4, {{{0, 10}, {}, {}}, {{0, 20}, {}, {}}, {{0, 30}, {}, {}}},
+          transpose::make(b1, b0, {0, transpose::new_dim, 2}, dummy_call({}, {b1})))),
+      matches(
+          allocate::make(b0, memory_type::heap, 4, {{{0, 10}, {}, {}}, {{0, 20}, {}, {}}, {{0, 30}, {}, {}}},
+              transpose::make(b1, b0, {0, transpose::new_dim, 2}, dummy_call({}, {b1})))));
+
   // Transposes that put trailing broadcasts at the end of the buffer should be dropped.
   ASSERT_THAT(simplify(block::make(
                   {check::make(buffer_rank(b0) == 2), transpose::make(b1, b0, {1, 4, 0, 3, 2}, dummy_call({}, {b1}))})),


### PR DESCRIPTION
This makes it possible for transpose ops to simplify entirely, e.g. `transpose(x, {0, -1, 2}` is a no-op if dimension 1 of x is a broadcast dimension.