### PR TITLE
Fix `substitute` for `loop::max_workers`

### DIFF
--- a/slinky/builder/substitute.cc
+++ b/slinky/builder/substitute.cc
@@ -270,6 +270,7 @@ public:
     const loop* ls = static_cast<const loop*>(self);
 
     if (!try_match(ls->sym, op->sym)) return;
+    if (!try_match(ls->max_workers, op->max_workers)) return;
     if (!try_match(ls->bounds, op->bounds)) return;
     if (!try_match(ls->step, op->step)) return;
     if (!try_match(ls->body, op->body)) return;
@@ -485,13 +486,15 @@ void substitutor::visit(const let_stmt* op) { set_result(mutate_let(this, op)); 
 void substitutor::visit(const loop* op) {
   interval_expr bounds = mutate(op->bounds);
   expr step = mutate(op->step);
+  expr max_workers = mutate(op->max_workers);
   var sym = enter_decl(op->sym);
   stmt body = sym.defined() ? mutate(op->body) : op->body;
   sym = sym.defined() ? sym : op->sym;
-  if (sym == op->sym && bounds.same_as(op->bounds) && step.same_as(op->step) && body.same_as(op->body)) {
+  if (sym == op->sym && bounds.same_as(op->bounds) && step.same_as(op->step) &&
+      max_workers.same_as(op->max_workers) && body.same_as(op->body)) {
     set_result(op);
   } else {
-    set_result(loop::make(sym, op->max_workers, std::move(bounds), std::move(step), std::move(body)));
+    set_result(loop::make(sym, std::move(max_workers), std::move(bounds), std::move(step), std::move(body)));
   }
   exit_decls();
 }

--- a/slinky/builder/test/substitute.cc
+++ b/slinky/builder/test/substitute.cc
@@ -71,6 +71,8 @@ TEST(substitute, shadowed) {
       matches(copy_stmt::make(nullptr, x, {u}, w, {z}, {})));
   ASSERT_THAT(substitute(copy_stmt::make(nullptr, x, {y}, w, {z}, u), u, v),
       matches(copy_stmt::make(nullptr, x, {y}, w, {z}, v)));
+  ASSERT_THAT(substitute(loop::make(x, u, {0, 10}, 1, check::make(x == y)), u, v),
+      matches(loop::make(x, v, {0, 10}, 1, check::make(x == y))));
 }
 
 TEST(match, basic) {
@@ -90,6 +92,11 @@ TEST(match, basic) {
   ASSERT_FALSE(match(let_stmt::make(x, y * z, check::make(x)), let_stmt::make(x, y, check::make(x))));
   ASSERT_FALSE(
       match(let_stmt::make(x, y * z, check::make(x)), let_stmt::make({{x, y * z}, {w, y * z}}, check::make(x))));
+
+  ASSERT_TRUE(
+      match(loop::make(x, u, {0, 10}, 1, check::make(x == y)), loop::make(x, u, {0, 10}, 1, check::make(x == y))));
+  ASSERT_FALSE(
+      match(loop::make(x, u, {0, 10}, 1, check::make(x == y)), loop::make(x, v, {0, 10}, 1, check::make(x == y))));
 
   {
     slinky::dim dims[2] = {{0, 10, 2}, {0, 1, 22}};


### PR DESCRIPTION
This was rarely an issue, but after #883, substitutions in these expressions are common.