### PR TITLE
Avoid redundant evaluation of `let_stmt` at root when possible.

### DIFF
--- a/slinky/builder/optimizations.cc
+++ b/slinky/builder/optimizations.cc
@@ -1963,7 +1963,28 @@ stmt optimize_symbols(const stmt& s, node_context& ctx) {
   reuse_shadows mutator;
   result = mutator.mutate(result);
 
-  if (mutator.max_symbol_id >= 0) {
+  if (const let_stmt* let = result.as<let_stmt>()) {
+    int max_symbol_id = std::max(mutator.max_symbol_id, let->max_symbol_id);
+    if (!let->is_constant) {
+      // We can help optimize `pipeline::evaluate` if we separate the constant and non-constant lets.
+      // This is definitely safe because a constant cannot depend on another let.
+      std::vector<std::pair<var, expr>> constants;
+      std::vector<std::pair<var, expr>> non_constants;
+      constants.reserve(let->lets.size());
+      non_constants.reserve(let->lets.size());
+      for (const auto& p : let->lets) {
+        if (p.second.as<constant>() || p.second.as<constant_buffer>()) {
+          constants.push_back(p);
+        } else {
+          non_constants.push_back(p);
+        }
+      }
+      stmt inner = let_stmt::make(std::move(non_constants), let->body, let->is_closure);
+      result = let_stmt::make(std::move(constants), std::move(inner), /*is_closure=*/false, max_symbol_id);
+    } else if (max_symbol_id >= 0 && max_symbol_id != let->max_symbol_id) {
+      result = let_stmt::make(let->lets, let->body, let->is_closure, max_symbol_id);
+    }
+  } else if (mutator.max_symbol_id >= 0) {
     // Some symbols were declared outside of any let_stmt.
     result = let_stmt::make(
         std::vector<std::pair<var, expr>>{}, std::move(result), /*is_closure=*/false, mutator.max_symbol_id);

--- a/slinky/runtime/expr_stmt.cc
+++ b/slinky/runtime/expr_stmt.cc
@@ -151,7 +151,9 @@ T* make_let(Lets&& lets, Body body) {
 expr let::make(std::vector<std::pair<var, expr>> lets, expr body) { return expr(make_let<let>(lets, std::move(body))); }
 expr let::make(span<std::pair<var, expr>> lets, expr body) { return expr(make_let<let>(lets, std::move(body))); }
 
-expr let::make(var sym, expr value, expr body) { return make({{sym, std::move(value)}}, std::move(body)); }
+expr let::make(var sym, expr value, expr body) {
+  return make({{sym, std::move(value)}}, std::move(body));
+}
 
 namespace {
 
@@ -164,12 +166,16 @@ int max_decl_id(span<std::pair<var, expr>> lets) {
 }
 
 bool is_self_assignment(const std::pair<var, expr>& let) { return is_variable(let.second, let.first); }
+bool is_value_constant(const std::pair<var, expr>& let) {
+  return let.second.as<constant>() || let.second.as<constant_buffer>();
+}
 
 }  // namespace
 
 stmt let_stmt::make(std::vector<std::pair<var, expr>> lets, stmt body, bool is_closure, int max_symbol_id) {
   let_stmt* n = make_let<let_stmt>(lets, std::move(body));
   n->is_closure = is_closure;
+  n->is_constant = std::all_of(n->lets.begin(), n->lets.end(), is_value_constant);
   n->max_symbol_id = std::max(max_symbol_id, max_decl_id(n->lets));
   assert(!is_closure || std::all_of(n->lets.begin(), n->lets.end(), is_self_assignment));
   return stmt(n);
@@ -178,12 +184,15 @@ stmt let_stmt::make(std::vector<std::pair<var, expr>> lets, stmt body, bool is_c
 stmt let_stmt::make(span<std::pair<var, expr>> lets, stmt body, bool is_closure, int max_symbol_id) {
   let_stmt* n = make_let<let_stmt>(lets, std::move(body));
   n->is_closure = is_closure;
+  n->is_constant = std::all_of(n->lets.begin(), n->lets.end(), is_value_constant);
   n->max_symbol_id = std::max(max_symbol_id, max_decl_id(n->lets));
   assert(!is_closure || std::all_of(n->lets.begin(), n->lets.end(), is_self_assignment));
   return stmt(n);
 }
 
-stmt let_stmt::make(var sym, expr value, stmt body) { return make({{sym, std::move(value)}}, std::move(body)); }
+stmt let_stmt::make(var sym, expr value, stmt body) {
+  return make({{sym, std::move(value)}}, std::move(body));
+}
 
 namespace {
 

--- a/slinky/runtime/pipeline.cc
+++ b/slinky/runtime/pipeline.cc
@@ -7,6 +7,15 @@
 
 namespace slinky {
 
+namespace {
+
+const let_stmt* as_constant_let(const stmt& s) {
+  const let_stmt* let = s.as<let_stmt>();
+  return let && let->is_constant ? let : nullptr;
+}
+
+}  // namespace
+
 void pipeline::setup(scalars args, buffers inputs, buffers outputs, eval_context& ctx) const {
   assert(args.size() == this->args.size());
   assert(inputs.size() == this->inputs.size());
@@ -21,20 +30,44 @@ void pipeline::setup(scalars args, buffers inputs, buffers outputs, eval_context
   for (std::size_t i = 0; i < outputs.size(); ++i) {
     ctx[this->outputs[i]] = reinterpret_cast<index_t>(outputs[i]);
   }
+
+  const stmt* s = &body;
+  while (const let_stmt* let = as_constant_let(*s)) {
+    ctx.reserve(let->max_symbol_id + 1);
+    for (const auto& i : let->lets) {
+      switch (i.second.type()) {
+      case expr_node_type::constant: ctx[i.first] = i.second.as<constant>()->value; break;
+      case expr_node_type::constant_buffer:
+        ctx[i.first] = reinterpret_cast<index_t>(i.second.as<constant_buffer>()->value.get());
+        break;
+      default: SLINKY_UNREACHABLE;
+      }
+    }
+    s = &let->body;
+  }
 }
 
 void pipeline::setup(buffers inputs, buffers outputs, eval_context& ctx) const { setup({}, inputs, outputs, ctx); }
 
-index_t pipeline::evaluate(eval_context& ctx) const { return slinky::evaluate(body, ctx); }
+index_t pipeline::evaluate(eval_context& ctx, bool is_set_up) const {
+  const stmt* s = &body;
+  if (is_set_up) {
+    // This context has already been set up, we can skip the constant lets.
+    while (const let_stmt* let = as_constant_let(*s)) {
+      s = &let->body;
+    }
+  }
+  return slinky::evaluate(*s, ctx);
+}
 
 index_t pipeline::evaluate(scalars args, buffers inputs, buffers outputs, eval_context& ctx) const {
   setup(args, inputs, outputs, ctx);
-  return slinky::evaluate(body, ctx);
+  return evaluate(ctx, /*is_set_up=*/true);
 }
 
 index_t pipeline::evaluate(buffers inputs, buffers outputs, eval_context& ctx) const {
   setup(inputs, outputs, ctx);
-  return slinky::evaluate(body, ctx);
+  return evaluate(ctx, /*is_set_up=*/true);
 }
 
 index_t pipeline::evaluate(scalars args, buffers inputs, buffers outputs) const {

--- a/slinky/runtime/pipeline.h
+++ b/slinky/runtime/pipeline.h
@@ -26,8 +26,8 @@ public:
   void setup(scalars args, buffers inputs, buffers outputs, eval_context& ctx) const;
   void setup(buffers inputs, buffers outputs, eval_context& ctx) const;
 
-  // Run an already set up pipeline.
-  index_t evaluate(eval_context& ctx) const;
+  // Run an already set up pipeline. If `is_set_up` is true, `ctx` must be unmodified from a previous call to `setup` above.
+  index_t evaluate(eval_context& ctx, bool is_set_up = false) const;
 
   // Combines setup + evaluate.
   index_t evaluate(scalars args, buffers inputs, buffers outputs, eval_context& ctx) const;

--- a/slinky/runtime/stmt.h
+++ b/slinky/runtime/stmt.h
@@ -207,6 +207,9 @@ public:
   // The values of every let must be a `variable` expression.
   bool is_closure;
 
+  // If true, all let values are either `constant` or `constant_buffer` exprs.
+  bool is_constant;
+
   // The maximum symbol id that `evaluate` may assign while evaluating this node, or -1 if it is unknown.
   // Any symbol `x` evaluated by `evaluate` must be contained in a `let_stmt` with `max_symbol_id > x`.
   int max_symbol_id = -1;


### PR DESCRIPTION
This change provides a mechanism to avoid redundantly evaluating the `let_stmt` containing all of the constants a pipeline uses every time the pipeline is evaluated:

1. We make a separate `let_stmt` containing only constants, at the root of the pipeline.
2. We mark `let_stmt`s that contain only constants as such.
3. `pipeline::setup` eagerly evaluates these constants.
4. `pipeline::evaluate` now has a new parameter `is_set_up`, default `false`, which if `true`, indicates that the constant lets at root should be skipped.