### PR TITLE
Make `substitute` always successful

### DIFF
--- a/slinky/builder/optimizations.cc
+++ b/slinky/builder/optimizations.cc
@@ -1258,8 +1258,7 @@ class sibling_fuser : public stmt_mutator {
   static bool fuse(const T* a, const T* b, stmt& result) {
     if (!a || !b || !can_fuse(a, b)) return false;
 
-    // We can't substitute here because it is possible that b declares a and uses it elsewhere.
-    stmt body = block::make({a->body, clone_buffer::make(b->sym, a->sym, b->body)});
+    stmt body = block::make({a->body, substitute(b->body, b->sym, a->sym)});
     result = clone_with(a, std::move(body));
     return true;
   }

--- a/slinky/builder/optimizations.cc
+++ b/slinky/builder/optimizations.cc
@@ -631,10 +631,10 @@ public:
         // This allocation's bounds were expanded to accommodate aliases. Make a new expanded allocation, and make the
         // original allocation a crop of the expanded allocation.
         const std::vector<var>& syms = info.shared_alloc_syms;
-        body = crop_buffer::make(op->sym, syms.back(), dims_bounds(op->dims), std::move(body));
         for (std::size_t i = 0; i + 1 < syms.size(); ++i) {
-          body = clone_buffer::make(syms[i], syms[i + 1], std::move(body));
+          body = substitute(body, syms[i], syms.back());
         }
+        body = crop_buffer::make(op->sym, syms.back(), dims_bounds(op->dims), std::move(body));
       }
       stmt result = allocate::make(sym, op->storage, op->elem_size, std::move(info.dims), std::move(body));
       // Wrap with the original buffer in case we want to use the metadata in the construction of the buffer.

--- a/slinky/builder/substitute.cc
+++ b/slinky/builder/substitute.cc
@@ -440,21 +440,34 @@ auto mutate_let(substitutor* this_, const T* op) {
   std::vector<std::pair<var, expr>> lets = to_vector(op->lets);
   bool changed = false;
   std::size_t decls_entered = 0;
-  for (auto& s : lets) {
-    expr value = this_->mutate(s.second);
-    changed = changed || !value.same_as(s.second);
-    s.second = std::move(value);
-    var decl = this_->enter_decl(s.first);
+  for (std::size_t i = 0; i < lets.size(); ++i) {
+    var decl = this_->enter_decl(lets[i].first);
     if (!decl.defined()) {
       this_->exit_decls(decls_entered);
-      break;
+      // We got shadowed partway through the lets. We need to stop here, terminate what remains, then add the previously
+      // substituted lets.
+      auto rest = T::make({lets.begin() + i, lets.end()}, op->body);
+      auto terminated_rest = this_->terminate(rest);
+      if (terminated_rest.same_as(rest)) {
+        if (!changed) {
+          return decltype(op->body){op};
+        } else {
+          return T::make(std::move(lets), op->body);
+        }
+      } else if (i == 0) {
+        return terminated_rest;
+      } else {
+        return T::make({lets.begin(), lets.begin() + i}, std::move(terminated_rest));
+      }
     }
-    changed = changed || decl != s.first;
-    s.first = decl;
+    expr value = this_->mutate(lets[i].second);
+    changed = changed || !value.same_as(lets[i].second) || decl != lets[i].first;
+    lets[i].first = decl;
+    lets[i].second = std::move(value);
     ++decls_entered;
   }
 
-  auto body = decls_entered == lets.size() ? this_->mutate(op->body) : op->body;
+  auto body = this_->mutate(op->body);
   changed = changed || !body.same_as(op->body);
   this_->exit_decls(decls_entered);
   if (!changed) {
@@ -489,13 +502,17 @@ void substitutor::visit(const loop* op) {
   expr max_workers = mutate(op->max_workers);
   var sym = enter_decl(op->sym);
   stmt body = sym.defined() ? mutate(op->body) : op->body;
-  sym = sym.defined() ? sym : op->sym;
-  if (sym == op->sym && bounds.same_as(op->bounds) && step.same_as(op->step) &&
-      max_workers.same_as(op->max_workers) && body.same_as(op->body)) {
-    set_result(op);
+  bool defined = sym.defined();
+  sym = defined ? sym : op->sym;
+  stmt result;
+  if (sym == op->sym && bounds.same_as(op->bounds) && step.same_as(op->step) && max_workers.same_as(op->max_workers) &&
+      body.same_as(op->body)) {
+    result = stmt(op);
   } else {
-    set_result(loop::make(sym, std::move(max_workers), std::move(bounds), std::move(step), std::move(body)));
+    result = loop::make(sym, std::move(max_workers), std::move(bounds), std::move(step), std::move(body));
   }
+  if (!defined) result = terminate(result);
+  set_result(std::move(result));
   exit_decls();
 }
 void substitutor::visit(const allocate* op) {
@@ -509,12 +526,16 @@ void substitutor::visit(const allocate* op) {
   }
   var sym = enter_decl(op->sym);
   stmt body = sym.defined() ? mutate(op->body) : op->body;
-  sym = sym.defined() ? sym : op->sym;
+  bool defined = sym.defined();
+  sym = defined ? sym : op->sym;
+  stmt result;
   if (!changed && sym == op->sym && elem_size.same_as(op->elem_size) && body.same_as(op->body)) {
-    set_result(op);
+    result = stmt(op);
   } else {
-    set_result(allocate::make(sym, op->storage, std::move(elem_size), std::move(dims), std::move(body)));
+    result = allocate::make(sym, op->storage, std::move(elem_size), std::move(dims), std::move(body));
   }
+  if (!defined) result = terminate(result);
+  set_result(std::move(result));
   exit_decls();
 }
 void substitutor::visit(const make_buffer* op) {
@@ -529,13 +550,17 @@ void substitutor::visit(const make_buffer* op) {
   }
   var sym = enter_decl(op->sym);
   stmt body = sym.defined() ? mutate(op->body) : op->body;
-  sym = sym.defined() ? sym : op->sym;
+  bool defined = sym.defined();
+  sym = defined ? sym : op->sym;
+  stmt result;
   if (!changed && sym == op->sym && base.same_as(op->base) && elem_size.same_as(op->elem_size) &&
       body.same_as(op->body)) {
-    set_result(op);
+    result = stmt(op);
   } else {
-    set_result(make_buffer::make(sym, std::move(base), std::move(elem_size), std::move(dims), std::move(body)));
+    result = make_buffer::make(sym, std::move(base), std::move(elem_size), std::move(dims), std::move(body));
   }
+  if (!defined) result = terminate(result);
+  set_result(std::move(result));
   exit_decls();
 }
 
@@ -554,12 +579,16 @@ void substitutor::visit(const slice_buffer* op) {
   }
   var sym = enter_decl(op->sym);
   stmt body = sym.defined() ? mutate(op->body) : op->body;
-  sym = sym.defined() ? sym : op->sym;
+  bool defined = sym.defined();
+  sym = defined ? sym : op->sym;
+  stmt result;
   if (!changed && sym == op->sym && src == op->src && body.same_as(op->body)) {
-    set_result(op);
+    result = stmt(op);
   } else {
-    set_result(slice_buffer::make(sym, src, std::move(at), std::move(body)));
+    result = slice_buffer::make(sym, src, std::move(at), std::move(body));
   }
+  if (!defined) result = terminate(result);
+  set_result(std::move(result));
   exit_decls();
 }
 void substitutor::visit(const slice_dim* op) {
@@ -567,12 +596,16 @@ void substitutor::visit(const slice_dim* op) {
   expr at = mutate(op->at);
   var sym = enter_decl(op->sym);
   stmt body = sym.defined() ? mutate(op->body) : op->body;
-  sym = sym.defined() ? sym : op->sym;
+  bool defined = sym.defined();
+  sym = defined ? sym : op->sym;
+  stmt result;
   if (sym == op->sym && src == op->src && at.same_as(op->at) && body.same_as(op->body)) {
-    set_result(op);
+    result = stmt(op);
   } else {
-    set_result(slice_dim::make(sym, src, op->dim, std::move(at), std::move(body)));
+    result = slice_dim::make(sym, src, op->dim, std::move(at), std::move(body));
   }
+  if (!defined) result = terminate(result);
+  set_result(std::move(result));
   exit_decls();
 }
 
@@ -615,12 +648,16 @@ void substitutor::visit(const crop_buffer* op) {
   }
   var sym = enter_decl(op->sym);
   stmt body = sym.defined() ? mutate(op->body) : op->body;
-  sym = sym.defined() ? sym : op->sym;
+  bool defined = sym.defined();
+  sym = defined ? sym : op->sym;
+  stmt result;
   if (changed || sym != op->sym || src != op->src || !body.same_as(op->body)) {
-    set_result(crop_buffer::make(sym, src, std::move(bounds), std::move(body)));
+    result = crop_buffer::make(sym, src, std::move(bounds), std::move(body));
   } else {
-    set_result(op);
+    result = stmt(op);
   }
+  if (!defined) result = terminate(result);
+  set_result(std::move(result));
   exit_decls();
 }
 
@@ -629,12 +666,16 @@ void substitutor::visit(const crop_dim* op) {
   interval_expr bounds = substitute_crop_bounds(this, src, op->src, op->dim, op->bounds);
   var sym = enter_decl(op->sym);
   stmt body = sym.defined() ? mutate(op->body) : op->body;
-  sym = sym.defined() ? sym : op->sym;
+  bool defined = sym.defined();
+  sym = defined ? sym : op->sym;
+  stmt result;
   if (sym == op->sym && src == op->src && bounds.same_as(op->bounds) && body.same_as(op->body)) {
-    set_result(op);
+    result = stmt(op);
   } else {
-    set_result(crop_dim::make(sym, src, op->dim, std::move(bounds), std::move(body)));
+    result = crop_dim::make(sym, src, op->dim, std::move(bounds), std::move(body));
   }
+  if (!defined) result = terminate(result);
+  set_result(std::move(result));
   exit_decls();
 }
 
@@ -642,12 +683,16 @@ void substitutor::visit(const async* op) {
   var sym = enter_decl(op->sym);
   stmt task = sym.defined() ? mutate(op->task) : op->task;
   stmt body = sym.defined() ? mutate(op->body) : op->body;
-  sym = sym.defined() ? sym : op->sym;
+  bool defined = sym.defined();
+  sym = defined ? sym : op->sym;
+  stmt result;
   if (sym == op->sym && task.same_as(op->task) && body.same_as(op->body)) {
-    set_result(op);
+    result = stmt(op);
   } else {
-    set_result(async::make(sym, std::move(task), std::move(body)));
+    result = async::make(sym, std::move(task), std::move(body));
   }
+  if (!defined) result = terminate(result);
+  set_result(std::move(result));
   exit_decls();
 }
 
@@ -695,12 +740,16 @@ void substitutor::visit(const transpose* op) {
   var src = visit_symbol(op->src);
   var sym = enter_decl(op->sym);
   stmt body = sym.defined() ? mutate(op->body) : op->body;
-  sym = sym.defined() ? sym : op->sym;
+  bool defined = sym.defined();
+  sym = defined ? sym : op->sym;
+  stmt result;
   if (sym != op->sym || src != op->src || !body.same_as(op->body)) {
-    set_result(transpose::make(sym, src, op->dims, std::move(body)));
+    result = transpose::make(sym, src, op->dims, std::move(body));
   } else {
-    set_result(op);
+    result = stmt(op);
   }
+  if (!defined) result = terminate(result);
+  set_result(std::move(result));
   exit_decls();
 }
 
@@ -766,12 +815,16 @@ void substitutor::visit(const clone_buffer* op) {
   var src = visit_symbol(op->src);
   var sym = enter_decl(op->sym);
   stmt body = sym.defined() ? mutate(op->body) : op->body;
-  sym = sym.defined() ? sym : op->sym;
+  bool defined = sym.defined();
+  sym = defined ? sym : op->sym;
+  stmt result;
   if (sym != op->sym || src != op->src || !body.same_as(op->body)) {
-    set_result(clone_buffer::make(sym, src, std::move(body)));
+    result = clone_buffer::make(sym, src, std::move(body));
   } else {
-    set_result(op);
+    result = stmt(op);
   }
+  if (!defined) result = terminate(result);
+  set_result(std::move(result));
   exit_decls();
 }
 
@@ -814,6 +867,22 @@ public:
       return replacement_symbol(replacement);
     } else {
       return x;
+    }
+  }
+
+  expr terminate(const expr& e) override {
+    if (depends_on(e, target).any()) {
+      return let::make(target, replacement, e);
+    } else {
+      return e;
+    }
+  }
+
+  stmt terminate(const stmt& s) override {
+    if (depends_on(s, target).any()) {
+      return let_stmt::make(target, replacement, s);
+    } else {
+      return s;
     }
   }
 };

--- a/slinky/builder/substitute.h
+++ b/slinky/builder/substitute.h
@@ -47,6 +47,9 @@ public:
   virtual var enter_decl(var sym) { return sym; }
   virtual void exit_decls(int n = 1) {}
 
+  virtual expr terminate(const expr& e) { return e; }
+  virtual stmt terminate(const stmt& s) { return s; }
+
   void visit(const variable* op) override;
   void visit(const let* op) override;
   void visit(const call* op) override;

--- a/slinky/builder/test/optimizations.cc
+++ b/slinky/builder/test/optimizations.cc
@@ -68,8 +68,18 @@ TEST(optimizations, fuse_siblings) {
                   allocate::make(x, memory_type::heap, 1, span<dim_expr>{}, use_buffer(x)),
                   allocate::make(y, memory_type::heap, 1, span<dim_expr>{}, use_buffer(y)),
               })),
+      matches(allocate::make(
+          x, memory_type::heap, 1, span<dim_expr>{}, block::make({use_buffer(x), use_buffer(x)}))));
+
+  ASSERT_THAT(fuse_siblings(block::make({
+                  allocate::make(x, memory_type::heap, 1, span<dim_expr>{},
+                      allocate::make(y, memory_type::heap, 1, span<dim_expr>{}, use_buffer(y))),
+                  allocate::make(z, memory_type::heap, 1, span<dim_expr>{},
+                      allocate::make(w, memory_type::heap, 1, span<dim_expr>{}, use_buffer(w))),
+              })),
       matches(allocate::make(x, memory_type::heap, 1, span<dim_expr>{},
-          block::make({use_buffer(x), clone_buffer::make(y, x, use_buffer(y))}))));
+          allocate::make(y, memory_type::heap, 1, span<dim_expr>{},
+              block::make({use_buffer(y), use_buffer(y)})))));
 
   ASSERT_THAT(fuse_siblings(block::make({
                   allocate::make(x, memory_type::heap, 1, span<dim_expr>{}, use_buffer(x)),
@@ -113,8 +123,7 @@ TEST(optimizations, fuse_siblings) {
                   crop_dim::make(z, y, 0, {0, 10}, crop_dim::make(w, z, 1, {0, 10}, use_buffer(w))),
               })),
       matches(crop_dim::make(x, y, 0, {0, 10},
-          block::make({crop_dim::make(z, x, 1, {0, 10}, use_buffer(z)),
-              clone_buffer::make(z, x, crop_dim::make(w, z, 1, {0, 10}, use_buffer(w)))}))));
+          crop_dim::make(z, x, 1, {0, 10}, block::make({use_buffer(z), use_buffer(z)})))));
 
   ASSERT_THAT(
       fuse_siblings(block::make({
@@ -125,7 +134,7 @@ TEST(optimizations, fuse_siblings) {
       matches(allocate::make(x, memory_type::heap, 1, span<dim_expr>{},
           block::make({
               use_buffer(x),
-              clone_buffer::make(y, x,
+              let_stmt::make(y, x,
                   allocate::make(
                       x, memory_type::heap, 1, span<dim_expr>{}, block::make({use_buffer(x), use_buffer(y)}))),
           }))));

--- a/slinky/builder/test/optimizations.cc
+++ b/slinky/builder/test/optimizations.cc
@@ -115,6 +115,20 @@ TEST(optimizations, fuse_siblings) {
       matches(crop_dim::make(x, y, 0, {0, 10},
           block::make({crop_dim::make(z, x, 1, {0, 10}, use_buffer(z)),
               clone_buffer::make(z, x, crop_dim::make(w, z, 1, {0, 10}, use_buffer(w)))}))));
+
+  ASSERT_THAT(
+      fuse_siblings(block::make({
+          allocate::make(x, memory_type::heap, 1, span<dim_expr>{}, use_buffer(x)),
+          allocate::make(y, memory_type::heap, 1, span<dim_expr>{},
+              allocate::make(x, memory_type::heap, 1, span<dim_expr>{}, block::make({use_buffer(x), use_buffer(y)}))),
+      })),
+      matches(allocate::make(x, memory_type::heap, 1, span<dim_expr>{},
+          block::make({
+              use_buffer(x),
+              clone_buffer::make(y, x,
+                  allocate::make(
+                      x, memory_type::heap, 1, span<dim_expr>{}, block::make({use_buffer(x), use_buffer(y)}))),
+          }))));
 }
 
 TEST(optimizations, remove_pure_dims) {

--- a/slinky/builder/test/substitute.cc
+++ b/slinky/builder/test/substitute.cc
@@ -52,14 +52,27 @@ TEST(substitute, basic) {
 
 TEST(substitute, shadowed) {
   ASSERT_THAT(substitute(let::make(x, y, x + z), x, w), matches(let::make(x, y, x + z)));
+  ASSERT_THAT(substitute(let::make(x, y, x + z), z, x), matches(let::make(z, x, let::make(x, y, x + z))));
+  ASSERT_THAT(substitute(let_stmt::make(x, y, check::make(expr(x) == expr(z))), x, w),
+      matches(let_stmt::make(x, y, check::make(expr(x) == expr(z)))));
+  ASSERT_THAT(substitute(let_stmt::make(x, y, check::make(expr(x) == expr(z))), z, x),
+      matches(let_stmt::make(z, x, let_stmt::make(x, y, check::make(expr(x) == expr(z))))));
 
   ASSERT_THAT(
       substitute(let::make({{x, 1}, {y, 2}}, z + 1), z, z + w), matches(let::make({{x, 1}, {y, 2}}, z + w + 1)));
+  ASSERT_THAT(substitute(let::make({{w, z}, {x, 1}}, x + z), z, x),
+      matches(let::make({{w, x}}, let::make(z, x, let::make(x, 1, x + z)))));
+  ASSERT_THAT(substitute(let::make({{w, z + 1}, {z, 2}}, w + z), z, z + 10),
+      matches(let::make({{w, z + 10 + 1}, {z, 2}}, w + z)));
+  ASSERT_THAT(substitute(let_stmt::make({{w, z}, {x, 1}}, check::make(expr(x) == expr(z))), z, x),
+      matches(let_stmt::make({{w, x}}, let_stmt::make(z, x, let_stmt::make(x, 1, check::make(expr(x) == expr(z)))))));
+  ASSERT_THAT(substitute(let_stmt::make({{w, z + 1}, {z, 2}}, check::make(expr(w) == expr(z))), z, z + 10),
+      matches(let_stmt::make({{w, z + 10 + 1}, {z, 2}}, check::make(expr(w) == expr(z)))));
 
   ASSERT_THAT(substitute(slice_dim::make(x, x, 2, 0, check::make(y == buffer_min(x, 3))), y, buffer_max(x, 3)),
-      matches(slice_dim::make(x, x, 2, 0, check::make(y == buffer_min(x, 3)))));
+      matches(let_stmt::make(y, buffer_max(x, 3), slice_dim::make(x, x, 2, 0, check::make(y == buffer_min(x, 3))))));
   ASSERT_THAT(substitute(slice_dim::make(x, u, 2, 0, check::make(y == buffer_min(x, 3))), y, buffer_max(x, 3)),
-      matches(slice_dim::make(x, u, 2, 0, check::make(y == buffer_min(x, 3)))));
+      matches(let_stmt::make(y, buffer_max(x, 3), slice_dim::make(x, u, 2, 0, check::make(y == buffer_min(x, 3))))));
   ASSERT_THAT(substitute(slice_dim::make(x, u, 2, 0, check::make(y == buffer_min(x, 3))), y, buffer_max(u, 3)),
       matches(slice_dim::make(x, u, 2, 0, check::make(buffer_max(u, 3) == buffer_min(x, 3)))));
 
@@ -73,6 +86,14 @@ TEST(substitute, shadowed) {
       matches(copy_stmt::make(nullptr, x, {y}, w, {z}, v)));
   ASSERT_THAT(substitute(loop::make(x, u, {0, 10}, 1, check::make(x == y)), u, v),
       matches(loop::make(x, v, {0, 10}, 1, check::make(x == y))));
+
+  auto use_buffer = [](var x) { return call_stmt::make(nullptr, span<var>{}, span<var>{&x, 1}, {}, {}); };
+
+  ASSERT_THAT(
+      substitute(
+          allocate::make(x, memory_type::heap, 1, span<dim_expr>{}, block::make({use_buffer(x), use_buffer(y)})), y, x),
+      matches(let_stmt::make(y, x,
+          allocate::make(x, memory_type::heap, 1, span<dim_expr>{}, block::make({use_buffer(x), use_buffer(y)})))));
 }
 
 TEST(match, basic) {


### PR DESCRIPTION
This change fixes something I've been annoyed about since almost day 1 of slinky: it is possible for `substitute` to "fail". This can happen because the target symbol being substituted is declared somewhere, and then the replacement is used inside that declaration. Before this change, `substitute` would stop substitution when it reached the declaration, leaving the result invalid. 

This change handles this case by inserting a `let` or `let_stmt` outside the declaration that implements the substitution, instead of just giving up.

This means that `fuse_siblings` can now use `substitute` instead of `clone_buffer`, which in turn enables `fuse_siblings` to be able to fuse nested siblings, where previously it could not due to the `clone_buffer` ops obstructing the fusion.