### PR TITLE
Strengthen `alias_in_place` optimization

### DIFF
--- a/slinky/builder/optimizations.cc
+++ b/slinky/builder/optimizations.cc
@@ -1104,8 +1104,7 @@ public:
     } else if (can_alias && fwd && fwd->defined() && buffers.lookup(*fwd) &&
                fold_factors_strides_same(op->dims, buffers[*fwd]->dims)) {
       inherit_aliases(forward, backward, op->sym, *fwd);
-      stmt cropped = crop_buffer::make(op->sym, op->sym, dims_bounds(op->dims), std::move(body));
-      set_result(clone_buffer::make(op->sym, *fwd, std::move(cropped)));
+      set_result(crop_buffer::make(op->sym, *fwd, dims_bounds(op->dims), std::move(body)));
     } else if (!body.same_as(op->body)) {
       set_result(clone_with(op, std::move(body)));
     } else {

--- a/slinky/builder/optimizations.cc
+++ b/slinky/builder/optimizations.cc
@@ -1066,6 +1066,18 @@ public:
     return true;
   }
 
+  // Update the available aliasing opportunities to account for an aliasing. This allows a chain of multiple operations
+  // to alias an input and an output to the same buffer.
+  static void inherit_aliases(symbol_map<var>& used, symbol_map<var>& other, var alias, var target) {
+    std::optional<var> inherited = other.lookup(alias);
+    if (inherited && inherited->defined() && *inherited != target) {
+      other[target] = *inherited;
+      if (used.lookup(*inherited) == alias) used[*inherited] = target;
+    } else {
+      other.erase(target);
+    }
+  }
+
   void visit(const allocate* op) override {
     auto set_buffer = set_value_in_scope(buffers, op->sym, {op->sym, to_vector(op->dims), loop_level});
     auto set_back = set_value_in_scope(backward, op->sym, var());
@@ -1087,12 +1099,11 @@ public:
 
     if (can_alias && back && back->defined() && buffers.lookup(*back) &&
         fold_factors_strides_same(op->dims, buffers[*back]->dims)) {
-      forward.erase(*back);
+      inherit_aliases(backward, forward, op->sym, *back);
       set_result(crop_buffer::make(op->sym, *back, dims_bounds(op->dims), std::move(body)));
     } else if (can_alias && fwd && fwd->defined() && buffers.lookup(*fwd) &&
                fold_factors_strides_same(op->dims, buffers[*fwd]->dims)) {
-      backward.erase(*fwd);
-
+      inherit_aliases(forward, backward, op->sym, *fwd);
       stmt cropped = crop_buffer::make(op->sym, op->sym, dims_bounds(op->dims), std::move(body));
       set_result(clone_buffer::make(op->sym, *fwd, std::move(cropped)));
     } else if (!body.same_as(op->body)) {
@@ -1142,8 +1153,12 @@ public:
         }
 
         std::optional<buffer_info>& input_alloc = buffers[op->inputs[i]];
-        if (!input_alloc || !input_alloc->allow_alias || !use_count[input_alloc->root] ||
-            *use_count[input_alloc->root] > 1) {
+        if (!input_alloc) continue;
+        if (input_alloc->root == output_alloc->root) {
+          // This call is already computed in place, there's nothing to alias.
+          continue;
+        }
+        if (!input_alloc->allow_alias || !use_count[input_alloc->root] || *use_count[input_alloc->root] > 1) {
           // We're traversing blocks backwards, if we already had a use, this is not the last use of the buffer, we
           // can't alias it.
           continue;

--- a/slinky/builder/test/BUILD
+++ b/slinky/builder/test/BUILD
@@ -57,6 +57,7 @@ cc_test(
     name = "elementwise",
     srcs = ["elementwise.cc"],
     deps = [
+        ":util",
         "//slinky/base/test:util",
         "//slinky/builder",
         "//slinky/runtime",

--- a/slinky/builder/test/CMakeLists.txt
+++ b/slinky/builder/test/CMakeLists.txt
@@ -31,7 +31,7 @@ add_builder_test(copy
     slinky_builder_test_util slinky_base slinky_builder slinky_runtime)
 
 add_builder_test(elementwise
-    slinky_base_test_util slinky_builder slinky_runtime)
+    slinky_builder_test_util slinky_base_test_util slinky_builder slinky_runtime)
 
 add_builder_test(pipeline
     slinky_builder_test_util slinky_base_test_util slinky_builder slinky_runtime)

--- a/slinky/builder/test/elementwise.cc
+++ b/slinky/builder/test/elementwise.cc
@@ -8,6 +8,7 @@
 #include <vector>
 
 #include "slinky/builder/pipeline.h"
+#include "slinky/builder/test/context.h"
 #include "slinky/runtime/expr.h"
 #include "slinky/runtime/pipeline.h"
 
@@ -207,8 +208,10 @@ public:
   void visit(const logical_not*) override { SLINKY_UNREACHABLE; }
 };
 
+// Builds a pipeline that evaluates `e` elementwise, runs it, and checks the result against a reference evaluation of
+// `e`. Returns the number of heap allocations the pipeline needed.
 template <typename T, std::size_t Rank>
-void test_expr_pipeline(node_context& ctx, int split, const expr& e) {
+std::size_t test_expr_pipeline(node_context& ctx, int split, const expr& e) {
   elementwise_pipeline_builder<T, Rank> builder(ctx);
   e.accept(&builder);
 
@@ -240,7 +243,8 @@ void test_expr_pipeline(node_context& ctx, int split, const expr& e) {
   std::vector<const raw_buffer*> outputs;
   outputs.push_back(&output_buf);
 
-  p.evaluate(inputs, outputs);
+  test_context eval_ctx;
+  p.evaluate(inputs, outputs, eval_ctx);
 
   elementwise_pipeline_evaluator<T, Rank> eval;
   eval.extents = extents;
@@ -250,6 +254,8 @@ void test_expr_pipeline(node_context& ctx, int split, const expr& e) {
   e.accept(&eval);
 
   for_each_element([&](T* output, T* eval_result) { ASSERT_EQ(*output, *eval_result); }, output_buf, eval.result);
+
+  return eval_ctx.heap.allocs.size();
 }
 
 namespace {
@@ -271,6 +277,15 @@ expr pow(expr x, int n) {
   }
 }
 
+// Horner's rule produces a chain of elementwise operations, each of which can be computed in place with the previous
+// one. Without loops, the whole chain should be computed in the output buffer, needing no allocations at all.
+void test_horners_pipeline(int split, const expr& e) {
+  std::size_t allocs = test_expr_pipeline<int, 1>(ctx, split, e);
+  if (split == 0) {
+    ASSERT_EQ(allocs, 0);
+  }
+}
+
 }  // namespace
 
 class elementwise : public testing::TestWithParam<int> {};
@@ -289,12 +304,11 @@ TEST_P(elementwise, exp8) {
       ctx, GetParam(), 1 + x + pow(x, 2) + pow(x, 3) + pow(x, 4) + pow(x, 5) + pow(x, 6) + pow(x, 7) + pow(x, 8));
 }
 
-TEST_P(elementwise, exp2_horners) { test_expr_pipeline<int, 1>(ctx, GetParam(), 1 + x * (1 + x)); }
-TEST_P(elementwise, exp3_horners) { test_expr_pipeline<int, 1>(ctx, GetParam(), 1 + x * (1 + x * (1 + x))); }
-TEST_P(elementwise, exp4_horners) { test_expr_pipeline<int, 1>(ctx, GetParam(), 1 + x * (1 + x * (1 + x * (1 + x)))); }
+TEST_P(elementwise, exp2_horners) { test_horners_pipeline(GetParam(), 1 + x * (1 + x)); }
+TEST_P(elementwise, exp3_horners) { test_horners_pipeline(GetParam(), 1 + x * (1 + x * (1 + x))); }
+TEST_P(elementwise, exp4_horners) { test_horners_pipeline(GetParam(), 1 + x * (1 + x * (1 + x * (1 + x)))); }
 TEST_P(elementwise, exp8_horners) {
-  test_expr_pipeline<int, 1>(
-      ctx, GetParam(), 1 + x * (1 + x * (1 + x * (1 + x * (1 + x * (1 + x * (1 + x * (1 + x))))))));
+  test_horners_pipeline(GetParam(), 1 + x * (1 + x * (1 + x * (1 + x * (1 + x * (1 + x * (1 + x * (1 + x))))))));
 }
 
 }  // namespace slinky


### PR DESCRIPTION
Currently, we can only alias a given allocation once. This change modifies the `alias_in_place` algorithm to allow aliases to propagate, allowing large sequences of operations to be computed in place in the same buffer.