### PR TITLE
Add a simplification to rewrite constant `allocate` nodes to `constant_buffer`

### DIFF
--- a/slinky/builder/simplify.cc
+++ b/slinky/builder/simplify.cc
@@ -863,7 +863,9 @@ public:
     return x;
   }
 
-  void visit(const constant* op) override { set_result(op, {point(expr(op)), {0, op->value}}); }
+  void visit(const constant* op) override {
+    set_result(op, {point(expr(op)), {0, op->value}});
+  }
 
   template <typename T>
   void visit_min_max(const T* op) {
@@ -1670,6 +1672,34 @@ public:
         body = block::make({end_before, end_body});
       } else {
         set_result(block::make({b->stmts.begin(), end_before}));
+        return;
+      }
+    }
+
+    if (is_zero(info.elem_size.value())) {
+      // This buffer doesn't actually allocate any memory, we might be able to rewrite it as a constant.
+      std::vector<slinky::dim> dims(info.dims.size());
+      bool all_constants = true;
+      for (std::size_t d = 0; d < info.dims.size(); ++d) {
+        const dim_expr& dim_d = info.dims[d].value();
+        auto min = as_constant(dim_d.bounds.min);
+        auto max = as_constant(dim_d.bounds.max);
+        auto stride = dim_d.stride.defined() ? as_constant(dim_d.stride) : std::optional<index_t>(0);
+        auto fold_factor = dim_d.fold_factor.defined() ? as_constant(dim_d.fold_factor)
+                                                       : std::optional<index_t>(slinky::dim::unfolded);
+        if (min && max && stride && fold_factor) {
+          dims[d].set_bounds(*min, *max);
+          dims[d].set_stride(*stride);
+          dims[d].set_fold_factor(*fold_factor);
+        } else {
+          all_constants = false;
+          break;
+        }
+      }
+      if (all_constants) {
+        raw_buffer_ptr buf = raw_buffer::make(dims.size(), 0, dims.empty() ? nullptr : dims.data());
+        set_result(block::make(
+            {std::move(before), constant_buffer::make(op->sym, std::move(buf), std::move(body)), std::move(after)}));
         return;
       }
     }

--- a/slinky/builder/test/simplify/simplify.cc
+++ b/slinky/builder/test/simplify/simplify.cc
@@ -702,6 +702,13 @@ TEST(simplify, allocate) {
                   x, memory_type::heap, 1, {dim::broadcast(), {bounds(2, 3), 4, 5}}, check::make(buffer_at(x)))),
       matches(allocate::make(
           x, memory_type::heap, 1, {dim::broadcast(), {bounds(2, 3), 4, expr()}}, check::make(buffer_at(x)))));
+
+  // An allocate with elem_size == 0 is rewritten to constant_buffer.
+  slinky::dim zero_dims[] = {{0, 255, 0, dim::unfolded}};
+  auto expected_zero_buf = raw_buffer::make(1, 0, zero_dims);
+  ASSERT_THAT(
+      simplify(allocate::make(x, memory_type::automatic, 0, {{{0, 255}, 0, dim::unfolded}}, check::make(buffer_at(x)))),
+      matches(constant_buffer::make(x, expected_zero_buf, check::make(buffer_at(x)))));
 }
 
 TEST(simplify, constant_buffer) {
@@ -1115,11 +1122,10 @@ TEST(simplify, transpose) {
 
   // A new_dim where the src dimension is provably a broadcast can use the src dimension instead, which makes this
   // transpose a no-op.
-  ASSERT_THAT(
-      simplify(allocate::make(b0, memory_type::heap, 4, {{{0, 10}, {}, {}}, {{0, 0}, 0, {}}, {{0, 30}, {}, {}}},
-          transpose::make(b1, b0, {0, transpose::new_dim, 2}, dummy_call({}, {b1})))),
-      matches(allocate::make(b0, memory_type::heap, 4, {{{0, 10}, {}, {}}, {{0, 0}, 0, {}}, {{0, 30}, {}, {}}},
-          dummy_call({}, {b0}))));
+  ASSERT_THAT(simplify(allocate::make(b0, memory_type::heap, 4, {{{0, 10}, {}, {}}, {{0, 0}, 0, {}}, {{0, 30}, {}, {}}},
+                  transpose::make(b1, b0, {0, transpose::new_dim, 2}, dummy_call({}, {b1})))),
+      matches(allocate::make(
+          b0, memory_type::heap, 4, {{{0, 10}, {}, {}}, {{0, 0}, 0, {}}, {{0, 30}, {}, {}}}, dummy_call({}, {b0}))));
 
   // The same, but the new_dim is the last dimension, so the transpose is a no-op instead of a truncate. The allocate
   // then drops the trailing broadcast dimension it no longer needs.
@@ -1131,9 +1137,8 @@ TEST(simplify, transpose) {
   ASSERT_THAT(
       simplify(allocate::make(b0, memory_type::heap, 4, {{{0, 10}, {}, {}}, {{0, 20}, {}, {}}, {{0, 30}, {}, {}}},
           transpose::make(b1, b0, {0, transpose::new_dim, 2}, dummy_call({}, {b1})))),
-      matches(
-          allocate::make(b0, memory_type::heap, 4, {{{0, 10}, {}, {}}, {{0, 20}, {}, {}}, {{0, 30}, {}, {}}},
-              transpose::make(b1, b0, {0, transpose::new_dim, 2}, dummy_call({}, {b1})))));
+      matches(allocate::make(b0, memory_type::heap, 4, {{{0, 10}, {}, {}}, {{0, 20}, {}, {}}, {{0, 30}, {}, {}}},
+          transpose::make(b1, b0, {0, transpose::new_dim, 2}, dummy_call({}, {b1})))));
 
   // Transposes that put trailing broadcasts at the end of the buffer should be dropped.
   ASSERT_THAT(simplify(block::make(

--- a/slinky/builder/test/simplify/simplify.cc
+++ b/slinky/builder/test/simplify/simplify.cc
@@ -3,8 +3,17 @@
 
 #include <cassert>
 #include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <iostream>
+#include <limits>
 #include <numeric>
+#include <optional>
+#include <utility>
+#include <vector>
 
+#include "slinky/base/arithmetic.h"
 #include "slinky/base/test/seeded_test.h"
 #include "slinky/builder/simplify.h"
 #include "slinky/builder/substitute.h"
@@ -13,6 +22,7 @@
 #include "slinky/runtime/evaluate.h"
 #include "slinky/runtime/expr.h"
 #include "slinky/runtime/print.h"
+#include "slinky/runtime/stmt.h"
 
 namespace slinky {
 


### PR DESCRIPTION
`allocate` with a zero `elem_size` is a common pattern. These buffers do not actually need to be allocated, they can be represented by `constant_buffer` instead.