### PR TITLE
Many small optimizations

### DIFF
--- a/slinky/builder/optimizations.cc
+++ b/slinky/builder/optimizations.cc
@@ -227,8 +227,8 @@ public:
   void visit(const call_stmt* op) override {
     if (op->attrs.name == "memcpy" && op->inputs.size() == 1 && op->outputs.size() == 1 &&
         is_a_and_b(op->inputs[0], op->outputs[0])) {
-      expr input_size = variable::make(op->inputs[0], buffer_field::size_bytes);
-      expr output_size = variable::make(op->outputs[0], buffer_field::size_bytes);
+      expr input_size = buffer_size_bytes(op->inputs[0]);
+      expr output_size = buffer_size_bytes(op->outputs[0]);
       set_result(check::make(input_size == output_size));
     } else {
       set_result(op);
@@ -2137,6 +2137,11 @@ public:
       // Assume we are both producing and consuming this buffer.
       consumed.insert(lookup_alias(*buf));
       produced.insert(lookup_alias(*buf));
+    } else if (in_check && (op->intrinsic == intrinsic::buffer_size_bytes || op->intrinsic == intrinsic::validate_buffer)) {
+      assert(op->args.size() == 1);
+      if (auto buf = as_variable(op->args[0])) {
+        produced.insert(lookup_alias(*buf));
+      }
     }
     barrier = barrier || is_barrier(op->intrinsic);
   }

--- a/slinky/runtime/buffer.cc
+++ b/slinky/runtime/buffer.cc
@@ -476,30 +476,35 @@ SLINKY_NO_STACK_PROTECTOR void copy(const raw_buffer& src, const raw_buffer& dst
   dst_opt.dims = SLINKY_ALLOCA(dim, dst.rank);
   internal::copy_small_n(dst.dims, dst.rank, dst_opt.dims);
 
-  raw_buffer src_opt = src;
-  src_opt.dims = SLINKY_ALLOCA(dim, src.rank);
-  internal::copy_small_n(src.dims, src.rank, src_opt.dims);
+  if (src.rank > 0) {
+    raw_buffer src_opt = src;
+    src_opt.dims = SLINKY_ALLOCA(dim, src.rank);
+    internal::copy_small_n(src.dims, src.rank, src_opt.dims);
 
-  // If the src has rank 0, then the padding is irrelevant, nothing is out of bounds.
-  if (src_opt.rank > 0 && pad.base) {
-    assert(dst_opt.elem_size == pad.elem_size);
+    if (pad.base) {
+      assert(dst_opt.elem_size == pad.elem_size);
 
-    raw_buffer pad_opt = pad;
-    pad_opt.dims = SLINKY_ALLOCA(dim, pad.rank);
-    internal::copy_small_n(pad.dims, pad.rank, pad_opt.dims);
+      raw_buffer pad_opt = pad;
+      pad_opt.dims = SLINKY_ALLOCA(dim, pad.rank);
+      internal::copy_small_n(pad.dims, pad.rank, pad_opt.dims);
 
-    optimize_dims(dst_opt, src_opt, pad_opt);
+      optimize_dims(dst_opt, src_opt, pad_opt);
 
-    // Implement the padding in all but the first dimension.
-    pad_impl(src_opt, dst_opt, pad_opt);
-    if (src_opt.base == dst_opt.base) {
-      // This is an in-place padded copy, we're done.
-      return;
+      // Implement the padding in all but the first dimension.
+      pad_impl(src_opt, dst_opt, pad_opt);
+      if (src_opt.base == dst_opt.base) {
+        // This is an in-place padded copy, we're done.
+        return;
+      }
+    } else {
+      optimize_dims(dst_opt, src_opt);
     }
+    copy_impl(src_opt, dst_opt);
   } else {
-    optimize_dims(dst_opt, src_opt);
+    // If the src has rank 0, then the padding is irrelevant, nothing is out of bounds.
+    optimize_dims(dst_opt);
+    copy_impl(const_cast<raw_buffer&>(src), dst_opt);
   }
-  copy_impl(src_opt, dst_opt);
 }
 
 void pad(const dim* in_bounds, const raw_buffer& dst, const raw_buffer& pad) {

--- a/slinky/runtime/buffer.cc
+++ b/slinky/runtime/buffer.cc
@@ -185,7 +185,7 @@ SLINKY_NO_STACK_PROTECTOR std::optional<std::size_t> raw_buffer::init_strides_im
     if (merge_prev && merge_next) {
       // This new dimension can be fused with both the previous and next dimensions.
       (at - 1)->dim_stride = at->dim_stride;
-      internal::copy_small_n(at + 1, dims_end - (at + 1), at);
+      std::copy(at + 1, dims_end, at);
       --dims_end;
     } else if (merge_prev) {
       // This new dimension can be fused with the previous dimension.
@@ -195,7 +195,7 @@ SLINKY_NO_STACK_PROTECTOR std::optional<std::size_t> raw_buffer::init_strides_im
       at->stride = stride;
     } else {
       // This new dimension can't be fused with any existing dimension.
-      internal::copy_small_n_backward(dims_end, dims_end - at, dims_end + 1);
+      std::copy_backward(at, dims_end, dims_end + 1);
       *at = {stride, dim_stride};
       ++dims_end;
     }
@@ -212,8 +212,8 @@ SLINKY_NO_STACK_PROTECTOR std::optional<std::size_t> raw_buffer::init_strides_im
       if (stride_i == dim::auto_stride) dim_i.set_stride(elem_size);
     } else if (dim_i.stride() != dim::auto_stride) {
       if (stride_i < 0) {
-	overflow |= stride_i == std::numeric_limits<index_t>::min();
-	stride_i = -stride_i;
+        overflow |= stride_i == std::numeric_limits<index_t>::min();
+        stride_i = -stride_i;
       }
       learn_dim(stride_i, alloc_extent_i);
     }

--- a/slinky/runtime/buffer.cc
+++ b/slinky/runtime/buffer.cc
@@ -175,9 +175,8 @@ SLINKY_NO_STACK_PROTECTOR std::optional<std::size_t> raw_buffer::init_strides_im
     overflow = overflow || mul_with_overflow(stride, extent, dim_stride);
 
     init_stride_dim d(stride, dim_stride);
-    index_t diff;
-    overflow = overflow || sub_with_overflow(d.dim_stride, d.stride, diff);
-    overflow = overflow || add_with_overflow(flat_max, diff, flat_max);
+    // d.dim_stride - d.stride cannot overflow if the above multiplication did not overflow.
+    overflow = overflow || add_with_overflow(flat_max, d.dim_stride - d.stride, flat_max);
 
     init_stride_dim* at = std::lower_bound(dims, dims_end, d);
     const bool merge_prev = at > dims && (at - 1)->dim_stride == d.stride;
@@ -246,9 +245,8 @@ SLINKY_NO_STACK_PROTECTOR std::optional<std::size_t> raw_buffer::init_strides_im
 
       index_t dim_stride = 0;
       overflow = overflow || mul_with_overflow(stride, alloc_extent_i, dim_stride);
-      index_t diff = 0;
-      overflow = overflow || sub_with_overflow(dim_stride, stride, diff);
-      overflow = overflow || add_with_overflow(flat_max, diff, flat_max);
+      // dim_stride - stride cannot overflow if the above multiplication did not overflow.
+      overflow = overflow || add_with_overflow(flat_max, dim_stride - stride, flat_max);
       stride = dim_stride;
     }
   } else {

--- a/slinky/runtime/buffer.cc
+++ b/slinky/runtime/buffer.cc
@@ -135,8 +135,6 @@ struct init_stride_dim {
 
   init_stride_dim() : stride(0), dim_stride(0) {}
   init_stride_dim(index_t stride, index_t dim_stride) : stride(stride), dim_stride(dim_stride) {}
-
-  bool operator<(const init_stride_dim& r) const { return dim_stride < r.dim_stride; }
 };
 
 SLINKY_INLINE bool is_stride_ok(index_t stride, index_t extent, span<const init_stride_dim> dims, bool& overflow) {
@@ -174,13 +172,15 @@ SLINKY_NO_STACK_PROTECTOR std::optional<std::size_t> raw_buffer::init_strides_im
     index_t dim_stride = 0;
     overflow = overflow || mul_with_overflow(stride, extent, dim_stride);
 
-    init_stride_dim d(stride, dim_stride);
-    // d.dim_stride - d.stride cannot overflow if the above multiplication did not overflow.
-    overflow = overflow || add_with_overflow(flat_max, d.dim_stride - d.stride, flat_max);
+    // dim_stride - stride cannot overflow if the above multiplication did not overflow.
+    overflow = overflow || add_with_overflow(flat_max, dim_stride - stride, flat_max);
 
-    init_stride_dim* at = std::lower_bound(dims, dims_end, d);
-    const bool merge_prev = at > dims && (at - 1)->dim_stride == d.stride;
-    const bool merge_next = at < dims_end && d.dim_stride == at->stride;
+    init_stride_dim* at = dims;
+    while (at < dims_end && at->dim_stride < dim_stride) {
+      ++at;
+    }
+    const bool merge_prev = at > dims && (at - 1)->dim_stride == stride;
+    const bool merge_next = at < dims_end && dim_stride == at->stride;
 
     if (merge_prev && merge_next) {
       // This new dimension can be fused with both the previous and next dimensions.
@@ -189,20 +189,18 @@ SLINKY_NO_STACK_PROTECTOR std::optional<std::size_t> raw_buffer::init_strides_im
       --dims_end;
     } else if (merge_prev) {
       // This new dimension can be fused with the previous dimension.
-      (at - 1)->dim_stride = d.dim_stride;
+      (at - 1)->dim_stride = dim_stride;
     } else if (merge_next) {
       // This new dimension can be fused with the next dimension.
-      at->stride = d.stride;
+      at->stride = stride;
     } else {
       // This new dimension can't be fused with any existing dimension.
       internal::copy_small_n_backward(dims_end, dims_end - at, dims_end + 1);
-      *at = d;
+      *at = {stride, dim_stride};
       ++dims_end;
     }
   };
 
-  std::size_t unknown_begin = rank;
-  std::size_t unknown_end = 0;
   for (std::size_t i = 0; i < rank; ++i) {
     slinky::dim& dim_i = this->dims[i];
     if (dim_i.stride() == 0) continue;
@@ -218,10 +216,6 @@ SLINKY_NO_STACK_PROTECTOR std::optional<std::size_t> raw_buffer::init_strides_im
         stride_val = 0;
       }
       learn_dim(std::abs(stride_val), alloc_extent_i);
-    } else {
-      // Track the range of dimensions we need to find the stride of.
-      unknown_begin = std::min(unknown_begin, i);
-      unknown_end = i + 1;
     }
   }
 
@@ -229,7 +223,7 @@ SLINKY_NO_STACK_PROTECTOR std::optional<std::size_t> raw_buffer::init_strides_im
     // All unknown strides can be contiguously assigned.
     index_t stride = dims->dim_stride;
 
-    for (std::size_t i = unknown_begin; i < unknown_end; ++i) {
+    for (std::size_t i = 0; i < rank; ++i) {
       slinky::dim& dim_i = this->dims[i];
       if (dim_i.stride() != dim::auto_stride) continue;
 
@@ -251,7 +245,7 @@ SLINKY_NO_STACK_PROTECTOR std::optional<std::size_t> raw_buffer::init_strides_im
     }
   } else {
     // An unknown stride might be assigned to fill a "hole" in the buffer.
-    for (std::size_t i = unknown_begin; i < unknown_end; ++i) {
+    for (std::size_t i = 0; i < rank; ++i) {
       slinky::dim& dim_i = this->dims[i];
       if (dim_i.stride() != dim::auto_stride) continue;
 

--- a/slinky/runtime/buffer.cc
+++ b/slinky/runtime/buffer.cc
@@ -203,19 +203,19 @@ SLINKY_NO_STACK_PROTECTOR std::optional<std::size_t> raw_buffer::init_strides_im
 
   for (std::size_t i = 0; i < rank; ++i) {
     slinky::dim& dim_i = this->dims[i];
-    if (dim_i.stride() == 0) continue;
+    index_t stride_i = dim_i.stride();
+    if (stride_i == 0) continue;
 
     index_t alloc_extent_i = alloc_extent(dim_i);
     if (alloc_extent_i <= 1) {
       // The buffer is empty or has extent 1, we don't care about the stride.
-      if (dim_i.stride() == dim::auto_stride) dim_i.set_stride(elem_size);
+      if (stride_i == dim::auto_stride) dim_i.set_stride(elem_size);
     } else if (dim_i.stride() != dim::auto_stride) {
-      index_t stride_val = dim_i.stride();
-      if (stride_val == std::numeric_limits<index_t>::min()) {
-        overflow = true;
-        stride_val = 0;
+      if (stride_i < 0) {
+	overflow |= stride_i == std::numeric_limits<index_t>::min();
+	stride_i = -stride_i;
       }
-      learn_dim(std::abs(stride_val), alloc_extent_i);
+      learn_dim(stride_i, alloc_extent_i);
     }
   }
 

--- a/slinky/runtime/buffer.cc
+++ b/slinky/runtime/buffer.cc
@@ -175,15 +175,31 @@ std::optional<std::size_t> raw_buffer::init_strides_impl(index_t alignment) {
     overflow = overflow || mul_with_overflow(stride, extent, dim_stride);
 
     init_stride_dim d(stride, dim_stride);
-    init_stride_dim* at = std::lower_bound(dims, dims_end, d);
-    internal::copy_small_n_backward(dims_end, dims_end - at, dims_end + 1);
-    *at = d;
-
     index_t diff;
     overflow = overflow || sub_with_overflow(d.dim_stride, d.stride, diff);
     overflow = overflow || add_with_overflow(flat_max, diff, flat_max);
 
-    ++dims_end;
+    init_stride_dim* at = std::lower_bound(dims, dims_end, d);
+    const bool merge_prev = at > dims && (at - 1)->dim_stride == d.stride;
+    const bool merge_next = at < dims_end && d.dim_stride == at->stride;
+
+    if (merge_prev && merge_next) {
+      // This new dimension can be fused with both the previous and next dimensions.
+      (at - 1)->dim_stride = at->dim_stride;
+      internal::copy_small_n(at + 1, dims_end - (at + 1), at);
+      --dims_end;
+    } else if (merge_prev) {
+      // This new dimension can be fused with the previous dimension.
+      (at - 1)->dim_stride = d.dim_stride;
+    } else if (merge_next) {
+      // This new dimension can be fused with the next dimension.
+      at->stride = d.stride;
+    } else {
+      // This new dimension can't be fused with any existing dimension.
+      internal::copy_small_n_backward(dims_end, dims_end - at, dims_end + 1);
+      *at = d;
+      ++dims_end;
+    }
   };
 
   std::size_t unknown_begin = rank;

--- a/slinky/runtime/buffer.cc
+++ b/slinky/runtime/buffer.cc
@@ -161,7 +161,7 @@ SLINKY_INLINE bool is_stride_ok(index_t stride, index_t extent, span<const init_
 
 }  // namespace
 
-std::optional<std::size_t> raw_buffer::init_strides_impl(index_t alignment) {
+SLINKY_NO_STACK_PROTECTOR std::optional<std::size_t> raw_buffer::init_strides_impl(index_t alignment) {
   // We remember the strides of the dims we know about, in sorted order.
   init_stride_dim* dims = SLINKY_ALLOCA(init_stride_dim, rank);
   // Initialize one past the end of dims to a sentinel value.
@@ -507,7 +507,7 @@ SLINKY_NO_STACK_PROTECTOR void copy(const raw_buffer& src, const raw_buffer& dst
   }
 }
 
-void pad(const dim* in_bounds, const raw_buffer& dst, const raw_buffer& pad) {
+SLINKY_NO_STACK_PROTECTOR void pad(const dim* in_bounds, const raw_buffer& dst, const raw_buffer& pad) {
   assert(dst.elem_size == pad.elem_size);
   if (dst.rank == 0) {
     return;

--- a/slinky/runtime/buffer.cc
+++ b/slinky/runtime/buffer.cc
@@ -164,6 +164,8 @@ SLINKY_INLINE bool is_stride_ok(index_t stride, index_t extent, span<const init_
 std::optional<std::size_t> raw_buffer::init_strides_impl(index_t alignment) {
   // We remember the strides of the dims we know about, in sorted order.
   init_stride_dim* dims = SLINKY_ALLOCA(init_stride_dim, rank);
+  // Initialize one past the end of dims to a sentinel value.
+  dims->stride = dims->dim_stride = elem_size;
   init_stride_dim* dims_end = dims;
   // Insert d into dims, sorted by dim_stride. Also track the flat max index of the buffer, to compute the size.
   index_t flat_max = 0;
@@ -226,35 +228,63 @@ std::optional<std::size_t> raw_buffer::init_strides_impl(index_t alignment) {
     }
   }
 
-  for (std::size_t i = unknown_begin; i < unknown_end; ++i) {
-    slinky::dim& dim_i = this->dims[i];
-    if (dim_i.stride() != dim::auto_stride) continue;
+  if (dims + 1 >= dims_end && dims->stride == elem_size) {
+    // All unknown strides can be contiguously assigned.
+    index_t stride = dims->dim_stride;
 
-    const index_t alloc_extent_i = alloc_extent(dim_i);
-    assert(alloc_extent_i > 1);
+    for (std::size_t i = unknown_begin; i < unknown_end; ++i) {
+      slinky::dim& dim_i = this->dims[i];
+      if (dim_i.stride() != dim::auto_stride) continue;
 
-    span<const init_stride_dim> known_dims{dims, dims_end};
-    if (is_stride_ok(elem_size, alloc_extent_i, known_dims, overflow)) {
-      // This dimension can have stride elem_size, no other stride could be better.
-      dim_i.set_stride(elem_size);
-      learn_dim(elem_size, alloc_extent_i);
-      continue;
-    }
+      const index_t alloc_extent_i = alloc_extent(dim_i);
+      assert(alloc_extent_i > 1);
 
-    // Loop through all the dimensions and see if a stride that is just outside any dimension is OK.
-    for (const init_stride_dim& dim_j : known_dims) {
-      index_t padded_candidate = 0;
-      overflow = overflow || add_with_overflow(dim_j.dim_stride, alignment - 1, padded_candidate);
-      index_t candidate = padded_candidate & ~(alignment - 1);
-
-      if (&dim_j == &known_dims.back() || is_stride_ok(candidate, alloc_extent_i, known_dims, overflow)) {
-        dim_i.set_stride(candidate);
-        learn_dim(candidate, alloc_extent_i);
-        // The dims are sorted, so no subsequent candidate will be better.
-        break;
+      if (stride != elem_size) {
+        index_t padded_stride = 0;
+        overflow = overflow || add_with_overflow(stride, alignment - 1, padded_stride);
+        stride = padded_stride & ~(alignment - 1);
       }
+      dim_i.set_stride(stride);
+
+      index_t dim_stride = 0;
+      overflow = overflow || mul_with_overflow(stride, alloc_extent_i, dim_stride);
+      index_t diff = 0;
+      overflow = overflow || sub_with_overflow(dim_stride, stride, diff);
+      overflow = overflow || add_with_overflow(flat_max, diff, flat_max);
+      stride = dim_stride;
     }
-    assert(dim_i.stride() != dim::auto_stride);
+  } else {
+    // An unknown stride might be assigned to fill a "hole" in the buffer.
+    for (std::size_t i = unknown_begin; i < unknown_end; ++i) {
+      slinky::dim& dim_i = this->dims[i];
+      if (dim_i.stride() != dim::auto_stride) continue;
+
+      const index_t alloc_extent_i = alloc_extent(dim_i);
+      assert(alloc_extent_i > 1);
+
+      span<const init_stride_dim> known_dims{dims, dims_end};
+      if (is_stride_ok(elem_size, alloc_extent_i, known_dims, overflow)) {
+        // This dimension can have stride elem_size, no other stride could be better.
+        dim_i.set_stride(elem_size);
+        learn_dim(elem_size, alloc_extent_i);
+        continue;
+      }
+
+      // Loop through all the dimensions and see if a stride that is just outside any dimension is OK.
+      for (const init_stride_dim& dim_j : known_dims) {
+        index_t padded_candidate = 0;
+        overflow = overflow || add_with_overflow(dim_j.dim_stride, alignment - 1, padded_candidate);
+        index_t candidate = padded_candidate & ~(alignment - 1);
+
+        if (&dim_j == &known_dims.back() || is_stride_ok(candidate, alloc_extent_i, known_dims, overflow)) {
+          dim_i.set_stride(candidate);
+          learn_dim(candidate, alloc_extent_i);
+          // The dims are sorted, so no subsequent candidate will be better.
+          break;
+        }
+      }
+      assert(dim_i.stride() != dim::auto_stride);
+    }
   }
 
   index_t size = 0;

--- a/slinky/runtime/buffer.cc
+++ b/slinky/runtime/buffer.cc
@@ -28,7 +28,6 @@ index_t alloc_extent(const dim& dim) {
 bool calculate_flat_bounds(std::size_t rank, const dim* dims, index_t& flat_min, index_t& flat_max) {
   flat_min = 0;
   flat_max = 0;
-  bool overflow = false;
 
   for (std::size_t i = 0; i < rank; ++i) {
     if (dims[i].stride() == 0) continue;
@@ -41,18 +40,17 @@ bool calculate_flat_bounds(std::size_t rank, const dim* dims, index_t& flat_min,
     }
 
     index_t stride = dims[i].stride();
-    overflow |= (stride == dim::auto_stride && extent > 1);
-
     index_t extent_minus_1;
-    index_t term_min;
-    index_t term_max;
-    overflow = overflow || sub_with_overflow(extent, static_cast<index_t>(1), extent_minus_1);
-    overflow = overflow || mul_with_overflow(extent_minus_1, std::min<index_t>(0, stride), term_min);
-    overflow = overflow || add_with_overflow(flat_min, term_min, flat_min);
-    overflow = overflow || mul_with_overflow(extent_minus_1, std::max<index_t>(0, stride), term_max);
-    overflow = overflow || add_with_overflow(flat_max, term_max, flat_max);
+    if (sub_with_overflow(extent, static_cast<index_t>(1), extent_minus_1)) return false;
+    index_t dim_stride;
+    if (mul_with_overflow(extent_minus_1, stride, dim_stride)) return false;
+    if (stride < 0) {
+      if (add_with_overflow(flat_min, dim_stride, flat_min)) return false;
+    } else {
+      if (add_with_overflow(flat_max, dim_stride, flat_max)) return false;
+    }
   }
-  return !overflow;
+  return true;
 }
 
 std::size_t alloc_size(std::size_t rank, std::size_t elem_size, const dim* dims) {

--- a/slinky/runtime/buffer.h
+++ b/slinky/runtime/buffer.h
@@ -424,30 +424,13 @@ public:
   std::optional<std::size_t> init_strides(index_t alignment = 1) {
     assert(alignment > 0);
     assert(is_power_of_two(alignment));
-    static_assert(dim::auto_stride >= 0, "");
-    if (rank == 0 || (rank == 1 && dims[0].fold_factor() == dim::unfolded && dims[0].stride() >= 0)) {
-      // Fast path for rank 0 or simple (unfolded, non-negative stride) buffers.
-      // elem_size is unsigned; a value that doesn't fit in a (signed) index_t is an overflow.
+    if (rank == 0) {
+      // Fast path for rank 0 buffers
       const index_t elem_size = static_cast<index_t>(this->elem_size);
       bool overflow = elem_size < 0;
       index_t size = 0;
-      if (rank == 1) {
-        slinky::dim& d = dims[0];
-        index_t stride = d.stride();
-        if (stride == dim::auto_stride) {
-          stride = elem_size;
-          d.set_stride(stride);
-        }
-        // `std::max` guards empty buffers (max < min).
-        overflow = overflow || sub_with_overflow(d.max(), d.min(), size);
-        overflow = overflow || mul_with_overflow(std::max<index_t>(size, 0), stride, size);
-      }
-
-      overflow = overflow || add_with_overflow(size, elem_size, size);
-      overflow = overflow || add_with_overflow(size, alignment - 1, size);
+      overflow = overflow || add_with_overflow(elem_size, alignment - 1, size);
       if (overflow) return std::nullopt;
-
-      assert(size >= 0);
       return static_cast<std::size_t>(size & ~(alignment - 1));
     }
     return init_strides_impl(alignment);

--- a/slinky/runtime/buffer.h
+++ b/slinky/runtime/buffer.h
@@ -86,7 +86,7 @@ public:
   index_t max() const { return max_; }
   index_t begin() const { return min_; }
   index_t end() const { return max_ + 1; }
-  index_t extent() const { return end() > begin() ? end() - begin() : 0; }
+  index_t extent() const { return max_ >= min_ ? max_ - min_ + 1 : 0; }
   index_t stride() const { return stride_; }
   index_t fold_factor() const { return fold_factor_; }
   bool empty() const { return max_ < min_; }

--- a/slinky/runtime/buffer.h
+++ b/slinky/runtime/buffer.h
@@ -543,7 +543,9 @@ private:
       if (src) {
         internal::copy_small_n(src, rank, dims);
       } else {
-        new (dims) slinky::dim[rank];
+        for (std::size_t i = 0; i < rank; ++i) {
+          new (&dims[i]) slinky::dim();
+        }
       }
     } else {
       dims = nullptr;

--- a/slinky/runtime/depends_on.cc
+++ b/slinky/runtime/depends_on.cc
@@ -78,8 +78,7 @@ public:
       case buffer_field::stride:
       case buffer_field::fold_factor: deps->buffer_dims = true; break;
       case buffer_field::rank:
-      case buffer_field::elem_size:
-      case buffer_field::size_bytes: deps->var = true; break;
+      case buffer_field::elem_size: deps->var = true; break;
       }
     }
   }
@@ -99,6 +98,9 @@ public:
         if (op->args[i].defined()) op->args[i].accept(this);
       }
     } else {
+      if (op->intrinsic == intrinsic::buffer_size_bytes || op->intrinsic == intrinsic::validate_buffer) {
+        is_pure = false;
+      }
       recursive_node_visitor::visit(op);
     }
   }
@@ -448,6 +450,7 @@ public:
     case intrinsic::and_then:
     case intrinsic::or_else:
     case intrinsic::buffer_at:
+    case intrinsic::buffer_size_bytes:
     case intrinsic::validate_buffer: break;
     };
 

--- a/slinky/runtime/evaluate.cc
+++ b/slinky/runtime/evaluate.cc
@@ -231,14 +231,12 @@ inline void* eval_buffer_at(const call* op, eval_context& ctx) {
   const raw_buffer* buf = ctx.lookup_buffer(*sym);
   assert(buf);
   void* result = buf->base;
+  if (!result) return nullptr;
   for (std::size_t d = 0; d < std::min(buf->rank, op->args.size() - 1); ++d) {
     if (op->args[d + 1].defined()) {
       index_t at = eval(op->args[d + 1], ctx);
-      if (result && buf->dims[d].contains(at)) {
-        result = offset_bytes_non_null(result, buf->dims[d].flat_offset_bytes(at));
-      } else {
-        result = nullptr;
-      }
+      if (!buf->dims[d].contains(at)) return nullptr;
+      result = offset_bytes_non_null(result, buf->dims[d].flat_offset_bytes(at));
     }
   }
   return result;

--- a/slinky/runtime/evaluate.cc
+++ b/slinky/runtime/evaluate.cc
@@ -688,8 +688,8 @@ SLINKY_NO_STACK_PROTECTOR inline index_t eval(const make_buffer* op, eval_contex
   raw_buffer buffer;
   buffer.elem_size = eval(op->elem_size, 0, ctx);
   // The base is very likely a buffer_at call, try to skip the eval overhead.
-  if (const call* c = op->base.as<call>()) {
-    buffer.base = reinterpret_cast<void*>(eval(c, ctx));
+  if (const call* c = as_intrinsic(op->base, intrinsic::buffer_at)) {
+    buffer.base = reinterpret_cast<void*>(eval_buffer_at(c, ctx));
   } else {
     buffer.base = reinterpret_cast<void*>(eval(op->base, 0, ctx));
   }

--- a/slinky/runtime/evaluate.cc
+++ b/slinky/runtime/evaluate.cc
@@ -614,6 +614,11 @@ inline index_t eval(const copy_stmt* op, eval_context& ctx) {
   SLINKY_UNREACHABLE << "copy_stmt should have been implemented by calls to copy/pad.";
 }
 
+SLINKY_NO_INLINE index_t allocate_failed(const allocate* op, eval_context& ctx) {
+  std::cerr << "allocate of " << op->sym << " failed." << std::endl;
+  return -1;
+}
+
 // Not using SLINKY_NO_STACK_PROTECTOR here because this actually could allocate a lot of memory on the stack.
 inline index_t eval(const allocate* op, eval_context& ctx) {
   allocated_buffer buffer;
@@ -661,13 +666,17 @@ inline index_t eval(const allocate* op, eval_context& ctx) {
 
   index_t result;
   if (!buffer.base && buffer.elem_count() > 0) {
-    std::cerr << "allocate of " << op->sym << " failed." << std::endl;
-    result = -1;
+    result = allocate_failed(op, ctx);
   } else {
     result = eval_with_value(op->body, op->sym, reinterpret_cast<index_t>(&buffer), ctx);
   }
   ctx.config->free(op->sym, &buffer, buffer.allocation);
   return result;
+}
+
+SLINKY_NO_INLINE index_t make_buffer_failed(const make_buffer* op, eval_context& ctx) {
+  std::cerr << "make_buffer of " << op->sym << " failed." << std::endl;
+  return -1;
 }
 
 SLINKY_NO_STACK_PROTECTOR inline index_t eval(const make_buffer* op, eval_context& ctx) {
@@ -702,8 +711,7 @@ SLINKY_NO_STACK_PROTECTOR inline index_t eval(const make_buffer* op, eval_contex
   }
 
   if (!validate_buffer(buffer)) {
-    std::cerr << "make_buffer of " << op->sym << " failed." << std::endl;
-    return -1;
+    return make_buffer_failed(op, ctx);
   }
 
   return eval_with_value(op->body, op->sym, reinterpret_cast<index_t>(&buffer), ctx);

--- a/slinky/runtime/evaluate.cc
+++ b/slinky/runtime/evaluate.cc
@@ -536,8 +536,13 @@ SLINKY_NO_INLINE index_t eval_loop_serial(const loop* op, eval_context& ctx) {
   ctx.reserve(op->sym.id + 1);
   index_t old_value = ctx.set(op->sym, 0);
   index_t result = 0;
-  for (index_t i = bounds.min; result == 0 && bounds.min <= i && i <= bounds.max; i += step) {
-    ctx.set(op->sym, i);
+  if (step > 0) {
+    for (index_t i = bounds.min; result == 0 && i <= bounds.max; i += step) {
+      ctx.set(op->sym, i);
+      result = eval(op->body, ctx);
+    }
+  } else {
+    ctx.set(op->sym, bounds.min);
     result = eval(op->body, ctx);
   }
   ctx.set(op->sym, old_value);

--- a/slinky/runtime/evaluate.cc
+++ b/slinky/runtime/evaluate.cc
@@ -173,7 +173,6 @@ inline index_t eval(const variable* op, eval_context& ctx) {
   case buffer_field::none: return value;
   case buffer_field::rank: return buf->rank;
   case buffer_field::elem_size: return buf->elem_size;
-  case buffer_field::size_bytes: return buf->size_bytes();
   case buffer_field::min: return buf->dim(op->dim).min();
   case buffer_field::max: return buf->dim(op->dim).max();
   case buffer_field::stride: return buf->dim(op->dim).stride();
@@ -324,6 +323,13 @@ inline index_t eval_validate_buffer(const call* op, eval_context& ctx) {
   return validate_buffer(*buf) ? 1 : 0;
 }
 
+inline index_t eval_buffer_size_bytes(const call* op, eval_context& ctx) {
+  assert(op->args.size() == 1);
+  var sym = *as_variable(op->args[0]);
+  const raw_buffer* buf = ctx.lookup_buffer(sym);
+  return buf ? buf->size_bytes() : 0;
+}
+
 inline index_t eval_wait_for(const call* op, eval_context& ctx) {
   assert(op->args.size() >= 1);
   for (expr_ref i : op->args) {
@@ -355,6 +361,7 @@ SLINKY_NO_INLINE index_t eval(const call* op, eval_context& ctx) {
   case intrinsic::or_else: return eval_short_circuit_op(op, ctx);
 
   case intrinsic::buffer_at: return reinterpret_cast<index_t>(eval_buffer_at(op, ctx));
+  case intrinsic::buffer_size_bytes: return eval_buffer_size_bytes(op, ctx);
 
   case intrinsic::semaphore_init: return eval_semaphore_init(op, ctx);
   case intrinsic::semaphore_signal: return eval_semaphore_signal(op, ctx);

--- a/slinky/runtime/expr.h
+++ b/slinky/runtime/expr.h
@@ -104,6 +104,8 @@ enum class intrinsic {
   // This function returns the address of the element x in (buf, x_0, x_1, ...). x can be any rank, including 0.
   buffer_at,
 
+  buffer_size_bytes,
+
   // These functions implement counting semaphores.
   // The first argument of all of these semaphore helpers is a pointer to an index_t that will be used as the semaphore,
   // and the second argument is a count.
@@ -134,7 +136,6 @@ enum class buffer_field : unsigned {
 
   rank,
   elem_size,
-  size_bytes,
 
   min,
   max,
@@ -727,6 +728,7 @@ expr buffer_extent(var buf, int dim);
 expr buffer_stride(var buf, int dim);
 expr buffer_fold_factor(var buf, int dim);
 expr validate_buffer(var buf);
+expr buffer_size_bytes(expr buf);
 
 interval_expr buffer_bounds(var buf, int dim);
 dim_expr buffer_dim(var buf, int dim);

--- a/slinky/runtime/expr_stmt.cc
+++ b/slinky/runtime/expr_stmt.cc
@@ -791,6 +791,7 @@ expr buffer_extent(var buf, int dim) { return (buffer_max(buf, dim) - buffer_min
 expr buffer_stride(var buf, int dim) { return variable::make(buf, buffer_field::stride, dim); }
 expr buffer_fold_factor(var buf, int dim) { return variable::make(buf, buffer_field::fold_factor, dim); }
 expr validate_buffer(var buf) { return call::make(intrinsic::validate_buffer, {buf}); }
+expr buffer_size_bytes(expr buf) { return call::make(intrinsic::buffer_size_bytes, {std::move(buf)}); }
 
 interval_expr buffer_bounds(var buf, int dim) { return {buffer_min(buf, dim), buffer_max(buf, dim)}; }
 dim_expr buffer_dim(var buf, int dim) {

--- a/slinky/runtime/print.cc
+++ b/slinky/runtime/print.cc
@@ -23,7 +23,6 @@ const char* to_string(buffer_field m) {
   switch (m) {
   case buffer_field::rank: return "rank";
   case buffer_field::elem_size: return "elem_size";
-  case buffer_field::size_bytes: return "size_bytes";
   case buffer_field::min: return "min";
   case buffer_field::max: return "max";
   case buffer_field::stride: return "stride";
@@ -42,6 +41,7 @@ const char* to_string(intrinsic fn) {
   case intrinsic::and_then: return "and_then";
   case intrinsic::or_else: return "or_else";
   case intrinsic::buffer_at: return "buffer_at";
+  case intrinsic::buffer_size_bytes: return "buffer_size_bytes";
   case intrinsic::semaphore_init: return "semaphore_init";
   case intrinsic::semaphore_signal: return "semaphore_signal";
   case intrinsic::semaphore_wait: return "semaphore_wait";
@@ -233,7 +233,6 @@ public:
     case buffer_field::none: *this << v->sym; return;
     case buffer_field::rank: *this << "buffer_rank(" << v->sym << ")"; return;
     case buffer_field::elem_size: *this << "buffer_elem_size(" << v->sym << ")"; return;
-    case buffer_field::size_bytes: *this << "buffer_size_bytes(" << v->sym << ")"; return;
     case buffer_field::min: *this << "buffer_min(" << v->sym << ", " << v->dim << ")"; return;
     case buffer_field::max: *this << "buffer_max(" << v->sym << ", " << v->dim << ")"; return;
     case buffer_field::stride: *this << "buffer_stride(" << v->sym << ", " << v->dim << ")"; return;

--- a/slinky/runtime/test/depends_on.cc
+++ b/slinky/runtime/test/depends_on.cc
@@ -59,6 +59,7 @@ TEST(depends_on, basic) {
   ASSERT_EQ(depends_on(buffer_min(x, 0), x), (depends_on_result{.buffer_dims = true, .buffer_bounds = true}));
   ASSERT_EQ(depends_on(buffer_stride(x, 0), x), (depends_on_result{.buffer_dims = true}));
   ASSERT_EQ(depends_on(buffer_elem_size(x), x), (depends_on_result{.var = true}));
+  ASSERT_EQ(depends_on(buffer_size_bytes(x), x), (depends_on_result{.var = true}));
 
   stmt loop_x = loop::make(x, loop::serial, {y, z}, 1, check::make(x && z));
   ASSERT_EQ(depends_on(loop_x, x), depends_on_result{});
@@ -114,6 +115,7 @@ TEST(depends_on, is_pure) {
   ASSERT_TRUE(is_pure(x + y));
   ASSERT_TRUE(is_pure(abs(x)));
   ASSERT_FALSE(is_pure(buffer_min(x, 0)));
+  ASSERT_FALSE(is_pure(buffer_size_bytes(x)));
   ASSERT_FALSE(is_pure(y + buffer_min(x, 0)));
 }
 

--- a/slinky/runtime/test/evaluate.cc
+++ b/slinky/runtime/test/evaluate.cc
@@ -69,7 +69,7 @@ TEST(evaluate, buffer_fields) {
 
   ASSERT_EQ(evaluate(buffer_rank(x), context), 1);
   ASSERT_EQ(evaluate(buffer_elem_size(x), context), 4);
-  ASSERT_EQ(evaluate(variable::make(x, buffer_field::size_bytes), context), 40);
+  ASSERT_EQ(evaluate(buffer_size_bytes(x), context), 40);
   ASSERT_EQ(evaluate(buffer_min(x, 0), context), 0);
   ASSERT_EQ(evaluate(buffer_max(x, 0), context), 9);
   ASSERT_EQ(evaluate(buffer_stride(x, 0), context), 4);


### PR DESCRIPTION
The bigger optimizations are:
- In `init_strides`, fuse dimensions as we learn about them, to avoid having to search/check as many dimensions.
- Add an `init_strides` fast path when all known dimensions are contiguous, which is the common case.
- Use `SLINKY_NO_STACK_PROTECTOR` on functions using `SLINKY_ALLOCA`

This change makes `init_strides` 2-3x faster, the bigger speedups coming from higher rank buffers.

Other minor optimizations:
- Make `buffer_size_bytes` an intrinsic instead of a `buffer_field`
- Avoid overhead in loops for negative steps.
- `buffer_at` evaluation is a little more efficient.
- When `copy`'s `src` is rank 0, avoid optimizing it. This is a common case (filling a buffer with a broadcast in every dimension).
