### PR TITLE
Add a `compact_nodes` optimization that stores nodes in contiguous chunks

### DIFF
--- a/slinky/base/span.h
+++ b/slinky/base/span.h
@@ -1,8 +1,11 @@
 #ifndef SLINKY_BASE_SPAN_H
 #define SLINKY_BASE_SPAN_H
 
+#include <algorithm>
 #include <array>
+#include <iterator>
 #include <limits>
+#include <type_traits>
 #include <cassert>
 #include <vector>
 
@@ -74,7 +77,6 @@ public:
   template <std::size_t N>
   span(const std::array<value_type, N>& x) : data_(std::data(x)), size_(N) {}
   span(const std::vector<value_type>& c) : data_(std::data(c)), size_(std::size(c)) {}
-
   // Allow shallow copying/assignment.
   span(const span&) = default;
   span(span&&) = default;
@@ -86,6 +88,8 @@ public:
   bool empty() const { return size() == 0; }
   const value_type* begin() const { return data_; }
   const value_type* end() const { return data_ + size(); }
+  std::reverse_iterator<const value_type*> rbegin() const { return std::reverse_iterator<const value_type*>(end()); }
+  std::reverse_iterator<const value_type*> rend() const { return std::reverse_iterator<const value_type*>(begin()); }
 
   const value_type& operator[](std::size_t i) const { return data_[i]; }
   const value_type& front() const { return data_[0]; }
@@ -94,6 +98,15 @@ public:
   span subspan(std::size_t offset) const { return span(data_ + offset, size() - offset); }
   span subspan(std::size_t offset, std::size_t size) const { return span(data_ + offset, size); }
 };
+
+template <typename T, typename U>
+bool operator==(span<T> a, span<U> b) {
+  return a.size() == b.size() && std::equal(a.begin(), a.end(), b.begin());
+}
+template <typename T, typename U>
+bool operator!=(span<T> a, span<U> b) {
+  return !(a == b);
+}
 
 template <typename T, std::size_t Extent = dynamic_extent>
 class mutable_span {
@@ -178,12 +191,17 @@ public:
 };
 
 template <typename T>
-std::vector<T> permute(span<const int> p, const std::vector<T>& x, T default_value = T()) {
+std::vector<T> permute(span<int> p, const std::vector<T>& x, T default_value = T()) {
   std::vector<T> result(p.size());
   for (std::size_t i = 0; i < p.size(); ++i) {
     result[i] = static_cast<std::size_t>(p[i]) < x.size() ? x[p[i]] : default_value;
   }
   return result;
+}
+
+template <typename T>
+std::vector<typename span<T>::value_type> to_vector(span<T> x) {
+  return {x.begin(), x.end()};
 }
 
 }  // namespace slinky

--- a/slinky/builder/BUILD
+++ b/slinky/builder/BUILD
@@ -11,6 +11,7 @@ cc_library(
     name = "builder",
     srcs = [
         "pipeline.cc",
+        "compact_nodes.cc",
         "node_mutator.cc",
         "optimizations.cc",
         "simplify.cc",

--- a/slinky/builder/CMakeLists.txt
+++ b/slinky/builder/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_library(slinky_builder
     pipeline.cc
+    compact_nodes.cc
     node_mutator.cc
     optimizations.cc
     simplify.cc

--- a/slinky/builder/compact_nodes.cc
+++ b/slinky/builder/compact_nodes.cc
@@ -1,0 +1,297 @@
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <new>
+#include <type_traits>
+#include <unordered_map>
+#include <utility>
+
+#include "slinky/base/ref_count.h"
+#include "slinky/base/util.h"
+#include "slinky/builder/node_mutator.h"
+#include "slinky/builder/optimizations.h"
+#include "slinky/runtime/expr.h"
+#include "slinky/runtime/stmt.h"
+
+namespace slinky {
+
+namespace {
+
+class arena : public ref_counted<arena> {
+  size_t next_;
+
+  arena() : next_(sizeof(arena)) {}
+
+public:
+  // A chunk comes from `::operator new`, so it is aligned to this, and can align anything it holds up to this much.
+  static constexpr std::size_t max_alignment = alignof(std::max_align_t);
+
+  static constexpr std::size_t block_size = 4096;
+
+  static slinky::ref_count<arena> make() {
+    return slinky::ref_count<arena>(new (::operator new(block_size)) arena());
+  }
+
+  // Returns memory for a node, padding to align it, or null if there is not enough space in this chunk.
+  void* allocate(std::size_t size, std::size_t alignment) {
+    assert(alignment <= max_alignment);
+    std::size_t offset = align_up(next_, alignment);
+    if (offset + size > block_size) {
+      // Out of space
+      return nullptr;
+    }
+    next_ = offset + size;
+    return reinterpret_cast<char*>(this) + offset;
+  }
+
+  static void destroy(arena* a) {
+    a->~arena();
+    ::operator delete(a);
+  }
+};
+
+constexpr std::size_t array_alignment = alignof(void*);
+
+// A node of type `T` that lives in an `arena`.
+template <typename T>
+class arena_node : public T {
+  slinky::ref_count<arena> arena_;
+
+public:
+  arena_node(const T& src, slinky::ref_count<arena> a) : T(src), arena_(std::move(a)) {
+    static_assert(alignof(arena_node) <= arena::max_alignment, "node is overaligned for a chunk");
+    static_assert(sizeof(arena_node) % array_alignment == 0, "node arrays would be misaligned");
+  }
+
+  void destroy() override {
+    // Don't destroy the arena before the base node destructor runs.
+    slinky::ref_count<arena> a = std::move(arena_);
+    this->~arena_node();
+  }
+};
+
+template <typename T>
+std::size_t size_of(span<T> x) {
+  static_assert(alignof(T) <= array_alignment, "array would not be aligned");
+  return align_up(x.size() * sizeof(T), array_alignment);
+}
+
+// The size of a node in the arena. Nodes that own arrays need room for them too.
+template <typename T>
+std::size_t size_of(const T&) {
+  return sizeof(arena_node<T>);
+}
+std::size_t size_of(const let& n) { return sizeof(arena_node<let>) + size_of(n.lets); }
+std::size_t size_of(const call& n) { return sizeof(arena_node<call>) + size_of(n.args); }
+std::size_t size_of(const let_stmt& n) { return sizeof(arena_node<let_stmt>) + size_of(n.lets); }
+std::size_t size_of(const block& n) { return sizeof(arena_node<block>) + size_of(n.stmts); }
+std::size_t size_of(const call_stmt& n) {
+  return sizeof(arena_node<call_stmt>) + size_of(n.inputs) + size_of(n.outputs) + size_of(n.scalars);
+}
+std::size_t size_of(const copy_stmt& n) {
+  return sizeof(arena_node<copy_stmt>) + size_of(n.src_x) + size_of(n.dst_x);
+}
+std::size_t size_of(const allocate& n) { return sizeof(arena_node<allocate>) + size_of(n.dims); }
+std::size_t size_of(const make_buffer& n) { return sizeof(arena_node<make_buffer>) + size_of(n.dims); }
+std::size_t size_of(const crop_buffer& n) { return sizeof(arena_node<crop_buffer>) + size_of(n.bounds); }
+std::size_t size_of(const slice_buffer& n) { return sizeof(arena_node<slice_buffer>) + size_of(n.at); }
+std::size_t size_of(const transpose& n) { return sizeof(arena_node<transpose>) + size_of(n.dims); }
+
+// Copy `src` into `storage`, and advance `storage` past it.
+template <typename T>
+span<T> make_span(void*& storage, span<T> src) {
+  T* result = static_cast<T*>(storage);
+  for (std::size_t i = 0; i < src.size(); ++i) {
+    new (result + i) T(src[i]);
+  }
+  storage = static_cast<char*>(storage) + size_of(src);
+  return span<T>(result, src.size());
+}
+
+template <typename T>
+const T* clone_into(void* mem, const T& n, ref_count<arena> a) {
+  return new (mem) arena_node<T>(n, std::move(a));
+}
+const let* clone_into(void* mem, const let& n, ref_count<arena> a) {
+  auto result = new (mem) arena_node<let>(n, std::move(a));
+  void* arrays = result + 1;
+  result->lets = make_span(arrays, n.lets);
+  return result;
+}
+const call* clone_into(void* mem, const call& n, ref_count<arena> a) {
+  auto result = new (mem) arena_node<call>(n, std::move(a));
+  void* arrays = result + 1;
+  result->args = make_span(arrays, n.args);
+  return result;
+}
+const let_stmt* clone_into(void* mem, const let_stmt& n, ref_count<arena> a) {
+  auto result = new (mem) arena_node<let_stmt>(n, std::move(a));
+  void* arrays = result + 1;
+  result->lets = make_span(arrays, n.lets);
+  return result;
+}
+const block* clone_into(void* mem, const block& n, ref_count<arena> a) {
+  auto result = new (mem) arena_node<block>(n, std::move(a));
+  void* arrays = result + 1;
+  result->stmts = make_span(arrays, n.stmts);
+  return result;
+}
+const call_stmt* clone_into(void* mem, const call_stmt& n, ref_count<arena> a) {
+  auto result = new (mem) arena_node<call_stmt>(n, std::move(a));
+  void* arrays = result + 1;
+  result->inputs = make_span(arrays, n.inputs);
+  result->outputs = make_span(arrays, n.outputs);
+  result->scalars = make_span(arrays, n.scalars);
+  return result;
+}
+const copy_stmt* clone_into(void* mem, const copy_stmt& n, ref_count<arena> a) {
+  auto result = new (mem) arena_node<copy_stmt>(n, std::move(a));
+  void* arrays = result + 1;
+  result->src_x = make_span(arrays, n.src_x);
+  result->dst_x = make_span(arrays, n.dst_x);
+  return result;
+}
+const allocate* clone_into(void* mem, const allocate& n, ref_count<arena> a) {
+  auto result = new (mem) arena_node<allocate>(n, std::move(a));
+  void* arrays = result + 1;
+  result->dims = make_span(arrays, n.dims);
+  return result;
+}
+const make_buffer* clone_into(void* mem, const make_buffer& n, ref_count<arena> a) {
+  auto result = new (mem) arena_node<make_buffer>(n, std::move(a));
+  void* arrays = result + 1;
+  result->dims = make_span(arrays, n.dims);
+  return result;
+}
+const crop_buffer* clone_into(void* mem, const crop_buffer& n, ref_count<arena> a) {
+  auto result = new (mem) arena_node<crop_buffer>(n, std::move(a));
+  void* arrays = result + 1;
+  result->bounds = make_span(arrays, n.bounds);
+  return result;
+}
+const slice_buffer* clone_into(void* mem, const slice_buffer& n, ref_count<arena> a) {
+  auto result = new (mem) arena_node<slice_buffer>(n, std::move(a));
+  void* arrays = result + 1;
+  result->at = make_span(arrays, n.at);
+  return result;
+}
+const transpose* clone_into(void* mem, const transpose& n, ref_count<arena> a) {
+  auto result = new (mem) arena_node<transpose>(n, std::move(a));
+  void* arrays = result + 1;
+  result->dims = make_span(arrays, n.dims);
+  return result;
+}
+
+class node_compactor : public node_mutator {
+  // The current arena we are building.
+  slinky::ref_count<arena> arena_;
+
+  std::unordered_map<const base_expr_node*, expr> exprs_;
+  std::unordered_map<const base_stmt_node*, stmt> stmts_;
+
+  // Reserve space in the current arena, making a new arena if needed.
+  void* reserve(std::size_t size, std::size_t alignment) {
+    void* result = arena_ != nullptr ? arena_->allocate(size, alignment) : nullptr;
+    if (!result) {
+      slinky::ref_count<arena> chunk = arena::make();
+      result = chunk->allocate(size, alignment);
+      if (!result) return nullptr;
+      arena_ = std::move(chunk);
+    }
+    return result;
+  }
+
+  expr take_result(const base_expr_node*) { return std::move(const_cast<expr&>(mutated_expr())); }
+  stmt take_result(const base_stmt_node*) { return std::move(const_cast<stmt&>(mutated_stmt())); }
+
+  template <typename T>
+  void compact(const T* op) {
+    // Reserve space in the arena for this node, and remember the arena this node belongs to.
+    std::size_t size = size_of(*op);
+    void* mem = reserve(size, alignof(arena_node<T>));
+    slinky::ref_count<arena> chunk = arena_;
+
+    node_mutator::visit(op);
+
+    if (!mem) {
+      // This node is too big for a chunk, just use the node we got.
+      return;
+    }
+
+    // Make a clone of the node in the reserved arena allocation, and use that as the result.
+    auto mutated = take_result(op);
+    const T* cloneable = mutated.template as<T>();
+    assert(cloneable);
+    assert(size_of(*cloneable) == size);
+    set_result(decltype(mutated)(clone_into(mem, *cloneable, std::move(chunk))));
+  }
+
+public:
+  using node_mutator::mutate;
+  expr mutate(const expr& e) override {
+    if (!e.defined()) return e;
+    auto i = exprs_.find(e.get());
+    if (i != exprs_.end()) return i->second;
+
+    expr result = node_mutator::mutate(e);
+    exprs_[e.get()] = result;
+    return result;
+  }
+
+  stmt mutate(const stmt& s) override {
+    if (!s.defined()) return s;
+    auto i = stmts_.find(s.get());
+    if (i != stmts_.end()) return i->second;
+
+    stmt result = stmt_mutator::mutate(s);
+    stmts_[s.get()] = result;
+    return result;
+  }
+
+  void visit(const variable* op) override { compact(op); }
+  void visit(const constant* op) override { compact(op); }
+  void visit(const constant_buffer* op) override { compact(op); }
+  void visit(const let* op) override { compact(op); }
+  void visit(const add* op) override { compact(op); }
+  void visit(const sub* op) override { compact(op); }
+  void visit(const mul* op) override { compact(op); }
+  void visit(const div* op) override { compact(op); }
+  void visit(const mod* op) override { compact(op); }
+  void visit(const class min* op) override { compact(op); }
+  void visit(const class max* op) override { compact(op); }
+  void visit(const equal* op) override { compact(op); }
+  void visit(const not_equal* op) override { compact(op); }
+  void visit(const less* op) override { compact(op); }
+  void visit(const less_equal* op) override { compact(op); }
+  void visit(const logical_and* op) override { compact(op); }
+  void visit(const logical_or* op) override { compact(op); }
+  void visit(const logical_not* op) override { compact(op); }
+  void visit(const class select* op) override { compact(op); }
+  void visit(const call* op) override { compact(op); }
+
+  void visit(const let_stmt* op) override { compact(op); }
+  void visit(const block* op) override { compact(op); }
+  void visit(const loop* op) override { compact(op); }
+  void visit(const call_stmt* op) override { compact(op); }
+  void visit(const copy_stmt* op) override { compact(op); }
+  void visit(const allocate* op) override { compact(op); }
+  void visit(const make_buffer* op) override { compact(op); }
+  void visit(const clone_buffer* op) override { compact(op); }
+  void visit(const crop_buffer* op) override { compact(op); }
+  void visit(const crop_dim* op) override { compact(op); }
+  void visit(const slice_buffer* op) override { compact(op); }
+  void visit(const slice_dim* op) override { compact(op); }
+  void visit(const transpose* op) override { compact(op); }
+  void visit(const async* op) override { compact(op); }
+  void visit(const check* op) override { compact(op); }
+};
+
+}  // namespace
+
+stmt compact_nodes(const stmt& s) {
+  if (!s.defined()) return s;
+
+  return node_compactor().mutate(s);
+}
+
+}  // namespace slinky

--- a/slinky/builder/compact_nodes.cc
+++ b/slinky/builder/compact_nodes.cc
@@ -23,19 +23,25 @@ class arena : public ref_counted<arena> {
   arena() : next_(sizeof(arena)) {}
 
 public:
-  // A chunk comes from `::operator new`, so it is aligned to this, and can align anything it holds up to this much.
-  static constexpr std::size_t max_alignment = alignof(std::max_align_t);
-
   static constexpr std::size_t block_size = 4096;
 
+  // A chunk is aligned to `block_size`, so it can align anything it holds up to this much.
+  static constexpr std::size_t max_alignment = block_size;
+
   static slinky::ref_count<arena> make() {
-    return slinky::ref_count<arena>(new (::operator new(block_size)) arena());
+    return slinky::ref_count<arena>(new (::operator new(block_size, std::align_val_t(block_size))) arena());
+  }
+
+  // Because chunks are aligned to `block_size`, the chunk an object lives in is the beginning of the block containing
+  // it. This lets nodes find the chunk that owns them without storing a pointer to it.
+  static arena* from(const void* p) {
+    return reinterpret_cast<arena*>(reinterpret_cast<std::uintptr_t>(p) & ~(block_size - 1));
   }
 
   // Returns memory for a node, padding to align it, or null if there is not enough space in this chunk.
   void* allocate(std::size_t size, std::size_t alignment) {
     assert(alignment <= max_alignment);
-    std::size_t offset = align_up(next_, alignment);
+    std::size_t offset = (next_ + alignment - 1) & ~(alignment - 1);
     if (offset + size > block_size) {
       // Out of space
       return nullptr;
@@ -46,7 +52,7 @@ public:
 
   static void destroy(arena* a) {
     a->~arena();
-    ::operator delete(a);
+    ::operator delete(a, std::align_val_t(block_size));
   }
 };
 
@@ -55,25 +61,27 @@ constexpr std::size_t array_alignment = alignof(void*);
 // A node of type `T` that lives in an `arena`.
 template <typename T>
 class arena_node : public T {
-  slinky::ref_count<arena> arena_;
-
 public:
-  arena_node(const T& src, slinky::ref_count<arena> a) : T(src), arena_(std::move(a)) {
+  arena_node(const T& src) : T(src) {
     static_assert(alignof(arena_node) <= arena::max_alignment, "node is overaligned for a chunk");
     static_assert(sizeof(arena_node) % array_alignment == 0, "node arrays would be misaligned");
+    arena::from(this)->add_ref();
   }
 
+  // These nodes find their arena from their own address, so they can only be constructed in an arena.
+  static void* operator new(std::size_t) = delete;
+  static void* operator new(std::size_t, void* mem) { return mem; }
+
   void destroy() override {
-    // Don't destroy the arena before the base node destructor runs.
-    slinky::ref_count<arena> a = std::move(arena_);
     this->~arena_node();
+    arena::from(this)->release();
   }
 };
 
 template <typename T>
 std::size_t size_of(span<T> x) {
   static_assert(alignof(T) <= array_alignment, "array would not be aligned");
-  return align_up(x.size() * sizeof(T), array_alignment);
+  return (x.size() * sizeof(T) + array_alignment - 1) & ~(array_alignment - 1);
 }
 
 // The size of a node in the arena. Nodes that own arrays need room for them too.
@@ -109,74 +117,74 @@ span<T> make_span(void*& storage, span<T> src) {
 }
 
 template <typename T>
-const T* clone_into(void* mem, const T& n, ref_count<arena> a) {
-  return new (mem) arena_node<T>(n, std::move(a));
+const T* clone_into(void* mem, const T& n) {
+  return new (mem) arena_node<T>(n);
 }
-const let* clone_into(void* mem, const let& n, ref_count<arena> a) {
-  auto result = new (mem) arena_node<let>(n, std::move(a));
+const let* clone_into(void* mem, const let& n) {
+  auto result = new (mem) arena_node<let>(n);
   void* arrays = result + 1;
   result->lets = make_span(arrays, n.lets);
   return result;
 }
-const call* clone_into(void* mem, const call& n, ref_count<arena> a) {
-  auto result = new (mem) arena_node<call>(n, std::move(a));
+const call* clone_into(void* mem, const call& n) {
+  auto result = new (mem) arena_node<call>(n);
   void* arrays = result + 1;
   result->args = make_span(arrays, n.args);
   return result;
 }
-const let_stmt* clone_into(void* mem, const let_stmt& n, ref_count<arena> a) {
-  auto result = new (mem) arena_node<let_stmt>(n, std::move(a));
+const let_stmt* clone_into(void* mem, const let_stmt& n) {
+  auto result = new (mem) arena_node<let_stmt>(n);
   void* arrays = result + 1;
   result->lets = make_span(arrays, n.lets);
   return result;
 }
-const block* clone_into(void* mem, const block& n, ref_count<arena> a) {
-  auto result = new (mem) arena_node<block>(n, std::move(a));
+const block* clone_into(void* mem, const block& n) {
+  auto result = new (mem) arena_node<block>(n);
   void* arrays = result + 1;
   result->stmts = make_span(arrays, n.stmts);
   return result;
 }
-const call_stmt* clone_into(void* mem, const call_stmt& n, ref_count<arena> a) {
-  auto result = new (mem) arena_node<call_stmt>(n, std::move(a));
+const call_stmt* clone_into(void* mem, const call_stmt& n) {
+  auto result = new (mem) arena_node<call_stmt>(n);
   void* arrays = result + 1;
   result->inputs = make_span(arrays, n.inputs);
   result->outputs = make_span(arrays, n.outputs);
   result->scalars = make_span(arrays, n.scalars);
   return result;
 }
-const copy_stmt* clone_into(void* mem, const copy_stmt& n, ref_count<arena> a) {
-  auto result = new (mem) arena_node<copy_stmt>(n, std::move(a));
+const copy_stmt* clone_into(void* mem, const copy_stmt& n) {
+  auto result = new (mem) arena_node<copy_stmt>(n);
   void* arrays = result + 1;
   result->src_x = make_span(arrays, n.src_x);
   result->dst_x = make_span(arrays, n.dst_x);
   return result;
 }
-const allocate* clone_into(void* mem, const allocate& n, ref_count<arena> a) {
-  auto result = new (mem) arena_node<allocate>(n, std::move(a));
+const allocate* clone_into(void* mem, const allocate& n) {
+  auto result = new (mem) arena_node<allocate>(n);
   void* arrays = result + 1;
   result->dims = make_span(arrays, n.dims);
   return result;
 }
-const make_buffer* clone_into(void* mem, const make_buffer& n, ref_count<arena> a) {
-  auto result = new (mem) arena_node<make_buffer>(n, std::move(a));
+const make_buffer* clone_into(void* mem, const make_buffer& n) {
+  auto result = new (mem) arena_node<make_buffer>(n);
   void* arrays = result + 1;
   result->dims = make_span(arrays, n.dims);
   return result;
 }
-const crop_buffer* clone_into(void* mem, const crop_buffer& n, ref_count<arena> a) {
-  auto result = new (mem) arena_node<crop_buffer>(n, std::move(a));
+const crop_buffer* clone_into(void* mem, const crop_buffer& n) {
+  auto result = new (mem) arena_node<crop_buffer>(n);
   void* arrays = result + 1;
   result->bounds = make_span(arrays, n.bounds);
   return result;
 }
-const slice_buffer* clone_into(void* mem, const slice_buffer& n, ref_count<arena> a) {
-  auto result = new (mem) arena_node<slice_buffer>(n, std::move(a));
+const slice_buffer* clone_into(void* mem, const slice_buffer& n) {
+  auto result = new (mem) arena_node<slice_buffer>(n);
   void* arrays = result + 1;
   result->at = make_span(arrays, n.at);
   return result;
 }
-const transpose* clone_into(void* mem, const transpose& n, ref_count<arena> a) {
-  auto result = new (mem) arena_node<transpose>(n, std::move(a));
+const transpose* clone_into(void* mem, const transpose& n) {
+  auto result = new (mem) arena_node<transpose>(n);
   void* arrays = result + 1;
   result->dims = make_span(arrays, n.dims);
   return result;
@@ -223,7 +231,7 @@ class node_compactor : public node_mutator {
     const T* cloneable = mutated.template as<T>();
     assert(cloneable);
     assert(size_of(*cloneable) == size);
-    set_result(decltype(mutated)(clone_into(mem, *cloneable, std::move(chunk))));
+    set_result(decltype(mutated)(clone_into(mem, *cloneable)));
   }
 
 public:

--- a/slinky/builder/node_mutator.cc
+++ b/slinky/builder/node_mutator.cc
@@ -213,7 +213,7 @@ void node_mutator::visit(const call_stmt* op) {
   if (!changed) {
     set_result(op);
   } else {
-    set_result(call_stmt::make(op->target, op->inputs, op->outputs, std::move(scalars), op->attrs));
+    set_result(call_stmt::make(op->target, op->inputs, op->outputs, std::move(scalars), *op->attrs));
   }
 }
 void node_mutator::visit(const copy_stmt* op) {

--- a/slinky/builder/optimizations.cc
+++ b/slinky/builder/optimizations.cc
@@ -100,7 +100,7 @@ bool is_linear(const expr& y, var x, expr& a, expr& b) {
 
 // Checks if the copy operands `src_x` and `dst_x[dst_d]` represent a simple copy that can be handled by slinky::copy.
 // dst_x dimensions other than `dst_d` are assumed to be handled by a different `is_copy` call.
-bool is_copy(var src, expr src_x, int src_d, var dst, span<const var> dst_x, int dst_d, expr& at, dim_expr& src_dim) {
+bool is_copy(var src, expr src_x, int src_d, var dst, span<var> dst_x, int dst_d, expr& at, dim_expr& src_dim) {
   if (const class select* s = src_x.as<class select>()) {
     // The src is a select of two things that might both be copies.
     expr at_t;
@@ -266,7 +266,7 @@ bool dim_has_stride(const dim_expr& d) {
   }
   return d.stride.defined();
 }
-bool any_stride_defined(span<const dim_expr> dims) { return std::any_of(dims.begin(), dims.end(), dim_has_stride); }
+bool any_stride_defined(span<dim_expr> dims) { return std::any_of(dims.begin(), dims.end(), dim_has_stride); }
 
 class copy_aliaser : public stmt_mutator {
   node_context& ctx;
@@ -500,7 +500,7 @@ public:
   }
 
   void visit(const allocate* op) override {
-    auto s = set_value_in_scope(buffers, op->sym, buffer_info(op->dims, op->elem_size));
+    auto s = set_value_in_scope(buffers, op->sym, buffer_info(to_vector(op->dims), op->elem_size));
     stmt body = mutate(op->body);
 
     scoped_trace trace("visit(const allocate*)");
@@ -722,7 +722,7 @@ public:
 
     alias_info a;
     a.target = op->src;
-    a.at = op->src_x;
+    a.at = to_vector(op->src_x);
     a.permutation.assign(info->dims.size(), transpose::new_dim);
     a.dims.resize(info->dims.size());
     for (int dst_d = 0; dst_d < static_cast<int>(op->dst_x.size()); ++dst_d) {
@@ -831,7 +831,7 @@ public:
   }
 
   void merge_buffer_info(symbol_map<buffer_info>& old_buffers, var sym, var src,
-      function_ref<void(alias_info&)> handler, span<const int> dim_map) {
+      function_ref<void(alias_info&)> handler, span<int> dim_map) {
     // Build sub_dims to substitute buffer metadata of sym with the corresponding src dimensions.
     // dim_map remaps dimensions: sym.dim[d] corresponds to src.dim[dim_map[d]].
     std::vector<dim_expr> sub_dims(dim_map.size());
@@ -897,7 +897,7 @@ public:
   }
 
   template <typename T>
-  void visit_buffer_mutator(const T* op, function_ref<void(alias_info&)> handler, span<const int> dim_map) {
+  void visit_buffer_mutator(const T* op, function_ref<void(alias_info&)> handler, span<int> dim_map) {
     // We need to know which alias candidates are added inside this mutator.
     symbol_map<buffer_info> old_buffers(buffers.size());
     std::swap(old_buffers, buffers);
@@ -1050,7 +1050,7 @@ public:
     }
   }
 
-  bool fold_factors_strides_same(const std::vector<dim_expr>& alloc_dims, const std::vector<dim_expr>& alias_dims) {
+  bool fold_factors_strides_same(span<dim_expr> alloc_dims, span<dim_expr> alias_dims) {
     if (alloc_dims.size() > alias_dims.size()) {
       return !(std::any_of(alloc_dims.begin(), alloc_dims.end(),
           [&](const dim_expr& i) { return i.stride.defined() || i.fold_factor.defined(); }));
@@ -1064,7 +1064,7 @@ public:
   }
 
   void visit(const allocate* op) override {
-    auto set_buffer = set_value_in_scope(buffers, op->sym, {op->sym, op->dims, loop_level});
+    auto set_buffer = set_value_in_scope(buffers, op->sym, {op->sym, to_vector(op->dims), loop_level});
     auto set_back = set_value_in_scope(backward, op->sym, var());
     auto set_fwd = set_value_in_scope(forward, op->sym, var());
     auto set_used = set_value_in_scope(use_count, op->sym, 0);
@@ -1221,7 +1221,7 @@ stmt alias_in_place(const stmt& s, const std::vector<buffer_expr_ptr>& outputs) 
 namespace {
 
 template <typename T>
-bool match(span<const T> a, span<const T> b) {
+bool match(span<T> a, span<T> b) {
   if (a.size() != b.size()) return false;
   for (std::size_t i = 0; i < a.size(); ++i) {
     if (!match(a[i], b[i])) return false;
@@ -1321,6 +1321,7 @@ stmt implement_copy(const copy_stmt* op, node_context& ctx) {
   var dst = ctx.insert_unique(ctx.name(op->dst) + ".sliced");
   call_stmt::attributes copy_attrs;
   copy_attrs.name = "copy";
+  var args[] = {op->src, dst, op->pad};
   stmt result = call_stmt::make(
       [impl = op->impl](const call_stmt* op, const eval_context& ctx) -> index_t {
         // TODO: This passes the src buffer as an output, not an input, because slinky thinks the bounds of inputs
@@ -1334,10 +1335,10 @@ stmt implement_copy(const copy_stmt* op, node_context& ctx) {
         impl(*src_buf, *dst_buf, *pad_buf);
         return 0;
       },
-      {}, {op->src, dst, op->pad}, {}, std::move(copy_attrs));
+      span<var>{}, args, {}, std::move(copy_attrs));
 
-  std::vector<expr> src_x = op->src_x;
-  std::vector<var> dst_x = op->dst_x;
+  std::vector<expr> src_x = to_vector(op->src_x);
+  std::vector<var> dst_x = to_vector(op->dst_x);
   std::vector<dim_expr> src_dims;
 
   // If we just leave these two arrays alone, the copy will be correct, but slow.
@@ -1534,7 +1535,7 @@ class pure_dims_remover : public stmt_mutator {
   static bool is_extent_one(const dim_expr& d) { return is_extent_one(d.bounds); }
 
   template <typename T>
-  static sliceable_dims find_sliceable(const std::vector<T>& dims) {
+  static sliceable_dims find_sliceable(span<T> dims) {
     sliceable_dims result = {};
     for (std::size_t i = 0; i < dims.size(); ++i) {
       if (is_extent_one(dims[i])) {
@@ -2257,7 +2258,7 @@ public:
     if (body.same_as(op->body)) {
       set_result(op);
     } else {
-      set_result(allocate::make(op->sym, op->storage, std::move(op->elem_size), std::move(op->dims), std::move(body)));
+      set_result(allocate::make(op->sym, op->storage, op->elem_size, op->dims, std::move(body)));
     }
   }
 

--- a/slinky/builder/optimizations.cc
+++ b/slinky/builder/optimizations.cc
@@ -225,7 +225,7 @@ public:
   }
 
   void visit(const call_stmt* op) override {
-    if (op->attrs.name == "memcpy" && op->inputs.size() == 1 && op->outputs.size() == 1 &&
+    if (op->attrs->name == "memcpy" && op->inputs.size() == 1 && op->outputs.size() == 1 &&
         is_a_and_b(op->inputs[0], op->outputs[0])) {
       expr input_size = buffer_size_bytes(op->inputs[0]);
       expr output_size = buffer_size_bytes(op->outputs[0]);
@@ -680,7 +680,7 @@ public:
 
   void visit(const call_stmt* op) override {
     set_result(op);
-    if (op->attrs.name == "memcpy") {
+    if (op->attrs->name == "memcpy") {
       assert(op->inputs.size() == 1);
       assert(op->outputs.size() == 1);
       var in = op->inputs[0];
@@ -1114,7 +1114,7 @@ public:
       add_use(input_alloc->root);
     }
 
-    if (op->attrs.name == "memcpy") {
+    if (op->attrs->name == "memcpy") {
       // We can't handle this, it should have been handled by copy_aliaser if it could be aliased.
       return;
     }
@@ -1134,7 +1134,7 @@ public:
       for (std::size_t i = 0; i < op->inputs.size(); ++i) {
         const std::size_t bit = o * op->inputs.size() + i;
         if (bit > 31) break;
-        if ((op->attrs.allow_in_place & (1 << bit)) == 0) {
+        if ((op->attrs->allow_in_place & (1 << bit)) == 0) {
           continue;
         }
 
@@ -1629,7 +1629,7 @@ public:
   }
 
   void visit(const call_stmt* op) override {
-    if (op->attrs.min_rank == std::numeric_limits<int>::max()) {
+    if (op->attrs->min_rank == std::numeric_limits<int>::max()) {
       return set_result(stmt{op});
     }
 
@@ -1639,7 +1639,7 @@ public:
     }
 
     std::vector<expr> slices(sliceable.size());
-    for (int d = slices.size() - 1; d >= op->attrs.min_rank; --d) {
+    for (int d = slices.size() - 1; d >= op->attrs->min_rank; --d) {
       if (sliceable.test(d)) {
         slices[d] = buffer_min(op->outputs.front(), d);
       }
@@ -2227,7 +2227,7 @@ public:
   using node_mutator::visit;
 
   void visit(const call_stmt* op) override {
-    if (op->attrs.name == "init_semaphores") {
+    if (op->attrs->name == "init_semaphores") {
       allocations[op->outputs[0]]->is_semaphores = true;
     }
 
@@ -2245,7 +2245,7 @@ public:
         // Remove the initialization call, because otherwise the following
         // substitute call will fail.
         const call_stmt* maybe_init = maybe_block->stmts[0].as<call_stmt>();
-        if (maybe_init && maybe_init->attrs.name == "init_semaphores") {
+        if (maybe_init && maybe_init->attrs->name == "init_semaphores") {
           std::vector<stmt> new_block(maybe_block->stmts.begin() + 1, maybe_block->stmts.end());
           body = block::make(new_block);
           body = substitute(body, op->sym, expr());

--- a/slinky/builder/optimizations.h
+++ b/slinky/builder/optimizations.h
@@ -58,6 +58,10 @@ stmt cleanup_semaphores(const stmt& s);
 // Lift constant lets to a single root let_stmt.
 stmt lift_constants(const stmt& s);
 
+// Rewrite the stmt into a single allocation. The allocation will only be freed after all the nodes stored in the
+// allocation are freed.
+stmt compact_nodes(const stmt& s);
+
 }  // namespace slinky
 
 #endif  // SLINKY_BUILDER_OPTIMIZATIONS_H

--- a/slinky/builder/pipeline.cc
+++ b/slinky/builder/pipeline.cc
@@ -549,7 +549,7 @@ stmt substitute_inputs(const stmt& s, const symbol_map<var>& subs) {
       }
 
       if (changed) {
-        set_result(call_stmt::make(op->target, inputs, op->outputs, to_vector(op->scalars), op->attrs));
+        set_result(call_stmt::make(op->target, inputs, op->outputs, to_vector(op->scalars), *op->attrs));
       } else {
         set_result(op);
       }
@@ -1495,8 +1495,8 @@ stmt inject_traces(const stmt& s, node_context& ctx) {
     }
 
     expr get_trace_arg(const call_stmt* op) {
-      if (!op->attrs.name.empty()) {
-        return get_trace_arg(op->attrs.name);
+      if (!op->attrs->name.empty()) {
+        return get_trace_arg(op->attrs->name);
       } else {
         return get_trace_arg("call");
       }

--- a/slinky/builder/pipeline.cc
+++ b/slinky/builder/pipeline.cc
@@ -514,7 +514,7 @@ void compute_innermost_locations(const std::vector<const func*>& order,
 }
 
 // Update dims vector by substittuting expression from the map.
-std::vector<dim_expr> substitute_from_map(std::vector<dim_expr> dims, span<const std::pair<expr, expr>> substitutions) {
+std::vector<dim_expr> substitute_from_map(std::vector<dim_expr> dims, span<std::pair<expr, expr>> substitutions) {
   for (dim_expr& dim : dims) {
     dim_expr new_dim = dim;
     for (const std::pair<expr, expr>& j : substitutions) {
@@ -549,7 +549,7 @@ stmt substitute_inputs(const stmt& s, const symbol_map<var>& subs) {
       }
 
       if (changed) {
-        set_result(call_stmt::make(op->target, std::move(inputs), op->outputs, op->scalars, op->attrs));
+        set_result(call_stmt::make(op->target, inputs, op->outputs, to_vector(op->scalars), op->attrs));
       } else {
         set_result(op);
       }
@@ -559,7 +559,7 @@ stmt substitute_inputs(const stmt& s, const symbol_map<var>& subs) {
       var src = subs[op->src] ? *subs[op->src] : op->src;
       var pad = subs[op->pad] ? *subs[op->pad] : op->pad;
       if (src != op->src || pad != op->pad) {
-        set_result(copy_stmt::make(op->impl, src, op->src_x, op->dst, op->dst_x, pad));
+        set_result(copy_stmt::make(op->impl, src, to_vector(op->src_x), op->dst, op->dst_x, pad));
       } else {
         set_result(op);
       }
@@ -1609,6 +1609,9 @@ stmt build_pipeline(node_context& ctx, const std::vector<buffer_expr_ptr>& input
   result = optimize_symbols(result, ctx);
 
   result = canonicalize_nodes(result);
+
+  // This pass rewrites the nodes to be compact in memory, the stmt should not be modified after this.
+  result = compact_nodes(result);
 
   if (is_verbose()) {
     std::cout << result << std::endl;

--- a/slinky/builder/rewrite.h
+++ b/slinky/builder/rewrite.h
@@ -455,15 +455,15 @@ public:
 };
 
 template <int matched>
-SLINKY_UNIQUE bool match_tuple(const std::tuple<>& t, const std::vector<expr>& x, match_context& ctx) {
+SLINKY_UNIQUE bool match_tuple(const std::tuple<>& t, span<expr> x, match_context& ctx) {
   return true;
 }
 template <int matched, typename A>
-SLINKY_UNIQUE bool match_tuple(const std::tuple<A>& t, const std::vector<expr>& x, match_context& ctx) {
+SLINKY_UNIQUE bool match_tuple(const std::tuple<A>& t, span<expr> x, match_context& ctx) {
   return match<matched>(std::get<0>(t), x[0], ctx);
 }
 template <int matched, typename A, typename B>
-SLINKY_UNIQUE bool match_tuple(const std::tuple<A, B>& t, const std::vector<expr>& x, match_context& ctx) {
+SLINKY_UNIQUE bool match_tuple(const std::tuple<A, B>& t, span<expr> x, match_context& ctx) {
   return match<matched>(std::get<0>(t), x[0], ctx) &&
          match<matched | pattern_info<A>::matched>(std::get<1>(t), x[1], ctx);
 }

--- a/slinky/builder/simplify.cc
+++ b/slinky/builder/simplify.cc
@@ -1466,8 +1466,8 @@ public:
   }
 
   void visit(const call_stmt* op) override {
-    call_stmt::symbol_list inputs = op->inputs;
-    call_stmt::symbol_list outputs = op->outputs;
+    call_stmt::symbol_list inputs = to_vector(op->inputs);
+    call_stmt::symbol_list outputs = to_vector(op->outputs);
     bool changed = false;
     auto visit_symbol_list = [&, this](call_stmt::symbol_list& list) {
       for (var& i : list) {
@@ -1481,7 +1481,7 @@ public:
     visit_symbol_list(inputs);
     visit_symbol_list(outputs);
 
-    std::vector<expr> scalars = op->scalars;
+    std::vector<expr> scalars = to_vector(op->scalars);
     for (expr& i : scalars) {
       expr new_i = mutate(i);
       if (!new_i.same_as(i)) {
@@ -2057,7 +2057,7 @@ public:
         }
         // Nested crops of the same buffer, and the crop isn't used.
         op_bounds.resize(std::max(op_bounds.size(), c->bounds.size()));
-        op_bounds = c->bounds & op_bounds;
+        op_bounds = to_vector(c->bounds) & op_bounds;
         op_src = c->src;
         info = get_buffer_info(op_src);
         op = nullptr;
@@ -2163,7 +2163,7 @@ public:
 
   void visit(const crop_buffer* op) override {
     var src = visit_symbol(op->src);
-    visit_crop(src == op->src ? op : nullptr, op->sym, src, op->bounds, op->body);
+    visit_crop(src == op->src ? op : nullptr, op->sym, src, to_vector(op->bounds), op->body);
   }
 
   void visit(const crop_dim* op) override {
@@ -2173,7 +2173,7 @@ public:
     visit_crop(src == op->src ? op : nullptr, op->sym, src, std::move(bounds), op->body);
   }
 
-  bool prove_slice_unaffected_by_crop(const std::vector<interval_expr>& bounds, const std::vector<expr>& at) {
+  bool prove_slice_unaffected_by_crop(span<interval_expr> bounds, span<expr> at) {
     for (size_t dim = at.size(); dim < bounds.size(); ++dim) {
       if (bounds[dim].min.defined() || bounds[dim].max.defined()) {
         return false;
@@ -2187,12 +2187,12 @@ public:
     return true;
   }
 
-  bool prove_slice_unaffected_by_crop(int dim, interval_expr bounds, const std::vector<expr>& at) {
+  bool prove_slice_unaffected_by_crop(int dim, interval_expr bounds, span<expr> at) {
     return dim >= static_cast<int>(at.size()) ? !(bounds.min.defined() || bounds.max.defined())
                                               : prove_true(bounds.contains(at[dim]));
   }
 
-  void visit_slice(const base_stmt_node* op, var op_sym, var op_src, const std::vector<expr>& op_at, stmt op_body) {
+  void visit_slice(const base_stmt_node* op, var op_sym, var op_src, span<expr> op_at, stmt op_body) {
     std::vector<expr> at(op_at.size());
     std::optional<buffer_info> info = buffers[op_src];
 
@@ -2292,7 +2292,7 @@ public:
     const std::optional<buffer_info>* src_info = &buffers[op->src];
 
     var src = visit_symbol(op->src);
-    std::vector<int> dims = op->dims;
+    std::vector<int> dims = to_vector(op->dims);
     while (src_info && *src_info) {
       if (const transpose* t = (*src_info)->decl.as<transpose>()) {
         if (t->sym == src) {
@@ -2302,7 +2302,7 @@ public:
             break;
           }
           // This is a transpose of another transpose. Rewrite this to directly transpose the parent.
-          dims = permute(dims, t->dims, transpose::new_dim);
+          dims = permute(dims, to_vector(t->dims), transpose::new_dim);
           src = t->src;
           src_info = &buffers[src];
           continue;
@@ -2358,7 +2358,8 @@ public:
         return body;
       } else if (!deps.buffer_dims) {
         return substitute(body, op->sym, src);
-      } else if (body.same_as(op->body) && src == op->src && dims == op->dims) {
+      } else if (body.same_as(op->body) && src == op->src &&
+                 std::equal(dims.begin(), dims.end(), op->dims.begin(), op->dims.end())) {
         return stmt(op);
       } else {
         return transpose::make(op->sym, src, dims, std::move(body));

--- a/slinky/builder/simplify.cc
+++ b/slinky/builder/simplify.cc
@@ -1490,7 +1490,7 @@ public:
       }
     }
     if (changed) {
-      set_result(call_stmt::make(op->target, std::move(inputs), std::move(outputs), std::move(scalars), op->attrs));
+      set_result(call_stmt::make(op->target, std::move(inputs), std::move(outputs), std::move(scalars), *op->attrs));
     } else {
       set_result(op);
     }

--- a/slinky/builder/slide_and_fold_storage.cc
+++ b/slinky/builder/slide_and_fold_storage.cc
@@ -43,7 +43,7 @@ void merge_crop(std::optional<box_expr>& bounds, int d, const interval_expr& new
   bounds_d = simplify_intersection(std::move(bounds_d), new_bounds);
 }
 
-void merge_crop(std::optional<box_expr>& bounds, const box_expr& new_bounds) {
+void merge_crop(std::optional<box_expr>& bounds, span<interval_expr> new_bounds) {
   if (!bounds) {
     bounds = box_expr();
   }
@@ -63,7 +63,7 @@ void define_undef_bounds(box_expr& bounds, var sym) {
 
 // Keep substituting substitutions until nothing happens.
 std::vector<dim_expr> recursive_substitute(
-    std::vector<dim_expr> dims, span<const std::pair<expr, expr>> substitutions) {
+    std::vector<dim_expr> dims, span<std::pair<expr, expr>> substitutions) {
   scoped_trace trace("recursive_substitute");
   while (true) {
     bool changed = false;
@@ -185,7 +185,7 @@ public:
   };
   symbol_map<std::vector<dim_fold_info>> fold_factors;
 
-  static std::vector<dim_fold_info> get_dim_fold_info(const std::vector<dim_expr>& dims) {
+  static std::vector<dim_fold_info> get_dim_fold_info(span<dim_expr> dims) {
     std::vector<dim_fold_info> info(dims.size(), dim_fold_info());
     for (std::size_t d = 0; d < dims.size(); ++d) {
       if (is_finite(dims[d].fold_factor)) {
@@ -315,7 +315,7 @@ public:
     for (int d = 0; d < static_cast<int>(op->dims.size()); ++d) {
       replacements.emplace_back(buffer_fold_factor(op->sym, d), fold_info[d].factor);
     }
-    std::vector<dim_expr> dims = recursive_substitute(op->dims, replacements);
+    std::vector<dim_expr> dims = recursive_substitute(to_vector(op->dims), replacements);
     // Replace infinite fold factors with undefined.
     for (dim_expr& d : dims) {
       if (is_positive_infinity(d.fold_factor)) d.fold_factor = expr();
@@ -443,7 +443,7 @@ public:
     }
   }
 
-  void visit_call_or_copy(span<const var> inputs, span<const var> outputs) {
+  void visit_call_or_copy(span<var> inputs, span<var> outputs) {
     scoped_trace trace("visit_call_or_copy");
 
     for (var input : inputs) {
@@ -684,7 +684,7 @@ public:
           std::fill_n(&sems(0, sems.dim(1).min()), stage_count, 1);
           return 0;
         },
-        {}, {l.semaphores}, {}, std::move(init_sems_attrs));
+        span<var>{}, span<var>{&l.semaphores, 1}, {}, std::move(init_sems_attrs));
     // We can fold the semaphores array by the number of threads we'll use.
     // TODO: Use the loop index and not the loop variable directly for semaphores so we don't need to do this.
     expr sem_fold_factor = stage_count;

--- a/slinky/builder/substitute.cc
+++ b/slinky/builder/substitute.cc
@@ -60,7 +60,7 @@ public:
     } else {
       if (!try_match(self->rank, op->rank)) return false;
       if (!try_match(self->elem_size, op->elem_size)) return false;
-      if (!try_match(span<const dim>{self->dims, self->rank}, span<const dim>{op->dims, op->rank})) return false;
+      if (!try_match(span<dim>{self->dims, self->rank}, span<dim>{op->dims, op->rank})) return false;
 
       assert(self->size_bytes() == op->size_bytes());
       if (self->size_bytes() > 128) {
@@ -413,7 +413,7 @@ bool match(expr_ref a, expr_ref b) { return matcher().try_match(a.get(), b.get()
 bool match(stmt_ref a, stmt_ref b) { return matcher().try_match(a.get(), b.get()); }
 bool match(const interval_expr& a, const interval_expr& b) { return matcher().try_match(a, b); }
 bool match(const dim_expr& a, const dim_expr& b) { return matcher().try_match(a, b); }
-bool match(const box_expr& a, const box_expr& b) { return matcher().try_match(a, b); }
+bool match(span<interval_expr> a, span<interval_expr> b) { return matcher().try_match(a, b); }
 
 int compare(const var& a, const var& b) {
   matcher m;
@@ -436,7 +436,7 @@ namespace {
 
 template <typename T>
 auto mutate_let(substitutor* this_, const T* op) {
-  std::vector<std::pair<var, expr>> lets = op->lets;
+  std::vector<std::pair<var, expr>> lets = to_vector(op->lets);
   bool changed = false;
   std::size_t decls_entered = 0;
   for (auto& s : lets) {
@@ -732,7 +732,7 @@ void substitutor::visit(const copy_stmt* op) {
 
   std::size_t decls_entered = 0;
   // copy_stmt is effectively a declaration of the dst_x symbols for the src_x expressions.
-  std::vector<var> dst_x = op->dst_x;
+  std::vector<var> dst_x = to_vector(op->dst_x);
   bool changed = false;
   for (var& i : dst_x) {
     var new_i = enter_decl(i);
@@ -820,11 +820,11 @@ class buffer_substitutor : public substitutor {
 public:
   var target;
   expr elem_size;
-  span<const dim_expr> dims;
+  span<dim_expr> dims;
   var def;
 
 public:
-  buffer_substitutor(var target, expr elem_size, span<const dim_expr> dims, var def = var())
+  buffer_substitutor(var target, expr elem_size, span<dim_expr> dims, var def = var())
       : target(target), elem_size(elem_size), dims(dims), def(def) {}
 
   var enter_decl(var x) override { return x != target ? x : var(); }
@@ -902,7 +902,7 @@ dim_expr substitute_buffer(const dim_expr& e, var buffer, const std::vector<dim_
   return {s.mutate(e.bounds), s.mutate(e.stride), s.mutate(e.fold_factor)};
 }
 
-std::vector<dim_expr> make_dims_from_bounds(const box_expr& bounds) {
+std::vector<dim_expr> make_dims_from_bounds(span<interval_expr> bounds) {
   std::vector<dim_expr> dims(bounds.size());
   for (index_t d = 0; d < static_cast<index_t>(bounds.size()); ++d) {
     dims[d].bounds = bounds[d];

--- a/slinky/builder/substitute.cc
+++ b/slinky/builder/substitute.cc
@@ -719,7 +719,7 @@ void substitutor::visit(const call_stmt* op) {
     changed = changed || !scalars[i].same_as(op->scalars[i]);
   }
   if (changed) {
-    set_result(call_stmt::make(op->target, std::move(inputs), std::move(outputs), std::move(scalars), op->attrs));
+    set_result(call_stmt::make(op->target, std::move(inputs), std::move(outputs), std::move(scalars), *op->attrs));
   } else {
     set_result(op);
   }

--- a/slinky/builder/substitute.h
+++ b/slinky/builder/substitute.h
@@ -18,7 +18,7 @@ SLINKY_INLINE bool match(index_t a, var b) { return false; }
 bool match(stmt_ref a, stmt_ref b);
 bool match(const interval_expr& a, const interval_expr& b);
 bool match(const dim_expr& a, const dim_expr& b);
-bool match(const box_expr& a, const box_expr& b);
+bool match(span<interval_expr> a, span<interval_expr> b);
 
 // Compute a sort ordering of two nodes based on their structure (not their values).
 int compare(const var& a, const var& b);
@@ -88,7 +88,7 @@ interval_expr substitute_buffer(
 dim_expr substitute_buffer(const dim_expr& e, var buffer, const std::vector<dim_expr>& dims, var def = var());
 
 // Helpers to make dims for use with `substitute_buffer` for bounds.
-std::vector<dim_expr> make_dims_from_bounds(const box_expr& bounds);
+std::vector<dim_expr> make_dims_from_bounds(span<interval_expr> bounds);
 std::vector<dim_expr> make_dims_from_bounds(int dim, const interval_expr& bounds);
 
 // Find `target` and replace it with `replacement`. Does not respect shadowing or implicit buffer metadata.

--- a/slinky/builder/test/l2_norm.cc
+++ b/slinky/builder/test/l2_norm.cc
@@ -132,8 +132,8 @@ TEST_P(l2_norm, pipeline) {
   fused_l2_norm(in_buf.cast<const float>(), ref_buf.cast<float>());
 
   for (index_t b = 0; b < B; ++b) {
-    auto out_b = span<const float>(&out_buf(0, b), D);
-    auto ref_b = span<const float>(&ref_buf(0, b), D);
+    auto out_b = span<float>(&out_buf(0, b), D);
+    auto ref_b = span<float>(&ref_buf(0, b), D);
     ASSERT_THAT(out_b, testing::Pointwise(testing::FloatNear(1e-6f), ref_b));
   }
 

--- a/slinky/builder/test/optimizations.cc
+++ b/slinky/builder/test/optimizations.cc
@@ -62,51 +62,51 @@ stmt dummy_call(std::vector<var> inputs, std::vector<var> outputs, call_stmt::at
 }  // namespace
 
 TEST(optimizations, fuse_siblings) {
-  auto use_buffer = [](var x) { return call_stmt::make(nullptr, {}, {x}, {}, {}); };
+  auto use_buffer = [](var x) { return call_stmt::make(nullptr, span<var>{}, span<var>{&x, 1}, {}, {}); };
 
   ASSERT_THAT(fuse_siblings(block::make({
-                  allocate::make(x, memory_type::heap, 1, {}, use_buffer(x)),
-                  allocate::make(y, memory_type::heap, 1, {}, use_buffer(y)),
+                  allocate::make(x, memory_type::heap, 1, span<dim_expr>{}, use_buffer(x)),
+                  allocate::make(y, memory_type::heap, 1, span<dim_expr>{}, use_buffer(y)),
               })),
-      matches(allocate::make(
-          x, memory_type::heap, 1, {}, block::make({use_buffer(x), clone_buffer::make(y, x, use_buffer(y))}))));
+      matches(allocate::make(x, memory_type::heap, 1, span<dim_expr>{},
+          block::make({use_buffer(x), clone_buffer::make(y, x, use_buffer(y))}))));
 
   ASSERT_THAT(fuse_siblings(block::make({
-                  allocate::make(x, memory_type::heap, 1, {}, use_buffer(x)),
-                  allocate::make(y, memory_type::heap, 2, {}, use_buffer(y)),
+                  allocate::make(x, memory_type::heap, 1, span<dim_expr>{}, use_buffer(x)),
+                  allocate::make(y, memory_type::heap, 2, span<dim_expr>{}, use_buffer(y)),
               })),
       matches(fuse_siblings(block::make({
-          allocate::make(x, memory_type::heap, 1, {}, use_buffer(x)),
-          allocate::make(y, memory_type::heap, 2, {}, use_buffer(y)),
+          allocate::make(x, memory_type::heap, 1, span<dim_expr>{}, use_buffer(x)),
+          allocate::make(y, memory_type::heap, 2, span<dim_expr>{}, use_buffer(y)),
       }))));
 
   ASSERT_THAT(fuse_siblings(block::make({
-                  allocate::make(x, memory_type::heap, 1, {}, use_buffer(x)),
-                  allocate::make(y, memory_type::stack, 1, {}, use_buffer(y)),
+                  allocate::make(x, memory_type::heap, 1, span<dim_expr>{}, use_buffer(x)),
+                  allocate::make(y, memory_type::stack, 1, span<dim_expr>{}, use_buffer(y)),
               })),
       matches(fuse_siblings(block::make({
-          allocate::make(x, memory_type::heap, 1, {}, use_buffer(x)),
-          allocate::make(y, memory_type::stack, 1, {}, use_buffer(y)),
+          allocate::make(x, memory_type::heap, 1, span<dim_expr>{}, use_buffer(x)),
+          allocate::make(y, memory_type::stack, 1, span<dim_expr>{}, use_buffer(y)),
       }))));
 
   ASSERT_THAT(fuse_siblings(block::make({
-                  allocate::make(x, memory_type::heap, 1, {{}}, use_buffer(x)),
-                  allocate::make(y, memory_type::heap, 1, {}, use_buffer(y)),
+                  allocate::make(x, memory_type::heap, 1, std::vector<dim_expr>{{}}, use_buffer(x)),
+                  allocate::make(y, memory_type::heap, 1, span<dim_expr>{}, use_buffer(y)),
               })),
       matches(fuse_siblings(block::make({
-          allocate::make(x, memory_type::heap, 1, {{}}, use_buffer(x)),
-          allocate::make(y, memory_type::heap, 1, {}, use_buffer(y)),
+          allocate::make(x, memory_type::heap, 1, std::vector<dim_expr>{{}}, use_buffer(x)),
+          allocate::make(y, memory_type::heap, 1, span<dim_expr>{}, use_buffer(y)),
       }))));
 
   ASSERT_THAT(fuse_siblings(block::make({
-                  allocate::make(x, memory_type::heap, 1, {}, use_buffer(x)),
+                  allocate::make(x, memory_type::heap, 1, span<dim_expr>{}, use_buffer(x)),
                   use_buffer(z),
-                  allocate::make(y, memory_type::heap, 1, {}, use_buffer(y)),
+                  allocate::make(y, memory_type::heap, 1, span<dim_expr>{}, use_buffer(y)),
               })),
       matches(block::make({
-          allocate::make(x, memory_type::heap, 1, {}, use_buffer(x)),
+          allocate::make(x, memory_type::heap, 1, span<dim_expr>{}, use_buffer(x)),
           use_buffer(z),
-          allocate::make(y, memory_type::heap, 1, {}, use_buffer(y)),
+          allocate::make(y, memory_type::heap, 1, span<dim_expr>{}, use_buffer(y)),
       })));
   ASSERT_THAT(fuse_siblings(block::make({
                   crop_dim::make(x, y, 0, {0, 10}, crop_dim::make(z, x, 1, {0, 10}, use_buffer(z))),
@@ -215,7 +215,9 @@ TEST(optimizations, remove_pure_dims) {
 }
 
 TEST(optimizations, optimize_symbols) {
-  auto make_dummy_decl = [](var x, stmt body) { return allocate::make(x, memory_type::heap, 1, {}, body); };
+  auto make_dummy_decl = [](var x, stmt body) {
+    return allocate::make(x, memory_type::heap, 1, span<dim_expr>{}, body);
+  };
 
   {
     // We don't know about x, we can't mutate it.
@@ -420,12 +422,10 @@ TEST(optimizations, lift_constants) {
   // Constants inside inner blocks or loops or lets get lifted to root let_stmt.
   stmt s = loop::make(x, loop::serial, {0, 10}, expr(),
       let_stmt::make(y, constant_buffer::make(buf1),
-          let_stmt::make(z, x + 1,
-              let_stmt::make(w, constant_buffer::make(buf2), dummy_call({y, w, z}, {})))));
+          let_stmt::make(z, x + 1, let_stmt::make(w, constant_buffer::make(buf2), dummy_call({y, w, z}, {})))));
 
   stmt expected = let_stmt::make({{y, constant_buffer::make(buf1)}, {w, constant_buffer::make(buf2)}},
-      loop::make(x, loop::serial, {0, 10}, expr(),
-          let_stmt::make(z, x + 1, dummy_call({y, w, z}, {}))));
+      loop::make(x, loop::serial, {0, 10}, expr(), let_stmt::make(z, x + 1, dummy_call({y, w, z}, {}))));
 
   ASSERT_THAT(lift_constants(s), matches(expected));
 

--- a/slinky/builder/test/pipeline.cc
+++ b/slinky/builder/test/pipeline.cc
@@ -19,7 +19,7 @@ namespace slinky {
 class call_nullifier : public node_mutator {
 public:
   void visit(const call_stmt* op) override {
-    set_result(call_stmt::make(nullptr, op->inputs, op->outputs, {}, op->attrs));
+    set_result(call_stmt::make(nullptr, op->inputs, op->outputs, {}, *op->attrs));
   }
 
   using node_mutator::visit;

--- a/slinky/builder/test/simplify/simplify.cc
+++ b/slinky/builder/test/simplify/simplify.cc
@@ -60,7 +60,7 @@ auto _ = []() {
 MATCHER_P(matches, x, "") { return match(arg, x); }
 
 stmt dummy_call(std::vector<var> inputs, std::vector<var> outputs, call_stmt::attributes attrs = {}) {
-  return call_stmt::make(nullptr, std::move(inputs), std::move(outputs), {}, std::move(attrs));
+  return call_stmt::make(nullptr, inputs, outputs, std::vector<expr>{}, std::move(attrs));
 }
 
 }  // namespace
@@ -231,8 +231,9 @@ TEST(simplify, basic) {
   ASSERT_THAT(simplify(select((y <= 0), select((x <= 0), z, x), z)), matches(select(0 < x && y <= 0, x, z)));
 
   ASSERT_THAT(simplify(crop_dim::make(y, x, 1, {expr(), expr()}, dummy_call({}, {y}))), matches(dummy_call({}, {x})));
-  ASSERT_THAT(simplify(crop_buffer::make(y, x, {}, dummy_call({}, {y}))), matches(dummy_call({}, {x})));
-  ASSERT_THAT(simplify(slice_buffer::make(y, x, {}, dummy_call({}, {y}))), matches(dummy_call({}, {x})));
+  ASSERT_THAT(
+      simplify(crop_buffer::make(y, x, std::vector<interval_expr>{}, dummy_call({}, {y}))), matches(dummy_call({}, {x})));
+  ASSERT_THAT(simplify(slice_buffer::make(y, x, std::vector<expr>{}, dummy_call({}, {y}))), matches(dummy_call({}, {x})));
 
   ASSERT_THAT(simplify(max(select(z <= 0, -1, select(1 <= y, min(x, z + -1), 0)) + 1, select((1 <= y), z, 0))),
       matches(select((1 <= y), max(z, 0), (0 < z))));
@@ -570,7 +571,7 @@ TEST(simplify, buffer_bounds) {
     return allocate::make(buf, memory_type::heap, 1, dims, body);
   };
   auto use_buffer = [](var b) { return dummy_call({}, {b}); };
-  auto use_buffers = [](std::vector<var> bs) { return call_stmt::make(nullptr, {}, std::move(bs), {}, {}); };
+  auto use_buffers = [](std::vector<var> bs) { return call_stmt::make(nullptr, span<var>{}, bs, {}, {}); };
   ASSERT_THAT(simplify(decl_bounds(b0, {buffer_bounds(b1, 0)},
                   crop_dim::make(b2, b0, 0, buffer_bounds(b1, 0) & bounds(x, y), use_buffer(b2)))),
       matches(decl_bounds(b0, {{buffer_bounds(b1, 0)}}, crop_dim::make(b2, b0, 0, bounds(x, y), use_buffer(b2)))));
@@ -666,8 +667,8 @@ TEST(simplify, clone) {
   ASSERT_THAT(simplify(clone_buffer::make(b1, b0, clone_buffer::make(b2, b1, check::make(b0 && b2)))),
       matches(check::make(b0)));
 
-  ASSERT_THAT(simplify(clone_buffer::make(b1, b0, transpose::make(b2, b1, {1, 0}, dummy_call({}, {b0, b2})))),
-      matches(transpose::make(b2, b0, {1, 0}, dummy_call({}, {b0, b2}))));
+  ASSERT_THAT(simplify(clone_buffer::make(b1, b0, transpose::make(b2, b1, std::vector<int>{1, 0}, dummy_call({}, {b0, b2})))),
+      matches(transpose::make(b2, b0, std::vector<int>{1, 0}, dummy_call({}, {b0, b2}))));
 
   // Clone should be substituted.
   ASSERT_THAT(simplify(clone_buffer::make(y, x, crop_dim::make(z, y, 0, {0, 0}, dummy_call({w}, {z})))),
@@ -761,7 +762,7 @@ TEST(simplify, slice_of_crop) {
       matches(slice_dim::make(b3, b0, 1, 0, body)));
 
   // Test support for slice_buffer.
-  ASSERT_THAT(simplify(crop_dim::make(b1, b0, 1, {0, 3}, slice_buffer::make(b3, b1, {{}, 0}, body))),
+  ASSERT_THAT(simplify(crop_dim::make(b1, b0, 1, {0, 3}, slice_buffer::make(b3, b1, std::vector<expr>{{}, 0}, body))),
       matches(slice_dim::make(b3, b0, 1, 0, body)));
 
   // Test support for slicing multiple dimensions.
@@ -769,15 +770,15 @@ TEST(simplify, slice_of_crop) {
       matches(slice_buffer::make(b3, b0, {{1}, {0}}, body)));
 
   // Slice entries beyond the known source rank are broadcast and can be trimmed.
-  ASSERT_THAT(simplify(allocate::make(b0, memory_type::heap, 1, {{bounds(0, x)}},
+  ASSERT_THAT(simplify(allocate::make(b0, memory_type::heap, 1, std::vector<dim_expr>{{bounds(0, x)}},
                   slice_buffer::make(b1, b0, {y, z}, dummy_call({b1}, {})))),
       matches(allocate::make(
-          b0, memory_type::heap, 1, {{bounds(0, x)}}, slice_dim::make(b1, b0, 0, y, dummy_call({b1}, {})))));
+          b0, memory_type::heap, 1, std::vector<dim_expr>{{bounds(0, x)}}, slice_dim::make(b1, b0, 0, y, dummy_call({b1}, {})))));
 
   // Slice of only broadcast dimensions is a no-op.
-  ASSERT_THAT(simplify(allocate::make(b0, memory_type::heap, 1, {{bounds(0, x)}},
+  ASSERT_THAT(simplify(allocate::make(b0, memory_type::heap, 1, std::vector<dim_expr>{{bounds(0, x)}},
                   slice_buffer::make(b1, b0, {expr(), z}, dummy_call({b1}, {})))),
-      matches(allocate::make(b0, memory_type::heap, 1, {{bounds(0, x)}}, dummy_call({b0}, {}))));
+      matches(allocate::make(b0, memory_type::heap, 1, std::vector<dim_expr>{{bounds(0, x)}}, dummy_call({b0}, {}))));
 
   // Slicing a dimension known to be broadcast is a no-op.
   ASSERT_THAT(simplify(allocate::make(b0, memory_type::heap, 1, {dim::broadcast(), {bounds(0, x), 1, expr()}},
@@ -842,15 +843,15 @@ TEST(simplify, crop) {
       })));
 
   // Bounds beyond the known source rank are broadcast and can be trimmed.
-  ASSERT_THAT(simplify(allocate::make(b0, memory_type::heap, 1, {{bounds(0, x)}},
+  ASSERT_THAT(simplify(allocate::make(b0, memory_type::heap, 1, std::vector<dim_expr>{{bounds(0, x)}},
                   crop_buffer::make(b1, b0, {{y, z}, {w, u}}, dummy_call({}, {b1})))),
       matches(allocate::make(
-          b0, memory_type::heap, 1, {{bounds(0, x)}}, crop_dim::make(b1, b0, 0, {y, z}, dummy_call({}, {b1})))));
+          b0, memory_type::heap, 1, std::vector<dim_expr>{{bounds(0, x)}}, crop_dim::make(b1, b0, 0, {y, z}, dummy_call({}, {b1})))));
 
   // Crop of a dimension beyond the known rank is a no-op.
   ASSERT_THAT(simplify(allocate::make(
-                  b0, memory_type::heap, 1, {{bounds(0, x)}}, crop_dim::make(b1, b0, 1, {y, z}, dummy_call({}, {b1})))),
-      matches(allocate::make(b0, memory_type::heap, 1, {{bounds(0, x)}}, dummy_call({}, {b0}))));
+                  b0, memory_type::heap, 1, std::vector<dim_expr>{{bounds(0, x)}}, crop_dim::make(b1, b0, 1, {y, z}, dummy_call({}, {b1})))),
+      matches(allocate::make(b0, memory_type::heap, 1, std::vector<dim_expr>{{bounds(0, x)}}, dummy_call({}, {b0}))));
 
   // Cropping a dimension known to be broadcast is a no-op.
   ASSERT_THAT(simplify(allocate::make(b0, memory_type::heap, 1, {dim::broadcast(), {bounds(0, x), 1, expr()}},
@@ -932,27 +933,27 @@ TEST(simplify, make_buffer) {
 
   // Transpose
   ASSERT_THAT(simplify(make_buffer::make(b1, buffer_at(b0), buffer_elem_size(b0), {buffer_dim(b0, 2)}, body)),
-      matches(transpose::make(b1, b0, {2}, body)));
+      matches(transpose::make(b1, b0, std::vector<int>{2}, body)));
   ASSERT_THAT(simplify(make_buffer::make(
                   b1, buffer_at(b0), buffer_elem_size(b0), {buffer_dim(b0, 0), buffer_dim(b0, 2)}, body)),
-      matches(transpose::make(b1, b0, {0, 2}, body)));
+      matches(transpose::make(b1, b0, std::vector<int>{0, 2}, body)));
 
   ASSERT_THAT(simplify(make_buffer::make(b1, buffer_at(b0), buffer_elem_size(b0),
                   {buffer_dim(b0, 0), dim::broadcast(), buffer_dim(b0, 2)}, body)),
-      matches(transpose::make(b1, b0, {0, transpose::new_dim, 2}, body)));
+      matches(transpose::make(b1, b0, std::vector<int>{0, transpose::new_dim, 2}, body)));
 
   ASSERT_THAT(
       simplify(allocate::make(b0, memory_type::heap, 4, {{{0, 10}, {}, {}}, {{0, 20}, {}, {}}, {{0, 30}, {}, {}}},
           make_buffer::make(b1, buffer_at(b0), buffer_elem_size(b0),
               {{{0, 10}, buffer_stride(b0, 0), {}}, {{0, 20}, buffer_stride(b0, 1), {}}}, dummy_call({}, {b0, b1})))),
       matches(allocate::make(b0, memory_type::heap, 4, {{{0, 10}, {}, {}}, {{0, 20}, {}, {}}, {{0, 30}, {}, {}}},
-          transpose::make(b1, b0, {0, 1}, dummy_call({}, {b0, b1})))));
+          transpose::make(b1, b0, std::vector<int>{0, 1}, dummy_call({}, {b0, b1})))));
 
   // Truncating a constant buffer.
   const dim const_dims[] = {dim::broadcast(), dim::broadcast()};
   auto const_buffer = slinky::raw_buffer::make(/*rank=*/2, /*elem_size=*/1, const_dims);
   ASSERT_THAT(
-      simplify(let_stmt::make(b0, constant_buffer::make(const_buffer), make_buffer::make(b1, buffer_at(b0, 0, 0), 1, {}, body))),
+      simplify(let_stmt::make(b0, constant_buffer::make(const_buffer), make_buffer::make(b1, buffer_at(b0, 0, 0), 1, std::vector<dim_expr>{}, body))),
       matches(let_stmt::make(b0, constant_buffer::make(const_buffer), transpose::make_truncate(b1, b0, 0, body))));
 
   // The same buffer
@@ -970,72 +971,72 @@ TEST(simplify, make_buffer) {
                   make_buffer::make(b1, buffer_at(b0), buffer_elem_size(b0),
                       {{{0, 0}, buffer_stride(b0, 1), {}}, {{0, 0}, buffer_stride(b0, 0)}}, dummy_call({}, {b1})))),
       matches(allocate::make(
-          b0, memory_type::heap, 4, {{{0, 0}, 0}, {{0, 0}, {}}}, transpose::make(b1, b0, {1}, dummy_call({}, {b1})))));
+          b0, memory_type::heap, 4, {{{0, 0}, 0}, {{0, 0}, {}}}, transpose::make(b1, b0, std::vector<int>{1}, dummy_call({}, {b1})))));
 }
 
 TEST(simplify, transpose) {
-  ASSERT_THAT(simplify(transpose::make(b1, b0, {2, 1, 0}, transpose::make(b2, b1, {2, 1, 0}, dummy_call({}, {b2})))),
-      matches(transpose::make(b2, b0, {0, 1, 2}, dummy_call({}, {b2}))));
-  ASSERT_THAT(simplify(transpose::make(b1, b0, {3, 2, 1}, transpose::make(b2, b1, {1, 0}, dummy_call({}, {b2})))),
-      matches(transpose::make(b2, b0, {2, 3}, dummy_call({}, {b2}))));
+  ASSERT_THAT(simplify(transpose::make(b1, b0, std::vector<int>{2, 1, 0}, transpose::make(b2, b1, std::vector<int>{2, 1, 0}, dummy_call({}, {b2})))),
+      matches(transpose::make(b2, b0, std::vector<int>{0, 1, 2}, dummy_call({}, {b2}))));
+  ASSERT_THAT(simplify(transpose::make(b1, b0, std::vector<int>{3, 2, 1}, transpose::make(b2, b1, std::vector<int>{1, 0}, dummy_call({}, {b2})))),
+      matches(transpose::make(b2, b0, std::vector<int>{2, 3}, dummy_call({}, {b2}))));
 
   ASSERT_THAT(
-      simplify(transpose::make(b1, b0, {2, 3},
-          transpose::make(b2, b1, {0, transpose::new_dim, 1}, check::make(buffer_min(b2, 2) == buffer_min(b0, 3))))),
+      simplify(transpose::make(b1, b0, std::vector<int>{2, 3},
+          transpose::make(b2, b1, std::vector<int>{0, transpose::new_dim, 1}, check::make(buffer_min(b2, 2) == buffer_min(b0, 3))))),
       matches(
-          transpose::make(b2, b0, {2, transpose::new_dim, 3}, check::make(buffer_min(b2, 2) == buffer_min(b0, 3)))));
+          transpose::make(b2, b0, std::vector<int>{2, transpose::new_dim, 3}, check::make(buffer_min(b2, 2) == buffer_min(b0, 3)))));
 
   // Make sure that an intermediate transpose that drops dimensions is not skipped.
-  ASSERT_THAT(simplify(transpose::make(b1, b0, {2, 1, 0},
-                  transpose::make(b2, b1, {}, transpose::make(b3, b2, {0, 1}, dummy_call({}, {b3}))))),
-      matches(transpose::make(b3, b0, {transpose::new_dim, transpose::new_dim}, dummy_call({}, {b3}))));
+  ASSERT_THAT(simplify(transpose::make(b1, b0, std::vector<int>{2, 1, 0},
+                  transpose::make(b2, b1, std::vector<int>{}, transpose::make(b3, b2, std::vector<int>{0, 1}, dummy_call({}, {b3}))))),
+      matches(transpose::make(b3, b0, std::vector<int>{transpose::new_dim, transpose::new_dim}, dummy_call({}, {b3}))));
 
   ASSERT_THAT(
       simplify(crop_buffer::make(b1, b0, {{x, y}, {z, w}}, transpose::make_truncate(b2, b1, 3, dummy_call({}, {b2})))),
       matches(crop_buffer::make(b1, b0, {{x, y}, {z, w}}, transpose::make_truncate(b2, b1, 3, dummy_call({}, {b2})))));
 
   ASSERT_THAT(simplify(crop_buffer::make(
-                  b1, b0, {{x, y}, {z, w}}, transpose::make(b2, b1, {1, 0}, check::make(buffer_max(b2, 0) <= w)))),
+                  b1, b0, {{x, y}, {z, w}}, transpose::make(b2, b1, std::vector<int>{1, 0}, check::make(buffer_max(b2, 0) <= w)))),
       matches(stmt()));
   ASSERT_THAT(simplify(crop_buffer::make(
-                  b1, b0, {{x, y}, {z, w}}, transpose::make(b2, b1, {1, 0}, check::make(buffer_max(b2, 1) <= w)))),
+                  b1, b0, {{x, y}, {z, w}}, transpose::make(b2, b1, std::vector<int>{1, 0}, check::make(buffer_max(b2, 1) <= w)))),
       matches(crop_buffer::make(
-          b1, b0, {{x, y}, {z, w}}, transpose::make(b2, b1, {1, 0}, check::make(buffer_max(b2, 1) <= w)))));
+          b1, b0, {{x, y}, {z, w}}, transpose::make(b2, b1, std::vector<int>{1, 0}, check::make(buffer_max(b2, 1) <= w)))));
 
   // Outer dim index exceeds the inner transpose's dims size; out-of-bounds dims become new_dim.
-  ASSERT_THAT(simplify(transpose::make(b1, b0, {1, 0}, transpose::make(b2, b1, {0, 2, 1}, dummy_call({}, {b2})))),
-      matches(transpose::make(b2, b0, {1, transpose::new_dim, 0}, dummy_call({}, {b2}))));
+  ASSERT_THAT(simplify(transpose::make(b1, b0, std::vector<int>{1, 0}, transpose::make(b2, b1, std::vector<int>{0, 2, 1}, dummy_call({}, {b2})))),
+      matches(transpose::make(b2, b0, std::vector<int>{1, transpose::new_dim, 0}, dummy_call({}, {b2}))));
 
   // A new_dim where the src dimension is provably a broadcast can use the src dimension instead, which makes this
   // transpose a no-op.
   ASSERT_THAT(simplify(allocate::make(b0, memory_type::heap, 4, {{{0, 10}, {}, {}}, {{0, 0}, 0, {}}, {{0, 30}, {}, {}}},
-                  transpose::make(b1, b0, {0, transpose::new_dim, 2}, dummy_call({}, {b1})))),
+                  transpose::make(b1, b0, std::vector<int>{0, transpose::new_dim, 2}, dummy_call({}, {b1})))),
       matches(allocate::make(
           b0, memory_type::heap, 4, {{{0, 10}, {}, {}}, {{0, 0}, 0, {}}, {{0, 30}, {}, {}}}, dummy_call({}, {b0}))));
 
   // The same, but the new_dim is the last dimension, so the transpose is a no-op instead of a truncate. The allocate
   // then drops the trailing broadcast dimension it no longer needs.
-  ASSERT_THAT(simplify(allocate::make(b0, memory_type::heap, 4, {{{0, 10}, {}, {}}, {{0, 0}, 0, {}}},
-                  transpose::make(b1, b0, {0, transpose::new_dim}, dummy_call({}, {b1})))),
-      matches(allocate::make(b0, memory_type::heap, 4, {{{0, 10}, {}, {}}}, dummy_call({}, {b0}))));
+  ASSERT_THAT(simplify(allocate::make(b0, memory_type::heap, 4, std::vector<dim_expr>{{{0, 10}, {}, {}}, {{0, 0}, 0, {}}},
+                  transpose::make(b1, b0, std::vector<int>{0, transpose::new_dim}, dummy_call({}, {b1})))),
+      matches(allocate::make(b0, memory_type::heap, 4, std::vector<dim_expr>{{{0, 10}, {}, {}}}, dummy_call({}, {b0}))));
 
   // The src dimension is not provably a broadcast, so the new_dim must be kept.
   ASSERT_THAT(
       simplify(allocate::make(b0, memory_type::heap, 4, {{{0, 10}, {}, {}}, {{0, 20}, {}, {}}, {{0, 30}, {}, {}}},
-          transpose::make(b1, b0, {0, transpose::new_dim, 2}, dummy_call({}, {b1})))),
+          transpose::make(b1, b0, std::vector<int>{0, transpose::new_dim, 2}, dummy_call({}, {b1})))),
       matches(allocate::make(b0, memory_type::heap, 4, {{{0, 10}, {}, {}}, {{0, 20}, {}, {}}, {{0, 30}, {}, {}}},
-          transpose::make(b1, b0, {0, transpose::new_dim, 2}, dummy_call({}, {b1})))));
+          transpose::make(b1, b0, std::vector<int>{0, transpose::new_dim, 2}, dummy_call({}, {b1})))));
 
   // Transposes that put trailing broadcasts at the end of the buffer should be dropped.
   ASSERT_THAT(simplify(block::make(
-                  {check::make(buffer_rank(b0) == 2), transpose::make(b1, b0, {1, 4, 0, 3, 2}, dummy_call({}, {b1}))})),
+                  {check::make(buffer_rank(b0) == 2), transpose::make(b1, b0, std::vector<int>{1, 4, 0, 3, 2}, dummy_call({}, {b1}))})),
       matches(
-          block::make({check::make(buffer_rank(b0) == 2), transpose::make(b1, b0, {1, 4, 0}, dummy_call({}, {b1}))})));
+          block::make({check::make(buffer_rank(b0) == 2), transpose::make(b1, b0, std::vector<int>{1, 4, 0}, dummy_call({}, {b1}))})));
 
   // We want to say that we don't allow shadowing in the simplifier. However, the simplifier does generate self-shadowed
   // transposes. This test case covers an issue where such self-shadowed transposes produced an infinite loop.
-  ASSERT_THAT(simplify(transpose::make(b0, b0, {}, transpose::make(b0, b0, {}, dummy_call({}, {b0})))),
-      matches(transpose::make(b0, b0, {}, transpose::make(b0, b0, {}, dummy_call({}, {b0})))));
+  ASSERT_THAT(simplify(transpose::make(b0, b0, std::vector<int>{}, transpose::make(b0, b0, std::vector<int>{}, dummy_call({}, {b0})))),
+      matches(transpose::make(b0, b0, std::vector<int>{}, transpose::make(b0, b0, std::vector<int>{}, dummy_call({}, {b0})))));
 }
 
 TEST(simplify, knowledge) {

--- a/slinky/builder/test/softmax.cc
+++ b/slinky/builder/test/softmax.cc
@@ -210,8 +210,8 @@ TEST_P(softmax, pipeline) {
   add_1(ref_buf.cast<const float>(), ref_buf.cast<float>());
 
   for (index_t b = 0; b < B; ++b) {
-    auto out_b = span<const float>(&out_buf(0, b), D);
-    auto ref_b = span<const float>(&ref_buf(0, b), D);
+    auto out_b = span<float>(&out_buf(0, b), D);
+    auto ref_b = span<float>(&ref_buf(0, b), D);
     ASSERT_THAT(out_b, testing::Pointwise(testing::FloatNear(1e-6f), ref_b));
   }
 

--- a/slinky/builder/test/util.h
+++ b/slinky/builder/test/util.h
@@ -40,7 +40,7 @@ std::string remove_windows_newlines(std::string s);
 
 std::string read_entire_file(const std::string& pathname);
 
-inline bool is_permutation(span<const int> p) {
+inline bool is_permutation(span<int> p) {
   std::vector<int> unpermuted(p.size());
   std::iota(unpermuted.begin(), unpermuted.end(), 0);
   return std::is_permutation(p.begin(), p.end(), unpermuted.begin());

--- a/slinky/runtime/buffer.cc
+++ b/slinky/runtime/buffer.cc
@@ -137,7 +137,7 @@ struct init_stride_dim {
   init_stride_dim(index_t stride, index_t dim_stride) : stride(stride), dim_stride(dim_stride) {}
 };
 
-SLINKY_INLINE bool is_stride_ok(index_t stride, index_t extent, span<const init_stride_dim> dims, bool& overflow) {
+SLINKY_INLINE bool is_stride_ok(index_t stride, index_t extent, span<init_stride_dim> dims, bool& overflow) {
   index_t dim_stride;
   if (mul_with_overflow(stride, extent, dim_stride)) {
     overflow = true;
@@ -252,7 +252,7 @@ SLINKY_NO_STACK_PROTECTOR std::optional<std::size_t> raw_buffer::init_strides_im
       const index_t alloc_extent_i = alloc_extent(dim_i);
       assert(alloc_extent_i > 1);
 
-      span<const init_stride_dim> known_dims{dims, dims_end};
+      span<init_stride_dim> known_dims{dims, dims_end};
       if (is_stride_ok(elem_size, alloc_extent_i, known_dims, overflow)) {
         // This dimension can have stride elem_size, no other stride could be better.
         dim_i.set_stride(elem_size);

--- a/slinky/runtime/buffer.h
+++ b/slinky/runtime/buffer.h
@@ -271,15 +271,15 @@ public:
   }
   bool contains() const { return true; }
 
-  std::ptrdiff_t flat_offset_bytes(span<const index_t> indices) const {
+  std::ptrdiff_t flat_offset_bytes(span<index_t> indices) const {
     index_t offset = 0;
     for (std::size_t i = 0; i < std::min(indices.size(), rank); ++i) {
       offset += dims[i].flat_offset_bytes(indices[i]);
     }
     return offset;
   }
-  void* address_at(span<const index_t> indices) const { return offset_bytes(base, flat_offset_bytes(indices)); }
-  bool contains(span<const index_t> indices) const {
+  void* address_at(span<index_t> indices) const { return offset_bytes(base, flat_offset_bytes(indices)); }
+  bool contains(span<index_t> indices) const {
     bool result = true;
     for (std::size_t i = 0; i < std::min(indices.size(), rank); ++i) {
       result = result && dims[i].contains(indices[i]);
@@ -292,7 +292,7 @@ public:
     assert(sizeof...(offsets) + 1 <= rank);
     translate_impl(dims, o0, offsets...);
   }
-  void translate(span<const index_t> offsets) {
+  void translate(span<index_t> offsets) {
     assert(offsets.size() <= rank);
     for (std::size_t i = 0; i < offsets.size(); ++i) {
       dims[i].translate(offsets[i]);
@@ -300,7 +300,7 @@ public:
   }
 
   // Remove dimensions `ds`. The dimensions must be sorted in ascending order.
-  void slice(span<const std::size_t> ds) {
+  void slice(span<std::size_t> ds) {
     if (ds.size() == 1) {
       slice(ds[0]);
       return;
@@ -609,7 +609,7 @@ public:
   // Construct a buffer with extents, and strides computed such that the stride of dimension
   // n is the product of all the extents of dimensions [0, n) and elem_size, i.e. the first
   // dimension is "innermost".
-  buffer(span<const index_t> extents, std::size_t elem_size = internal::type_info<T>::size)
+  buffer(span<index_t> extents, std::size_t elem_size = internal::type_info<T>::size)
       : buffer(extents.size(), elem_size) {
     slinky::dim* d = dims;
     for (index_t extent : extents) {
@@ -676,8 +676,8 @@ public:
   auto& at() const { return *base(); }
   auto& operator()() const { return *base(); }
 
-  auto& at(span<const index_t> indices) const { return *offset_bytes_non_null(base(), flat_offset_bytes(indices)); }
-  auto& operator()(span<const index_t> indices) const { return at(indices); }
+  auto& at(span<index_t> indices) const { return *offset_bytes_non_null(base(), flat_offset_bytes(indices)); }
+  auto& operator()(span<index_t> indices) const { return at(indices); }
 
   // This differs from `raw_buffer::dim(std::size_t)` because it will expand the rank with broadcast dimensions if
   // necessary to return a reference to dimension d.
@@ -843,7 +843,7 @@ SLINKY_INLINE bool attempt_fuse(std::ptrdiff_t inner, std::ptrdiff_t outer, raw_
 
 template <typename... Bufs>
 SLINKY_INLINE bool attempt_fuse(
-    std::ptrdiff_t inner, std::ptrdiff_t outer, span<const int> dim_sets, raw_buffer& buf, Bufs&... bufs) {
+    std::ptrdiff_t inner, std::ptrdiff_t outer, span<int> dim_sets, raw_buffer& buf, Bufs&... bufs) {
   if (static_cast<int>(dim_sets.size()) > outer && dim_sets[outer] != dim_sets[inner]) {
     // These two dims are not part of the same set. Don't fuse them.
     return false;
@@ -871,7 +871,7 @@ bool all(Args... args) {
 // dimensions are considered to be in the same set.
 // Returns true if the sort changed the ordering of the dimensions.
 template <typename... Bufs>
-bool sort_dims(span<const int> dim_sets, raw_buffer& buf, Bufs&... bufs) {
+bool sort_dims(span<int> dim_sets, raw_buffer& buf, Bufs&... bufs) {
   // We only attempt to sort the dimensions that exist in all buffers. We could do better here, sometimes we can
   // swap implicit broadcast dimensions with another broadcast dimension.
   const size_t rank = std::min({buf.rank, bufs.rank...});
@@ -902,7 +902,7 @@ bool sort_dims(raw_buffer& buf, Bufs&... bufs) {
 // likely to be more efficient. `dim_sets` is an optional span of integers that indicates sets of dimensions that are
 // eligible for fusion. By default, all dimensions are considered to be part of the same set.
 template <typename... Bufs>
-int fuse_contiguous_dims(span<const int> dim_sets, raw_buffer& buf, Bufs&... bufs) {
+int fuse_contiguous_dims(span<int> dim_sets, raw_buffer& buf, Bufs&... bufs) {
   int fused = 0;
   for (std::ptrdiff_t d = static_cast<std::ptrdiff_t>(buf.rank) - 1; d > 0; --d) {
     fused += internal::attempt_fuse(d - 1, d, dim_sets, buf, bufs...);
@@ -920,7 +920,7 @@ int fuse_contiguous_dims(raw_buffer& buf, Bufs&... bufs) {
 
 // Call both `sort_dims` and `fuse_contiguous_dims` on the buffers.
 template <typename... Bufs>
-int optimize_dims(span<const int> dim_sets, raw_buffer& buf, Bufs&... bufs) {
+int optimize_dims(span<int> dim_sets, raw_buffer& buf, Bufs&... bufs) {
   // The order of operations here is for performance: It's a lot faster to fuse dimensions than sort them. So we fuse
   // what we can before sorting, then if the sorting changed the order of the dimensions, attempt to fuse again.
   int fused = fuse_contiguous_dims(dim_sets, buf, bufs...);

--- a/slinky/runtime/depends_on.cc
+++ b/slinky/runtime/depends_on.cc
@@ -32,7 +32,7 @@ public:
   dependencies() {}
   dependencies(std::map<var, depends_on_result>& unknown_deps) : unknown_deps(&unknown_deps) {}
   dependencies(std::vector<std::pair<var, depends_on_result*>> var_deps) : var_deps(var_deps) {}
-  dependencies(span<const std::pair<var, depends_on_result&>> deps) {
+  dependencies(span<std::pair<var, depends_on_result&>> deps) {
     var_deps.reserve(deps.size());
     for (const auto& i : deps) {
       var_deps.push_back({i.first, &i.second});
@@ -290,13 +290,13 @@ public:
 
 }  // namespace
 
-void depends_on(expr_ref e, span<const std::pair<var, depends_on_result&>> var_deps) {
+void depends_on(expr_ref e, span<std::pair<var, depends_on_result&>> var_deps) {
   if (var_deps.empty()) return;
   dependencies v(var_deps);
   if (e.defined()) e.accept(&v);
 }
 
-void depends_on(stmt_ref s, span<const std::pair<var, depends_on_result&>> var_deps) {
+void depends_on(stmt_ref s, span<std::pair<var, depends_on_result&>> var_deps) {
   scoped_trace trace("depends_on");
   if (var_deps.empty()) return;
   dependencies v(var_deps);
@@ -332,7 +332,7 @@ depends_on_result depends_on(stmt_ref s, var x) {
   return r;
 }
 
-depends_on_result depends_on(expr_ref e, span<const var> xs) {
+depends_on_result depends_on(expr_ref e, span<var> xs) {
   depends_on_result r;
   std::vector<std::pair<var, depends_on_result&>> var_deps;
   for (var x : xs) {
@@ -342,7 +342,7 @@ depends_on_result depends_on(expr_ref e, span<const var> xs) {
   return r;
 }
 
-depends_on_result depends_on(stmt_ref s, span<const var> xs) {
+depends_on_result depends_on(stmt_ref s, span<var> xs) {
   depends_on_result r;
   std::vector<std::pair<var, depends_on_result&>> var_deps;
   for (var x : xs) {

--- a/slinky/runtime/depends_on.h
+++ b/slinky/runtime/depends_on.h
@@ -35,15 +35,15 @@ struct depends_on_result {
 };
 
 // Check if the node depends on a symbol or set of symbols.
-void depends_on(expr_ref e, span<const std::pair<var, depends_on_result&>> var_deps);
-void depends_on(stmt_ref s, span<const std::pair<var, depends_on_result&>> var_deps);
+void depends_on(expr_ref e, span<std::pair<var, depends_on_result&>> var_deps);
+void depends_on(stmt_ref s, span<std::pair<var, depends_on_result&>> var_deps);
 void depends_on(expr_ref e, var x, depends_on_result& deps);
 void depends_on(stmt_ref s, var x, depends_on_result& deps);
 depends_on_result depends_on(expr_ref e, var x);
 depends_on_result depends_on(const interval_expr& e, var x);
 depends_on_result depends_on(stmt_ref s, var x);
-depends_on_result depends_on(expr_ref e, span<const var> xs);
-depends_on_result depends_on(stmt_ref s, span<const var> xs);
+depends_on_result depends_on(expr_ref e, span<var> xs);
+depends_on_result depends_on(stmt_ref s, span<var> xs);
 
 // Check if buffer can be safely substituted.
 bool can_substitute_buffer(const depends_on_result& r);

--- a/slinky/runtime/evaluate.cc
+++ b/slinky/runtime/evaluate.cc
@@ -226,7 +226,7 @@ SLINKY_NO_STACK_PROTECTOR inline index_t eval_let(const T* op, eval_context& ctx
 
   std::size_t context_size = 0;
   for (const auto& let : op->lets) {
-    context_size = std::max(context_size, let.first.id);
+    context_size = std::max<size_t>(context_size, let.first.id);
   }
   ctx.reserve(context_size + 1);
 

--- a/slinky/runtime/expr.h
+++ b/slinky/runtime/expr.h
@@ -24,9 +24,9 @@ class expr;
 
 class var {
 public:
-  using type = std::size_t;
+  using type = std::uint32_t;
 
-  static constexpr type invalid = static_cast<size_t>(-1);
+  static constexpr type invalid = static_cast<type>(-1);
 
   type id;
 
@@ -132,7 +132,7 @@ enum class intrinsic {
 // True if `fn` can be evaluated if its arguments are constants.
 bool can_evaluate(intrinsic fn);
 
-enum class buffer_field : unsigned {
+enum class buffer_field : std::uint8_t {
   none = 0,
 
   rank,
@@ -406,7 +406,7 @@ public:
   buffer_field field;
 
   // If `field` is a per-dimension field, which dimension being referenced.
-  int dim;
+  std::int16_t dim;
 
   void accept(expr_visitor* v) const override;
 

--- a/slinky/runtime/expr.h
+++ b/slinky/runtime/expr.h
@@ -7,6 +7,7 @@
 #include <initializer_list>
 #include <map>
 #include <memory>
+#include <new>
 #include <optional>
 #include <string>
 #include <vector>
@@ -167,7 +168,12 @@ public:
     }
   }
 
-  static void destroy(base_node* p) { delete p; }
+  virtual void destroy() { delete this; }
+  static void destroy(base_node* p) { p->destroy(); }
+
+  // Nodes are allocated with trailing storage for the arrays they own, so they must not be freed by a
+  // deallocation function that assumes the size of the node.
+  static void operator delete(void* p) { ::operator delete(p); }
 };
 
 using base_expr_node = base_node<expr_node_type, expr_visitor>;
@@ -376,12 +382,15 @@ class let : public expr_node<let> {
 public:
   // Conceptually, these are evaluated and placed on the stack in order, i.e. lets later in this
   // list can use the values defined by earlier lets in the list.
-  std::vector<std::pair<var, expr>> lets;
+  span<std::pair<var, expr>> lets;
   expr body;
+
+  ~let();
 
   void accept(expr_visitor* v) const override;
 
   static expr make(std::vector<std::pair<var, expr>> lets, expr body);
+  static expr make(span<std::pair<var, expr>> lets, expr body);
 
   static expr make(var sym, expr value, expr body);
 
@@ -545,7 +554,9 @@ public:
   callable target;
 
   // Arguments to the function.
-  std::vector<expr> args;
+  span<expr> args;
+
+  ~call();
 
   void accept(expr_visitor* v) const override;
 
@@ -735,8 +746,8 @@ dim_expr buffer_dim(var buf, int dim);
 std::vector<dim_expr> buffer_dims(var buf, int rank);
 std::vector<dim_expr> buffer_dims(const raw_buffer& buf);
 
-expr buffer_at(expr buf, span<const expr> at);
-expr buffer_at(expr buf, span<const var> at);
+expr buffer_at(expr buf, span<expr> at);
+expr buffer_at(expr buf, span<var> at);
 expr buffer_at(expr buf);
 
 template <typename... Args>
@@ -745,13 +756,13 @@ expr buffer_at(expr buf, expr at0, Args... at) {
   return buffer_at(buf, args);
 }
 
-box_expr dims_bounds(span<const dim_expr> dims);
+box_expr dims_bounds(span<dim_expr> dims);
 
 expr semaphore_init(expr sem, expr count = expr());
 expr semaphore_signal(expr sem, expr count = expr());
-expr semaphore_signal(span<const expr> sems, span<const expr> counts = {});
+expr semaphore_signal(span<expr> sems, span<expr> counts = {});
 expr semaphore_wait(expr sem, expr count = expr());
-expr semaphore_wait(span<const expr> sems, span<const expr> counts = {});
+expr semaphore_wait(span<expr> sems, span<expr> counts = {});
 
 expr wait_for(expr task);
 expr wait_for(std::vector<expr> tasks);

--- a/slinky/runtime/expr_stmt.cc
+++ b/slinky/runtime/expr_stmt.cc
@@ -216,6 +216,12 @@ crop_buffer::~crop_buffer() { destroy_span(bounds); }
 slice_buffer::~slice_buffer() { destroy_span(at); }
 transpose::~transpose() { destroy_span(dims); }
 
+call_stmt::call_stmt(const call_stmt& other)
+    : stmt_node<call_stmt>(other), target(other.target), inputs(other.inputs), outputs(other.outputs),
+      scalars(other.scalars) {
+  if (other.attrs) attrs = std::make_unique<attributes>(*other.attrs);
+}
+
 call_stmt::~call_stmt() {
   destroy_span(inputs);
   destroy_span(outputs);
@@ -610,7 +616,7 @@ stmt call_stmt::make(
   n->inputs = make_span(arrays, inputs);
   n->outputs = make_span(arrays, outputs);
   n->scalars = make_span(arrays, scalars);
-  n->attrs = std::move(attrs);
+  n->attrs = std::make_unique<attributes>(std::move(attrs));
   return stmt(n);
 }
 

--- a/slinky/runtime/expr_stmt.cc
+++ b/slinky/runtime/expr_stmt.cc
@@ -61,6 +61,56 @@ bool can_evaluate(intrinsic fn) {
   }
 }
 
+// A node's arrays are constructed in its own allocation, immediately following the node. This layout is private to
+// the nodes we make here; nothing but the `span` of each array escapes.
+// Every element type we put in a node array has at most this alignment, so every array can be aligned the same way,
+// and the storage a node needs can be computed before allocating it.
+constexpr std::size_t array_alignment = alignof(void*);
+
+// The number of bytes the elements of `x` occupy in the storage of the node that owns them.
+template <typename Array>
+std::size_t size_of(const Array& x) {
+  using T = typename Array::value_type;
+  static_assert(alignof(T) <= array_alignment, "node array elements must not be overaligned");
+  return align_up(x.size() * sizeof(T), array_alignment);
+}
+
+// Construct an array in `storage` by moving the elements of `src` into it, and advance `storage` past it.
+template <typename T>
+span<T> make_span(void*& storage, std::vector<T>& src) {
+  T* result = static_cast<T*>(storage);
+  for (std::size_t i = 0; i < src.size(); ++i) {
+    new (result + i) T(std::move(src[i]));
+  }
+  storage = static_cast<char*>(storage) + size_of(src);
+  return span<T>(result, src.size());
+}
+
+// Construct an array in `storage` by copying `src`, which we don't own, and advance `storage` past it.
+template <typename T>
+span<T> make_span(void*& storage, span<T> src) {
+  T* result = static_cast<T*>(storage);
+  for (std::size_t i = 0; i < src.size(); ++i) {
+    new (result + i) T(src[i]);
+  }
+  storage = static_cast<char*>(storage) + size_of(src);
+  return span<T>(result, src.size());
+}
+
+template <typename T>
+void destroy_span(span<T> x) {
+  for (const T& i : x) {
+    const_cast<T&>(i).~T();
+  }
+}
+
+// Allocate a node with `array_bytes` of storage for its arrays following it.
+template <typename T>
+T* make_node(std::size_t array_bytes = 0) {
+  static_assert(sizeof(T) % array_alignment == 0, "node arrays would be misaligned");
+  return new (::operator new(sizeof(T) + array_bytes)) T();
+}
+
 template <typename T>
 expr make_bin_op(expr a, expr b) {
   // Here we eagerly constant fold arithmetic.
@@ -82,22 +132,30 @@ expr make_bin_op(expr a, expr b) {
   return expr(n);
 }
 
-template <typename T, typename Body>
-T* make_let(std::vector<std::pair<var, expr>> lets, Body body) {
-  auto n = new T();
-  n->lets = std::move(lets);
+template <typename T, typename Lets, typename Body>
+T* make_let(Lets&& lets, Body body) {
+  auto n = make_node<T>(size_of(lets));
+  void* arrays = n + 1;
+  n->lets = make_span(arrays, lets);
   n->body = std::move(body);
   return n;
 }
 
 expr let::make(std::vector<std::pair<var, expr>> lets, expr body) {
-  return expr(make_let<let>(std::move(lets), std::move(body)));
+  return expr(make_let<let>(lets, std::move(body)));
 }
+expr let::make(span<std::pair<var, expr>> lets, expr body) { return expr(make_let<let>(lets, std::move(body))); }
 
 expr let::make(var sym, expr value, expr body) { return make({{sym, std::move(value)}}, std::move(body)); }
 
 stmt let_stmt::make(std::vector<std::pair<var, expr>> lets, stmt body, bool is_closure) {
-  let_stmt* n = make_let<let_stmt>(std::move(lets), std::move(body));
+  let_stmt* n = make_let<let_stmt>(lets, std::move(body));
+  n->is_closure = is_closure;
+  return stmt(n);
+}
+
+stmt let_stmt::make(span<std::pair<var, expr>> lets, stmt body, bool is_closure) {
+  let_stmt* n = make_let<let_stmt>(lets, std::move(body));
   n->is_closure = is_closure;
   return stmt(n);
 }
@@ -146,6 +204,28 @@ const constant* make_constant(std::int64_t value) {
 }
 
 }  // namespace
+
+let::~let() { destroy_span(lets); }
+call::~call() { destroy_span(args); }
+
+let_stmt::~let_stmt() { destroy_span(lets); }
+block::~block() { destroy_span(stmts); }
+allocate::~allocate() { destroy_span(dims); }
+make_buffer::~make_buffer() { destroy_span(dims); }
+crop_buffer::~crop_buffer() { destroy_span(bounds); }
+slice_buffer::~slice_buffer() { destroy_span(at); }
+transpose::~transpose() { destroy_span(dims); }
+
+call_stmt::~call_stmt() {
+  destroy_span(inputs);
+  destroy_span(outputs);
+  destroy_span(scalars);
+}
+
+copy_stmt::~copy_stmt() {
+  destroy_span(src_x);
+  destroy_span(dst_x);
+}
 
 expr::expr(std::int64_t x) : expr(make_constant(x)) {}
 expr::expr(var sym) : expr(make_variable(sym)) {}
@@ -501,10 +581,11 @@ expr select::make(expr condition, expr true_value, expr false_value) {
 }
 
 expr call::make(slinky::intrinsic i, callable target, std::vector<expr> args) {
-  auto n = new call();
+  auto n = make_node<call>(size_of(args));
   n->intrinsic = i;
   n->target = std::move(target);
-  n->args = std::move(args);
+  void* arrays = n + 1;
+  n->args = make_span(arrays, args);
   expr result(n);
 
   if (n->target || can_evaluate(i)) {
@@ -522,26 +603,37 @@ expr call::make(callable target, std::vector<expr> args) {
 }
 
 stmt call_stmt::make(
-    call_stmt::callable target, symbol_list inputs, symbol_list outputs, std::vector<expr> scalars, attributes attrs) {
-  auto n = new call_stmt();
+    call_stmt::callable target, span<var> inputs, span<var> outputs, std::vector<expr> scalars, attributes attrs) {
+  auto n = make_node<call_stmt>(size_of(inputs) + size_of(outputs) + size_of(scalars));
+  void* arrays = n + 1;
   n->target = std::move(target);
-  n->inputs = std::move(inputs);
-  n->outputs = std::move(outputs);
-  n->scalars = std::move(scalars);
+  n->inputs = make_span(arrays, inputs);
+  n->outputs = make_span(arrays, outputs);
+  n->scalars = make_span(arrays, scalars);
   n->attrs = std::move(attrs);
+  return stmt(n);
+}
+
+template <typename DstX>
+stmt make_copy_stmt(copy_stmt::callable impl, var src, std::vector<expr> src_x, var dst, DstX&& dst_x, var pad) {
+  auto n = make_node<copy_stmt>(size_of(src_x) + size_of(dst_x));
+  void* arrays = n + 1;
+  n->src = src;
+  n->src_x = make_span(arrays, src_x);
+  n->dst = dst;
+  n->dst_x = make_span(arrays, dst_x);
+  n->pad = pad;
+  n->impl = impl;
   return stmt(n);
 }
 
 stmt copy_stmt::make(
     copy_stmt::callable impl, var src, std::vector<expr> src_x, var dst, std::vector<var> dst_x, var pad) {
-  auto n = new copy_stmt();
-  n->src = src;
-  n->src_x = std::move(src_x);
-  n->dst = dst;
-  n->dst_x = std::move(dst_x);
-  n->pad = pad;
-  n->impl = impl;
-  return stmt(n);
+  return make_copy_stmt(impl, src, std::move(src_x), dst, std::move(dst_x), pad);
+}
+
+stmt copy_stmt::make(copy_stmt::callable impl, var src, std::vector<expr> src_x, var dst, span<var> dst_x, var pad) {
+  return make_copy_stmt(impl, src, std::move(src_x), dst, dst_x, pad);
 }
 
 namespace {
@@ -585,8 +677,9 @@ stmt block::make(std::vector<stmt> stmts) {
   } else if (stmts.size() == 1) {
     return std::move(stmts[0]);
   } else {
-    auto n = new block();
-    n->stmts = std::move(stmts);
+    auto n = make_node<block>(size_of(stmts));
+    void* arrays = n + 1;
+  n->stmts = make_span(arrays, stmts);
     return stmt(n);
   }
 }
@@ -612,24 +705,44 @@ stmt loop::make(var sym, expr max_workers, interval_expr bounds, expr step, stmt
   return stmt(l);
 }
 
-stmt allocate::make(var sym, memory_type storage, expr elem_size, std::vector<dim_expr> dims, stmt body) {
-  auto n = new allocate();
+template <typename Dims>
+stmt make_allocate(var sym, memory_type storage, expr elem_size, Dims&& dims, stmt body) {
+  auto n = make_node<allocate>(size_of(dims));
   n->sym = sym;
   n->storage = storage;
   n->elem_size = std::move(elem_size);
-  n->dims = std::move(dims);
+  void* arrays = n + 1;
+  n->dims = make_span(arrays, dims);
+  n->body = std::move(body);
+  return stmt(n);
+}
+
+stmt allocate::make(var sym, memory_type storage, expr elem_size, std::vector<dim_expr> dims, stmt body) {
+  return make_allocate(sym, storage, std::move(elem_size), dims, std::move(body));
+}
+
+stmt allocate::make(var sym, memory_type storage, expr elem_size, span<dim_expr> dims, stmt body) {
+  return make_allocate(sym, storage, std::move(elem_size), dims, std::move(body));
+}
+
+template <typename Dims>
+stmt make_make_buffer(var sym, expr base, expr elem_size, Dims&& dims, stmt body) {
+  auto n = make_node<make_buffer>(size_of(dims));
+  n->sym = sym;
+  n->base = std::move(base);
+  n->elem_size = std::move(elem_size);
+  void* arrays = n + 1;
+  n->dims = make_span(arrays, dims);
   n->body = std::move(body);
   return stmt(n);
 }
 
 stmt make_buffer::make(var sym, expr base, expr elem_size, std::vector<dim_expr> dims, stmt body) {
-  auto n = new make_buffer();
-  n->sym = sym;
-  n->base = std::move(base);
-  n->elem_size = std::move(elem_size);
-  n->dims = std::move(dims);
-  n->body = std::move(body);
-  return stmt(n);
+  return make_make_buffer(sym, std::move(base), std::move(elem_size), dims, std::move(body));
+}
+
+stmt make_buffer::make(var sym, expr base, expr elem_size, span<dim_expr> dims, stmt body) {
+  return make_make_buffer(sym, std::move(base), std::move(elem_size), dims, std::move(body));
 }
 
 stmt clone_buffer::make(var sym, var src, stmt body) {
@@ -640,13 +753,23 @@ stmt clone_buffer::make(var sym, var src, stmt body) {
   return stmt(n);
 }
 
-stmt crop_buffer::make(var sym, var src, std::vector<interval_expr> bounds, stmt body) {
-  auto n = new crop_buffer();
+template <typename Bounds>
+stmt make_crop_buffer(var sym, var src, Bounds&& bounds, stmt body) {
+  auto n = make_node<crop_buffer>(size_of(bounds));
   n->sym = sym;
   n->src = src;
-  n->bounds = std::move(bounds);
+  void* arrays = n + 1;
+  n->bounds = make_span(arrays, bounds);
   n->body = std::move(body);
   return stmt(n);
+}
+
+stmt crop_buffer::make(var sym, var src, std::vector<interval_expr> bounds, stmt body) {
+  return make_crop_buffer(sym, src, bounds, std::move(body));
+}
+
+stmt crop_buffer::make(var sym, var src, span<interval_expr> bounds, stmt body) {
+  return make_crop_buffer(sym, src, bounds, std::move(body));
 }
 
 stmt crop_dim::make(var sym, var src, int dim, interval_expr bounds, stmt body) {
@@ -659,13 +782,23 @@ stmt crop_dim::make(var sym, var src, int dim, interval_expr bounds, stmt body) 
   return stmt(n);
 }
 
-stmt slice_buffer::make(var sym, var src, std::vector<expr> at, stmt body) {
-  auto n = new slice_buffer();
+template <typename At>
+stmt make_slice_buffer(var sym, var src, At&& at, stmt body) {
+  auto n = make_node<slice_buffer>(size_of(at));
   n->sym = sym;
   n->src = src;
-  n->at = std::move(at);
+  void* arrays = n + 1;
+  n->at = make_span(arrays, at);
   n->body = std::move(body);
   return stmt(n);
+}
+
+stmt slice_buffer::make(var sym, var src, std::vector<expr> at, stmt body) {
+  return make_slice_buffer(sym, src, at, std::move(body));
+}
+
+stmt slice_buffer::make(var sym, var src, span<expr> at, stmt body) {
+  return make_slice_buffer(sym, src, at, std::move(body));
 }
 
 stmt slice_dim::make(var sym, var src, int dim, expr at, stmt body) {
@@ -678,13 +811,23 @@ stmt slice_dim::make(var sym, var src, int dim, expr at, stmt body) {
   return stmt(n);
 }
 
-stmt transpose::make(var sym, var src, std::vector<int> dims, stmt body) {
-  auto n = new transpose();
+template <typename Dims>
+stmt make_transpose(var sym, var src, Dims&& dims, stmt body) {
+  auto n = make_node<transpose>(size_of(dims));
   n->sym = sym;
   n->src = src;
-  n->dims = dims;
+  void* arrays = n + 1;
+  n->dims = make_span(arrays, dims);
   n->body = std::move(body);
   return stmt(n);
+}
+
+stmt transpose::make(var sym, var src, std::vector<int> dims, stmt body) {
+  return make_transpose(sym, src, dims, std::move(body));
+}
+
+stmt transpose::make(var sym, var src, span<int> dims, stmt body) {
+  return make_transpose(sym, src, dims, std::move(body));
 }
 
 stmt transpose::make_truncate(var sym, var src, int rank, stmt body) {
@@ -693,7 +836,7 @@ stmt transpose::make_truncate(var sym, var src, int rank, stmt body) {
   return make(sym, src, std::move(dims), std::move(body));
 }
 
-bool transpose::is_truncate(span<const int> dims) {
+bool transpose::is_truncate(span<int> dims) {
   for (std::size_t i = 0; i < dims.size(); ++i) {
     if (dims[i] != static_cast<int>(i)) return false;
   }
@@ -814,7 +957,7 @@ std::vector<dim_expr> buffer_dims(const raw_buffer& buf) {
   return result;
 }
 
-expr buffer_at(expr buf, span<const expr> at) {
+expr buffer_at(expr buf, span<expr> at) {
   std::vector<expr> args;
   args.reserve(at.size() + 1);
   args.push_back(std::move(buf));
@@ -822,7 +965,7 @@ expr buffer_at(expr buf, span<const expr> at) {
   return call::make(intrinsic::buffer_at, std::move(args));
 }
 
-expr buffer_at(expr buf, span<const var> at) {
+expr buffer_at(expr buf, span<var> at) {
   std::vector<expr> args;
   args.reserve(at.size() + 1);
   args.push_back(std::move(buf));
@@ -832,7 +975,7 @@ expr buffer_at(expr buf, span<const var> at) {
 
 expr buffer_at(expr buf) { return call::make(intrinsic::buffer_at, {std::move(buf)}); }
 
-box_expr dims_bounds(span<const dim_expr> dims) {
+box_expr dims_bounds(span<dim_expr> dims) {
   box_expr result(dims.size());
   for (std::size_t d = 0; d < dims.size(); ++d) {
     result[d] = dims[d].bounds;
@@ -892,7 +1035,7 @@ expr semaphore_wait(expr sem, expr count) {
 
 namespace {
 
-expr semaphore_helper(intrinsic fn, span<const expr> sems, span<const expr> counts) {
+expr semaphore_helper(intrinsic fn, span<expr> sems, span<expr> counts) {
   std::vector<expr> args(sems.size() * 2);
   for (std::size_t i = 0; i < sems.size(); ++i) {
     args[i * 2 + 0] = sems[i];
@@ -905,10 +1048,10 @@ expr semaphore_helper(intrinsic fn, span<const expr> sems, span<const expr> coun
 
 }  // namespace
 
-expr semaphore_signal(span<const expr> sems, span<const expr> counts) {
+expr semaphore_signal(span<expr> sems, span<expr> counts) {
   return semaphore_helper(intrinsic::semaphore_signal, sems, counts);
 }
-expr semaphore_wait(span<const expr> sems, span<const expr> counts) {
+expr semaphore_wait(span<expr> sems, span<expr> counts) {
   return semaphore_helper(intrinsic::semaphore_wait, sems, counts);
 }
 

--- a/slinky/runtime/pipeline.h
+++ b/slinky/runtime/pipeline.h
@@ -19,7 +19,7 @@ public:
 
   stmt body;
 
-  using scalars = span<const index_t>;
+  using scalars = span<index_t>;
   using buffers = span<const raw_buffer*>;
 
   // Set up the context to run the pipeline, but do not run it.

--- a/slinky/runtime/print.cc
+++ b/slinky/runtime/print.cc
@@ -370,8 +370,8 @@ public:
 
   void visit(const call_stmt* n) override {
     *this << indent() << "call(";
-    if (!n->attrs.name.empty()) {
-      *this << n->attrs.name;
+    if (!n->attrs->name.empty()) {
+      *this << n->attrs->name;
     } else if (n->target) {
       *this << "<anonymous target>";
     } else {

--- a/slinky/runtime/print.cc
+++ b/slinky/runtime/print.cc
@@ -202,7 +202,7 @@ public:
   }
 
   template <typename T>
-  void print_vector(span<const T> v, const std::string& sep = ", ") {
+  void print_vector(span<T> v, const std::string& sep = ", ") {
     for (std::size_t i = 0; i < v.size(); ++i) {
       *this << v[i];
       if (i + 1 < v.size()) {
@@ -213,6 +213,12 @@ public:
 
   template <typename T>
   printer& operator<<(const std::vector<T>& v) {
+    print_vector(v);
+    return *this;
+  }
+
+  template <typename T>
+  printer& operator<<(span<T> v) {
     print_vector(v);
     return *this;
   }
@@ -265,7 +271,7 @@ public:
     }
     *this << ", " << buf.elem_size << ", {";
     if (buf.rank > 0) {
-      print_vector(span<const dim>{buf.dims, buf.rank}, ", ");
+      print_vector(span<dim>{buf.dims, buf.rank}, ", ");
     }
     *this << "})";
   }

--- a/slinky/runtime/stmt.h
+++ b/slinky/runtime/stmt.h
@@ -154,8 +154,10 @@ public:
   span<var> inputs;
   span<var> outputs;
   span<expr> scalars;
-  attributes attrs;
+  std::unique_ptr<attributes> attrs;
 
+  call_stmt() = default;
+  call_stmt(const call_stmt& other);
   ~call_stmt();
 
   void accept(stmt_visitor* v) const override;

--- a/slinky/runtime/stmt.h
+++ b/slinky/runtime/stmt.h
@@ -151,14 +151,16 @@ public:
   callable target;
   // These are not actually used during evaluation. They are only here for analyzing the IR, so we can know what will be
   // accessed (and how) by the callable.
-  symbol_list inputs;
-  symbol_list outputs;
-  std::vector<expr> scalars;
+  span<var> inputs;
+  span<var> outputs;
+  span<expr> scalars;
   attributes attrs;
+
+  ~call_stmt();
 
   void accept(stmt_visitor* v) const override;
 
-  static stmt make(callable target, symbol_list inputs, symbol_list outputs, std::vector<expr> scalars, attributes attrs);
+  static stmt make(callable target, span<var> inputs, span<var> outputs, std::vector<expr> scalars, attributes attrs);
 
   static constexpr stmt_node_type static_type = stmt_node_type::call_stmt;
 };
@@ -168,9 +170,9 @@ public:
   using callable = std::function<void(const raw_buffer&, const raw_buffer&, const raw_buffer& pad)>;
 
   var src;
-  std::vector<expr> src_x;
+  span<expr> src_x;
   var dst;
-  std::vector<var> dst_x;
+  span<var> dst_x;
   // If defined, the copy will be padded with the values from this buffer when `src` is out of bounds of `dst`.
   var pad;
 
@@ -178,9 +180,12 @@ public:
   // The implementation must only perform a copy and no other operations.
   callable impl;
 
+  ~copy_stmt();
+
   void accept(stmt_visitor* v) const override;
 
   static stmt make(callable impl, var src, std::vector<expr> src_x, var dst, std::vector<var> dst_x, var pad);
+  static stmt make(callable impl, var src, std::vector<expr> src_x, var dst, span<var> dst_x, var pad);
 
   static constexpr stmt_node_type static_type = stmt_node_type::copy_stmt;
 };
@@ -191,8 +196,10 @@ class let_stmt : public stmt_node<let_stmt> {
 public:
   // Conceptually, these are evaluated and placed on the stack in order, i.e. lets later in this
   // list can use the values defined by earlier lets in the list.
-  std::vector<std::pair<var, expr>> lets;
+  span<std::pair<var, expr>> lets;
   stmt body;
+
+  ~let_stmt();
 
   // If this is true, then the body does not access any symbols outside of those defined by `lets`.
   // The values of every let must be a `variable` expression.
@@ -201,6 +208,7 @@ public:
   void accept(stmt_visitor* v) const override;
 
   static stmt make(std::vector<std::pair<var, expr>> lets, stmt body, bool is_closure = false);
+  static stmt make(span<std::pair<var, expr>> lets, stmt body, bool is_closure = false);
 
   static stmt make(var sym, expr value, stmt body);
 
@@ -209,7 +217,9 @@ public:
 
 class block : public stmt_node<block> {
 public:
-  std::vector<stmt> stmts;
+  span<stmt> stmts;
+
+  ~block();
 
   void accept(stmt_visitor* v) const override;
 
@@ -268,12 +278,15 @@ public:
   var sym;
   memory_type storage;
   expr elem_size;
-  std::vector<dim_expr> dims;
+  span<dim_expr> dims;
   stmt body;
+
+  ~allocate();
 
   void accept(stmt_visitor* v) const override;
 
   static stmt make(var sym, memory_type storage, expr elem_size, std::vector<dim_expr> dims, stmt body);
+  static stmt make(var sym, memory_type storage, expr elem_size, span<dim_expr> dims, stmt body);
 
   static constexpr stmt_node_type static_type = stmt_node_type::allocate;
 };
@@ -285,12 +298,15 @@ public:
   var sym;
   expr base;
   expr elem_size;
-  std::vector<dim_expr> dims;
+  span<dim_expr> dims;
   stmt body;
+
+  ~make_buffer();
 
   void accept(stmt_visitor* v) const override;
 
   static stmt make(var sym, expr base, expr elem_size, std::vector<dim_expr> dims, stmt body);
+  static stmt make(var sym, expr base, expr elem_size, span<dim_expr> dims, stmt body);
 
   static constexpr stmt_node_type static_type = stmt_node_type::make_buffer;
 };
@@ -316,12 +332,15 @@ class crop_buffer : public stmt_node<crop_buffer> {
 public:
   var sym;
   var src;
-  std::vector<interval_expr> bounds;
+  span<interval_expr> bounds;
   stmt body;
+
+  ~crop_buffer();
 
   void accept(stmt_visitor* v) const override;
 
   static stmt make(var sym, var src, std::vector<interval_expr> bounds, stmt body);
+  static stmt make(var sym, var src, span<interval_expr> bounds, stmt body);
 
   static constexpr stmt_node_type static_type = stmt_node_type::crop_buffer;
 };
@@ -350,12 +369,15 @@ class slice_buffer : public stmt_node<slice_buffer> {
 public:
   var sym;
   var src;
-  std::vector<expr> at;
+  span<expr> at;
   stmt body;
+
+  ~slice_buffer();
 
   void accept(stmt_visitor* v) const override;
 
   static stmt make(var sym, var src, std::vector<expr> at, stmt body);
+  static stmt make(var sym, var src, span<expr> at, stmt body);
 
   static constexpr stmt_node_type static_type = stmt_node_type::slice_buffer;
 };
@@ -384,17 +406,20 @@ public:
 
   var sym;
   var src;
-  std::vector<int> dims;
+  span<int> dims;
   stmt body;
+
+  ~transpose();
 
   static constexpr int new_dim = std::numeric_limits<int>::max();
 
-  static bool is_truncate(span<const int> dims);
+  static bool is_truncate(span<int> dims);
   bool is_truncate() const;
 
   void accept(stmt_visitor* v) const override;
 
   static stmt make(var sym, var src, std::vector<int> dims, stmt body);
+  static stmt make(var sym, var src, span<int> dims, stmt body);
   static stmt make_truncate(var sym, var src, int rank, stmt body);
 
   static constexpr stmt_node_type static_type = stmt_node_type::transpose;

--- a/slinky/runtime/test/buffer.cc
+++ b/slinky/runtime/test/buffer.cc
@@ -35,11 +35,11 @@ void init_random(Rng& rng, buffer<T, N>& buf) {
 }
 
 template <typename F>
-void for_each_index(span<const dim> dims, int d, index_t* is, const F& f) {
+void for_each_index(span<dim> dims, int d, index_t* is, const F& f) {
   if (d == 0) {
     for (index_t i = dims[0].begin(); i < dims[0].end(); ++i) {
       is[0] = i;
-      f(span<const index_t>(is, is + dims.size()));
+      f(span<index_t>(is, is + dims.size()));
     }
   } else {
     for (index_t i = dims[d].begin(); i < dims[d].end(); ++i) {
@@ -50,9 +50,9 @@ void for_each_index(span<const dim> dims, int d, index_t* is, const F& f) {
 }
 
 template <typename F>
-SLINKY_NO_STACK_PROTECTOR void for_each_index(span<const dim> dims, const F& f) {
+SLINKY_NO_STACK_PROTECTOR void for_each_index(span<dim> dims, const F& f) {
   if (dims.empty()) {
-    f(span<const index_t>{});
+    f(span<index_t>{});
   } else {
     index_t* i = SLINKY_ALLOCA(index_t, dims.size());
     for_each_index(dims, dims.size() - 1, i, f);
@@ -60,7 +60,7 @@ SLINKY_NO_STACK_PROTECTOR void for_each_index(span<const dim> dims, const F& f) 
 }
 template <typename F>
 void for_each_index(const raw_buffer& buf, const F& f) {
-  for_each_index(span<const dim>{buf.dims, buf.rank}, f);
+  for_each_index(span<dim>{buf.dims, buf.rank}, f);
 }
 
 template <typename T, std::size_t N, typename Value>

--- a/slinky/runtime/test/depends_on.cc
+++ b/slinky/runtime/test/depends_on.cc
@@ -120,25 +120,26 @@ TEST(depends_on, is_pure) {
 }
 
 TEST(find_buffer_dependencies, basic) {
-  ASSERT_THAT(find_buffer_dependencies(crop_buffer::make(z, y, {}, dummy_call({x}, {z})),
+  ASSERT_THAT(find_buffer_dependencies(crop_buffer::make(z, y, span<interval_expr>{}, dummy_call({x}, {z})),
                   /*input=*/false, /*output=*/true),
       testing::ElementsAre(y));
   ASSERT_EQ(find_buffer_data_dependency(buffer_at(x)), x);
   ASSERT_EQ(find_buffer_data_dependency(buffer_at(x, buffer_min(y, 0))), x);
   ASSERT_EQ(find_buffer_data_dependency(buffer_at(x) + buffer_at(y)), var());
 
-  ASSERT_THAT(find_buffer_dependencies(crop_buffer::make(x, y, {}, dummy_call({y}, {x}))), testing::ElementsAre(y));
-  ASSERT_THAT(find_buffer_dependencies(crop_buffer::make(z, y, {}, dummy_call({x}, {z})),
+  ASSERT_THAT(find_buffer_dependencies(crop_buffer::make(x, y, span<interval_expr>{}, dummy_call({y}, {x}))),
+      testing::ElementsAre(y));
+  ASSERT_THAT(find_buffer_dependencies(crop_buffer::make(z, y, span<interval_expr>{}, dummy_call({x}, {z})),
                   /*input=*/true, /*output=*/false),
       testing::ElementsAre(x));
-  ASSERT_THAT(find_buffer_dependencies(crop_buffer::make(z, y, {}, dummy_call({x}, {z})),
+  ASSERT_THAT(find_buffer_dependencies(crop_buffer::make(z, y, span<interval_expr>{}, dummy_call({x}, {z})),
                   /*input=*/false, /*output=*/true),
       testing::ElementsAre(y));
 
   stmt test = block::make({
-      crop_buffer::make(z, x, {}, dummy_call({y}, {z})),
-      slice_buffer::make(z, w, {}, dummy_call({y}, {z})),
-      make_buffer::make(v, buffer_at(u), buffer_elem_size(u), {}, dummy_call({x}, {v})),
+      crop_buffer::make(z, x, span<interval_expr>{}, dummy_call({y}, {z})),
+      slice_buffer::make(z, w, span<expr>{}, dummy_call({y}, {z})),
+      make_buffer::make(v, buffer_at(u), buffer_elem_size(u), std::vector<dim_expr>{}, dummy_call({x}, {v})),
   });
 
   ASSERT_THAT(find_buffer_dependencies(test, /*input=*/true, /*output=*/false), testing::ElementsAre(x, y));

--- a/slinky/runtime/test/evaluate.cc
+++ b/slinky/runtime/test/evaluate.cc
@@ -96,7 +96,7 @@ TEST(evaluate, call) {
         calls.push_back(ctx[x]);
         return 0;
       },
-      {}, {}, {}, {});
+      span<var>{}, span<var>{}, {}, {});
 
   eval_context context;
   context[x] = 2;
@@ -121,7 +121,7 @@ TEST(evaluate, loop) {
           sum_x += ctx[x];
           return 0;
         },
-        {}, {}, {}, {});
+        span<var>{}, span<var>{}, {}, {});
 
     stmt l = loop::make(x, max_workers, range(2, 12), 3, c);
 
@@ -152,7 +152,7 @@ stmt make_check(var buffer, std::vector<int> extents, const void* base = nullptr
         }
         return 0;
       },
-      {}, {buffer}, {}, {});
+      span<var>{}, {&buffer, 1}, {}, {});
 }
 
 TEST(evaluate, buffer_fields_broadcast) {
@@ -317,24 +317,24 @@ TEST(evaluate, transpose) {
 
   auto buf_before = buf;
 
-  evaluate(transpose::make(x, x, {0, 1}, make_check(x, {10, 20}, buf.base())), ctx);
-  evaluate(transpose::make(x, x, {3, 1}, make_check(x, {40, 20}, buf.base())), ctx);
-  evaluate(transpose::make(y, x, {0, 1},
+  evaluate(transpose::make(x, x, std::vector<int>{0, 1}, make_check(x, {10, 20}, buf.base())), ctx);
+  evaluate(transpose::make(x, x, std::vector<int>{3, 1}, make_check(x, {40, 20}, buf.base())), ctx);
+  evaluate(transpose::make(y, x, std::vector<int>{0, 1},
                block::make({
                    make_check(x, {10, 20, 30, 40}, buf.base()),
                    make_check(y, {10, 20}, buf.base()),
                })),
       ctx);
-  evaluate(transpose::make(y, x, {2, 1},
+  evaluate(transpose::make(y, x, std::vector<int>{2, 1},
                block::make({
                    make_check(x, {10, 20, 30, 40}, buf.base()),
                    make_check(y, {30, 20}, buf.base()),
                })),
       ctx);
-  evaluate(transpose::make(y, x, {0, 1, 2, 3, 0}, make_check(y, {10, 20, 30, 40, 10}, buf.base())), ctx);
+  evaluate(transpose::make(y, x, std::vector<int>{0, 1, 2, 3, 0}, make_check(y, {10, 20, 30, 40, 10}, buf.base())), ctx);
 
   // The last dimension is a broadcast and is dropped.
-  evaluate(transpose::make(y, x, {0, 5}, make_check(y, {10}, buf.base())), ctx);
+  evaluate(transpose::make(y, x, std::vector<int>{0, 5}, make_check(y, {10}, buf.base())), ctx);
   ASSERT_EQ(buf_before, buf);
 }
 
@@ -400,14 +400,14 @@ TEST(evaluate, async) {
         ++state;
         return 0;
       },
-      {}, {}, {}, {});
+      span<var>{}, span<var>{}, {}, {});
   auto make_check_state = [&](index_t value) {
     return call_stmt::make(
         [value, &state](const call_stmt* op, eval_context& ctx) -> index_t {
           assert(state == value);
           return 0;
         },
-        {}, {}, {}, {});
+        span<var>{}, span<var>{}, {}, {});
   };
 
   stmt test = async::make(x,

--- a/slinky/runtime/test/evaluate_benchmark.cc
+++ b/slinky/runtime/test/evaluate_benchmark.cc
@@ -33,7 +33,7 @@ stmt make_call_counter(std::atomic<int>& calls) {
         ++calls;
         return 0;
       },
-      {}, {}, {}, {});
+      span<var>{}, span<var>{}, {}, {});
 }
 stmt make_call_counter(std::atomic<int>& calls, nanoseconds task_size) {
   return call_stmt::make(
@@ -43,7 +43,7 @@ stmt make_call_counter(std::atomic<int>& calls, nanoseconds task_size) {
         while (clock::now() < end) {}
         return 0;
       },
-      {}, {}, {}, {});
+      span<var>{}, span<var>{}, {}, {});
 }
 
 stmt make_loop(stmt body) { return loop::make(x, loop::serial, range(0, iterations), 1, body); }

--- a/slinky/runtime/visualize.cc
+++ b/slinky/runtime/visualize.cc
@@ -110,6 +110,12 @@ public:
     return *this;
   }
 
+  template <typename T>
+  js_printer& operator<<(span<T> v) {
+    print_vector(v);
+    return *this;
+  }
+
   js_printer& operator<<(const stmt& s) {
     if (s.defined()) {
       ++depth;
@@ -138,7 +144,7 @@ public:
     *this << "make_buffer('<constant>', 0, "
           << (n->value ? n->value->elem_size : 0) << ", [";
     if (n->value && n->value->rank > 0) {
-      print_vector(span<const dim>{n->value->dims, n->value->rank}, ", ");
+      print_vector(span<dim>{n->value->dims, n->value->rank}, ", ");
     }
     *this << "])";
   }


### PR DESCRIPTION
This improves the memory locality of the slinky program nodes, which can reduce overhead substantially.

Nodes now allocate memory for the arrays they contain after the node itself, and the array is now a `span` pointing to that memory. This is an unfortunately pretty viral change, most of the diffs in this PR are noise due to this.

Fixes #466