### PR TITLE
Make `let_stmt` store the max symbol declared in `body`

### DIFF
--- a/slinky/builder/node_mutator.cc
+++ b/slinky/builder/node_mutator.cc
@@ -70,7 +70,7 @@ stmt clone_with(const transpose* op, var sym, stmt new_body) {
 stmt clone_with(const async* op, var sym, stmt new_body) { return async::make(sym, op->task, std::move(new_body)); }
 
 stmt clone_with(const let_stmt* op, stmt new_body) {
-  return let_stmt::make(op->lets, std::move(new_body), op->is_closure);
+  return let_stmt::make(op->lets, std::move(new_body), op->is_closure, op->max_symbol_id);
 }
 
 stmt clone_with(const loop* op, stmt new_body) { return clone_with(op, op->sym, std::move(new_body)); }
@@ -141,7 +141,7 @@ void node_mutator::visit(const variable* op) { set_result(op); }
 void node_mutator::visit(const constant* op) { set_result(op); }
 void node_mutator::visit(const constant_buffer* op) { set_result(op); }
 void node_mutator::visit(const let* op) { set_result(mutate_let(this, op)); }
-void node_mutator::visit(const let_stmt* op) { set_result(mutate_let(this, op, op->is_closure)); }
+void node_mutator::visit(const let_stmt* op) { set_result(mutate_let(this, op, op->is_closure, op->max_symbol_id)); }
 void node_mutator::visit(const add* op) { set_result(mutate_binary(this, op)); }
 void node_mutator::visit(const sub* op) { set_result(mutate_binary(this, op)); }
 void node_mutator::visit(const mul* op) { set_result(mutate_binary(this, op)); }

--- a/slinky/builder/optimizations.cc
+++ b/slinky/builder/optimizations.cc
@@ -1776,7 +1776,14 @@ class reuse_shadows : public stmt_mutator {
   // Buffers that can be mutated in place are true in this map.
   symbol_map<bool> can_mutate;
 
+  void declare(var x) {
+    if (x.defined()) max_symbol_id = std::max<int>(max_symbol_id, x.id);
+  }
+
 public:
+  // The largest symbol id declared in the scope we are mutating.
+  int max_symbol_id = -1;
+
   template <typename T>
   void visit_buffer_mutator(const T* op) {
     stmt body = op->body;
@@ -1789,6 +1796,7 @@ public:
       sym = op->src;
       body = substitute(body, op->sym, sym);
     }
+    declare(sym);
 
     // Buffers start out mutable.
     can_mutate[op->sym] = true;
@@ -1804,11 +1812,12 @@ public:
 
   template <typename T>
   void visit_buffer_decl(const T* op, bool decl_mutable = true) {
+    declare(op->sym);
     can_mutate[op->sym] = decl_mutable;
     stmt_mutator::visit(op);
   }
 
-  stmt mutate_closure(stmt s) {
+  stmt make_closure(stmt s, var extra_sym = var()) {
     // We're entering a stmt executed in parallel. All the buffers in scope cannot be mutated in this scope.
     symbol_map<bool> old_can_mutate;
     std::swap(can_mutate, old_can_mutate);
@@ -1819,35 +1828,61 @@ public:
     std::vector<std::pair<var, expr>> lets;
     for (var i : referenced) {
       lets.push_back({i, expr(i)});
+      declare(i);
     }
-    return let_stmt::make(std::move(lets), std::move(s), /*is_closure=*/true);
+    return let_stmt::make(std::move(lets), std::move(s), /*is_closure=*/true, max_symbol_id);
   }
 
   void visit(const loop* op) override {
+    declare(op->sym);
     if (!prove_true(op->max_workers == loop::serial)) {
-      stmt body = mutate_closure(op->body);
+      // The closure is its own let_stmt with its own max_symbol_id.
+      const int old_max_symbol_id = max_symbol_id;
+      max_symbol_id = -1;
+
+      // Include the loop variable declaration in the closure.
+      declare(op->sym);
+      stmt body = make_closure(op->body);
       set_result(loop::make(op->sym, op->max_workers, op->bounds, op->step, std::move(body)));
+
+      max_symbol_id = old_max_symbol_id;
     } else {
       stmt_mutator::visit(op);
     }
   }
 
   void visit(const async* op) override {
+    declare(op->sym);
     // We're entering an async task. All the buffers in scope cannot be mutated in this scope.
-    stmt task = mutate_closure(op->task);
-    stmt body = mutate_closure(op->body);
+    const int old_max_symbol_id = max_symbol_id;
+    max_symbol_id = -1;
+    stmt task = make_closure(op->task);
+    max_symbol_id = -1;
+    stmt body = make_closure(op->body);
     set_result(async::make(op->sym, std::move(task), std::move(body)));
+    max_symbol_id = old_max_symbol_id;
   }
 
   void visit(const allocate* op) override { visit_buffer_decl(op); }
   void visit(const make_buffer* op) override { visit_buffer_decl(op); }
+  void visit(const clone_buffer* op) override {
+    declare(op->sym);
+    stmt_mutator::visit(op);
+  }
   void visit(const let_stmt* op) override {
+    const int old_max_symbol_id = max_symbol_id;
+    max_symbol_id = -1;
+
     for (const auto& p : op->lets) {
+      declare(p.first);
       if (p.second.as<constant_buffer>()) {
         can_mutate[p.first] = false;
       }
     }
-    stmt_mutator::visit(op);
+    stmt body = mutate(op->body);
+    set_result(let_stmt::make(op->lets, std::move(body), op->is_closure, max_symbol_id));
+
+    max_symbol_id = old_max_symbol_id;
   }
 
   void visit(const crop_buffer* op) override { visit_buffer_mutator(op); }
@@ -1865,7 +1900,15 @@ stmt deshadow(const stmt& s, span<var> symbols, node_context& ctx) {
 }
 stmt optimize_symbols(const stmt& s, node_context& ctx) {
   scoped_trace trace("optimize_symbols");
-  return reuse_shadows().mutate(s);
+  reuse_shadows mutator;
+  stmt result = mutator.mutate(s);
+
+  if (mutator.max_symbol_id >= 0) {
+    // Some symbols were declared outside of any let_stmt.
+    result = let_stmt::make(
+        std::vector<std::pair<var, expr>>{}, std::move(result), /*is_closure=*/false, mutator.max_symbol_id);
+  }
+  return result;
 }
 
 namespace {
@@ -2138,7 +2181,8 @@ public:
       // Assume we are both producing and consuming this buffer.
       consumed.insert(lookup_alias(*buf));
       produced.insert(lookup_alias(*buf));
-    } else if (in_check && (op->intrinsic == intrinsic::buffer_size_bytes || op->intrinsic == intrinsic::validate_buffer)) {
+    } else if (in_check &&
+               (op->intrinsic == intrinsic::buffer_size_bytes || op->intrinsic == intrinsic::validate_buffer)) {
       assert(op->args.size() == 1);
       if (auto buf = as_variable(op->args[0])) {
         produced.insert(lookup_alias(*buf));

--- a/slinky/builder/test/optimizations.cc
+++ b/slinky/builder/test/optimizations.cc
@@ -218,19 +218,20 @@ TEST(optimizations, optimize_symbols) {
   auto make_dummy_decl = [](var x, stmt body) {
     return allocate::make(x, memory_type::heap, 1, span<dim_expr>{}, body);
   };
+  auto empty_let = [](stmt body) { return let_stmt::make(std::vector<std::pair<var, expr>>{}, std::move(body)); };
 
   {
     // We don't know about x, we can't mutate it.
     node_context ctx = symbols;
     ASSERT_THAT(optimize_symbols(crop_dim::make(y, x, 0, {0, 0}, check::make(y)), ctx),
-        matches(crop_dim::make(y, x, 0, {0, 0}, check::make(y))));
+        matches(empty_let(crop_dim::make(y, x, 0, {0, 0}, check::make(y)))));
   }
 
   {
     // We know about x, we can mutate it.
     node_context ctx = symbols;
     ASSERT_THAT(optimize_symbols(make_dummy_decl(x, crop_dim::make(y, x, 0, {0, 0}, check::make(y))), ctx),
-        matches(make_dummy_decl(x, crop_dim::make(x, x, 0, {0, 0}, check::make(x)))));
+        matches(empty_let(make_dummy_decl(x, crop_dim::make(x, x, 0, {0, 0}, check::make(x))))));
   }
 
   {
@@ -238,13 +239,14 @@ TEST(optimizations, optimize_symbols) {
     ASSERT_THAT(
         optimize_symbols(
             make_dummy_decl(x, crop_dim::make(y, x, 0, {0, 0}, crop_dim::make(z, y, 0, {0, 0}, check::make(z)))), ctx),
-        matches(make_dummy_decl(x, crop_dim::make(x, x, 0, {0, 0}, crop_dim::make(x, x, 0, {0, 0}, check::make(x))))));
+        matches(empty_let(
+            make_dummy_decl(x, crop_dim::make(x, x, 0, {0, 0}, crop_dim::make(x, x, 0, {0, 0}, check::make(x)))))));
   }
 
   {
     node_context ctx = symbols;
     ASSERT_THAT(optimize_symbols(make_dummy_decl(y, crop_dim::make(x, y, 0, {0, 0}, check::make(y))), ctx),
-        matches(make_dummy_decl(y, crop_dim::make(x, y, 0, {0, 0}, check::make(y)))));
+        matches(empty_let(make_dummy_decl(y, crop_dim::make(x, y, 0, {0, 0}, check::make(y))))));
   }
 }
 

--- a/slinky/builder/test/visualize/parallel_stencils_0.html
+++ b/slinky/builder/test/visualize/parallel_stencils_0.html
@@ -349,87 +349,89 @@ function trace_begin(x) { return x; }
 function trace_end(x) { return 1; }
 let __trace_names = allocate('__trace_names', 1, [{bounds:[0, 0], stride:1, fold_factor:1}], true);
 function pipeline(in1, in2, out) {
-  check(in1);
-  check((buffer_rank(in1) == 2));
-  check(validate_buffer(in1));
-  check(in2);
-  check((buffer_rank(in2) == 2));
-  check(validate_buffer(in2));
-  check(out);
-  check((buffer_rank(out) == 2));
-  check(validate_buffer(out));
-  check((buffer_elem_size(in1) == 2));
-  check((buffer_elem_size(in2) == 2));
-  check((buffer_elem_size(out) == 2));
-  check(or_else((buffer_fold_factor(out, 0) <= 0), (buffer_max(out, 0) < (buffer_fold_factor(out, 0) + buffer_min(out, 0)))));
-  check(or_else((buffer_fold_factor(out, 1) <= 0), (buffer_max(out, 1) < (buffer_fold_factor(out, 1) + buffer_min(out, 1)))));
-  check((buffer_min(in1, 0) < buffer_min(out, 0)));
-  check((buffer_max(out, 0) < buffer_max(in1, 0)));
-  check((buffer_min(in1, 1) < buffer_min(out, 1)));
-  check((buffer_max(out, 1) < buffer_max(in1, 1)));
-  check(((buffer_min(in2, 0) + 2) <= buffer_min(out, 0)));
-  check(((buffer_max(out, 0) + 2) <= buffer_max(in2, 0)));
-  check(((buffer_min(in2, 1) + 2) <= buffer_min(out, 1)));
-  check(((buffer_max(out, 1) + 2) <= buffer_max(in2, 1)));
-  { let intm4 = allocate('intm4', 2, [
-      {bounds:[buffer_min(out, 0), buffer_max(out, 0)], stride:NaN, fold_factor:NaN},
-      {bounds:[buffer_min(out, 1), buffer_max(out, 1)], stride:NaN, fold_factor:1}
-    ]);
-    { let intm3 = allocate('intm3', 2, [
+  {
+    check(in1);
+    check((buffer_rank(in1) == 2));
+    check(validate_buffer(in1));
+    check(in2);
+    check((buffer_rank(in2) == 2));
+    check(validate_buffer(in2));
+    check(out);
+    check((buffer_rank(out) == 2));
+    check(validate_buffer(out));
+    check((buffer_elem_size(in1) == 2));
+    check((buffer_elem_size(in2) == 2));
+    check((buffer_elem_size(out) == 2));
+    check(or_else((buffer_fold_factor(out, 0) <= 0), (buffer_max(out, 0) < (buffer_fold_factor(out, 0) + buffer_min(out, 0)))));
+    check(or_else((buffer_fold_factor(out, 1) <= 0), (buffer_max(out, 1) < (buffer_fold_factor(out, 1) + buffer_min(out, 1)))));
+    check((buffer_min(in1, 0) < buffer_min(out, 0)));
+    check((buffer_max(out, 0) < buffer_max(in1, 0)));
+    check((buffer_min(in1, 1) < buffer_min(out, 1)));
+    check((buffer_max(out, 1) < buffer_max(in1, 1)));
+    check(((buffer_min(in2, 0) + 2) <= buffer_min(out, 0)));
+    check(((buffer_max(out, 0) + 2) <= buffer_max(in2, 0)));
+    check(((buffer_min(in2, 1) + 2) <= buffer_min(out, 1)));
+    check(((buffer_max(out, 1) + 2) <= buffer_max(in2, 1)));
+    { let intm4 = allocate('intm4', 2, [
         {bounds:[buffer_min(out, 0), buffer_max(out, 0)], stride:NaN, fold_factor:NaN},
         {bounds:[buffer_min(out, 1), buffer_max(out, 1)], stride:NaN, fold_factor:1}
       ]);
-      { let intm2 = allocate('intm2', 2, [
-          {bounds:[(buffer_min(out, 0) + -2), (buffer_max(out, 0) + 2)], stride:NaN, fold_factor:NaN},
-          {bounds:[(buffer_min(out, 1) + -2), (buffer_max(out, 1) + 2)], stride:NaN, fold_factor:5}
+      { let intm3 = allocate('intm3', 2, [
+          {bounds:[buffer_min(out, 0), buffer_max(out, 0)], stride:NaN, fold_factor:NaN},
+          {bounds:[buffer_min(out, 1), buffer_max(out, 1)], stride:NaN, fold_factor:1}
         ]);
-        { let intm1 = allocate('intm1', 2, [
-            {bounds:[(buffer_min(out, 0) + -1), (buffer_max(out, 0) + 1)], stride:NaN, fold_factor:NaN},
-            {bounds:[(buffer_min(out, 1) + -1), (buffer_max(out, 1) + 1)], stride:NaN, fold_factor:3}
+        { let intm2 = allocate('intm2', 2, [
+            {bounds:[(buffer_min(out, 0) + -2), (buffer_max(out, 0) + 2)], stride:NaN, fold_factor:NaN},
+            {bounds:[(buffer_min(out, 1) + -2), (buffer_max(out, 1) + 2)], stride:NaN, fold_factor:5}
           ]);
-          let __loop_min = (buffer_min(out, 1) + -6);
-          let __loop_max = buffer_max(out, 1);
-          let __loop_step = 1;
-          for(let out_y = __loop_min; out_y <= __loop_max; out_y += __loop_step) {
-            { let __intm1 = crop_dim(intm1, 1, [(out_y + 1), (out_y + 1)]); {
-              let intm1 = __intm1;
-              consume(in1);
-              produce(intm1);
-              __event_t++;
-            }}
-            { let __intm3 = crop_dim(intm3, 1, [out_y, out_y]); {
-              let intm3 = __intm3;
-              consume(intm1);
-              produce(intm3);
-              __event_t++;
-            }}
-            { let __intm2 = crop_dim(intm2, 1, [(out_y + 2), (out_y + 2)]); {
-              let intm2 = __intm2;
-              consume(in2);
-              produce(intm2);
-              __event_t++;
-            }}
-            { let __intm4 = crop_dim(intm4, 1, [out_y, out_y]); {
-              let intm4 = __intm4;
-              consume(intm2);
-              produce(intm4);
-              __event_t++;
-            }}
-            { let __out_out_y = crop_dim(out, 1, [out_y, out_y]); {
-              let out_out_y = __out_out_y;
-              consume(intm3);
-              consume(intm4);
-              produce(out_out_y);
-              __event_t++;
-            }}
+          { let intm1 = allocate('intm1', 2, [
+              {bounds:[(buffer_min(out, 0) + -1), (buffer_max(out, 0) + 1)], stride:NaN, fold_factor:NaN},
+              {bounds:[(buffer_min(out, 1) + -1), (buffer_max(out, 1) + 1)], stride:NaN, fold_factor:3}
+            ]);
+            let __loop_min = (buffer_min(out, 1) + -6);
+            let __loop_max = buffer_max(out, 1);
+            let __loop_step = 1;
+            for(let out_y = __loop_min; out_y <= __loop_max; out_y += __loop_step) {
+              { let __intm1 = crop_dim(intm1, 1, [(out_y + 1), (out_y + 1)]); {
+                let intm1 = __intm1;
+                consume(in1);
+                produce(intm1);
+                __event_t++;
+              }}
+              { let __intm3 = crop_dim(intm3, 1, [out_y, out_y]); {
+                let intm3 = __intm3;
+                consume(intm1);
+                produce(intm3);
+                __event_t++;
+              }}
+              { let __intm2 = crop_dim(intm2, 1, [(out_y + 2), (out_y + 2)]); {
+                let intm2 = __intm2;
+                consume(in2);
+                produce(intm2);
+                __event_t++;
+              }}
+              { let __intm4 = crop_dim(intm4, 1, [out_y, out_y]); {
+                let intm4 = __intm4;
+                consume(intm2);
+                produce(intm4);
+                __event_t++;
+              }}
+              { let __out_out_y = crop_dim(out, 1, [out_y, out_y]); {
+                let out_out_y = __out_out_y;
+                consume(intm3);
+                consume(intm4);
+                produce(out_out_y);
+                __event_t++;
+              }}
+            }
+            free(intm1);
           }
-          free(intm1);
+          free(intm2);
         }
-        free(intm2);
+        free(intm3);
       }
-      free(intm3);
+      free(intm4);
     }
-    free(intm4);
   }
 }
 let in1 = allocate('in1', 2, [{bounds: [-1, 20], stride:2, fold_factor:NaN}, {bounds: [-1, 30], stride:44, fold_factor:NaN}], true);

--- a/slinky/builder/test/visualize/parallel_stencils_1.html
+++ b/slinky/builder/test/visualize/parallel_stencils_1.html
@@ -349,84 +349,86 @@ function trace_begin(x) { return x; }
 function trace_end(x) { return 1; }
 let __trace_names = allocate('__trace_names', 1, [{bounds:[0, 0], stride:1, fold_factor:1}], true);
 function pipeline(in1, in2, out) {
-  check(in1);
-  check((buffer_rank(in1) == 2));
-  check(validate_buffer(in1));
-  check(in2);
-  check((buffer_rank(in2) == 2));
-  check(validate_buffer(in2));
-  check(out);
-  check((buffer_rank(out) == 2));
-  check(validate_buffer(out));
-  check((buffer_elem_size(in1) == 2));
-  check((buffer_elem_size(in2) == 2));
-  check((buffer_elem_size(out) == 2));
-  check(or_else((buffer_fold_factor(out, 0) <= 0), (buffer_max(out, 0) < (buffer_fold_factor(out, 0) + buffer_min(out, 0)))));
-  check(or_else((buffer_fold_factor(out, 1) <= 0), (buffer_max(out, 1) < (buffer_fold_factor(out, 1) + buffer_min(out, 1)))));
-  check((buffer_min(in1, 0) < buffer_min(out, 0)));
-  check((buffer_max(out, 0) < buffer_max(in1, 0)));
-  check((buffer_min(in1, 1) < buffer_min(out, 1)));
-  check((buffer_max(out, 1) < buffer_max(in1, 1)));
-  check(((buffer_min(in2, 0) + 2) <= buffer_min(out, 0)));
-  check(((buffer_max(out, 0) + 2) <= buffer_max(in2, 0)));
-  check(((buffer_min(in2, 1) + 2) <= buffer_min(out, 1)));
-  check(((buffer_max(out, 1) + 2) <= buffer_max(in2, 1)));
-  { let intm1 = allocate('intm1', 2, [
-      {bounds:[(buffer_min(out, 0) + -1), (buffer_max(out, 0) + 1)], stride:NaN, fold_factor:NaN},
-      {bounds:[(buffer_min(out, 1) + -1), (buffer_max(out, 1) + 1)], stride:NaN, fold_factor:NaN}
-    ]);
-    consume(in1);
-    produce(intm1);
-    __event_t++;
-    { let intm4 = allocate('intm4', 2, [
-        {bounds:[buffer_min(out, 0), buffer_max(out, 0)], stride:NaN, fold_factor:NaN},
-        {bounds:[buffer_min(out, 1), buffer_max(out, 1)], stride:NaN, fold_factor:2}
+  {
+    check(in1);
+    check((buffer_rank(in1) == 2));
+    check(validate_buffer(in1));
+    check(in2);
+    check((buffer_rank(in2) == 2));
+    check(validate_buffer(in2));
+    check(out);
+    check((buffer_rank(out) == 2));
+    check(validate_buffer(out));
+    check((buffer_elem_size(in1) == 2));
+    check((buffer_elem_size(in2) == 2));
+    check((buffer_elem_size(out) == 2));
+    check(or_else((buffer_fold_factor(out, 0) <= 0), (buffer_max(out, 0) < (buffer_fold_factor(out, 0) + buffer_min(out, 0)))));
+    check(or_else((buffer_fold_factor(out, 1) <= 0), (buffer_max(out, 1) < (buffer_fold_factor(out, 1) + buffer_min(out, 1)))));
+    check((buffer_min(in1, 0) < buffer_min(out, 0)));
+    check((buffer_max(out, 0) < buffer_max(in1, 0)));
+    check((buffer_min(in1, 1) < buffer_min(out, 1)));
+    check((buffer_max(out, 1) < buffer_max(in1, 1)));
+    check(((buffer_min(in2, 0) + 2) <= buffer_min(out, 0)));
+    check(((buffer_max(out, 0) + 2) <= buffer_max(in2, 0)));
+    check(((buffer_min(in2, 1) + 2) <= buffer_min(out, 1)));
+    check(((buffer_max(out, 1) + 2) <= buffer_max(in2, 1)));
+    { let intm1 = allocate('intm1', 2, [
+        {bounds:[(buffer_min(out, 0) + -1), (buffer_max(out, 0) + 1)], stride:NaN, fold_factor:NaN},
+        {bounds:[(buffer_min(out, 1) + -1), (buffer_max(out, 1) + 1)], stride:NaN, fold_factor:NaN}
       ]);
-      { let intm3 = allocate('intm3', 2, [
+      consume(in1);
+      produce(intm1);
+      __event_t++;
+      { let intm4 = allocate('intm4', 2, [
           {bounds:[buffer_min(out, 0), buffer_max(out, 0)], stride:NaN, fold_factor:NaN},
           {bounds:[buffer_min(out, 1), buffer_max(out, 1)], stride:NaN, fold_factor:2}
         ]);
-        { let intm2 = allocate('intm2', 2, [
-            {bounds:[(buffer_min(out, 0) + -2), (buffer_max(out, 0) + 2)], stride:NaN, fold_factor:NaN},
-            {bounds:[(buffer_min(out, 1) + -2), (buffer_max(out, 1) + 2)], stride:NaN, fold_factor:6}
+        { let intm3 = allocate('intm3', 2, [
+            {bounds:[buffer_min(out, 0), buffer_max(out, 0)], stride:NaN, fold_factor:NaN},
+            {bounds:[buffer_min(out, 1), buffer_max(out, 1)], stride:NaN, fold_factor:2}
           ]);
-          let __loop_min = (buffer_min(out, 1) + -4);
-          let __loop_max = buffer_max(out, 1);
-          let __loop_step = 2;
-          for(let out_y = __loop_min; out_y <= __loop_max; out_y += __loop_step) {
-            { let __intm3 = crop_dim(intm3, 1, [out_y, (out_y + 1)]); {
-              let intm3 = __intm3;
-              consume(intm1);
-              produce(intm3);
-              __event_t++;
-            }}
-            { let __intm2 = crop_dim(intm2, 1, [(out_y + 2), (out_y + 3)]); {
-              let intm2 = __intm2;
-              consume(in2);
-              produce(intm2);
-              __event_t++;
-            }}
-            { let __intm4 = crop_dim(intm4, 1, [out_y, (out_y + 1)]); {
-              let intm4 = __intm4;
-              consume(intm2);
-              produce(intm4);
-              __event_t++;
-            }}
-            { let __out_out_y = crop_dim(out, 1, [out_y, (out_y + 1)]); {
-              let out_out_y = __out_out_y;
-              consume(intm3);
-              consume(intm4);
-              produce(out_out_y);
-              __event_t++;
-            }}
+          { let intm2 = allocate('intm2', 2, [
+              {bounds:[(buffer_min(out, 0) + -2), (buffer_max(out, 0) + 2)], stride:NaN, fold_factor:NaN},
+              {bounds:[(buffer_min(out, 1) + -2), (buffer_max(out, 1) + 2)], stride:NaN, fold_factor:6}
+            ]);
+            let __loop_min = (buffer_min(out, 1) + -4);
+            let __loop_max = buffer_max(out, 1);
+            let __loop_step = 2;
+            for(let out_y = __loop_min; out_y <= __loop_max; out_y += __loop_step) {
+              { let __intm3 = crop_dim(intm3, 1, [out_y, (out_y + 1)]); {
+                let intm3 = __intm3;
+                consume(intm1);
+                produce(intm3);
+                __event_t++;
+              }}
+              { let __intm2 = crop_dim(intm2, 1, [(out_y + 2), (out_y + 3)]); {
+                let intm2 = __intm2;
+                consume(in2);
+                produce(intm2);
+                __event_t++;
+              }}
+              { let __intm4 = crop_dim(intm4, 1, [out_y, (out_y + 1)]); {
+                let intm4 = __intm4;
+                consume(intm2);
+                produce(intm4);
+                __event_t++;
+              }}
+              { let __out_out_y = crop_dim(out, 1, [out_y, (out_y + 1)]); {
+                let out_out_y = __out_out_y;
+                consume(intm3);
+                consume(intm4);
+                produce(out_out_y);
+                __event_t++;
+              }}
+            }
+            free(intm2);
           }
-          free(intm2);
+          free(intm3);
         }
-        free(intm3);
+        free(intm4);
       }
-      free(intm4);
+      free(intm1);
     }
-    free(intm1);
   }
 }
 let in1 = allocate('in1', 2, [{bounds: [-1, 20], stride:2, fold_factor:NaN}, {bounds: [-1, 30], stride:44, fold_factor:NaN}], true);

--- a/slinky/builder/test/visualize/parallel_stencils_2.html
+++ b/slinky/builder/test/visualize/parallel_stencils_2.html
@@ -349,87 +349,89 @@ function trace_begin(x) { return x; }
 function trace_end(x) { return 1; }
 let __trace_names = allocate('__trace_names', 1, [{bounds:[0, 0], stride:1, fold_factor:1}], true);
 function pipeline(in1, in2, out) {
-  check(in1);
-  check((buffer_rank(in1) == 2));
-  check(validate_buffer(in1));
-  check(in2);
-  check((buffer_rank(in2) == 2));
-  check(validate_buffer(in2));
-  check(out);
-  check((buffer_rank(out) == 2));
-  check(validate_buffer(out));
-  check((buffer_elem_size(in1) == 2));
-  check((buffer_elem_size(in2) == 2));
-  check((buffer_elem_size(out) == 2));
-  check(or_else((buffer_fold_factor(out, 0) <= 0), (buffer_max(out, 0) < (buffer_fold_factor(out, 0) + buffer_min(out, 0)))));
-  check(or_else((buffer_fold_factor(out, 1) <= 0), (buffer_max(out, 1) < (buffer_fold_factor(out, 1) + buffer_min(out, 1)))));
-  check((buffer_min(in1, 0) < buffer_min(out, 0)));
-  check((buffer_max(out, 0) < buffer_max(in1, 0)));
-  check((buffer_min(in1, 1) < buffer_min(out, 1)));
-  check((buffer_max(out, 1) < buffer_max(in1, 1)));
-  check(((buffer_min(in2, 0) + 2) <= buffer_min(out, 0)));
-  check(((buffer_max(out, 0) + 2) <= buffer_max(in2, 0)));
-  check(((buffer_min(in2, 1) + 2) <= buffer_min(out, 1)));
-  check(((buffer_max(out, 1) + 2) <= buffer_max(in2, 1)));
-  { let intm4 = allocate('intm4', 2, [
-      {bounds:[buffer_min(out, 0), buffer_max(out, 0)], stride:NaN, fold_factor:NaN},
-      {bounds:[buffer_min(out, 1), buffer_max(out, 1)], stride:NaN, fold_factor:2}
-    ]);
-    { let intm3 = allocate('intm3', 2, [
+  {
+    check(in1);
+    check((buffer_rank(in1) == 2));
+    check(validate_buffer(in1));
+    check(in2);
+    check((buffer_rank(in2) == 2));
+    check(validate_buffer(in2));
+    check(out);
+    check((buffer_rank(out) == 2));
+    check(validate_buffer(out));
+    check((buffer_elem_size(in1) == 2));
+    check((buffer_elem_size(in2) == 2));
+    check((buffer_elem_size(out) == 2));
+    check(or_else((buffer_fold_factor(out, 0) <= 0), (buffer_max(out, 0) < (buffer_fold_factor(out, 0) + buffer_min(out, 0)))));
+    check(or_else((buffer_fold_factor(out, 1) <= 0), (buffer_max(out, 1) < (buffer_fold_factor(out, 1) + buffer_min(out, 1)))));
+    check((buffer_min(in1, 0) < buffer_min(out, 0)));
+    check((buffer_max(out, 0) < buffer_max(in1, 0)));
+    check((buffer_min(in1, 1) < buffer_min(out, 1)));
+    check((buffer_max(out, 1) < buffer_max(in1, 1)));
+    check(((buffer_min(in2, 0) + 2) <= buffer_min(out, 0)));
+    check(((buffer_max(out, 0) + 2) <= buffer_max(in2, 0)));
+    check(((buffer_min(in2, 1) + 2) <= buffer_min(out, 1)));
+    check(((buffer_max(out, 1) + 2) <= buffer_max(in2, 1)));
+    { let intm4 = allocate('intm4', 2, [
         {bounds:[buffer_min(out, 0), buffer_max(out, 0)], stride:NaN, fold_factor:NaN},
         {bounds:[buffer_min(out, 1), buffer_max(out, 1)], stride:NaN, fold_factor:2}
       ]);
-      { let intm2 = allocate('intm2', 2, [
-          {bounds:[(buffer_min(out, 0) + -2), (buffer_max(out, 0) + 2)], stride:NaN, fold_factor:NaN},
-          {bounds:[(buffer_min(out, 1) + -2), (buffer_max(out, 1) + 2)], stride:NaN, fold_factor:6}
+      { let intm3 = allocate('intm3', 2, [
+          {bounds:[buffer_min(out, 0), buffer_max(out, 0)], stride:NaN, fold_factor:NaN},
+          {bounds:[buffer_min(out, 1), buffer_max(out, 1)], stride:NaN, fold_factor:2}
         ]);
-        { let intm1 = allocate('intm1', 2, [
-            {bounds:[(buffer_min(out, 0) + -1), (buffer_max(out, 0) + 1)], stride:NaN, fold_factor:NaN},
-            {bounds:[(buffer_min(out, 1) + -1), (buffer_max(out, 1) + 1)], stride:NaN, fold_factor:4}
+        { let intm2 = allocate('intm2', 2, [
+            {bounds:[(buffer_min(out, 0) + -2), (buffer_max(out, 0) + 2)], stride:NaN, fold_factor:NaN},
+            {bounds:[(buffer_min(out, 1) + -2), (buffer_max(out, 1) + 2)], stride:NaN, fold_factor:6}
           ]);
-          let __loop_min = (buffer_min(out, 1) + -6);
-          let __loop_max = buffer_max(out, 1);
-          let __loop_step = 2;
-          for(let out_y = __loop_min; out_y <= __loop_max; out_y += __loop_step) {
-            { let __intm1 = crop_dim(intm1, 1, [(out_y + 1), (out_y + 2)]); {
-              let intm1 = __intm1;
-              consume(in1);
-              produce(intm1);
-              __event_t++;
-            }}
-            { let __intm3 = crop_dim(intm3, 1, [out_y, (out_y + 1)]); {
-              let intm3 = __intm3;
-              consume(intm1);
-              produce(intm3);
-              __event_t++;
-            }}
-            { let __intm2 = crop_dim(intm2, 1, [(out_y + 2), (out_y + 3)]); {
-              let intm2 = __intm2;
-              consume(in2);
-              produce(intm2);
-              __event_t++;
-            }}
-            { let __intm4 = crop_dim(intm4, 1, [out_y, (out_y + 1)]); {
-              let intm4 = __intm4;
-              consume(intm2);
-              produce(intm4);
-              __event_t++;
-            }}
-            { let __out_out_y = crop_dim(out, 1, [out_y, (out_y + 1)]); {
-              let out_out_y = __out_out_y;
-              consume(intm3);
-              consume(intm4);
-              produce(out_out_y);
-              __event_t++;
-            }}
+          { let intm1 = allocate('intm1', 2, [
+              {bounds:[(buffer_min(out, 0) + -1), (buffer_max(out, 0) + 1)], stride:NaN, fold_factor:NaN},
+              {bounds:[(buffer_min(out, 1) + -1), (buffer_max(out, 1) + 1)], stride:NaN, fold_factor:4}
+            ]);
+            let __loop_min = (buffer_min(out, 1) + -6);
+            let __loop_max = buffer_max(out, 1);
+            let __loop_step = 2;
+            for(let out_y = __loop_min; out_y <= __loop_max; out_y += __loop_step) {
+              { let __intm1 = crop_dim(intm1, 1, [(out_y + 1), (out_y + 2)]); {
+                let intm1 = __intm1;
+                consume(in1);
+                produce(intm1);
+                __event_t++;
+              }}
+              { let __intm3 = crop_dim(intm3, 1, [out_y, (out_y + 1)]); {
+                let intm3 = __intm3;
+                consume(intm1);
+                produce(intm3);
+                __event_t++;
+              }}
+              { let __intm2 = crop_dim(intm2, 1, [(out_y + 2), (out_y + 3)]); {
+                let intm2 = __intm2;
+                consume(in2);
+                produce(intm2);
+                __event_t++;
+              }}
+              { let __intm4 = crop_dim(intm4, 1, [out_y, (out_y + 1)]); {
+                let intm4 = __intm4;
+                consume(intm2);
+                produce(intm4);
+                __event_t++;
+              }}
+              { let __out_out_y = crop_dim(out, 1, [out_y, (out_y + 1)]); {
+                let out_out_y = __out_out_y;
+                consume(intm3);
+                consume(intm4);
+                produce(out_out_y);
+                __event_t++;
+              }}
+            }
+            free(intm1);
           }
-          free(intm1);
+          free(intm2);
         }
-        free(intm2);
+        free(intm3);
       }
-      free(intm3);
+      free(intm4);
     }
-    free(intm4);
   }
 }
 let in1 = allocate('in1', 2, [{bounds: [-1, 20], stride:2, fold_factor:NaN}, {bounds: [-1, 30], stride:44, fold_factor:NaN}], true);

--- a/slinky/builder/test/visualize/stencil_split_0.html
+++ b/slinky/builder/test/visualize/stencil_split_0.html
@@ -349,31 +349,33 @@ function trace_begin(x) { return x; }
 function trace_end(x) { return 1; }
 let __trace_names = allocate('__trace_names', 1, [{bounds:[0, 0], stride:1, fold_factor:1}], true);
 function pipeline(__in, out) {
-  check(__in);
-  check((buffer_rank(__in) == 2));
-  check(validate_buffer(__in));
-  check(out);
-  check((buffer_rank(out) == 2));
-  check(validate_buffer(out));
-  check((buffer_elem_size(__in) == 2));
-  check((buffer_elem_size(out) == 2));
-  check(or_else((buffer_fold_factor(out, 0) <= 0), (buffer_max(out, 0) < (buffer_fold_factor(out, 0) + buffer_min(out, 0)))));
-  check(or_else((buffer_fold_factor(out, 1) <= 0), (buffer_max(out, 1) < (buffer_fold_factor(out, 1) + buffer_min(out, 1)))));
-  check((buffer_min(__in, 0) < buffer_min(out, 0)));
-  check((buffer_max(out, 0) < buffer_max(__in, 0)));
-  check((buffer_min(__in, 1) < buffer_min(out, 1)));
-  check((buffer_max(out, 1) < buffer_max(__in, 1)));
-  { let intm = allocate('intm', 2, [
-      {bounds:[(buffer_min(out, 0) + -1), (buffer_max(out, 0) + 1)], stride:NaN, fold_factor:NaN},
-      {bounds:[(buffer_min(out, 1) + -1), (buffer_max(out, 1) + 1)], stride:NaN, fold_factor:NaN}
-    ]);
-    consume(__in);
-    produce(intm);
-    __event_t++;
-    consume(intm);
-    produce(out);
-    __event_t++;
-    free(intm);
+  {
+    check(__in);
+    check((buffer_rank(__in) == 2));
+    check(validate_buffer(__in));
+    check(out);
+    check((buffer_rank(out) == 2));
+    check(validate_buffer(out));
+    check((buffer_elem_size(__in) == 2));
+    check((buffer_elem_size(out) == 2));
+    check(or_else((buffer_fold_factor(out, 0) <= 0), (buffer_max(out, 0) < (buffer_fold_factor(out, 0) + buffer_min(out, 0)))));
+    check(or_else((buffer_fold_factor(out, 1) <= 0), (buffer_max(out, 1) < (buffer_fold_factor(out, 1) + buffer_min(out, 1)))));
+    check((buffer_min(__in, 0) < buffer_min(out, 0)));
+    check((buffer_max(out, 0) < buffer_max(__in, 0)));
+    check((buffer_min(__in, 1) < buffer_min(out, 1)));
+    check((buffer_max(out, 1) < buffer_max(__in, 1)));
+    { let intm = allocate('intm', 2, [
+        {bounds:[(buffer_min(out, 0) + -1), (buffer_max(out, 0) + 1)], stride:NaN, fold_factor:NaN},
+        {bounds:[(buffer_min(out, 1) + -1), (buffer_max(out, 1) + 1)], stride:NaN, fold_factor:NaN}
+      ]);
+      consume(__in);
+      produce(intm);
+      __event_t++;
+      consume(intm);
+      produce(out);
+      __event_t++;
+      free(intm);
+    }
   }
 }
 let __in = allocate('in', 2, [{bounds: [-1, 20], stride:2, fold_factor:NaN}, {bounds: [-1, 30], stride:44, fold_factor:NaN}], true);

--- a/slinky/builder/test/visualize/stencil_split_1.html
+++ b/slinky/builder/test/visualize/stencil_split_1.html
@@ -349,42 +349,44 @@ function trace_begin(x) { return x; }
 function trace_end(x) { return 1; }
 let __trace_names = allocate('__trace_names', 1, [{bounds:[0, 0], stride:1, fold_factor:1}], true);
 function pipeline(__in, out) {
-  check(__in);
-  check((buffer_rank(__in) == 2));
-  check(validate_buffer(__in));
-  check(out);
-  check((buffer_rank(out) == 2));
-  check(validate_buffer(out));
-  check((buffer_elem_size(__in) == 2));
-  check((buffer_elem_size(out) == 2));
-  check(or_else((buffer_fold_factor(out, 0) <= 0), (buffer_max(out, 0) < (buffer_fold_factor(out, 0) + buffer_min(out, 0)))));
-  check(or_else((buffer_fold_factor(out, 1) <= 0), (buffer_max(out, 1) < (buffer_fold_factor(out, 1) + buffer_min(out, 1)))));
-  check((buffer_min(__in, 0) < buffer_min(out, 0)));
-  check((buffer_max(out, 0) < buffer_max(__in, 0)));
-  check((buffer_min(__in, 1) < buffer_min(out, 1)));
-  check((buffer_max(out, 1) < buffer_max(__in, 1)));
-  { let intm = allocate('intm', 2, [
-      {bounds:[(buffer_min(out, 0) + -1), (buffer_max(out, 0) + 1)], stride:NaN, fold_factor:NaN},
-      {bounds:[(buffer_min(out, 1) + -1), (buffer_max(out, 1) + 1)], stride:NaN, fold_factor:3}
-    ]);
-    let __loop_min = (buffer_min(out, 1) + -2);
-    let __loop_max = buffer_max(out, 1);
-    let __loop_step = 1;
-    for(let out_y = __loop_min; out_y <= __loop_max; out_y += __loop_step) {
-      { let __intm = crop_dim(intm, 1, [(out_y + 1), (out_y + 1)]); {
-        let intm = __intm;
-        consume(__in);
-        produce(intm);
-        __event_t++;
-      }}
-      { let __out_out_y = crop_dim(out, 1, [out_y, out_y]); {
-        let out_out_y = __out_out_y;
-        consume(intm);
-        produce(out_out_y);
-        __event_t++;
-      }}
+  {
+    check(__in);
+    check((buffer_rank(__in) == 2));
+    check(validate_buffer(__in));
+    check(out);
+    check((buffer_rank(out) == 2));
+    check(validate_buffer(out));
+    check((buffer_elem_size(__in) == 2));
+    check((buffer_elem_size(out) == 2));
+    check(or_else((buffer_fold_factor(out, 0) <= 0), (buffer_max(out, 0) < (buffer_fold_factor(out, 0) + buffer_min(out, 0)))));
+    check(or_else((buffer_fold_factor(out, 1) <= 0), (buffer_max(out, 1) < (buffer_fold_factor(out, 1) + buffer_min(out, 1)))));
+    check((buffer_min(__in, 0) < buffer_min(out, 0)));
+    check((buffer_max(out, 0) < buffer_max(__in, 0)));
+    check((buffer_min(__in, 1) < buffer_min(out, 1)));
+    check((buffer_max(out, 1) < buffer_max(__in, 1)));
+    { let intm = allocate('intm', 2, [
+        {bounds:[(buffer_min(out, 0) + -1), (buffer_max(out, 0) + 1)], stride:NaN, fold_factor:NaN},
+        {bounds:[(buffer_min(out, 1) + -1), (buffer_max(out, 1) + 1)], stride:NaN, fold_factor:3}
+      ]);
+      let __loop_min = (buffer_min(out, 1) + -2);
+      let __loop_max = buffer_max(out, 1);
+      let __loop_step = 1;
+      for(let out_y = __loop_min; out_y <= __loop_max; out_y += __loop_step) {
+        { let __intm = crop_dim(intm, 1, [(out_y + 1), (out_y + 1)]); {
+          let intm = __intm;
+          consume(__in);
+          produce(intm);
+          __event_t++;
+        }}
+        { let __out_out_y = crop_dim(out, 1, [out_y, out_y]); {
+          let out_out_y = __out_out_y;
+          consume(intm);
+          produce(out_out_y);
+          __event_t++;
+        }}
+      }
+      free(intm);
     }
-    free(intm);
   }
 }
 let __in = allocate('in', 2, [{bounds: [-1, 20], stride:2, fold_factor:NaN}, {bounds: [-1, 30], stride:44, fold_factor:NaN}], true);

--- a/slinky/builder/test/visualize/stencil_split_2.html
+++ b/slinky/builder/test/visualize/stencil_split_2.html
@@ -349,42 +349,44 @@ function trace_begin(x) { return x; }
 function trace_end(x) { return 1; }
 let __trace_names = allocate('__trace_names', 1, [{bounds:[0, 0], stride:1, fold_factor:1}], true);
 function pipeline(__in, out) {
-  check(__in);
-  check((buffer_rank(__in) == 2));
-  check(validate_buffer(__in));
-  check(out);
-  check((buffer_rank(out) == 2));
-  check(validate_buffer(out));
-  check((buffer_elem_size(__in) == 2));
-  check((buffer_elem_size(out) == 2));
-  check(or_else((buffer_fold_factor(out, 0) <= 0), (buffer_max(out, 0) < (buffer_fold_factor(out, 0) + buffer_min(out, 0)))));
-  check(or_else((buffer_fold_factor(out, 1) <= 0), (buffer_max(out, 1) < (buffer_fold_factor(out, 1) + buffer_min(out, 1)))));
-  check((buffer_min(__in, 0) < buffer_min(out, 0)));
-  check((buffer_max(out, 0) < buffer_max(__in, 0)));
-  check((buffer_min(__in, 1) < buffer_min(out, 1)));
-  check((buffer_max(out, 1) < buffer_max(__in, 1)));
-  { let intm = allocate('intm', 2, [
-      {bounds:[(buffer_min(out, 0) + -1), (buffer_max(out, 0) + 1)], stride:NaN, fold_factor:NaN},
-      {bounds:[(buffer_min(out, 1) + -1), (buffer_max(out, 1) + 1)], stride:NaN, fold_factor:4}
-    ]);
-    let __loop_min = (buffer_min(out, 1) + -2);
-    let __loop_max = buffer_max(out, 1);
-    let __loop_step = 2;
-    for(let out_y = __loop_min; out_y <= __loop_max; out_y += __loop_step) {
-      { let __intm = crop_dim(intm, 1, [(out_y + 1), (out_y + 2)]); {
-        let intm = __intm;
-        consume(__in);
-        produce(intm);
-        __event_t++;
-      }}
-      { let __out_out_y = crop_dim(out, 1, [out_y, (out_y + 1)]); {
-        let out_out_y = __out_out_y;
-        consume(intm);
-        produce(out_out_y);
-        __event_t++;
-      }}
+  {
+    check(__in);
+    check((buffer_rank(__in) == 2));
+    check(validate_buffer(__in));
+    check(out);
+    check((buffer_rank(out) == 2));
+    check(validate_buffer(out));
+    check((buffer_elem_size(__in) == 2));
+    check((buffer_elem_size(out) == 2));
+    check(or_else((buffer_fold_factor(out, 0) <= 0), (buffer_max(out, 0) < (buffer_fold_factor(out, 0) + buffer_min(out, 0)))));
+    check(or_else((buffer_fold_factor(out, 1) <= 0), (buffer_max(out, 1) < (buffer_fold_factor(out, 1) + buffer_min(out, 1)))));
+    check((buffer_min(__in, 0) < buffer_min(out, 0)));
+    check((buffer_max(out, 0) < buffer_max(__in, 0)));
+    check((buffer_min(__in, 1) < buffer_min(out, 1)));
+    check((buffer_max(out, 1) < buffer_max(__in, 1)));
+    { let intm = allocate('intm', 2, [
+        {bounds:[(buffer_min(out, 0) + -1), (buffer_max(out, 0) + 1)], stride:NaN, fold_factor:NaN},
+        {bounds:[(buffer_min(out, 1) + -1), (buffer_max(out, 1) + 1)], stride:NaN, fold_factor:4}
+      ]);
+      let __loop_min = (buffer_min(out, 1) + -2);
+      let __loop_max = buffer_max(out, 1);
+      let __loop_step = 2;
+      for(let out_y = __loop_min; out_y <= __loop_max; out_y += __loop_step) {
+        { let __intm = crop_dim(intm, 1, [(out_y + 1), (out_y + 2)]); {
+          let intm = __intm;
+          consume(__in);
+          produce(intm);
+          __event_t++;
+        }}
+        { let __out_out_y = crop_dim(out, 1, [out_y, (out_y + 1)]); {
+          let out_out_y = __out_out_y;
+          consume(intm);
+          produce(out_out_y);
+          __event_t++;
+        }}
+      }
+      free(intm);
     }
-    free(intm);
   }
 }
 let __in = allocate('in', 2, [{bounds: [-1, 20], stride:2, fold_factor:NaN}, {bounds: [-1, 30], stride:44, fold_factor:NaN}], true);

--- a/slinky/builder/test/visualize/stencil_split_3.html
+++ b/slinky/builder/test/visualize/stencil_split_3.html
@@ -349,42 +349,44 @@ function trace_begin(x) { return x; }
 function trace_end(x) { return 1; }
 let __trace_names = allocate('__trace_names', 1, [{bounds:[0, 0], stride:1, fold_factor:1}], true);
 function pipeline(__in, out) {
-  check(__in);
-  check((buffer_rank(__in) == 2));
-  check(validate_buffer(__in));
-  check(out);
-  check((buffer_rank(out) == 2));
-  check(validate_buffer(out));
-  check((buffer_elem_size(__in) == 2));
-  check((buffer_elem_size(out) == 2));
-  check(or_else((buffer_fold_factor(out, 0) <= 0), (buffer_max(out, 0) < (buffer_fold_factor(out, 0) + buffer_min(out, 0)))));
-  check(or_else((buffer_fold_factor(out, 1) <= 0), (buffer_max(out, 1) < (buffer_fold_factor(out, 1) + buffer_min(out, 1)))));
-  check((buffer_min(__in, 0) < buffer_min(out, 0)));
-  check((buffer_max(out, 0) < buffer_max(__in, 0)));
-  check((buffer_min(__in, 1) < buffer_min(out, 1)));
-  check((buffer_max(out, 1) < buffer_max(__in, 1)));
-  { let intm = allocate('intm', 2, [
-      {bounds:[(buffer_min(out, 0) + -1), (buffer_max(out, 0) + 1)], stride:NaN, fold_factor:NaN},
-      {bounds:[(buffer_min(out, 1) + -1), (buffer_max(out, 1) + 1)], stride:NaN, fold_factor:5}
-    ]);
-    let __loop_min = (buffer_min(out, 1) + -2);
-    let __loop_max = buffer_max(out, 1);
-    let __loop_step = 3;
-    for(let out_y = __loop_min; out_y <= __loop_max; out_y += __loop_step) {
-      { let __intm = crop_dim(intm, 1, [(out_y + 1), (out_y + 3)]); {
-        let intm = __intm;
-        consume(__in);
-        produce(intm);
-        __event_t++;
-      }}
-      { let __out_out_y = crop_dim(out, 1, [out_y, (out_y + 2)]); {
-        let out_out_y = __out_out_y;
-        consume(intm);
-        produce(out_out_y);
-        __event_t++;
-      }}
+  {
+    check(__in);
+    check((buffer_rank(__in) == 2));
+    check(validate_buffer(__in));
+    check(out);
+    check((buffer_rank(out) == 2));
+    check(validate_buffer(out));
+    check((buffer_elem_size(__in) == 2));
+    check((buffer_elem_size(out) == 2));
+    check(or_else((buffer_fold_factor(out, 0) <= 0), (buffer_max(out, 0) < (buffer_fold_factor(out, 0) + buffer_min(out, 0)))));
+    check(or_else((buffer_fold_factor(out, 1) <= 0), (buffer_max(out, 1) < (buffer_fold_factor(out, 1) + buffer_min(out, 1)))));
+    check((buffer_min(__in, 0) < buffer_min(out, 0)));
+    check((buffer_max(out, 0) < buffer_max(__in, 0)));
+    check((buffer_min(__in, 1) < buffer_min(out, 1)));
+    check((buffer_max(out, 1) < buffer_max(__in, 1)));
+    { let intm = allocate('intm', 2, [
+        {bounds:[(buffer_min(out, 0) + -1), (buffer_max(out, 0) + 1)], stride:NaN, fold_factor:NaN},
+        {bounds:[(buffer_min(out, 1) + -1), (buffer_max(out, 1) + 1)], stride:NaN, fold_factor:5}
+      ]);
+      let __loop_min = (buffer_min(out, 1) + -2);
+      let __loop_max = buffer_max(out, 1);
+      let __loop_step = 3;
+      for(let out_y = __loop_min; out_y <= __loop_max; out_y += __loop_step) {
+        { let __intm = crop_dim(intm, 1, [(out_y + 1), (out_y + 3)]); {
+          let intm = __intm;
+          consume(__in);
+          produce(intm);
+          __event_t++;
+        }}
+        { let __out_out_y = crop_dim(out, 1, [out_y, (out_y + 2)]); {
+          let out_out_y = __out_out_y;
+          consume(intm);
+          produce(out_out_y);
+          __event_t++;
+        }}
+      }
+      free(intm);
     }
-    free(intm);
   }
 }
 let __in = allocate('in', 2, [{bounds: [-1, 20], stride:2, fold_factor:NaN}, {bounds: [-1, 30], stride:44, fold_factor:NaN}], true);

--- a/slinky/runtime/evaluate.cc
+++ b/slinky/runtime/evaluate.cc
@@ -251,17 +251,16 @@ SLINKY_INLINE index_t eval_let_value(expr_ref e, eval_context& ctx) {
   return eval_non_inlined(e, ctx);
 }
 
+SLINKY_INLINE void reserve_symbols(const let_stmt* op, eval_context& ctx) { ctx.reserve(op->max_symbol_id + 1); }
+SLINKY_INLINE void reserve_symbols(const let* op, eval_context& ctx) {}
+
 template <typename T>
 SLINKY_NO_STACK_PROTECTOR inline index_t eval_let(const T* op, eval_context& ctx) {
   // This is a bit ugly but we really want to avoid heap allocations here.
   const size_t size = op->lets.size();
   index_t* old_values = SLINKY_ALLOCA(index_t, size);
 
-  std::size_t context_size = 0;
-  for (const auto& let : op->lets) {
-    context_size = std::max<size_t>(context_size, let.first.id);
-  }
-  ctx.reserve(context_size + 1);
+  reserve_symbols(op, ctx);
 
   for (size_t i = 0; i < size; ++i) {
     const auto& let = op->lets[i];
@@ -466,10 +465,8 @@ SLINKY_INLINE index_t eval(stmt_ref op, eval_context& ctx) { return eval<call_st
 
 template <typename... Ts>
 SLINKY_INLINE index_t eval_with_value(stmt_ref op, var sym, index_t value, eval_context& ctx) {
-  ctx.reserve(sym.id + 1);
   index_t old_value = ctx.set(sym, value);
   index_t result = eval<Ts...>(op, ctx);
-  // ctx might have grown and invalidated the ctx_value reference.
   ctx.set(sym, old_value);
   return result;
 }
@@ -508,8 +505,10 @@ inline index_t eval(const block* op, eval_context& ctx) {
 SLINKY_NO_INLINE void init_context(
     eval_context& context, const eval_context& parent_context, const let_stmt* closure, var exclude = var()) {
   if (closure) {
-    // The body is a closure, so we know exactly which symbols we need to copy to the new local context.
-    context.reserve(parent_context.size());
+    // The body is a closure, so we know exactly which symbols we need to copy to the new local context, and how big
+    // it needs to be.
+    assert(closure->max_symbol_id >= 0);
+    context.reserve(closure->max_symbol_id + 1);
     context.config = parent_context.config;
 
     // Assume that this let_stmt is a closure for this loop. We'll evaluate the values using the parent
@@ -520,9 +519,7 @@ SLINKY_NO_INLINE void init_context(
         // it. However, we are going to overwrite it below.
         continue;
       }
-      auto src = as_variable(i.second);
-      assert(src);
-      context.set(i.first, parent_context.lookup(*src));
+      context.set(i.first, parent_context.lookup(i.first));
     }
   } else {
     // We don't have a closure, just copy the whole context.
@@ -547,10 +544,12 @@ SLINKY_NO_INLINE index_t eval_loop_parallel(const loop* op, index_t max_workers,
   }
 
   if (n == 1) {
+    if (closure) {
+      // The closure is a no-op, except for this, don't drop it.
+      ctx.reserve(closure->max_symbol_id + 1);
+    }
     return eval_with_value<block, crop_dim>(body, op->sym, bounds.min, ctx);
   } else {
-    ctx.reserve(op->sym.id + 1);
-
     thread_pool* pool = ctx.config->thread_pool;
     assert(pool);
 
@@ -593,11 +592,7 @@ SLINKY_NO_INLINE index_t eval_loop_serial(const loop* op, eval_context& ctx) {
   interval bounds = eval(op->bounds, ctx);
   index_t step = eval(op->step, 1, ctx);
   assert(step != 0);
-  // TODO(https://github.com/dsharlet/slinky/issues/3): We don't get a reference to ctx[op->sym] here
-  // because the context could grow and invalidate the reference. This could be fixed by having evaluate
-  // fully traverse the expression to find the max var, and pre-allocate the context up front. It's
-  // not clear this optimization is necessary yet.
-  ctx.reserve(op->sym.id + 1);
+  // We don't get a reference to ctx[op->sym] here because the context could grow and invalidate the reference.
   index_t old_value = ctx.set(op->sym, 0);
   index_t result = 0;
   if (step > 0) {
@@ -642,7 +637,6 @@ SLINKY_NO_INLINE index_t eval(const async* op, eval_context& ctx) {
     task_body();
   }
 
-  ctx.reserve(op->sym.id + 1);
   index_t old_sym = 0;
   if (op->sym.defined()) ctx.set(op->sym, reinterpret_cast<index_t>(&*task));
 

--- a/slinky/runtime/evaluate.h
+++ b/slinky/runtime/evaluate.h
@@ -1,6 +1,7 @@
 #ifndef SLINKY_RUNTIME_EVALUATE_H
 #define SLINKY_RUNTIME_EVALUATE_H
 
+#include <cassert>
 #include <cstdlib>
 #include <optional>
 
@@ -82,6 +83,7 @@ public:
 
   // This is always inlined to avoid msan false positives if the value hasn't been set already yet.
   SLINKY_INLINE index_t set(var id, index_t value) {
+    assert(id.id < values_.size());
     index_t& value_ref = values_[id.id];
     index_t old_value = value_ref;
     value_ref = value;

--- a/slinky/runtime/expr_stmt.cc
+++ b/slinky/runtime/expr_stmt.cc
@@ -141,22 +141,38 @@ T* make_let(Lets&& lets, Body body) {
   return n;
 }
 
-expr let::make(std::vector<std::pair<var, expr>> lets, expr body) {
-  return expr(make_let<let>(lets, std::move(body)));
-}
+expr let::make(std::vector<std::pair<var, expr>> lets, expr body) { return expr(make_let<let>(lets, std::move(body))); }
 expr let::make(span<std::pair<var, expr>> lets, expr body) { return expr(make_let<let>(lets, std::move(body))); }
 
 expr let::make(var sym, expr value, expr body) { return make({{sym, std::move(value)}}, std::move(body)); }
 
-stmt let_stmt::make(std::vector<std::pair<var, expr>> lets, stmt body, bool is_closure) {
+namespace {
+
+int max_decl_id(span<std::pair<var, expr>> lets) {
+  int result = -1;
+  for (const std::pair<var, expr>& i : lets) {
+    result = std::max<int>(i.first.id, result);
+  }
+  return result;
+}
+
+bool is_self_assignment(const std::pair<var, expr>& let) { return is_variable(let.second, let.first); }
+
+}  // namespace
+
+stmt let_stmt::make(std::vector<std::pair<var, expr>> lets, stmt body, bool is_closure, int max_symbol_id) {
   let_stmt* n = make_let<let_stmt>(lets, std::move(body));
   n->is_closure = is_closure;
+  n->max_symbol_id = std::max(max_symbol_id, max_decl_id(n->lets));
+  assert(!is_closure || std::all_of(n->lets.begin(), n->lets.end(), is_self_assignment));
   return stmt(n);
 }
 
-stmt let_stmt::make(span<std::pair<var, expr>> lets, stmt body, bool is_closure) {
+stmt let_stmt::make(span<std::pair<var, expr>> lets, stmt body, bool is_closure, int max_symbol_id) {
   let_stmt* n = make_let<let_stmt>(lets, std::move(body));
   n->is_closure = is_closure;
+  n->max_symbol_id = std::max(max_symbol_id, max_decl_id(n->lets));
+  assert(!is_closure || std::all_of(n->lets.begin(), n->lets.end(), is_self_assignment));
   return stmt(n);
 }
 
@@ -687,7 +703,7 @@ stmt block::make(std::vector<stmt> stmts) {
   } else {
     auto n = make_node<block>(size_of(stmts));
     void* arrays = n + 1;
-  n->stmts = make_span(arrays, stmts);
+    n->stmts = make_span(arrays, stmts);
     return stmt(n);
   }
 }

--- a/slinky/runtime/stmt.h
+++ b/slinky/runtime/stmt.h
@@ -207,10 +207,14 @@ public:
   // The values of every let must be a `variable` expression.
   bool is_closure;
 
+  // The maximum symbol id that `evaluate` may assign while evaluating this node, or -1 if it is unknown.
+  // Any symbol `x` evaluated by `evaluate` must be contained in a `let_stmt` with `max_symbol_id > x`.
+  int max_symbol_id = -1;
+
   void accept(stmt_visitor* v) const override;
 
-  static stmt make(std::vector<std::pair<var, expr>> lets, stmt body, bool is_closure = false);
-  static stmt make(span<std::pair<var, expr>> lets, stmt body, bool is_closure = false);
+  static stmt make(std::vector<std::pair<var, expr>> lets, stmt body, bool is_closure = false, int max_symbol_id = -1);
+  static stmt make(span<std::pair<var, expr>> lets, stmt body, bool is_closure = false, int max_symbol_id = -1);
 
   static stmt make(var sym, expr value, stmt body);
 

--- a/slinky/runtime/test/evaluate.cc
+++ b/slinky/runtime/test/evaluate.cc
@@ -17,6 +17,12 @@ node_context ctx;
 var x(ctx, "x");
 var y(ctx, "y");
 
+eval_context make_context() {
+  eval_context result;
+  result.reserve(y.id + 1);
+  return result;
+}
+
 }  // namespace
 
 bool operator==(const raw_buffer& a, const raw_buffer& b) {
@@ -30,7 +36,7 @@ bool operator==(const raw_buffer& a, const raw_buffer& b) {
 }
 
 TEST(evaluate, arithmetic) {
-  eval_context context;
+  eval_context context = make_context();
   context[x] = 4;
 
   ASSERT_EQ(evaluate(x + 5, context), 9);
@@ -63,7 +69,7 @@ TEST(evaluate, arithmetic) {
 }
 
 TEST(evaluate, buffer_fields) {
-  eval_context context;
+  eval_context context = make_context();
   buffer<int, 1> buf({10});
   context[x] = reinterpret_cast<index_t>(&buf);
 
@@ -83,7 +89,7 @@ TEST(evaluate, user_defined_call) {
     return x * y;
   };
 
-  eval_context context;
+  eval_context context = make_context();
   context[x] = 3;
   context[y] = 4;
   ASSERT_EQ(evaluate(call::make(intrinsic::none, fn, {x, y}), context), 12);
@@ -98,7 +104,7 @@ TEST(evaluate, call) {
       },
       span<var>{}, span<var>{}, {}, {});
 
-  eval_context context;
+  eval_context context = make_context();
   context[x] = 2;
 
   int result = evaluate(c, context);
@@ -108,7 +114,7 @@ TEST(evaluate, call) {
 }
 
 TEST(evaluate, loop) {
-  eval_context ctx;
+  eval_context ctx = make_context();
   thread_pool_impl t;
   eval_config cfg;
   cfg.thread_pool = &t;
@@ -156,7 +162,7 @@ stmt make_check(var buffer, std::vector<int> extents, const void* base = nullptr
 }
 
 TEST(evaluate, buffer_fields_broadcast) {
-  eval_context ctx;
+  eval_context ctx = make_context();
   buffer<int, 1> buf({10});
   ctx[x] = reinterpret_cast<index_t>(&buf);
 
@@ -166,26 +172,30 @@ TEST(evaluate, buffer_fields_broadcast) {
 }
 
 TEST(evaluate, allocate) {
-  eval_context ctx;
+  eval_context ctx = make_context();
   expr elem_size = 1;
-  evaluate(allocate::make(x, memory_type::automatic, elem_size, {{{0, 3}, 1}}, make_check(x, {4}, not_null)));
-  evaluate(allocate::make(x, memory_type::automatic, elem_size, {{{0, 3}, 1}, dim::broadcast()}, make_check(x, {4}, not_null)));
-  evaluate(allocate::make(
-      x, memory_type::automatic, elem_size, {{{0, 3}, 1}, dim::broadcast(), dim::broadcast()}, make_check(x, {4}, not_null)));
+  evaluate(allocate::make(x, memory_type::automatic, elem_size, {{{0, 3}, 1}}, make_check(x, {4}, not_null)), ctx);
+  evaluate(allocate::make(x, memory_type::automatic, elem_size, {{{0, 3}, 1}, dim::broadcast()},
+               make_check(x, {4}, not_null)),
+      ctx);
+  evaluate(allocate::make(x, memory_type::automatic, elem_size,
+               {{{0, 3}, 1}, dim::broadcast(), dim::broadcast()}, make_check(x, {4}, not_null)),
+      ctx);
 }
 
 TEST(evaluate, make_buffer) {
-  eval_context ctx;
+  eval_context ctx = make_context();
   expr base = 0;
   expr elem_size = 1;
-  evaluate(make_buffer::make(x, base, elem_size, {{{0, 3}, 1}}, make_check(x, {4})));
-  evaluate(make_buffer::make(x, base, elem_size, {{{0, 3}, 1}, dim::broadcast()}, make_check(x, {4})));
+  evaluate(make_buffer::make(x, base, elem_size, {{{0, 3}, 1}}, make_check(x, {4})), ctx);
+  evaluate(make_buffer::make(x, base, elem_size, {{{0, 3}, 1}, dim::broadcast()}, make_check(x, {4})), ctx);
   evaluate(
-      make_buffer::make(x, base, elem_size, {{{0, 3}, 1}, dim::broadcast(), dim::broadcast()}, make_check(x, {4})));
+      make_buffer::make(x, base, elem_size, {{{0, 3}, 1}, dim::broadcast(), dim::broadcast()}, make_check(x, {4})),
+      ctx);
 }
 
 TEST(evaluate, crop_dim) {
-  eval_context ctx;
+  eval_context ctx = make_context();
   buffer<int, 2> buf({10, 20});
   buf.allocate();
   ctx[x] = reinterpret_cast<index_t>(&buf);
@@ -214,7 +224,7 @@ TEST(evaluate, crop_dim) {
 }
 
 TEST(evaluate, crop_buffer) {
-  eval_context ctx;
+  eval_context ctx = make_context();
   buffer<int, 4> buf({10, 20, 30, 40});
   buf.allocate();
   ctx[x] = reinterpret_cast<index_t>(&buf);
@@ -250,7 +260,7 @@ TEST(evaluate, crop_buffer) {
 }
 
 TEST(evaluate, slice_dim) {
-  eval_context ctx;
+  eval_context ctx = make_context();
   buffer<int, 3> buf({10, 20, 30});
   buf.allocate();
   ctx[x] = reinterpret_cast<index_t>(&buf);
@@ -271,7 +281,7 @@ TEST(evaluate, slice_dim) {
 }
 
 TEST(evaluate, slice_buffer) {
-  eval_context ctx;
+  eval_context ctx = make_context();
   buffer<int, 4> buf({10, 20, 30, 40});
   buf.allocate();
   ctx[x] = reinterpret_cast<index_t>(&buf);
@@ -310,7 +320,7 @@ TEST(evaluate, slice_buffer) {
 }
 
 TEST(evaluate, transpose) {
-  eval_context ctx;
+  eval_context ctx = make_context();
   buffer<int, 4> buf({10, 20, 30, 40});
   buf.allocate();
   ctx[x] = reinterpret_cast<index_t>(&buf);
@@ -339,7 +349,7 @@ TEST(evaluate, transpose) {
 }
 
 TEST(evaluate, clone_buffer) {
-  eval_context ctx;
+  eval_context ctx = make_context();
   buffer<int, 2> buf({10, 20});
   buf.allocate();
   ctx[y] = reinterpret_cast<index_t>(&buf);
@@ -356,7 +366,7 @@ TEST(evaluate, clone_buffer) {
 }
 
 TEST(evaluate, semaphore) {
-  eval_context ctx;
+  eval_context ctx = make_context();
   thread_pool_impl t;
   eval_config cfg;
   cfg.thread_pool = &t;
@@ -387,7 +397,7 @@ TEST(evaluate, semaphore) {
 }
 
 TEST(evaluate, async) {
-  eval_context ctx;
+  eval_context ctx = make_context();
   thread_pool_impl t;
   eval_config cfg;
   cfg.thread_pool = &t;

--- a/slinky/runtime/test/evaluate_benchmark.cc
+++ b/slinky/runtime/test/evaluate_benchmark.cc
@@ -48,6 +48,15 @@ stmt make_call_counter(std::atomic<int>& calls, nanoseconds task_size) {
 
 stmt make_loop(stmt body) { return loop::make(x, loop::serial, range(0, iterations), 1, body); }
 
+eval_context& bench_context() {
+  static eval_context ctx = [] {
+    eval_context c;
+    c.reserve(w.id + 1);
+    return c;
+  }();
+  return ctx;
+}
+
 // For nodes that need a buffer, we can add a buffer outside that loop, the cost of constructing it will be negligible.
 std::vector<dim_expr> make_dims(int rank) {
   std::vector<dim_expr> dims;
@@ -66,7 +75,7 @@ void BM_call(benchmark::State& state) {
   stmt body = make_loop(make_call_counter(calls));
 
   for (auto _ : state) {
-    evaluate(body);
+    evaluate(body, bench_context());
   }
 
   state.SetItemsProcessed(calls);
@@ -85,7 +94,7 @@ void BM_let(benchmark::State& state) {
   stmt body = make_loop(let_stmt::make(values, make_call_counter(calls)));
 
   for (auto _ : state) {
-    evaluate(body);
+    evaluate(body, bench_context());
   }
 
   state.SetItemsProcessed(calls);
@@ -99,7 +108,7 @@ void BM_block(benchmark::State& state) {
   stmt body = make_loop(block::make(call_counters));
 
   for (auto _ : state) {
-    evaluate(body);
+    evaluate(body, bench_context());
   }
 
   state.SetItemsProcessed(calls);
@@ -114,7 +123,7 @@ void BM_crop_dim(benchmark::State& state) {
   stmt body = make_buf(src, 3, l);
 
   for (auto _ : state) {
-    evaluate(body);
+    evaluate(body, bench_context());
   }
 
   state.SetItemsProcessed(calls);
@@ -129,7 +138,7 @@ void BM_crop_buffer(benchmark::State& state) {
   stmt body = make_buf(src, 3, l);
 
   for (auto _ : state) {
-    evaluate(body);
+    evaluate(body, bench_context());
   }
 
   state.SetItemsProcessed(calls);
@@ -144,7 +153,7 @@ void BM_slice_dim(benchmark::State& state) {
   stmt body = make_buf(src, 3, l);
 
   for (auto _ : state) {
-    evaluate(body);
+    evaluate(body, bench_context());
   }
 
   state.SetItemsProcessed(calls);
@@ -159,7 +168,7 @@ void BM_slice_buffer(benchmark::State& state) {
   stmt body = make_buf(src, 3, l);
 
   for (auto _ : state) {
-    evaluate(body);
+    evaluate(body, bench_context());
   }
 
   state.SetItemsProcessed(calls);
@@ -174,7 +183,7 @@ void BM_transpose(benchmark::State& state) {
   stmt body = make_buf(src, 3, l);
 
   for (auto _ : state) {
-    evaluate(body);
+    evaluate(body, bench_context());
   }
 
   state.SetItemsProcessed(calls);
@@ -188,7 +197,7 @@ void BM_allocate(benchmark::State& state) {
   stmt body = make_loop(op);
 
   for (auto _ : state) {
-    evaluate(body);
+    evaluate(body, bench_context());
   }
 
   state.SetItemsProcessed(calls);
@@ -216,7 +225,7 @@ void BM_make_buffer(benchmark::State& state, dim_type kind) {
   stmt body = make_buf(src, rank, l);
 
   for (auto _ : state) {
-    evaluate(body);
+    evaluate(body, bench_context());
   }
 
   state.SetItemsProcessed(calls);
@@ -243,6 +252,7 @@ void benchmark_parallel_loop(benchmark::State& state, bool synchronize, nanoseco
   body = loop::make(x, workers, range(0, iterations), 1, body);
 
   eval_context eval_ctx;
+  eval_ctx.reserve(w.id + 1);
   eval_config config;
   thread_pool_impl t(workers - 1);
   config.thread_pool = &t;


### PR DESCRIPTION
This allows `evaluate` to assert the context is big enough, instead of every declaration potentially resizing it.

This *mostly* fixes #3. It still doesn't fully eliminate the possibility of the context being resized, because `let_stmt` can still grow the context. However, this eliminates likely almost all of the overhead associated with `eval_context::reserve` calls.