### PR TITLE
Minor evaluate optimizations

### DIFF
--- a/slinky/runtime/evaluate.cc
+++ b/slinky/runtime/evaluate.cc
@@ -891,36 +891,22 @@ SLINKY_NO_STACK_PROTECTOR inline index_t eval(const slice_dim* op, eval_context&
 }
 
 SLINKY_NO_STACK_PROTECTOR inline index_t eval(const transpose* op, eval_context& ctx) {
-  if (op->sym == op->src && op->is_truncate()) {
-    raw_buffer* src_buf = reinterpret_cast<raw_buffer*>(ctx.lookup(op->src));
-    assert(src_buf);
+  const raw_buffer* src_buf = reinterpret_cast<const raw_buffer*>(ctx.lookup(op->src));
+  assert(src_buf);
 
-    // In-place truncate, all we need to do is set the rank (and restore it).
-    std::size_t old_rank = src_buf->rank;
-    src_buf->rank = op->dims.size();
-    index_t result = eval(op->body, ctx);
-    src_buf->rank = old_rank;
-    return result;
-  } else {
-    const raw_buffer* src_buf = reinterpret_cast<const raw_buffer*>(ctx.lookup(op->src));
-    assert(src_buf);
+  // Make the transposed dims.
+  raw_buffer sym_buf;
+  sym_buf.base = src_buf->base;
+  sym_buf.elem_size = src_buf->elem_size;
+  sym_buf.rank = op->dims.size();
+  sym_buf.dims = SLINKY_ALLOCA(dim, op->dims.size());
 
-    // Make the transposed dims.
-    dim* dims = SLINKY_ALLOCA(dim, op->dims.size());
-    for (std::size_t i = 0; i < op->dims.size(); ++i) {
-      dims[i] = src_buf->dim(op->dims[i]);
-    }
-
-    raw_buffer sym_buf;
-    sym_buf.base = src_buf->base;
-    sym_buf.elem_size = src_buf->elem_size;
-    sym_buf.rank = op->dims.size();
-    sym_buf.dims = dims;
-
-    remove_trailing_broadcasts(sym_buf);
-
-    return eval_with_value(op->body, op->sym, reinterpret_cast<index_t>(&sym_buf), ctx);
+  for (std::size_t i = 0; i < op->dims.size(); ++i) {
+    sym_buf.dims[i] = src_buf->dim(op->dims[i]);
   }
+  remove_trailing_broadcasts(sym_buf);
+
+  return eval_with_value(op->body, op->sym, reinterpret_cast<index_t>(&sym_buf), ctx);
 }
 
 SLINKY_NO_INLINE index_t check_failed(const check* op, eval_context& ctx) {

--- a/slinky/runtime/evaluate.cc
+++ b/slinky/runtime/evaluate.cc
@@ -748,8 +748,11 @@ SLINKY_NO_STACK_PROTECTOR inline index_t eval_shadowed(const crop_buffer* op, ev
     old_bounds[d].min = old_min;
     old_bounds[d].max = old_max;
 
-    interval bounds = eval(op->bounds[d], {old_min, old_max}, ctx);
-    buffer->crop(d, bounds.min, bounds.max);
+    const interval_expr& bounds_d = op->bounds[d];
+    if (bounds_d.min.defined() || bounds_d.max.defined()) {
+      interval bounds = eval(bounds_d, {old_min, old_max}, ctx);
+      buffer->crop(d, bounds.min, bounds.max);
+    }
   }
 
   index_t result = eval(op->body, ctx);
@@ -772,8 +775,12 @@ SLINKY_NO_STACK_PROTECTOR inline index_t eval_unshadowed(const crop_buffer* op, 
   // Dims beyond rank are broadcasts; cropping them is a no-op.
   for (std::size_t d = 0; d < std::min(op->bounds.size(), src_buf->rank); ++d) {
     const slinky::dim& dim = static_cast<const raw_buffer&>(sym_buf).dims[d];
-    interval bounds = eval(op->bounds[d], {dim.min(), dim.max()}, ctx);
-    sym_buf.crop(d, bounds.min, bounds.max);
+
+    const interval_expr& bounds_d = op->bounds[d];
+    if (bounds_d.min.defined() || bounds_d.max.defined()) {
+      interval bounds = eval(bounds_d, {dim.min(), dim.max()}, ctx);
+      sym_buf.crop(d, bounds.min, bounds.max);
+    }
   }
 
   return eval_with_value(op->body, op->sym, reinterpret_cast<index_t>(&sym_buf), ctx);

--- a/slinky/runtime/evaluate.cc
+++ b/slinky/runtime/evaluate.cc
@@ -184,7 +184,8 @@ inline index_t eval(const variable* op, eval_context& ctx) {
 inline index_t eval(const constant* op) { return op->value; }
 inline index_t eval(const constant_buffer* op) { return reinterpret_cast<index_t>(op->value.get()); }
 
-SLINKY_NO_STACK_PROTECTOR inline index_t eval(const let* op, eval_context& ctx) {
+template <typename T>
+SLINKY_NO_STACK_PROTECTOR inline index_t eval_let(const T* op, eval_context& ctx) {
   // This is a bit ugly but we really want to avoid heap allocations here.
   const size_t size = op->lets.size();
   index_t* old_values = SLINKY_ALLOCA(index_t, size);
@@ -204,6 +205,10 @@ SLINKY_NO_STACK_PROTECTOR inline index_t eval(const let* op, eval_context& ctx) 
     ctx.set(op->lets[i].first, old_values[i]);
   }
   return result;
+}
+
+inline index_t eval(const let* op, eval_context& ctx) {
+  return eval_let(op, ctx);
 }
 
 inline index_t eval(const logical_not* op, eval_context& ctx) { return eval(op->a, ctx) == 0; }
@@ -415,27 +420,8 @@ SLINKY_NO_INLINE index_t eval_non_inlined(stmt_ref op, eval_context& ctx) {
   }
 }
 
-SLINKY_NO_STACK_PROTECTOR inline index_t eval(const let_stmt* op, eval_context& ctx) {
-  // This is a bit ugly but we really want to avoid heap allocations here.
-  const size_t size = op->lets.size();
-  index_t* old_values = SLINKY_ALLOCA(index_t, size);
-
-  std::size_t context_size = 0;
-  for (const auto& let : op->lets) {
-    context_size = std::max(context_size, let.first.id);
-  }
-  ctx.reserve(context_size + 1);
-
-  for (size_t i = 0; i < size; ++i) {
-    const auto& let = op->lets[i];
-    old_values[i] = ctx.set(let.first, eval(let.second, ctx));
-  }
-  index_t result = eval(op->body, ctx);
-  for (size_t i = 0; i < size; ++i) {
-    const auto& let = op->lets[i];
-    ctx.set(let.first, old_values[i]);
-  }
-  return result;
+inline index_t eval(const let_stmt* op, eval_context& ctx) {
+  return eval_let(op, ctx);
 }
 
 inline index_t eval(const block* op, eval_context& ctx) {

--- a/slinky/runtime/evaluate.cc
+++ b/slinky/runtime/evaluate.cc
@@ -207,7 +207,7 @@ SLINKY_NO_STACK_PROTECTOR inline index_t eval_let(const T* op, eval_context& ctx
   return result;
 }
 
-inline index_t eval(const let* op, eval_context& ctx) {
+SLINKY_INLINE index_t eval(const let* op, eval_context& ctx) {
   return eval_let(op, ctx);
 }
 
@@ -420,7 +420,7 @@ SLINKY_NO_INLINE index_t eval_non_inlined(stmt_ref op, eval_context& ctx) {
   }
 }
 
-inline index_t eval(const let_stmt* op, eval_context& ctx) {
+SLINKY_INLINE index_t eval(const let_stmt* op, eval_context& ctx) {
   return eval_let(op, ctx);
 }
 

--- a/slinky/runtime/test/buffer.cc
+++ b/slinky/runtime/test/buffer.cc
@@ -9,6 +9,7 @@
 #include <cstdint>
 #include <numeric>
 #include <optional>
+#include <utility>
 
 #include "slinky/base/test/seeded_test.h"
 #include "slinky/runtime/print.h"
@@ -1116,8 +1117,6 @@ TEST(can_fuse, negative_strides) {
   EXPECT_FALSE(can_fuse(dim{0, 9, -2}, dim{0, 4, 20}));
   EXPECT_FALSE(can_fuse(dim{0, 9, 2}, dim{0, 4, -20}));
 }
-
-constexpr int max_stride = 3;
 
 bool can_fuse_oracle(const dim& d0, const dim& d1) {
   dim fused;

--- a/slinky/runtime/test/evaluate_benchmark.cc
+++ b/slinky/runtime/test/evaluate_benchmark.cc
@@ -105,9 +105,9 @@ BENCHMARK(BM_block)->RangeMultiplier(2)->Range(2, 16);
 
 void BM_crop_dim(benchmark::State& state) {
   std::atomic<int> calls = 0;
-  stmt c = crop_dim::make(dst, state.range(0) ? src : dst, 0, {1, 10}, make_call_counter(calls));
+  stmt c = crop_dim::make(state.range(0) ? src : dst, src, 0, {1, 10}, make_call_counter(calls));
   stmt l = make_loop(c);
-  stmt body = make_buf(src, 3, make_buf(dst, 3, l));
+  stmt body = make_buf(src, 3, l);
 
   for (auto _ : state) {
     evaluate(body);
@@ -120,9 +120,9 @@ BENCHMARK(BM_crop_dim)->DenseRange(0, 1);
 
 void BM_crop_buffer(benchmark::State& state) {
   std::atomic<int> calls = 0;
-  stmt c = crop_buffer::make(dst, state.range(0) ? src : dst, {{1, 10}, {}, {2, 20}}, make_call_counter(calls));
+  stmt c = crop_buffer::make(state.range(0) ? src : dst, src, {{1, 10}, {}, {2, 20}}, make_call_counter(calls));
   stmt l = make_loop(c);
-  stmt body = make_buf(src, 3, make_buf(dst, 3, l));
+  stmt body = make_buf(src, 3, l);
 
   for (auto _ : state) {
     evaluate(body);
@@ -135,9 +135,9 @@ BENCHMARK(BM_crop_buffer)->DenseRange(0, 1);
 
 void BM_slice_dim(benchmark::State& state) {
   std::atomic<int> calls = 0;
-  stmt c = slice_dim::make(dst, state.range(0) ? src : dst, 1, 10, make_call_counter(calls));
+  stmt c = slice_dim::make(state.range(0) ? src : dst, src, 1, 10, make_call_counter(calls));
   stmt l = make_loop(c);
-  stmt body = make_buf(src, 3, make_buf(dst, 3, l));
+  stmt body = make_buf(src, 3, l);
 
   for (auto _ : state) {
     evaluate(body);
@@ -150,9 +150,9 @@ BENCHMARK(BM_slice_dim)->DenseRange(0, 1);
 
 void BM_slice_buffer(benchmark::State& state) {
   std::atomic<int> calls = 0;
-  stmt c = slice_buffer::make(dst, state.range(0) ? src : dst, {10, {}, 20}, make_call_counter(calls));
+  stmt c = slice_buffer::make(state.range(0) ? src : dst, src, {10, {}, 20}, make_call_counter(calls));
   stmt l = make_loop(c);
-  stmt body = make_buf(src, 3, make_buf(dst, 3, l));
+  stmt body = make_buf(src, 3, l);
 
   for (auto _ : state) {
     evaluate(body);
@@ -165,9 +165,9 @@ BENCHMARK(BM_slice_buffer)->DenseRange(0, 1);
 
 void BM_transpose(benchmark::State& state) {
   std::atomic<int> calls = 0;
-  stmt c = transpose::make(dst, state.range(0) ? src : dst, {2, 1, 0}, make_call_counter(calls));
+  stmt c = transpose::make(state.range(0) ? src : dst, src, {0, 1, 2}, make_call_counter(calls));
   stmt l = make_loop(c);
-  stmt body = make_buf(src, 3, make_buf(dst, 3, l));
+  stmt body = make_buf(src, 3, l);
 
   for (auto _ : state) {
     evaluate(body);


### PR DESCRIPTION
`transpose` and `crop_buffer` get a little bit faster (and generate less code, which might enable other inlining opportunities).

This also tweaks the benchmarks to use one less buffer (outside the benchmarking loop).