### PR TITLE
Various minor fixes

### DIFF
--- a/slinky/builder/rewrite.h
+++ b/slinky/builder/rewrite.h
@@ -133,7 +133,8 @@ SLINKY_UNIQUE expr_ref substitute(const pattern_wildcard<N>&, const match_contex
 
 template <int N>
 SLINKY_UNIQUE std::ostream& operator<<(std::ostream& os, const pattern_wildcard<N>&) {
-  static constexpr char names[] = "xyzwuv";
+  static constexpr char names[] = "xyzwuvt";
+  static_assert(N + 1 < sizeof(names));
   return os << names[N];
 }
 

--- a/slinky/builder/simplify.cc
+++ b/slinky/builder/simplify.cc
@@ -2644,7 +2644,7 @@ public:
   void visit(const logical_or* op) override { visit_logical_and_or(op, std::max(sign, 0)); }
 
   void visit(const logical_not* op) override {
-    expr a = strip_boolean(mutate(op->a, -sign));
+    expr a = mutate(op->a, 0);
     if (auto ca = as_constant(a)) {
       set_result(*ca != 0 ? 0 : 1);
     } else if (sign != 0) {

--- a/slinky/builder/simplify.cc
+++ b/slinky/builder/simplify.cc
@@ -560,12 +560,12 @@ public:
     }
 
     void learn_from_less(const expr& a, const expr& b) {
-      if (const class max* r = b.as<class max>()) {
-        // a < max(x, y) ==> a < x && a < y
+      if (const class min* r = b.as<class min>()) {
+        // a < min(x, y) ==> a < x && a < y
         learn_from_less(a, r->a);
         learn_from_less(a, r->b);
-      } else if (const class min* l = a.as<class min>()) {
-        // min(x, y) < b ==> x < b && y < b
+      } else if (const class max* l = a.as<class max>()) {
+        // max(x, y) < b ==> x < b && y < b
         learn_from_less(l->a, b);
         learn_from_less(l->b, b);
       } else {
@@ -580,12 +580,12 @@ public:
       }
     }
     void learn_from_less_equal(const expr& a, const expr& b) {
-      if (const class max* r = b.as<class max>()) {
-        // a <= max(x, y) ==> a <= x && a <= y
+      if (const class min* r = b.as<class min>()) {
+        // a <= min(x, y) ==> a <= x && a <= y
         learn_from_less_equal(a, r->a);
         learn_from_less_equal(a, r->b);
-      } else if (const class min* l = a.as<class min>()) {
-        // min(x, y) <= b ==> x <= b && y <= b
+      } else if (const class max* l = a.as<class max>()) {
+        // max(x, y) <= b ==> x <= b && y <= b
         learn_from_less_equal(l->a, b);
         learn_from_less_equal(l->b, b);
       } else {

--- a/slinky/builder/simplify.cc
+++ b/slinky/builder/simplify.cc
@@ -612,7 +612,7 @@ public:
         learn_from_less_equal(lt->a, lt->b);
       } else if (const equal* eq = c.as<equal>()) {
         learn_from_equal(eq->a, eq->b);
-      } else if (!as_constant(c) && !as_variable(c)) {
+      } else if (!as_constant(c) && is_boolean(c)) {
         // We couldn't learn anything, just add the whole expression as a fact, if it isn't a constant or variable,
         // which could rewrite the value from any x not zero to 1.
         facts.push_back({c, expr(true)});

--- a/slinky/builder/simplify.cc
+++ b/slinky/builder/simplify.cc
@@ -2736,15 +2736,6 @@ public:
 
 }  // namespace
 
-bool can_evaluate(intrinsic fn) {
-  switch (fn) {
-  case intrinsic::negative_infinity:
-  case intrinsic::positive_infinity:
-  case intrinsic::indeterminate: return false;
-  default: return true;
-  }
-}
-
 expr constant_lower_bound(const expr& x) { return constant_evaluator(false).mutate(x, -1); }
 expr constant_upper_bound(const expr& x) { return constant_evaluator(false).mutate(x, 1); }
 std::optional<index_t> evaluate_constant(const expr& x) { return as_constant(constant_evaluator().mutate(x, 0)); }

--- a/slinky/builder/simplify.h
+++ b/slinky/builder/simplify.h
@@ -24,9 +24,6 @@ interval_expr bounds_of(
 interval_expr bounds_of(
     const interval_expr& x, const bounds_map& bounds = bounds_map(), const alignment_map& alignment = alignment_map());
 
-// True if `fn` can be evaluated if its arguments are constants.
-bool can_evaluate(intrinsic fn);
-
 // Determine a lower or upper bound of x that is conservative if the bound can be made constant.
 expr constant_lower_bound(const expr& x);
 expr constant_upper_bound(const expr& x);

--- a/slinky/builder/simplify_rules.h
+++ b/slinky/builder/simplify_rules.h
@@ -462,10 +462,10 @@ bool apply_mod_rules(Fn&& apply) {
 template <typename Fn>
 bool apply_less_rules(Fn&& apply) {
   return
-      apply(rewrite::positive_infinity() < x, false, is_finite(x)) ||
+      apply(rewrite::positive_infinity() < x, false) ||
+      apply(x < rewrite::negative_infinity(), false) ||
       apply(rewrite::negative_infinity() < x, true, is_finite(x)) ||
       apply(x < rewrite::positive_infinity(), true, is_finite(x)) ||
-      apply(x < rewrite::negative_infinity(), false, is_finite(x)) ||
       apply(x < x, false) ||
       apply(x < y + 1, x <= y) ||
       apply(x + -1 < y, x <= y) ||

--- a/slinky/builder/simplify_rules.h
+++ b/slinky/builder/simplify_rules.h
@@ -630,24 +630,17 @@ bool apply_equal_rules(Fn&& apply) {
       apply(y == max(x, y), x <= y) ||
       apply(y == min(x, y), y <= x) ||
     
-      apply(max(x, c0)/c1 == c2,
+      apply(max(x, c0)/may_be<1>(c1) == c2,
         x/c1 == c2, c1 > 0 && c0/c1 < c2,
         x < (c2 + 1)*c1, c1 > 0 && c0/c1 == c2,
-        false, c1 > 0) ||
-      apply(min(x, c0)/c1 == c2,
+        false, c1 > 0 && c0/c1 > c2) ||
+      apply(min(x, c0)/may_be<1>(c1) == c2,
         x/c1 == c2, c1 > 0 && c0/c1 > c2,
         x >= c2*c1, c1 > 0 && c0/c1 == c2,
-        false, c1 > 0) ||
+        false, c1 > 0 && c0/c1 < c2) ||
 
       apply(max(x, c0) == max(x, c1), x >= eval(max(c0, c1)), c0 != c1) ||
       apply(min(x, c0) == min(x, c1), x <= eval(min(c0, c1)), c0 != c1) ||
-
-      apply(max(x, c0) == c1,
-        false, c0 > c1,
-        x == c1, c0 < c1) ||
-      apply(min(x, c0) == c1,
-        false, c0 < c1,
-        x == c1, c0 > c1) ||
 
       false;
 }

--- a/slinky/builder/slide_and_fold_storage.cc
+++ b/slinky/builder/slide_and_fold_storage.cc
@@ -714,8 +714,8 @@ public:
     stmt body;
     {
       // We can use narrower bounds for the loop var, because the loop var not necessarily will reach max if step > 1.
-      auto set_expr_bounds = set_value_in_scope(
-          expr_bounds, op->sym, {loop_bounds.min, loop_bounds.min + align_down(loop_bounds.extent() - 1, op->step)});
+      auto set_expr_bounds = set_value_in_scope(expr_bounds, op->sym,
+          {loop_bounds.min, loop_bounds.min + align_down(loop_bounds.max - loop_bounds.min, op->step)});
 
       auto maybe_min = as_constant(loop_bounds.min);
       auto maybe_step = as_constant(op->step);

--- a/slinky/builder/test/simplify/expr_generator.h
+++ b/slinky/builder/test/simplify/expr_generator.h
@@ -63,7 +63,7 @@ public:
     case 4: return rng_() % 8 != 0 ? ac() && bc() : and_then(ac(), bc());
     case 5: return rng_() % 8 != 0 ? ac() || bc() : or_else(ac(), bc());
     case 6: return !random_condition(depth - 1);
-    default: SLINKY_UNREACHABLE;
+    default: SLINKY_UNREACHABLE; return expr{};
     }
   }
 
@@ -88,7 +88,7 @@ public:
       case 8: return random_constant();
       case 9: return random_variable();
       case 10: return random_condition(depth);
-      default: SLINKY_UNREACHABLE;
+      default: SLINKY_UNREACHABLE; return expr{};
       }
     }
   }

--- a/slinky/builder/test/simplify/simplify.cc
+++ b/slinky/builder/test/simplify/simplify.cc
@@ -1217,6 +1217,11 @@ TEST(simplify, bounds_of) {
 }
 
 TEST(constant_lower_bound, basic) {
+  ASSERT_THAT(constant_lower_bound(min(x, 0)), matches(min(x, 0)));
+  ASSERT_THAT(constant_lower_bound(max(x, 0)), matches(0));
+  ASSERT_THAT(constant_lower_bound(!min(x, 0)), matches(0));
+  ASSERT_THAT(constant_lower_bound(!min(x, -1)), matches(0));  // TODO: We might be able to prove this is 1
+  ASSERT_THAT(constant_lower_bound(!max(x, 0)), matches(0));
   ASSERT_THAT(constant_lower_bound(min(x, 0) < 0), matches(0));
   ASSERT_THAT(constant_lower_bound(min(x, 0) * 256 < 0), matches(0));
   ASSERT_THAT(constant_lower_bound(max(x, 0) < 0), matches(0));
@@ -1240,6 +1245,10 @@ TEST(constant_lower_bound, basic) {
 TEST(constant_upper_bound, basic) {
   ASSERT_THAT(constant_upper_bound(min(x, 4)), matches(4));
   ASSERT_THAT(constant_upper_bound(max(x, 4)), matches(max(x, 4)));
+  ASSERT_THAT(constant_upper_bound(!min(x, 0)), matches(1));
+  ASSERT_THAT(constant_upper_bound(!min(x, -1)), matches(1));  // TODO: We might be able to prove this is 0
+  ASSERT_THAT(constant_upper_bound(!max(x, 0)), matches(1));
+  ASSERT_THAT(constant_upper_bound(!max(x, 1)), matches(1));  // TODO: We might be able to prove this is 0
   ASSERT_THAT(constant_upper_bound(x - min(y, 4)), matches(x - min(y, 4)));
   ASSERT_THAT(constant_upper_bound(x - max(y, 4)), matches(x - 4));
   ASSERT_THAT(constant_upper_bound(x * 3), matches(x * 3));

--- a/slinky/builder/test/simplify/simplify.cc
+++ b/slinky/builder/test/simplify/simplify.cc
@@ -1079,22 +1079,22 @@ TEST(simplify, knowledge) {
       matches(check::make(x % 6 == 3)));
 
   ASSERT_THAT(
-      simplify(block::make({check::make(3 <= max(x, y)), check::make(3 <= x)})), matches(check::make(3 <= max(x, y))));
-  ASSERT_THAT(simplify(block::make({check::make(3 <= min(x, y)), check::make(3 <= x)})),
-      matches(block::make({check::make(3 <= min(x, y)), check::make(3 <= x)})));
+      simplify(block::make({check::make(3 <= min(x, y)), check::make(3 <= x)})), matches(check::make(3 <= min(x, y))));
+  ASSERT_THAT(simplify(block::make({check::make(3 <= max(x, y)), check::make(3 <= x)})),
+      matches(block::make({check::make(3 <= max(x, y)), check::make(3 <= x)})));
   ASSERT_THAT(
-      simplify(block::make({check::make(3 < max(x, y)), check::make(3 < x)})), matches(check::make(3 < max(x, y))));
-  ASSERT_THAT(simplify(block::make({check::make(3 < min(x, y)), check::make(3 < x)})),
-      matches(block::make({check::make(3 < min(x, y)), check::make(3 < x)})));
+      simplify(block::make({check::make(3 < min(x, y)), check::make(3 < x)})), matches(check::make(3 < min(x, y))));
+  ASSERT_THAT(simplify(block::make({check::make(3 < max(x, y)), check::make(3 < x)})),
+      matches(block::make({check::make(3 < max(x, y)), check::make(3 < x)})));
 
   ASSERT_THAT(
-      simplify(block::make({check::make(min(x, y) <= 4), check::make(x <= 4)})), matches(check::make(min(x, y) <= 4)));
-  ASSERT_THAT(simplify(block::make({check::make(max(x, y) <= 4), check::make(x <= 4)})),
-      matches(block::make({check::make(max(x, y) <= 4), check::make(x <= 4)})));
+      simplify(block::make({check::make(max(x, y) <= 4), check::make(x <= 4)})), matches(check::make(max(x, y) <= 4)));
+  ASSERT_THAT(simplify(block::make({check::make(min(x, y) <= 4), check::make(x <= 4)})),
+      matches(block::make({check::make(min(x, y) <= 4), check::make(x <= 4)})));
   ASSERT_THAT(
-      simplify(block::make({check::make(min(x, y) < 4), check::make(x < 4)})), matches(check::make(min(x, y) < 4)));
-  ASSERT_THAT(simplify(block::make({check::make(max(x, y) < 4), check::make(x < 4)})),
-      matches(block::make({check::make(max(x, y) < 4), check::make(x < 4)})));
+      simplify(block::make({check::make(max(x, y) < 4), check::make(x < 4)})), matches(check::make(max(x, y) < 4)));
+  ASSERT_THAT(simplify(block::make({check::make(min(x, y) < 4), check::make(x < 4)})),
+      matches(block::make({check::make(min(x, y) < 4), check::make(x < 4)})));
 
   ASSERT_THAT(simplify(block::make({check::make(x == 3), check::make(x == 3)})), matches(check::make(x == 3)));
   ASSERT_THAT(simplify(block::make({check::make(x < 3), check::make(x < 4)})), matches(check::make(x < 3)));

--- a/slinky/runtime/expr.h
+++ b/slinky/runtime/expr.h
@@ -126,6 +126,9 @@ enum class intrinsic {
   validate_buffer,
 };
 
+// True if `fn` can be evaluated if its arguments are constants.
+bool can_evaluate(intrinsic fn);
+
 enum class buffer_field : unsigned {
   none = 0,
 

--- a/slinky/runtime/expr_stmt.cc
+++ b/slinky/runtime/expr_stmt.cc
@@ -52,6 +52,15 @@ std::optional<var> node_context::lookup(const std::string& name) const {
   return i != name_to_sym.end() ? std::optional<var>(i->second) : std::nullopt;
 }
 
+bool can_evaluate(intrinsic fn) {
+  switch (fn) {
+  case intrinsic::negative_infinity:
+  case intrinsic::positive_infinity:
+  case intrinsic::indeterminate: return false;
+  default: return true;
+  }
+}
+
 template <typename T>
 expr make_bin_op(expr a, expr b) {
   auto n = new T();

--- a/slinky/runtime/expr_stmt.cc
+++ b/slinky/runtime/expr_stmt.cc
@@ -702,9 +702,9 @@ bool is_variable(expr_ref x, var b, buffer_field field, int dim) {
 
 expr abs(expr x) { return call::make(intrinsic::abs, {std::move(x)}); }
 expr align_down(expr x, const expr& a) { return (std::move(x) / a) * a; }
-expr align_up(expr x, const expr& a) { return ((std::move(x) + a - 1) / a) * a; }
+expr align_up(expr x, const expr& a) { return ((std::move(x) + (a - 1)) / a) * a; }
 interval_expr align(interval_expr x, const expr& a) {
-  return {align_down(std::move(x.min), a), align_up(std::move(x.max) + 1, a) - 1};
+  return {align_down(std::move(x.min), a), ((std::move(x.max) + a) / a) * a - 1};
 }
 
 expr and_then(expr a, expr b) { return call::make(intrinsic::and_then, {std::move(a), std::move(b)}); }

--- a/slinky/runtime/expr_stmt.cc
+++ b/slinky/runtime/expr_stmt.cc
@@ -115,11 +115,11 @@ const variable* make_variable(var sym) {
 }
 
 const constant* get_constant(std::int64_t value) {
-  static const constant* zero = make_static_constant<0>();
-  static const constant* one = make_static_constant<1>();
   if (value == 0) {
+    static const constant* zero = make_static_constant<0>();
     return zero;
   } else if (value == 1) {
+    static const constant* one = make_static_constant<1>();
     return one;
   } else {
     return nullptr;


### PR DESCRIPTION
- Fix incorrect knowledge learning for comparisons of `min`/`max`
- Fix incorrect constant bounds for `logical_not`
- Fix printing of out of bounds wildcard
- Fix substitution of non-boolean facts
- Avoid static initializer thread safety overhead when not needed in `get_constant`
- Clean up some expressions to avoid generating unnecessary work for the simplifier.