### PR TITLE
Optimize constant evaluation

### DIFF
--- a/slinky/builder/rewrite.h
+++ b/slinky/builder/rewrite.h
@@ -851,6 +851,66 @@ SLINKY_UNIQUE bool match(match_context& ctx, Pattern p, const Target& x) {
   return match_any_variant(p, x, ctx);
 }
 
+// The node type a target must have for `Pattern` to be able to match it, or `none` if `Pattern` can match more than one
+// node type.
+template <typename Pattern>
+struct pattern_required_type {
+  static constexpr expr_node_type value = pattern_info<Pattern>::type;
+};
+template <typename A, index_t Default>
+struct pattern_required_type<pattern_optional<A, Default>> {
+  static constexpr expr_node_type value = expr_node_type::none;
+};
+template <typename T, typename A, index_t Default, typename B>
+struct pattern_required_type<pattern_binary<T, pattern_optional<A, Default>, B>> {
+  static constexpr expr_node_type value = expr_node_type::none;
+};
+template <typename T, typename A, typename B, index_t Default>
+struct pattern_required_type<pattern_binary<T, A, pattern_optional<B, Default>>> {
+  static constexpr expr_node_type value = expr_node_type::none;
+};
+template <typename T, typename A, index_t DefaultA, typename B, index_t DefaultB>
+struct pattern_required_type<pattern_binary<T, pattern_optional<A, DefaultA>, pattern_optional<B, DefaultB>>> {
+  static constexpr expr_node_type value = expr_node_type::none;
+};
+
+// Returns false if `p` definitely cannot match `x`, using only node types known at compile time.
+template <typename Pattern, typename Target>
+SLINKY_INLINE bool could_match(const Pattern&, const Target&) {
+  // We don't know anything about this target.
+  return true;
+}
+
+SLINKY_INLINE bool could_match_type(expr_node_type required, expr_node_type actual) {
+  return required == expr_node_type::none || required == actual;
+}
+
+template <typename T, typename A, typename B>
+SLINKY_INLINE bool could_match(const pattern_binary<T, A, B>&, const pattern_binary<T, pattern_expr, pattern_expr>& x) {
+  constexpr expr_node_type a_type = pattern_required_type<A>::value;
+  constexpr expr_node_type b_type = pattern_required_type<B>::value;
+  if (a_type == expr_node_type::none && b_type == expr_node_type::none) return true;
+
+  const expr_node_type xa = x.a.e.type();
+  const expr_node_type xb = x.b.e.type();
+  if (could_match_type(a_type, xa) && could_match_type(b_type, xb)) return true;
+  // A commutative pattern is also matched with the operands swapped.
+  return pattern_info<pattern_binary<T, A, B>>::could_commute && could_match_type(a_type, xb) &&
+         could_match_type(b_type, xa);
+}
+
+template <typename C, typename T, typename F>
+SLINKY_INLINE bool could_match(
+    const pattern_select<C, T, F>&, const pattern_select<pattern_expr, pattern_expr, pattern_expr>& x) {
+  constexpr expr_node_type c_type = pattern_required_type<C>::value;
+  constexpr expr_node_type t_type = pattern_required_type<T>::value;
+  constexpr expr_node_type f_type = pattern_required_type<F>::value;
+  if (c_type == expr_node_type::none && t_type == expr_node_type::none && f_type == expr_node_type::none) return true;
+
+  return could_match_type(c_type, x.c.e.type()) && could_match_type(t_type, x.t.e.type()) &&
+         could_match_type(f_type, x.f.e.type());
+}
+
 template <typename Target>
 class base_rewriter {
   Target x;
@@ -893,6 +953,8 @@ public:
   // The last predicate is optional and defaults to true.
   template <typename Pattern, typename... ReplacementPredicate>
   SLINKY_INLINE bool operator()(Pattern p, ReplacementPredicate... r_pr) {
+    if (!could_match(p, x)) return false;
+
     match_context ctx;
     if (!match_any_variant(p, x, ctx)) return false;
 

--- a/slinky/builder/simplify.cc
+++ b/slinky/builder/simplify.cc
@@ -660,9 +660,6 @@ public:
   static bool prove_constant_true(const expr& e) {
     if (!e.defined()) return false;
 
-    std::optional<index_t> ec = evaluate_constant(e);
-    if (ec) return *ec != 0;
-
     // e is constant true if we know it has bounds that don't include zero.
     std::optional<index_t> a = evaluate_constant_lower_bound(e);
     if (a && *a > 0) return true;
@@ -672,9 +669,6 @@ public:
 
   static bool prove_constant_false(const expr& e) {
     if (!e.defined()) return false;
-
-    std::optional<index_t> ec = evaluate_constant(e);
-    if (ec) return *ec == 0;
 
     // e is constant false if we know its bounds are [0, 0].
     std::optional<index_t> a = evaluate_constant_lower_bound(e);
@@ -2481,6 +2475,8 @@ public:
   template <typename T>
   void visit_min_max(const T* op, bool take_constant) {
     expr a = mutate(op->a);
+    // If we can take a constant operand, an undefined operand doesn't make the result undefined.
+    if (!a.defined() && !take_constant) return set_result(expr{});
     expr b = mutate(op->b);
     auto ca = as_constant(a);
     auto cb = as_constant(b);
@@ -2516,8 +2512,17 @@ public:
     }
   }
 
-  void visit(const add* op) override { set_binary_result(op, mutate(op->a), mutate(op->b, sign)); }
-  void visit(const sub* op) override { set_binary_result(op, mutate(op->a), mutate(op->b, -sign)); }
+  template <typename T>
+  void visit_add_sub(const T* op, int b_sign) {
+    expr a = mutate(op->a);
+    if (!a.defined()) return set_result(expr{});
+    expr b = mutate(op->b, b_sign);
+    if (!b.defined()) return set_result(expr{});
+    set_binary_result(op, std::move(a), std::move(b));
+  }
+
+  void visit(const add* op) override { visit_add_sub(op, sign); }
+  void visit(const sub* op) override { visit_add_sub(op, -sign); }
 
   static int sign_of(const expr& x) {
     if (is_positive(x)) return 1;
@@ -2528,6 +2533,9 @@ public:
   template <typename T>
   void visit_mul_div(const T* op) {
     expr a = mutate(op->a, 0);
+    // When constant folding, an undefined operand makes the result undefined. When looking for a bound, it does not:
+    // we might still find one by mutating the operand again with a non-zero sign below.
+    if (sign == 0 && !a.defined()) return set_result(expr{});
     expr b = mutate(op->b, 0);
     if (sign == 0 || is_constant(a, 0) || is_constant(b, 0) || (as_constant(a) && as_constant(b))) {
       set_binary_result(op, std::move(a), std::move(b));
@@ -2553,8 +2561,20 @@ public:
 
   void visit(const mod* op) override {
     if (sign == 0) {
-      set_binary_result(op, mutate(op->a), mutate(op->b));
-    } else if (sign < 0) {
+      expr a = mutate(op->a);
+      if (!a.defined()) return set_result(expr{});
+      expr b = mutate(op->b);
+      if (!b.defined()) return set_result(expr{});
+      return set_binary_result(op, std::move(a), std::move(b));
+    }
+    if (auto ca = as_constant(mutate(op->a, 0))) {
+      if (auto cb = as_constant(mutate(op->b, 0))) {
+        // If both operands are constants, the bound is the exact result, unless it overflows.
+        expr result = make_or_eval_binary<mod>(*ca, *cb);
+        if (as_constant(result)) return set_result(std::move(result));
+      }
+    }
+    if (sign < 0) {
       // We know that 0 <= a % b < upper_bound(abs(b)). We might be able to do better if a is constant, but even that is
       // not easy, because an upper bound of a is not necessarily an upper bound of a % b.
       set_result(expr(0));
@@ -2574,7 +2594,17 @@ public:
   template <typename T>
   void visit_logical(const T* op) {
     if (sign == 0) {
-      set_binary_result(op, mutate(op->a), mutate(op->b));
+      expr a = mutate(op->a);
+      if (!a.defined()) return set_result(expr{});
+      expr b = mutate(op->b);
+      if (!b.defined()) return set_result(expr{});
+      set_binary_result(op, std::move(a), std::move(b));
+    } else if (auto ca = as_constant(mutate(op->a, 0))) {
+      if (auto cb = as_constant(mutate(op->b, 0))) {
+        set_result(make_binary<T>(*ca, *cb));
+      } else {
+        set_result(expr(sign < 0 ? 0 : 1));
+      }
     } else {
       // If we don't know anything about a logical op, the result is either 0 or 1.
       set_result(expr(sign < 0 ? 0 : 1));
@@ -2591,16 +2621,22 @@ public:
     // - For an upper bound, we want to know if this can ever be true, so we want the lower bound of the lhs and the
     // upper bound of the rhs.
     expr a = mutate(op->a, -sign);
+    auto ca = as_constant(a);
+    if (sign != 0 && !ca) {
+      // We can only compare constants, and we don't need `b` to know the result is either 0 or 1.
+      return set_result(expr(sign < 0 ? 0 : 1));
+    } else if (!a.defined()) {
+      return set_result(expr{});
+    }
     expr b = mutate(op->b);
 
-    auto ca = as_constant(a);
     auto cb = as_constant(b);
     if (ca && cb) {
       set_result(make_binary<T>(*ca, *cb));
     } else if (sign != 0) {
       // If we don't know anything about a logical op, the result is either 0 or 1.
       set_result(expr(sign < 0 ? 0 : 1));
-    } else if (!a.defined() || !b.defined()) {
+    } else if (!b.defined()) {
       set_result(expr());
     } else if (a.same_as(op->a) && b.same_as(op->b)) {
       set_result(expr(op));
@@ -2613,16 +2649,20 @@ public:
 
   template <typename T>
   void visit_logical_and_or(const T* op, int new_sign) {
+    constexpr bool is_and = std::is_same<T, logical_and>::value;
     expr a = strip_boolean(mutate(op->a, new_sign));
+    if (auto ca = as_constant(a)) {
+      if ((*ca != 0) != is_and) return set_result(boolean(std::move(a)));
+    }
     expr b = strip_boolean(mutate(op->b, new_sign));
 
     if (as_constant(b)) std::swap(a, b);
 
     if (auto ca = as_constant(a)) {
       if (*ca) {
-        set_result(boolean(std::is_same<T, logical_and>::value ? std::move(b) : std::move(a)));
+        set_result(boolean(is_and ? std::move(b) : std::move(a)));
       } else {
-        set_result(boolean(std::is_same<T, logical_and>::value ? std::move(a) : std::move(b)));
+        set_result(boolean(is_and ? std::move(a) : std::move(b)));
       }
     } else if (sign != 0) {
       // If we don't know anything about a logical op, the result is either 0 or 1.
@@ -2662,17 +2702,23 @@ public:
     if (auto cc = as_constant(c)) {
       set_result(mutate(*cc ? op->true_value : op->false_value));
       return;
+    } else if (!c.defined() && sign == 0) {
+      // When constant folding, we need a constant condition. When looking for a bound, we might still find one if both
+      // values are constants.
+      return set_result(expr{});
     }
 
     expr t = mutate(op->true_value);
+    if (!t.defined()) return set_result(expr{});
     expr f = mutate(op->false_value);
+    if (!f.defined()) return set_result(expr{});
     auto ct = as_constant(t);
     auto cf = as_constant(f);
     if (sign < 0 && ct && cf) {
       set_result(expr(std::min(*ct, *cf)));
     } else if (sign > 0 && ct && cf) {
       set_result(expr(std::max(*ct, *cf)));
-    } else if (!c.defined() || !t.defined() || !f.defined()) {
+    } else if (!c.defined()) {
       set_result(expr());
     } else if (c.same_as(op->condition) && t.same_as(op->true_value) && f.same_as(op->false_value)) {
       set_result(op);
@@ -2698,6 +2744,9 @@ public:
       const bool is_and = op->intrinsic == intrinsic::and_then;
       const int new_sign = is_and ? std::min(sign, 0) : std::max(sign, 0);
       expr a = strip_boolean(mutate(op->args[0], new_sign));
+      if (auto ca = as_constant(a)) {
+        if ((*ca != 0) != is_and) return set_result(boolean(std::move(a)));
+      }
       expr b = strip_boolean(mutate(op->args[1], new_sign));
 
       if (auto ca = as_constant(a)) {

--- a/slinky/builder/simplify.cc
+++ b/slinky/builder/simplify.cc
@@ -672,10 +672,9 @@ public:
 
     // e is constant false if we know its bounds are [0, 0].
     std::optional<index_t> a = evaluate_constant_lower_bound(e);
-    if (!a) return false;
+    if (!a || *a != 0) return false;
     std::optional<index_t> b = evaluate_constant_upper_bound(e);
-    if (!b) return false;
-    return *a == 0 && *b == 0;
+    return b && *b == 0;
   }
 
   // Attempt to prove that the interval only contains true or false.

--- a/slinky/builder/simplify.cc
+++ b/slinky/builder/simplify.cc
@@ -2530,7 +2530,10 @@ public:
     // we might still find one by mutating the operand again with a non-zero sign below.
     if (sign == 0 && !a.defined()) return set_result(expr{});
     expr b = mutate(op->b, 0);
-    if (sign == 0 || is_constant(a, 0) || is_constant(b, 0) || (as_constant(a) && as_constant(b))) {
+    if (is_constant(a, 0) || is_constant(b, 0)) {
+      // `0*x`, `x*0`, `0/x` and `x/0` are all 0, we don't need to know anything about the other operand.
+      return set_result(expr(0));
+    } else if (sign == 0 || (as_constant(a) && as_constant(b))) {
       set_binary_result(op, std::move(a), std::move(b));
       return;
     }
@@ -2555,9 +2558,13 @@ public:
   void visit(const mod* op) override {
     if (sign == 0) {
       expr a = mutate(op->a);
-      if (!a.defined()) return set_result(expr{});
       expr b = mutate(op->b);
-      if (!b.defined()) return set_result(expr{});
+      if (is_constant(a, 0) || is_constant(b, 0) || is_constant(b, 1)) {
+        // `0%x`, `x%0` and `x%1` are all 0, we don't need to know anything about the other operand.
+        return set_result(expr(0));
+      } else if (!a.defined() || !b.defined()) {
+        return set_result(expr{});
+      }
       return set_binary_result(op, std::move(a), std::move(b));
     }
     if (auto ca = as_constant(mutate(op->a, 0))) {

--- a/slinky/builder/simplify.cc
+++ b/slinky/builder/simplify.cc
@@ -2637,6 +2637,16 @@ public:
   void visit(const less* op) override { visit_less(op); }
   void visit(const less_equal* op) override { visit_less(op); }
 
+  void set_boolean_result(expr x) {
+    if (x.defined()) {
+      set_result(boolean(std::move(x)));
+    } else if (sign != 0) {
+      set_result(sign < 0 ? 0 : 1);
+    } else {
+      set_result(expr());
+    }
+  }
+
   template <typename T>
   void visit_logical_and_or(const T* op, int new_sign) {
     constexpr bool is_and = std::is_same<T, logical_and>::value;
@@ -2649,11 +2659,8 @@ public:
     if (as_constant(b)) std::swap(a, b);
 
     if (auto ca = as_constant(a)) {
-      if (*ca) {
-        set_result(boolean(is_and ? std::move(b) : std::move(a)));
-      } else {
-        set_result(boolean(is_and ? std::move(a) : std::move(b)));
-      }
+      // `a` is the identity for this op, so the result is `b`, which might be undefined.
+      set_boolean_result((*ca != 0) == is_and ? std::move(b) : std::move(a));
     } else if (sign != 0) {
       // If we don't know anything about a logical op, the result is either 0 or 1.
       set_result(expr(sign < 0 ? 0 : 1));
@@ -2740,17 +2747,11 @@ public:
       expr b = strip_boolean(mutate(op->args[1], new_sign));
 
       if (auto ca = as_constant(a)) {
-        if (*ca) {
-          set_result(boolean(is_and ? std::move(b) : std::move(a)));
-        } else {
-          set_result(boolean(is_and ? std::move(a) : std::move(b)));
-        }
+        // `a` is the identity for this op, so the result is `b`, which might be undefined.
+        set_boolean_result((*ca != 0) == is_and ? std::move(b) : std::move(a));
       } else if (auto cb = as_constant(b)) {
-        if (*cb) {
-          set_result(boolean(is_and ? std::move(a) : std::move(b)));
-        } else {
-          set_result(boolean(is_and ? std::move(b) : std::move(a)));
-        }
+        // `b` is the identity for this op, so the result is `a`, which might be undefined.
+        set_boolean_result((*cb != 0) == is_and ? std::move(a) : std::move(b));
       } else if (sign != 0) {
         // If we don't know anything about a logical op, the result is either 0 or 1.
         set_result(expr(sign < 0 ? 0 : 1));

--- a/slinky/builder/simplify.cc
+++ b/slinky/builder/simplify.cc
@@ -809,13 +809,10 @@ public:
   void visit_min_max(const T* op) {
     expr_info a_info;
     expr a = mutate(op->a, &a_info);
+    if (!a.defined()) return set_result(expr(), expr_info());
     expr_info b_info;
     expr b = mutate(op->b, &b_info);
-
-    if (!a.defined() || !b.defined()) {
-      set_result(expr(), expr_info());
-      return;
-    }
+    if (!b.defined()) return set_result(expr(), expr_info());
 
     // We need to check between the bounds and a/b themselves to avoid the possibility of something like:
     // min(x, y + 1) not simplifying if we know the bounds of x are [0, y] and the bounds of y are [z, w],
@@ -864,13 +861,10 @@ public:
   void visit_binary(const T* op) {
     expr_info a_info;
     expr a = mutate(op->a, &a_info);
+    if (!a.defined()) return set_result(expr(), expr_info());
     expr_info b_info;
     expr b = mutate(op->b, &b_info);
-
-    if (!a.defined() || !b.defined()) {
-      set_result(expr(), expr_info());
-      return;
-    }
+    if (!b.defined()) return set_result(expr(), expr_info());
 
     if (T::static_type == expr_node_type::mul) {
       // TODO: This is really ugly, we should have a better way of expressing such simplifications.
@@ -956,13 +950,10 @@ public:
   void visit_logical(const T* op, bool coerce_boolean = false) {
     expr_info a_info;
     expr a = coerce_boolean ? mutate_boolean(op->a, &a_info) : mutate(op->a, &a_info);
+    if (!a.defined()) return set_result(expr(), expr_info());
     expr_info b_info;
     expr b = coerce_boolean ? mutate_boolean(op->b, &b_info) : mutate(op->b, &b_info);
-
-    if (!a.defined() || !b.defined()) {
-      set_result(expr(), expr_info());
-      return;
-    }
+    if (!b.defined()) return set_result(expr(), expr_info());
 
     expr result = simplify(op, a, b);
     if (!result.same_as(op)) {

--- a/slinky/builder/simplify.cc
+++ b/slinky/builder/simplify.cc
@@ -2445,7 +2445,7 @@ class constant_evaluator : public node_mutator {
   bool constant_required = true;
 
 public:
-  constant_evaluator(bool constant_required = true) : constant_required(constant_required) {}
+  constant_evaluator(int sign = 0, bool constant_required = true) : sign(sign), constant_required(constant_required) {}
 
   using node_mutator::mutate;
   expr mutate(const expr& x) {
@@ -2779,14 +2779,14 @@ public:
 
 }  // namespace
 
-expr constant_lower_bound(const expr& x) { return constant_evaluator(false).mutate(x, -1); }
-expr constant_upper_bound(const expr& x) { return constant_evaluator(false).mutate(x, 1); }
-std::optional<index_t> evaluate_constant(const expr& x) { return as_constant(constant_evaluator().mutate(x, 0)); }
+expr constant_lower_bound(const expr& x) { return constant_evaluator(-1, false).mutate(x); }
+expr constant_upper_bound(const expr& x) { return constant_evaluator(1, false).mutate(x); }
+std::optional<index_t> evaluate_constant(const expr& x) { return as_constant(constant_evaluator().mutate(x)); }
 std::optional<index_t> evaluate_constant_lower_bound(const expr& x) {
-  return as_constant(constant_evaluator().mutate(x, -1));
+  return as_constant(constant_evaluator(-1).mutate(x));
 }
 std::optional<index_t> evaluate_constant_upper_bound(const expr& x) {
-  return as_constant(constant_evaluator().mutate(x, 1));
+  return as_constant(constant_evaluator(1).mutate(x));
 }
 
 std::optional<bool> attempt_to_prove(

--- a/slinky/builder/simplify.cc
+++ b/slinky/builder/simplify.cc
@@ -50,8 +50,6 @@ void ensure_is_point(interval_expr& x) {
   }
 }
 
-
-
 // Rewrite `make_decl(block::make(stmts))` to be `block::make(make_decl(i) for i in stmts if i depends on sym else i)`.
 template <class Fn>
 stmt lift_decl_invariants(stmt body, var sym, Fn&& make_decl) {
@@ -801,9 +799,7 @@ public:
     return x;
   }
 
-  void visit(const constant* op) override {
-    set_result(op, {point(expr(op)), {0, op->value}});
-  }
+  void visit(const constant* op) override { set_result(op, {point(expr(op)), {0, op->value}}); }
 
   template <typename T>
   void visit_min_max(const T* op) {
@@ -1641,8 +1637,8 @@ public:
       }
       if (all_constants) {
         raw_buffer_ptr buf = raw_buffer::make(dims.size(), 0, dims.empty() ? nullptr : dims.data());
-        set_result(block::make(
-            {std::move(before), let_stmt::make(op->sym, constant_buffer::make(std::move(buf)), std::move(body)), std::move(after)}));
+        set_result(block::make({std::move(before),
+            let_stmt::make(op->sym, constant_buffer::make(std::move(buf)), std::move(body)), std::move(after)}));
         return;
       }
     }
@@ -2452,6 +2448,13 @@ public:
   constant_evaluator(bool constant_required = true) : constant_required(constant_required) {}
 
   using node_mutator::mutate;
+  expr mutate(const expr& x) {
+    switch (x.type()) {
+    case expr_node_type::constant: return x;
+    case expr_node_type::variable: return constant_required ? expr() : x;
+    default: return node_mutator::mutate(x);
+    }
+  }
   expr mutate(const expr& x, int sign) {
     int old_sign = this->sign;
     this->sign = sign;

--- a/slinky/builder/simplify_exprs.cc
+++ b/slinky/builder/simplify_exprs.cc
@@ -198,6 +198,16 @@ expr simplify(const less* op, expr a, expr b) {
 }
 
 expr simplify(const less_equal* op, expr a, expr b) {
+  // Do a few quick checks before rewriting to less.
+  auto r = make_rewriter(pattern_expr{a} <= pattern_expr{b});
+  if (r(rewrite::negative_infinity() <= x, true) ||
+      r(x <= rewrite::positive_infinity(), true) || 
+      r(x <= x, true) ||
+      r(x <= y - 1, x < y) || 
+      r(x - 1 <= y, x < y)) {
+    return r.result;
+  }
+
   // Rewrite to !(b < a) and simplify that instead.
   expr result = simplify(static_cast<const logical_not*>(nullptr),
       simplify(static_cast<const less*>(nullptr), std::move(b), std::move(a)));

--- a/slinky/builder/simplify_rules.h
+++ b/slinky/builder/simplify_rules.h
@@ -281,7 +281,6 @@ bool apply_add_rules(Fn&& apply) {
       apply(x + rewrite::positive_infinity(), rewrite::positive_infinity(), is_finite(x)) ||
       apply(x + rewrite::negative_infinity(), rewrite::negative_infinity(), is_finite(x)) ||
       apply(x*may_be<1>(c0) + x*may_be<1>(c1), x*eval(c0 + c1)) ||
-      apply(x + 0, x) ||
       apply(x + (x - y), x*2 - y) ||
       apply(x + (y - x), y) ||
       apply(x + x*y, x*(y + 1), !is_constant(x)) ||
@@ -317,7 +316,6 @@ bool apply_sub_rules(Fn&& apply) {
   return
       apply(x - rewrite::positive_infinity(), rewrite::negative_infinity(), is_finite(x)) ||
       apply(x - rewrite::negative_infinity(), rewrite::positive_infinity(), is_finite(x)) ||
-      apply(x - 0, x) ||
       apply(x*may_be<1>(c0) - x*may_be<1>(c1), x*eval(c0 - c1)) ||
       apply(x - y*c0, x + y*eval(-c0)) ||
       apply(x - y/c0, x + y/eval(-c0), c0 <= 0) ||
@@ -386,8 +384,6 @@ bool apply_mul_rules(Fn&& apply) {
       apply(rewrite::negative_infinity()*c0,
         rewrite::negative_infinity(), c0 > 0,
         rewrite::positive_infinity(), c0 < 0) ||
-      apply(x*0, 0) ||
-      apply(x*1, x) ||
       apply((x*c0)*c1, x*eval(c0*c1)) ||
       apply((x + c0)*c1, x*c1 + eval(c0*c1)) ||
       apply((c0 - x)*c1, x*eval(-c1) + eval(c0*c1)) ||
@@ -410,9 +406,6 @@ bool apply_div_rules(Fn&& apply) {
       apply(rewrite::negative_infinity()/c0,
         rewrite::negative_infinity(), c0 > 0,
         rewrite::positive_infinity(), c0 < 0) ||
-      apply(x/0, 0) ||
-      apply(0/x, 0) ||
-      apply(x/1, x) ||
       apply(x/-1, -x) ||
       apply(x/x, x != 0) ||
 
@@ -447,8 +440,6 @@ bool apply_div_rules(Fn&& apply) {
 template <typename Fn>
 bool apply_mod_rules(Fn&& apply) {
   return
-      apply(x%1, 0) ||
-      apply(x%0, 0) ||
       apply(x%x, 0) ||
 
       apply((x + c0)%c1, (x + eval(c0%c1))%c1, c0%c1 != c0) ||

--- a/slinky/builder/simplify_rules.h
+++ b/slinky/builder/simplify_rules.h
@@ -468,7 +468,6 @@ bool apply_less_rules(Fn&& apply) {
       apply(x < rewrite::positive_infinity(), true, is_finite(x)) ||
       apply(x < x, false) ||
       apply(x < y + 1, x <= y) ||
-      apply(x + -1 < y, x <= y) ||
 
       // These rules taken from:
       // https://github.com/halide/Halide/blob/e9f8b041f63a1a337ce3be0b07de5a1cfa6f2f65/src/Simplify_LT.cpp#L87-L169

--- a/slinky/builder/test/replica_pipeline.cc
+++ b/slinky/builder/test/replica_pipeline.cc
@@ -89,11 +89,11 @@ auto p = []() -> ::slinky::pipeline {
   auto _replica_fn_2 = [=](const buffer<const void>& i0, const buffer<void>& o0) -> index_t {
     const buffer<const void>* input_buffers[] = {&i0};
     const buffer<void>* output_buffers[] = {&o0};
-    const func::input inputs[] = {{in, {{((((x * 2)) + 0)), ((((x * 2)) + 1))}, {((((y * 2)) + 0)), ((((y * 2)) + 1))}}}};
+    const func::input inputs[] = {{in, {{((x * 2)), ((((x * 2)) + 1))}, {((y * 2)), ((((y * 2)) + 1))}}}};
     const std::vector<var> outputs[] = {{x, y}};
     return ::slinky::internal::replica_pipeline_handler(input_buffers, output_buffers, inputs, outputs);
   };
-  auto _fn_1 = func::make(std::move(_replica_fn_2), {{in, {{((((x * 2)) + 0)), ((((x * 2)) + 1))}, {((((y * 2)) + 0)), ((((y * 2)) + 1))}}}}, {{intm, {x, y}}}, {});
+  auto _fn_1 = func::make(std::move(_replica_fn_2), {{in, {{((x * 2)), ((((x * 2)) + 1))}, {((y * 2)), ((((y * 2)) + 1))}}}}, {{intm, {x, y}}}, {});
   auto _replica_fn_3 = [=](const buffer<const void>& i0, const buffer<const void>& i1, const buffer<void>& o0) -> index_t {
     const buffer<const void>* input_buffers[] = {&i0, &i1};
     const buffer<void>* output_buffers[] = {&o0};
@@ -281,7 +281,7 @@ auto p = []() -> ::slinky::pipeline {
   };
   auto _fn_4 = func::make(std::move(_replica_fn_5), {{in2, {point(x), point(y)}}}, {{intm2, {x, y}}}, {});
   auto _6 = out->sym();
-  auto _fn_0 = func::make_copy({{intm1, {point(x), point(((y - 0)))}, {point(expr()), {0, (((((((((buffer_max(_3, 1)) - (buffer_min(_3, 1)))) + 1)) - 0)) - 1))}}, {point(expr()), {0, (((((((buffer_max(_3, 1)) - (buffer_min(_3, 1)))) + 1)) - 1))}}, {}}, {intm2, {point(x), point(((y - (((((buffer_max(_3, 1)) - (buffer_min(_3, 1)))) + 1)))))}, {point(expr()), {0, (((((((((buffer_max(_6, 1)) - (buffer_min(_6, 1)))) + 1)) - (((((buffer_max(_3, 1)) - (buffer_min(_3, 1)))) + 1)))) - 1))}}, {point(expr()), {(((((buffer_max(_3, 1)) - (buffer_min(_3, 1)))) + 1)), (((((((buffer_max(_6, 1)) - (buffer_min(_6, 1)))) + 1)) - 1))}}, {}}}, {out, {x, y}});
+  auto _fn_0 = func::make_copy({{intm1, {point(x), point(y)}, {point(expr()), {0, (((((((buffer_max(_3, 1)) - (buffer_min(_3, 1)))) + 1)) - 1))}}, {point(expr()), {0, (((((((buffer_max(_3, 1)) - (buffer_min(_3, 1)))) + 1)) - 1))}}, {}}, {intm2, {point(x), point(((y - (((((buffer_max(_3, 1)) - (buffer_min(_3, 1)))) + 1)))))}, {point(expr()), {0, (((((((((buffer_max(_6, 1)) - (buffer_min(_6, 1)))) + 1)) - (((((buffer_max(_3, 1)) - (buffer_min(_3, 1)))) + 1)))) - 1))}}, {point(expr()), {(((((buffer_max(_3, 1)) - (buffer_min(_3, 1)))) + 1)), (((((((buffer_max(_6, 1)) - (buffer_min(_6, 1)))) + 1)) - 1))}}, {}}}, {out, {x, y}});
   auto p = build_pipeline(ctx, {}, {in1, in2}, {out}, {}, {.no_alias_buffers = true});
   return p;
 };

--- a/slinky/builder/test/simplify/rule_tester.h
+++ b/slinky/builder/test/simplify/rule_tester.h
@@ -133,7 +133,7 @@ class rule_tester {
       m.constants[i] = expr_gen_.random_constant();
     }
     for (std::size_t i = 0; i < rewrite::symbol_count; ++i) {
-      exprs[i] = expr_gen_.random_expr(0);
+      exprs[i] = expr_gen_.random_expr(1);
       m.vars[i] = exprs[i].get();
     }
   }
@@ -141,14 +141,18 @@ class rule_tester {
 public:
   rule_tester() : expr_gen_(rng_, var_count) {}
 
-  SLINKY_NO_INLINE void test_expr(expr pattern, expr replacement, const std::string& rule_str) {
+  SLINKY_NO_INLINE void test_expr(expr pattern, expr replacement, const std::string& rule_str, bool& applied) {
+    expr simplified = simplify(pattern);
+    if (pattern.same_as(simplified)) {
+      // We didn't apply the rule, maybe the pattern constant folded.
+      return;
+    }
+    applied = true;
+
     if (contains_infinity(pattern)) {
       // TODO: Maybe there's a way to test this...
       return;
     }
-
-    expr simplified = simplify(pattern);
-    ASSERT_FALSE(pattern.same_as(simplified)) << "Rule did not apply: " << rule_str << "\nTo: " << pattern << "\n";
 
     eval_context ctx;
     for (int test = 0; test < 100; ++test) {
@@ -176,23 +180,7 @@ public:
 
   template <typename Pattern, typename Replacement>
   bool operator()(const Pattern& p, const Replacement& r) {
-    // This function needs to be kept small and simple, because it is instantiated by hundreds of different rules.
-    std::stringstream rule_str;
-    rule_str << p << " -> " << r;
-
-    rewrite::match_context m;
-    init_match_context(m);
-
-    expr pattern = expr(substitute(p, m));
-    bool overflowed = false;
-    expr replacement = expr(substitute(r, m, overflowed));
-    assert(!overflowed);
-
-    // Make sure the expressions have the same value when evaluated.
-    test_expr(pattern, replacement, rule_str.str());
-
-    // Returning false means the rule applicator will continue to the next rule.
-    return false;
+    return operator()(p, r, 1);
   }
 
   template <typename Pattern, typename Replacement, typename Predicate>
@@ -204,6 +192,7 @@ public:
     // Some rules are very picky about a large number of constants, which makes it very unlikely to generate an
     // expression that the rule applies to.
     rewrite::match_context m;
+    bool rule_applied = false;
     for (int test = 0; test < 100000; ++test) {
       init_match_context(m);
       bool overflowed = false;
@@ -213,13 +202,13 @@ public:
         assert(!overflowed);
 
         // Make sure the expressions have the same value when evaluated.
-        test_expr(pattern, replacement, rule_str.str());
-
-        // Returning false means the rule applicator will continue to the next rule.
-        return false;
+        test_expr(pattern, replacement, rule_str.str(), rule_applied);
+        if (rule_applied) {
+          // Returning false means the rule applicator will continue to the next rule.
+          return false;
+        }
       }
     }
-    const bool rule_applied = false;
     // We failed to apply the rule to an expression.
     EXPECT_TRUE(rule_applied) << rule_str.str();
     // Returning true stops any more tests.

--- a/slinky/builder/test/simplify/simplify.cc
+++ b/slinky/builder/test/simplify/simplify.cc
@@ -1289,14 +1289,14 @@ TEST(evaluate_constant_lower_bound, basic) {
   ASSERT_EQ(evaluate_constant_lower_bound(min(1, max(x, 1))), 1);
   ASSERT_EQ(evaluate_constant_lower_bound(clamp(x, -2, 3)), -2);
 
-  ASSERT_EQ(evaluate_constant_lower_bound(x || false), std::nullopt);
-  ASSERT_EQ(evaluate_constant_lower_bound(false || x), std::nullopt);
+  ASSERT_EQ(evaluate_constant_lower_bound(x || false), false);
+  ASSERT_EQ(evaluate_constant_lower_bound(false || x), false);
   ASSERT_EQ(evaluate_constant_lower_bound(x || true), true);
   ASSERT_EQ(evaluate_constant_lower_bound(true || x), true);
   ASSERT_EQ(evaluate_constant_lower_bound(x && false), false);
   ASSERT_EQ(evaluate_constant_lower_bound(false && x), false);
-  ASSERT_EQ(evaluate_constant_lower_bound(x && true), std::nullopt);
-  ASSERT_EQ(evaluate_constant_lower_bound(true && x), std::nullopt);
+  ASSERT_EQ(evaluate_constant_lower_bound(x && true), false);
+  ASSERT_EQ(evaluate_constant_lower_bound(true && x), false);
 }
 
 TEST(evaluate_constant_upper_bound, basic) {
@@ -1321,14 +1321,14 @@ TEST(evaluate_constant_upper_bound, basic) {
   ASSERT_EQ(evaluate_constant_upper_bound(max(x, 0) < 0), 0);
   ASSERT_EQ(evaluate_constant_upper_bound(max(x, 0) * 256 < 0), 0);
 
-  ASSERT_EQ(evaluate_constant_upper_bound(x || false), std::nullopt);
-  ASSERT_EQ(evaluate_constant_upper_bound(false || x), std::nullopt);
+  ASSERT_EQ(evaluate_constant_upper_bound(x || false), true);
+  ASSERT_EQ(evaluate_constant_upper_bound(false || x), true);
   ASSERT_EQ(evaluate_constant_upper_bound(x || true), true);
   ASSERT_EQ(evaluate_constant_upper_bound(true || x), true);
   ASSERT_EQ(evaluate_constant_upper_bound(x && false), false);
   ASSERT_EQ(evaluate_constant_upper_bound(false && x), false);
-  ASSERT_EQ(evaluate_constant_upper_bound(x && true), std::nullopt);
-  ASSERT_EQ(evaluate_constant_upper_bound(true && x), std::nullopt);
+  ASSERT_EQ(evaluate_constant_upper_bound(x && true), true);
+  ASSERT_EQ(evaluate_constant_upper_bound(true && x), true);
 }
 
 TEST(evaluate_constant, basic) {

--- a/slinky/runtime/expr_stmt.cc
+++ b/slinky/runtime/expr_stmt.cc
@@ -13,7 +13,6 @@
 #include "slinky/runtime/print.h"
 #include "slinky/runtime/stmt.h"
 
-
 namespace slinky {
 
 var::var(node_context& ctx, const std::string& name) : var(ctx.insert_unique(name)) {}
@@ -160,20 +159,56 @@ expr constant_buffer::make(const_raw_buffer_ptr value) {
   return expr(n);
 }
 
-expr add::make(expr a, expr b) { return make_bin_op<add>(std::move(a), std::move(b)); }
-expr sub::make(expr a, expr b) { return make_bin_op<sub>(std::move(a), std::move(b)); }
-expr mul::make(expr a, expr b) { return make_bin_op<mul>(std::move(a), std::move(b)); }
-expr div::make(expr a, expr b) { return make_bin_op<div>(std::move(a), std::move(b)); }
-expr mod::make(expr a, expr b) { return make_bin_op<mod>(std::move(a), std::move(b)); }
+expr add::make(expr a, expr b) {
+  if (is_zero(a)) return b;
+  if (is_zero(b)) return a;
+  return make_bin_op<add>(std::move(a), std::move(b));
+}
+expr sub::make(expr a, expr b) {
+  if (is_zero(b)) return a;
+  return make_bin_op<sub>(std::move(a), std::move(b));
+}
+expr mul::make(expr a, expr b) {
+  if (is_zero(a) || is_one(b)) return a;
+  if (is_zero(b) || is_one(a)) return b;
+  return make_bin_op<mul>(std::move(a), std::move(b));
+}
+expr div::make(expr a, expr b) {
+  // Division by zero is defined to be zero.
+  if (is_zero(a) || is_one(b)) return a;
+  if (is_zero(b)) return b;
+  return make_bin_op<div>(std::move(a), std::move(b));
+}
+expr mod::make(expr a, expr b) {
+  // `0%x`, `x%0` and `x%1` are all zero.
+  if (is_zero(a) || is_zero(b) || is_one(b)) return expr(0);
+  return make_bin_op<mod>(std::move(a), std::move(b));
+}
 expr min::make(expr a, expr b) { return make_bin_op<min>(std::move(a), std::move(b)); }
 expr max::make(expr a, expr b) { return make_bin_op<max>(std::move(a), std::move(b)); }
 expr equal::make(expr a, expr b) { return make_bin_op<equal>(std::move(a), std::move(b)); }
 expr not_equal::make(expr a, expr b) { return make_bin_op<not_equal>(std::move(a), std::move(b)); }
 expr less::make(expr a, expr b) { return make_bin_op<less>(std::move(a), std::move(b)); }
 expr less_equal::make(expr a, expr b) { return make_bin_op<less_equal>(std::move(a), std::move(b)); }
-expr logical_and::make(expr a, expr b) { return make_bin_op<logical_and>(std::move(a), std::move(b)); }
-expr logical_or::make(expr a, expr b) { return make_bin_op<logical_or>(std::move(a), std::move(b)); }
+expr logical_and::make(expr a, expr b) {
+  // A false operand makes the result false. A true operand is the identity, but only if the other operand is already a
+  // boolean, otherwise we'd lose the conversion of the result to 0 or 1.
+  if (is_false(a) || is_false(b)) return expr(0);
+  if (is_true(a) && is_boolean(b)) return b;
+  if (is_true(b) && is_boolean(a)) return a;
+  return make_bin_op<logical_and>(std::move(a), std::move(b));
+}
+expr logical_or::make(expr a, expr b) {
+  // A true operand makes the result true. A false operand is the identity, but only if the other operand is already a
+  // boolean, otherwise we'd lose the conversion of the result to 0 or 1.
+  if (is_true(a) || is_true(b)) return expr(1);
+  if (is_false(a) && is_boolean(b)) return b;
+  if (is_false(b) && is_boolean(a)) return a;
+  return make_bin_op<logical_or>(std::move(a), std::move(b));
+}
 expr logical_not::make(expr a) {
+  if (is_true(a)) return expr(0);
+  if (is_false(a)) return expr(1);
   logical_not* n = new logical_not();
   n->a = std::move(a);
   return expr(n);
@@ -446,15 +481,14 @@ expr call::make(slinky::intrinsic i, callable target, std::vector<expr> args) {
   return expr(n);
 }
 
-expr call::make(slinky::intrinsic i, std::vector<expr> args) {
-  return call::make(i, nullptr, std::move(args));
-}
+expr call::make(slinky::intrinsic i, std::vector<expr> args) { return call::make(i, nullptr, std::move(args)); }
 
 expr call::make(callable target, std::vector<expr> args) {
   return call::make(intrinsic::none, std::move(target), std::move(args));
 }
 
-stmt call_stmt::make(call_stmt::callable target, symbol_list inputs, symbol_list outputs, std::vector<expr> scalars, attributes attrs) {
+stmt call_stmt::make(
+    call_stmt::callable target, symbol_list inputs, symbol_list outputs, std::vector<expr> scalars, attributes attrs) {
   auto n = new call_stmt();
   n->target = std::move(target);
   n->inputs = std::move(inputs);
@@ -464,7 +498,8 @@ stmt call_stmt::make(call_stmt::callable target, symbol_list inputs, symbol_list
   return stmt(n);
 }
 
-stmt copy_stmt::make(copy_stmt::callable impl, var src, std::vector<expr> src_x, var dst, std::vector<var> dst_x, var pad) {
+stmt copy_stmt::make(
+    copy_stmt::callable impl, var src, std::vector<expr> src_x, var dst, std::vector<var> dst_x, var pad) {
   auto n = new copy_stmt();
   n->src = src;
   n->src_x = std::move(src_x);


### PR DESCRIPTION
This speeds up `evaluate_constant*` by:
- Adding early returns for undefined expressions, so we don't evaluate other expressions we won't need.
- Cleaning up no-op arithmetic with identity values.

It also has an optimization of more general `simplify`, by doing a type-based pattern matching check before digging into the actual pattern matching.