### PR TITLE
Fix use-after-free of the memory pool in `eval_context`

### DIFF
--- a/slinky/base/thread_pool_impl.cc
+++ b/slinky/base/thread_pool_impl.cc
@@ -56,18 +56,25 @@ std::size_t thread_pool_impl::task_impl::shard::work(task_body& body) {
 }
 
 bool thread_pool_impl::task_impl::work(std::size_t worker) {
-  task_body body = body_;
   std::size_t done = 0;
-  // The first iteration of this loop runs the work allocated to this worker. Subsequent iterations of this loop are
-  // stealing work from other workers.
-  const std::size_t i0 = worker % shard_count_;
-  for (std::size_t i = i0; i < shard_count_; ++i) {
-    done += shards_[i].work(body);
+  {
+    task_body body = body_;
+    // The first iteration of this loop runs the work allocated to this worker. Subsequent iterations of this loop are
+    // stealing work from other workers.
+    const std::size_t i0 = worker % shard_count_;
+    for (std::size_t i = i0; i < shard_count_; ++i) {
+      done += shards_[i].work(body);
+    }
+    for (std::size_t i = 0; i < i0; ++i) {
+      done += shards_[i].work(body);
+    }
+    // Destroy `body` before decrementing active_workers_ below, so the destructor does not run after the caller
+    // disposes of it.
   }
-  for (std::size_t i = 0; i < i0; ++i) {
-    done += shards_[i].work(body);
+  if (done > 0) {
+    todo_ -= done;
   }
-  return done > 0 && (todo_ -= done) == 0;
+  return --active_workers_ == 0;
 }
 
 bool thread_pool_impl::task_impl::work() {
@@ -80,7 +87,7 @@ bool thread_pool_impl::task_impl::work() {
 }
 
 bool thread_pool_impl::task_impl::all_work_started() const {
-  if (done()) return true;
+  if (todo_ == 0) return true;
   for (std::size_t i = 0; i < shard_count_; ++i) {
     const shard& s = shards_[i];
     if (s.i < s.end) return false;

--- a/slinky/base/thread_pool_impl.h
+++ b/slinky/base/thread_pool_impl.h
@@ -31,6 +31,7 @@ public:
     std::size_t shard_count_;
     // How many workers can start working on this loop. Decremented as workers begin working.
     std::atomic<int> max_workers_;
+    std::atomic<int> active_workers_{0};
 
     alignas(cache_line_size) std::atomic<std::size_t> todo_;
 
@@ -58,7 +59,13 @@ public:
 
     // Return a unique worker ID for this loop. Negative worker IDs are invalid, indicating no more workers should work
     // on this loop.
-    int allocate_worker() { return --max_workers_; }
+    int allocate_worker() {
+      int w = --max_workers_;
+      if (w >= 0) {
+        active_workers_.fetch_add(1, std::memory_order_relaxed);
+      }
+      return w;
+    }
 
     // Work on the loop. This returns when work on all items in the loop has started, but may return before all items
     // are complete. Returns true if this call resulted in the loop being done, but the loop may not be done.
@@ -68,7 +75,7 @@ public:
     // Returns true if there is no work left to start.
     bool all_work_started() const;
 
-    bool done() const override { return todo_ == 0; }
+    bool done() const override { return todo_ == 0 && active_workers_ == 0; }
   };
 
 private:


### PR DESCRIPTION
Our thread pool has a slightly janky characteristic: some workers can run after the loop is done. #875 added a memory pool on the `eval_context` object, the destructor of which tries to use `eval_config`, which may be destroyed by the caller when this task runs.

This fixes this issue, by ensuring that the task is destroyed before returning control to the caller of `parallel_for`. This appears to have negligible impact on performance, if anything it might be a small improvement.